### PR TITLE
Enforce sudo requirement for verify helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Presenter is a monolithic, production-ready lyrics/Bible/timers display applicat
 - Production environment is updated only after explicit user approval; ensure zero-downtime handoff and rollback plan.
 - Always prioritize the fastest path for the user to test changes on the development instance, then promote to production for other operators once sign-off is received.
 - Docker is now the primary demo platform. Keep the gateway (`./scripts/docker/run-gateway.sh`) running on port 80 with manifests mounted from `${XDG_DATA_HOME:-$HOME/.local/share}/presenter-demos/manifests`. For each feature branch checkout, launch or refresh its dedicated stack via `./scripts/docker/run-demo.sh`. **Agents are responsible for starting, stopping, and keeping these demos current without prompting the user.** Ensure only one demo per repository folder is active—`run-demo.sh` already stops stale containers for the same repo—and immediately tear down any legacy systemd or bare-metal presenter services so they never conflict with Docker-managed demos.
+- Always invoke `./scripts/dev/verify-and-refresh.sh` with `sudo -E` so Docker commands succeed while tests still run as your user; the helper now enforces this requirement at startup.
 
 ## Database Management (Pre-release)
 - We are still before our first public release. Treat the schema as mutable: **never add incremental migrations**. Instead, evolve the single initial migration (or equivalent schema definition) directly whenever the data model changes.

--- a/scripts/dev/verify-and-refresh.sh
+++ b/scripts/dev/verify-and-refresh.sh
@@ -6,6 +6,31 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "$REPO_ROOT"
 
+if [[ $EUID -ne 0 ]]; then
+  echo "[verify] This helper must be launched via sudo -E ./scripts/dev/verify-and-refresh.sh" >&2
+  exit 1
+fi
+
+if [[ -z "${SUDO_USER:-}" ]]; then
+  echo "[verify] SUDO_USER not set; use sudo -E so tests run as your account." >&2
+  exit 1
+fi
+
+ORIGINAL_USER="$SUDO_USER"
+ORIGINAL_HOME="$(getent passwd "$ORIGINAL_USER" | cut -d: -f6)"
+NVM_DIR_DEFAULT="${ORIGINAL_HOME}/.nvm"
+ORIGINAL_PATH="$(sudo -H -u "$ORIGINAL_USER" HOME="$ORIGINAL_HOME" NVM_DIR="$NVM_DIR_DEFAULT" bash -lc 'source ~/.profile >/dev/null 2>&1; source ~/.bashrc >/dev/null 2>&1; if [ -s "$NVM_DIR/nvm.sh" ]; then source "$NVM_DIR/nvm.sh"; fi; echo $PATH')"
+RUN_AS_ORIGINAL() {
+  local cmd=("$@")
+  local quoted=$(printf '%q ' "${cmd[@]}")
+  sudo -H -u "$ORIGINAL_USER" HOME="$ORIGINAL_HOME" PATH="$ORIGINAL_PATH" NVM_DIR="$NVM_DIR_DEFAULT" bash -lc "source ~/.profile >/dev/null 2>&1; source ~/.bashrc >/dev/null 2>&1; if [ -s "$NVM_DIR/nvm.sh" ]; then source "$NVM_DIR/nvm.sh"; fi; ${quoted}"
+}
+
+if ! docker info >/dev/null 2>&1; then
+  echo "[verify] Docker daemon is not reachable even under sudo." >&2
+  exit 1
+fi
+
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 BRANCH_SLUG="$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')"
 REPO_SLUG="$(basename "$REPO_ROOT")"
@@ -52,7 +77,7 @@ done
 DISPLAY_NAME="${CUSTOM_DISPLAY_NAME:-$DISPLAY_NAME_DEFAULT}"
 
 echo "[verify] Running cargo test"
-cargo test
+RUN_AS_ORIGINAL cargo test
 
 RUN_ARGS=("--name" "$REPO_SLUG" "--display-name" "$DISPLAY_NAME" "--port" "$DEMO_PORT")
 if [[ "$FORCE_REBUILD" -eq 1 ]]; then
@@ -66,7 +91,7 @@ echo "[verify] Restarting gateway"
 "$REPO_ROOT/scripts/docker/run-gateway.sh"
 
 echo "[verify] Running Playwright suite"
-npm run test:playwright
+RUN_AS_ORIGINAL npm run test:playwright
 
 echo "[verify] Refreshing Docker demo for project '$REPO_SLUG' (post-tests)"
 "$REPO_ROOT/scripts/docker/run-demo.sh" "--name" "$REPO_SLUG" "--display-name" "$DISPLAY_NAME" "--port" "$DEMO_PORT"


### PR DESCRIPTION
## Summary
- document the sudo -E requirement for demo verification in AGENTS handbook
- enforce sudo usage inside verify-and-refresh helper and run cargo/npm using the invoking user’s environment
- load NVM/NPM PATH so Playwright tests continue to work when launched from sudo wrapper

## Testing
- sudo -E ./scripts/dev/verify-and-refresh.sh --force
