### PR TITLE
docs: add agent handbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Presenter is a monolithic, production-ready lyrics/Bible/timers display applicat
 ## Collaboration & Decision Log
 - Capture architectural decisions in numbered ADRs under `docs/adr/` and cross-reference them from PRs when applicable.
 - Use GitHub Issues as the primary location for comprehensive feature plans; do not commit temporary planning documents to the repository. Keep plan updates and implementation notes in issue comments.
-- Surface open questions or scope uncertainties directly in PRs to secure answers before merge.
+- Surface open questions or scope uncertainties directly to the project owner (user) in the active conversation; PR comments alone are insufficient.
 
 ## Immediate Next Actions
 - Refine documentation to describe the precise church workflows this application must support.


### PR DESCRIPTION
## Summary
- add AGENTS.md outlining mission, guardrails, branching rules, and merge checklist
- document research requirement for choosing state-of-the-art tools

## Testing
- documentation only; no runtime code changes