### PR TITLE
feat: reduce trigger latency and stabilise demo tooling

### DIFF
--- a/crates/presenter-bible/Cargo.toml
+++ b/crates/presenter-bible/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 presenter-core = { path = "../presenter-core" }
 reqwest.workspace = true
+tokio.workspace = true
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tracing.workspace = true
 rusqlite = { version = "0.32", features = ["bundled"] }
@@ -19,4 +20,3 @@ tempfile = "3.10"
 workspace = true
 
 [dev-dependencies]
-tokio.workspace = true

--- a/crates/presenter-bible/src/lib.rs
+++ b/crates/presenter-bible/src/lib.rs
@@ -4,8 +4,11 @@ use presenter_core::{bible::BibleIngestionBatch, BiblePassage, BibleReference, B
 use rusqlite::{types::ValueRef, Connection};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fs;
 use std::io::{Cursor, Read, Write};
+use std::path::PathBuf;
 use std::str;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use tracing::warn;
 use zip::read::ZipArchive;
@@ -20,6 +23,39 @@ pub struct HttpBibleContentProvider {
     client: reqwest::Client,
 }
 
+fn resolve_cache_path(url: &str) -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("PRESENTER_BIBLE_CACHE_DIR") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir).join(sanitise_url(url)));
+        }
+    }
+    if let Some(base) = std::env::var_os("XDG_CACHE_HOME") {
+        let mut path = PathBuf::from(base);
+        path.push("presenter");
+        path.push("bibles");
+        path.push(sanitise_url(url));
+        return Some(path);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let mut path = PathBuf::from(home);
+        path.push(".cache");
+        path.push("presenter");
+        path.push("bibles");
+        path.push(sanitise_url(url));
+        return Some(path);
+    }
+    None
+}
+
+fn sanitise_url(url: &str) -> String {
+    url.chars()
+        .map(|ch| match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '-' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
 impl HttpBibleContentProvider {
     pub fn new() -> Result<Self> {
         let client = reqwest::Client::builder()
@@ -32,9 +68,63 @@ impl HttpBibleContentProvider {
 #[async_trait]
 impl BibleContentProvider for HttpBibleContentProvider {
     async fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>> {
-        let response = self.client.get(url).send().await?;
-        let response = response.error_for_status()?;
-        Ok(response.bytes().await?.to_vec())
+        let cache_path = resolve_cache_path(url);
+        let mut last_error: Option<anyhow::Error> = None;
+
+        for attempt in 0..3 {
+            match self.client.get(url).send().await {
+                Ok(response) => match response.error_for_status() {
+                    Ok(success) => match success.bytes().await {
+                        Ok(bytes) => {
+                            let bytes = bytes.to_vec();
+                            if let Some(path) = cache_path.as_ref() {
+                                if let Some(parent) = path.parent() {
+                                    if let Err(err) = fs::create_dir_all(parent) {
+                                        warn!(?err, "failed to create bible cache directory");
+                                    }
+                                }
+                                if let Err(err) = fs::write(path, &bytes) {
+                                    warn!(?err, path = %path.display(), "failed to write bible cache");
+                                }
+                            }
+                            return Ok(bytes);
+                        }
+                        Err(err) => {
+                            last_error = Some(err.into());
+                        }
+                    },
+                    Err(err) => {
+                        last_error = Some(err.into());
+                    }
+                },
+                Err(err) => {
+                    last_error = Some(err.into());
+                }
+            }
+
+            if attempt < 2 {
+                let backoff = Duration::from_secs(2_u64.pow(attempt as u32));
+                tokio::time::sleep(backoff).await;
+            }
+        }
+
+        if let Some(path) = cache_path.as_ref() {
+            if path.exists() {
+                warn!(
+                    path = %path.display(),
+                    error = ?last_error,
+                    "using cached bible archive after download failure"
+                );
+                return fs::read(path).with_context(|| {
+                    format!(
+                        "failed to read cached bible archive from {}",
+                        path.display()
+                    )
+                });
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow!("failed to download bible archive")))
     }
 }
 

--- a/crates/presenter-server/src/operator_script.js
+++ b/crates/presenter-server/src/operator_script.js
@@ -67,6 +67,7 @@
     searchOpen: false,
     clearingSlide: false,
     searchDragging: false,
+    skipClickTrigger: null,
     draggingPresentationId: null,
     draggingFromSearch: false,
     catalogTopHeight: resolvedCatalogHeight,
@@ -3851,6 +3852,18 @@ function updateCardWarnings(card) {
     const card = event.target.closest('[data-slide-id]');
     if (!card) return;
     const slideId = card.dataset.slideId;
+    const now = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+    if (state.mode === 'live' && state.skipClickTrigger) {
+      if (state.skipClickTrigger.slideId === slideId && state.skipClickTrigger.expiresAt >= now) {
+        state.skipClickTrigger = null;
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (state.skipClickTrigger.expiresAt < now) {
+        state.skipClickTrigger = null;
+      }
+    }
     const presentationId = state.currentPresentationId;
     if (!presentationId) return;
     const actionButton = event.target.closest('[data-action]');
@@ -3891,6 +3904,33 @@ function updateCardWarnings(card) {
   }
 
   function handleSlidesPointerDown(event) {
+    if (state.mode === 'live') {
+      if (event.button !== 0) {
+        state.pendingFocus = null;
+        return;
+      }
+      const actionButton = event.target.closest('[data-action]');
+      const editableField = event.target.closest('[data-field]');
+      if (actionButton || editableField) {
+        state.pendingFocus = null;
+        return;
+      }
+      const card = event.target.closest('[data-slide-id]');
+      const presentationId = state.currentPresentationId || state.stagePresentationId;
+      const slideId = card ? card.dataset.slideId : null;
+      if (card && presentationId && slideId) {
+        const now = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now();
+        state.skipClickTrigger = { slideId, expiresAt: now + 250 };
+        state.currentPresentationId = presentationId;
+        state.focusedSlideId = slideId;
+        triggerSlide(presentationId, slideId, card);
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      state.pendingFocus = null;
+      return;
+    }
     const field = event.target.closest('[data-field]');
     if (!field) {
       state.pendingFocus = null;

--- a/crates/presenter-server/src/state.rs
+++ b/crates/presenter-server/src/state.rs
@@ -30,6 +30,7 @@ pub struct AppState {
     resolume_registry: ResolumeRegistry,
     stage_connections: StageConnections,
     heartbeat_config: StageHeartbeatConfig,
+    presentation_cache: Arc<RwLock<HashMap<PresentationId, Arc<Presentation>>>>,
     #[cfg(test)]
     bible_ingestion_override: Option<std::sync::Arc<dyn TestBibleIngestion + Send + Sync>>,
 }
@@ -50,6 +51,7 @@ impl AppState {
             resolume_registry,
             stage_connections,
             heartbeat_config,
+            presentation_cache: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(test)]
             bible_ingestion_override: None,
         };
@@ -148,6 +150,7 @@ impl AppState {
             .repository
             .create_presentation(library_id, name)
             .await?;
+        self.cache_presentation_ref(&presentation).await;
         let summaries = self.repository.list_library_summaries(None).await?;
         let summary = summaries.into_iter().find(|summary| summary.id == id);
         Ok((id, lib_name, presentation, summary))
@@ -160,7 +163,15 @@ impl AppState {
     ) -> anyhow::Result<()> {
         self.repository
             .rename_presentation(presentation_id, name)
-            .await
+            .await?;
+        {
+            let mut guard = self.presentation_cache.write().await;
+            if let Some(entry) = guard.get_mut(&presentation_id) {
+                let pres = Arc::make_mut(entry);
+                pres.name = name.to_string();
+            }
+        }
+        Ok(())
     }
 
     pub async fn list_bible_translations(&self) -> anyhow::Result<Vec<BibleTranslation>> {
@@ -388,6 +399,39 @@ impl AppState {
         Ok(())
     }
 
+    async fn presentation_from_cache(
+        &self,
+        presentation_id: PresentationId,
+    ) -> anyhow::Result<Arc<Presentation>> {
+        if let Some(cached) = {
+            let guard = self.presentation_cache.read().await;
+            guard.get(&presentation_id).cloned()
+        } {
+            return Ok(cached);
+        }
+        let detail = self
+            .repository
+            .fetch_presentation_detail(presentation_id)
+            .await?;
+        let Some((_, _, presentation)) = detail else {
+            return Err(anyhow::anyhow!("presentation not found"));
+        };
+        let arc = Arc::new(presentation);
+        let mut guard = self.presentation_cache.write().await;
+        guard.insert(presentation_id, arc.clone());
+        Ok(arc)
+    }
+
+    async fn cache_presentation_ref(&self, presentation: &Presentation) {
+        let mut guard = self.presentation_cache.write().await;
+        guard.insert(presentation.id, Arc::new(presentation.clone()));
+    }
+
+    async fn cache_presentation_value(&self, presentation: Presentation) {
+        let mut guard = self.presentation_cache.write().await;
+        guard.insert(presentation.id, Arc::new(presentation));
+    }
+
     pub async fn stage_display_snapshot(
         &self,
         layout_code: &str,
@@ -420,13 +464,8 @@ impl AppState {
         current_slide_id: SlideId,
         next_slide_id: Option<SlideId>,
     ) -> anyhow::Result<()> {
-        let detail = self
-            .repository
-            .fetch_presentation_detail(presentation_id)
-            .await?;
-        let Some((_, _, presentation)) = detail else {
-            anyhow::bail!("presentation not found");
-        };
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
 
         if !presentation
             .slides
@@ -452,11 +491,8 @@ impl AppState {
             next_slide_id,
         );
         self.repository.upsert_stage_state(&stage_state).await?;
-        let resolution = stage_resolution_from_presentation(
-            &presentation,
-            Some(current_slide_id),
-            next_slide_id,
-        );
+        let resolution =
+            stage_resolution_from_presentation(presentation, Some(current_slide_id), next_slide_id);
         self.broadcast_stage_resolution(resolution).await?;
         Ok(())
     }
@@ -473,9 +509,16 @@ impl AppState {
         &self,
         presentation_id: PresentationId,
     ) -> anyhow::Result<Option<(LibraryId, String, Presentation)>> {
-        self.repository
+        let detail = self
+            .repository
             .fetch_presentation_detail(presentation_id)
-            .await
+            .await?;
+        if let Some((library_id, library_name, presentation)) = detail {
+            self.cache_presentation_ref(&presentation).await;
+            Ok(Some((library_id, library_name, presentation)))
+        } else {
+            Ok(None)
+        }
     }
 
     pub async fn update_slide_content(
@@ -487,10 +530,8 @@ impl AppState {
         stage: String,
         group: Option<String>,
     ) -> anyhow::Result<Slide> {
-        let (_, _, presentation) = self
-            .presentation_detail(presentation_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
 
         let existing_slide = presentation
             .slides
@@ -517,12 +558,21 @@ impl AppState {
             stage_text.clone(),
             group.clone(),
         );
+        let updated_slide = Slide::new(existing_slide.order, content.clone()).with_id(slide_id);
 
         self.repository
             .update_slide_content(presentation_id, slide_id, &content)
             .await?;
 
-        let updated_slide = Slide::new(existing_slide.order, content.clone()).with_id(slide_id);
+        let mut updated_presentation = presentation.clone();
+        if let Some(slot) = updated_presentation
+            .slides
+            .iter_mut()
+            .find(|slide| slide.id == slide_id)
+        {
+            *slot = updated_slide.clone();
+        }
+        self.cache_presentation_value(updated_presentation).await;
 
         self.broadcast_stage_snapshots().await?;
 
@@ -534,11 +584,9 @@ impl AppState {
         presentation_id: PresentationId,
         position: Option<u32>,
     ) -> anyhow::Result<Vec<Slide>> {
-        let (_, _, presentation) = self
-            .presentation_detail(presentation_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
-        let mut slides = presentation.slides;
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
+        let mut slides = presentation.slides.clone();
         let insert_at = position
             .map(|value| value as usize)
             .unwrap_or(slides.len())
@@ -550,6 +598,9 @@ impl AppState {
             .await?;
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
+        let mut updated_presentation = presentation.clone();
+        updated_presentation.slides = slides.clone();
+        self.cache_presentation_value(updated_presentation).await;
         self.broadcast_stage_snapshots().await?;
         Ok(slides)
     }
@@ -559,11 +610,9 @@ impl AppState {
         presentation_id: PresentationId,
         slide_id: SlideId,
     ) -> anyhow::Result<Vec<Slide>> {
-        let (_, _, presentation) = self
-            .presentation_detail(presentation_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
-        let mut slides = presentation.slides;
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
+        let mut slides = presentation.slides.clone();
         let index = slides
             .iter()
             .position(|slide| slide.id == slide_id)
@@ -576,6 +625,9 @@ impl AppState {
             .await?;
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
+        let mut updated_presentation = presentation.clone();
+        updated_presentation.slides = slides.clone();
+        self.cache_presentation_value(updated_presentation).await;
         self.broadcast_stage_snapshots().await?;
         Ok(slides)
     }
@@ -585,11 +637,9 @@ impl AppState {
         presentation_id: PresentationId,
         slide_id: SlideId,
     ) -> anyhow::Result<Vec<Slide>> {
-        let (_, _, presentation) = self
-            .presentation_detail(presentation_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
-        let mut slides = presentation.slides;
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
+        let mut slides = presentation.slides.clone();
         let index = slides
             .iter()
             .position(|slide| slide.id == slide_id)
@@ -604,6 +654,9 @@ impl AppState {
             .await?;
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
+        let mut updated_presentation = presentation.clone();
+        updated_presentation.slides = slides.clone();
+        self.cache_presentation_value(updated_presentation).await;
         self.broadcast_stage_snapshots().await?;
         Ok(slides)
     }
@@ -613,12 +666,10 @@ impl AppState {
         presentation_id: PresentationId,
         order: Vec<SlideId>,
     ) -> anyhow::Result<Vec<Slide>> {
-        let (_, _, presentation) = self
-            .presentation_detail(presentation_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
+        let presentation_arc = self.presentation_from_cache(presentation_id).await?;
+        let presentation = presentation_arc.as_ref();
         let mut map = HashMap::new();
-        for slide in presentation.slides {
+        for slide in presentation.slides.clone() {
             map.insert(slide.id, slide);
         }
         if order.len() != map.len() {
@@ -637,6 +688,9 @@ impl AppState {
             .await?;
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
+        let mut updated_presentation = presentation.clone();
+        updated_presentation.slides = slides.clone();
+        self.cache_presentation_value(updated_presentation).await;
         self.broadcast_stage_snapshots().await?;
         Ok(slides)
     }
@@ -909,9 +963,22 @@ fn stage_resolution_from_presentation(
     current_slide_id: Option<SlideId>,
     next_slide_id: Option<SlideId>,
 ) -> StageResolution {
-    let resolved = presentation.resolved_slides();
+    #[derive(Clone)]
+    struct SlideCtx<'a> {
+        slide: &'a Slide,
+        effective_group: Option<String>,
+    }
 
-    if resolved.is_empty() {
+    fn to_stage_display(ctx: &SlideCtx<'_>) -> StageDisplaySlide {
+        StageDisplaySlide {
+            main: ctx.slide.content.main.value().to_string(),
+            translation: ctx.slide.content.translation.value().to_string(),
+            stage: ctx.slide.content.stage.value().to_string(),
+            group: ctx.effective_group.clone(),
+        }
+    }
+
+    if presentation.slides.is_empty() {
         return StageResolution {
             presentation_id: Some(presentation.id),
             presentation_name: Some(presentation.name.clone()),
@@ -922,33 +989,72 @@ fn stage_resolution_from_presentation(
         };
     }
 
-    let resolve_by_id = |id: SlideId| resolved.iter().find(|slide| slide.id == id);
+    let mut effective_group: Option<String> = None;
+    let mut first: Option<SlideCtx<'_>> = None;
+    let mut second: Option<SlideCtx<'_>> = None;
+    let mut current_ctx: Option<SlideCtx<'_>> = None;
+    let mut current_order: Option<u32> = None;
+    let mut next_by_id: Option<SlideCtx<'_>> = None;
+    let mut next_after_current: Option<SlideCtx<'_>> = None;
 
-    let current_resolved = current_slide_id.and_then(resolve_by_id);
-    let fallback_current = current_resolved.or_else(|| resolved.first());
+    for slide in &presentation.slides {
+        if let Some(group) = slide.content.group.as_ref() {
+            effective_group = Some(group.name().to_string());
+        }
+        let ctx = SlideCtx {
+            slide,
+            effective_group: effective_group.clone(),
+        };
+        if first.is_none() {
+            first = Some(ctx.clone());
+        } else if second.is_none() {
+            second = Some(ctx.clone());
+        }
 
-    let next_resolved = next_slide_id
-        .and_then(resolve_by_id)
-        .or_else(|| fallback_current.and_then(|current| find_next_resolved(&resolved, current)));
+        if let Some(target_next) = next_slide_id {
+            if slide.id == target_next {
+                next_by_id = Some(ctx.clone());
+            }
+        }
+
+        if current_ctx.is_none() {
+            if let Some(target_current) = current_slide_id {
+                if slide.id == target_current {
+                    current_order = Some(slide.order);
+                    current_ctx = Some(ctx.clone());
+                }
+            }
+        } else if next_after_current.is_none() {
+            if let Some(order) = current_order {
+                if slide.order > order {
+                    next_after_current = Some(ctx.clone());
+                }
+            }
+        }
+    }
+
+    let resolved_current = current_ctx.or_else(|| first.clone());
+    let resolved_next = if let Some(next_ctx) = next_by_id {
+        Some(next_ctx)
+    } else if current_order.is_some() {
+        next_after_current.clone()
+    } else {
+        second.clone()
+    };
+
+    let current_slide_id_value = resolved_current.as_ref().map(|ctx| ctx.slide.id);
+    let next_slide_id_value = resolved_next.as_ref().map(|ctx| ctx.slide.id);
+    let current_slide = resolved_current.as_ref().map(to_stage_display);
+    let next_slide = resolved_next.as_ref().map(to_stage_display);
 
     StageResolution {
         presentation_id: Some(presentation.id),
         presentation_name: Some(presentation.name.clone()),
-        current_slide_id: fallback_current.map(|slide| slide.id),
-        current: fallback_current.map(StageDisplaySlide::from),
-        next_slide_id: next_resolved.map(|slide| slide.id),
-        next: next_resolved.map(StageDisplaySlide::from),
+        current_slide_id: current_slide_id_value,
+        current: current_slide,
+        next_slide_id: next_slide_id_value,
+        next: next_slide,
     }
-}
-
-fn find_next_resolved<'a>(
-    slides: &'a [presenter_core::slide::ResolvedSlide],
-    current: &presenter_core::slide::ResolvedSlide,
-) -> Option<&'a presenter_core::slide::ResolvedSlide> {
-    slides
-        .iter()
-        .filter(|slide| slide.order > current.order)
-        .min_by_key(|slide| slide.order)
 }
 
 fn build_stage_snapshot(

--- a/scripts/docker/run-gateway.sh
+++ b/scripts/docker/run-gateway.sh
@@ -29,6 +29,9 @@ done
 
 export PRESENTER_MANIFEST_DIR="$MANIFEST_DIR"
 
+# Ensure any existing gateway container is removed so the latest verify run owns it.
+"${DOCKER_CMD[@]}" rm -f presenter-gateway >/dev/null 2>&1 || true
+
 CMD=("${DOCKER_CMD[@]}" compose -f "$REPO_ROOT/docker-compose.gateway.yml" up -d)
 if [[ "$FORCE" -eq 1 ]]; then
   CMD+=("--build")

--- a/tests/e2e/operator.spec.ts
+++ b/tests/e2e/operator.spec.ts
@@ -470,6 +470,7 @@ test.describe('Operator control surface', () => {
   }
 
   await searchInput.fill('Nadej');
+  await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const slideResult = searchResults
     .locator('[data-role="search-result-item"][data-kind="slide"]')
@@ -485,6 +486,7 @@ test.describe('Operator control surface', () => {
   }
 
   await searchInput.fill('Nadej');
+  await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const presentationResult = searchResults
     .locator('[data-role="search-result-item"][data-kind="presentation"]')
@@ -498,6 +500,7 @@ test.describe('Operator control surface', () => {
   await expect(searchResults).toHaveAttribute('data-visible', 'false');
 
   await searchInput.fill('Nadej');
+  await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const searchPresentationResults = searchResults.locator('[data-role="search-result-item"][data-kind="presentation"]');
   const existingPresentationIds = new Set(
@@ -507,8 +510,14 @@ test.describe('Operator control surface', () => {
       )
     ).filter((value) => Boolean(value))
   );
+  await expect(async () => {
+    const count = await searchPresentationResults.count();
+    if (count === 0) {
+      throw new Error('no presentation search results');
+    }
+    return count;
+  }).toPass({ timeout: 5_000, intervals: [200] });
   const candidateCount = await searchPresentationResults.count();
-  expect(candidateCount).toBeGreaterThan(0);
   let insertionResult = searchPresentationResults.first();
   let insertionTitle = '';
   let insertionPresentationId = '';
@@ -542,6 +551,7 @@ test.describe('Operator control surface', () => {
   }).toPass({ timeout: 5_000, intervals: [200] });
 
   await searchInput.fill('Nadej');
+  await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const dropzonePresentationResults = searchResults.locator(
     '[data-role="search-result-item"][data-kind="presentation"]',
@@ -553,8 +563,14 @@ test.describe('Operator control surface', () => {
       )
     ).filter((value) => Boolean(value))
   );
+  await expect(async () => {
+    const count = await dropzonePresentationResults.count();
+    if (count === 0) {
+      throw new Error('no dropzone candidates');
+    }
+    return count;
+  }).toPass({ timeout: 5_000, intervals: [200] });
   const dropzoneCandidateCount = await dropzonePresentationResults.count();
-  expect(dropzoneCandidateCount).toBeGreaterThan(0);
   let dropzoneCandidate = dropzonePresentationResults.first();
   for (let index = 0; index < dropzoneCandidateCount; index += 1) {
     const candidate = dropzonePresentationResults.nth(index);
@@ -750,8 +766,9 @@ test.describe('Operator control surface', () => {
     await timerStagePage.goto(new URL('/stage/timer', baseURL).toString());
     await timerStagePage.waitForSelector('#countdown-value', { state: 'attached' });
 
-    await slideButton.click();
     const stageTriggerAt = Date.now();
+    await slideButton.dispatchEvent('pointerdown', { button: 0 });
+    await slideButton.dispatchEvent('pointerup', { button: 0 });
     await expect(async () => {
       const className = await slideButton.evaluate((el) => el.className);
       if (className.includes('is-loading')) {
@@ -776,7 +793,7 @@ test.describe('Operator control surface', () => {
     const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const initialRegex = new RegExp(escapeRegex(initialStageText), 'i');
     const stageLatency = Date.now() - stageTriggerAt;
-    expect(stageLatency).toBeLessThanOrEqual(5_000);
+    expect(stageLatency).toBeLessThanOrEqual(800);
     await expect(page.locator('[data-role="stage-current"]')).toContainText(initialRegex, {
       timeout: 2_000,
       ignoreCase: true,
@@ -793,7 +810,7 @@ test.describe('Operator control surface', () => {
     const forwardStageText = (await currentTextLocator.innerText()).trim();
     const forwardRegex = new RegExp(escapeRegex(forwardStageText), 'i');
     const arrowLatency = Date.now() - arrowStart;
-    expect(arrowLatency).toBeLessThanOrEqual(2_000);
+    expect(arrowLatency).toBeLessThanOrEqual(800);
     await expect(page.locator('[data-role="stage-current"]')).toContainText(forwardRegex, {
       timeout: 2_000,
       ignoreCase: true,
@@ -802,7 +819,7 @@ test.describe('Operator control surface', () => {
     await page.keyboard.press('ArrowLeft');
     await expect(currentTextLocator).toContainText(initialRegex, { timeout: 5_000 });
     const leftLatency = Date.now() - leftStart;
-    expect(leftLatency).toBeLessThanOrEqual(2_000);
+    expect(leftLatency).toBeLessThanOrEqual(800);
     await expect(page.locator('[data-role="stage-current"]')).toContainText(initialStageText, {
       timeout: 2_000,
       ignoreCase: true,


### PR DESCRIPTION
## Summary
- cache presentation details and streamline stage resolution to eliminate per-trigger database hits and reduce slide trigger latency
- add a pointer-down fast path plus stronger Playwright coverage for operator interactions
- cache bible downloads with retry/backoff and ensure the verify script always restarts the shared gateway container cleanly

## Testing
- cargo test
- npm run test:playwright -- --project=chromium tests/e2e/operator.spec.ts --retries=0
- npm run test:playwright -- --project=chromium --workers=1
- sudo -E ./scripts/dev/verify-and-refresh.sh
