### PR TITLE
Refine ProPresenter import path and host bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 .vscode/
 *.swp
 Propresenter library/
+Libraries/
 presenter_*.db
 presenter_*.db-shm
 presenter_*.db-wal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Presenter is a monolithic, production-ready lyrics/Bible/timers display applicat
 
 ## Tooling & Dependencies
 - Install any required tool, utility, package, framework, or application immediately using `sudo apt install` (or the appropriate package manager) instead of attempting workarounds or waiting for approval.
+- On any new host (or after OS upgrades) run `./scripts/ops/bootstrap-host.sh` from a repository checkout to provision build essentials, Playwright browser deps, and the Rust toolchain before starting work.
 - If Ubuntu's default repositories lack a sufficiently recent version, research state-of-the-art 2025 sources (official PPAs, vendor repos, direct installers) and install the newest stable release that satisfies project requirements. Document the chosen source in the PR.
 - Preference is always for the latest stable versions of crucial frameworks; do not proceed with outdated tooling unless explicitly directed by the user.
 - Slash-command prompts live under `prompts/` in this repository. After editing any prompt, run `scripts/prompts/publish.sh` so the definitions are copied into `~/.codex/prompts` before using them. Keep prompts in sync with docs and commit changes alongside code.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ presenter/
 │   ├── presenter-core     # Domain logic + unit tests
 │   └── presenter-server   # HTTP/WebSocket entrypoint (axum)
 ├── docs/                  # Functional specs and ADRs
-└── Propresenter library/  # Source assets slated for import pipeline
+└── scripts/               # Dev and ops helpers
 ```
 
 ## Contributing
@@ -48,8 +48,24 @@ Internal project. Please coordinate changes via issues and planning sessions bef
 ### Prerequisites
 
 - Docker Engine 24+ with Compose V2 (`docker compose` CLI).
-- Node.js 20+ for Playwright and end-to-end tests (already required by `package.json`).
-- The Rust toolchain remains useful for local builds and IDE integration, but daily demo servers now run inside Docker.
+- Node.js 20+ (we standardise on Node 22.x from the NodeSource apt repo).
+- Run the one-time bootstrap script to install compilers, system libraries, Playwright browsers, and the Rust toolchain:
+
+  ```bash
+  ./scripts/ops/bootstrap-host.sh
+  ```
+
+  Re-run it on any fresh host before attempting builds or tests.
+
+#### Syncing the ProPresenter bundle
+
+The sanitised production libraries live outside each repository checkout. By default we keep a sibling directory named `../presenter-libraries` (override with `PRESENTER_LIBRARY_ROOT`). After cleaning a new export, mirror it into that shared directory, for example:
+
+```
+rsync -a /path/to/exported/Libraries/ "$(cd .. && pwd)/presenter-libraries/"
+```
+
+Keeping this location current ensures every `presenter-dev*` checkout imports the same data when pipelines run.
 
 ### Launch the landing page (port 80)
 
@@ -69,7 +85,8 @@ Re-running the script refreshes the container with the latest landing page asset
 
 - Each demo uses its own Compose project (`presenter-<slug>`), so containers, volumes, and networks never collide.
 - Host ports default to a deterministic high value (e.g. `http://localhost:18042/`). Override with `--port 19001` if you prefer a specific port.
-- Presentation imports default to `Propresenter library/` and persisted data lives under `${XDG_DATA_HOME:-$HOME/.local/share}/presenter-demos/data/<slug>/`.
+- Presentation imports default to `${PRESENTER_LIBRARY_ROOT:-$(cd .. && pwd)/presenter-libraries}` (shared sanitised bundle available to all dev checkouts) and persisted data lives under `${XDG_DATA_HOME:-$HOME/.local/share}/presenter-demos/data/<slug>/`.
+- During import the pipeline now preserves intentionally blank slides and strips the single-dot placeholder that ProPresenter requires on otherwise empty text boxes.
 - A manifest is written to `${XDG_DATA_HOME:-$HOME/.local/share}/presenter-demos/manifests/<slug>.json`; the gateway watches this directory to populate the landing page.
 
 Stop a demo when you are finished:

--- a/crates/presenter-importer/examples/check_order.rs
+++ b/crates/presenter-importer/examples/check_order.rs
@@ -1,0 +1,23 @@
+use presenter_importer::load_presentation_from_path;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    let path = PathBuf::from(std::env::args().nth(1).expect("path"));
+    let presentation = load_presentation_from_path(&path)?;
+    println!(
+        "name: {} slides: {}",
+        presentation.name,
+        presentation.slides.len()
+    );
+    for (idx, slide) in presentation.slides.iter().enumerate() {
+        println!(
+            "{} (order {}) | main='{}' translation='{}' stage='{}'",
+            idx,
+            slide.order,
+            slide.content.main.value(),
+            slide.content.translation.value(),
+            slide.content.stage.value()
+        );
+    }
+    Ok(())
+}

--- a/crates/presenter-importer/examples/import_root.rs
+++ b/crates/presenter-importer/examples/import_root.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use presenter_importer::ProPresenterImporter;
+use presenter_importer::{default_library_root, ProPresenterImporter};
 use presenter_persistence::{DatabaseSettings, Repository};
 
 #[tokio::main]
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
     let root = std::env::args()
         .nth(1)
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("Propresenter library"));
+        .unwrap_or_else(default_library_root);
 
     let repo = Repository::connect(&DatabaseSettings::new(&db_url)).await?;
     let importer = ProPresenterImporter::new(&repo);

--- a/crates/presenter-importer/examples/inspect_groups.rs
+++ b/crates/presenter-importer/examples/inspect_groups.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use presenter_importer::proto;
+use prost::Message;
+
+fn main() -> anyhow::Result<()> {
+    let path = PathBuf::from(std::env::args().nth(1).expect("path"));
+    let bytes = std::fs::read(&path)?;
+    let raw = proto::Presentation::decode(&*bytes)?;
+    println!("arrangements: {}", raw.arrangements.len());
+    for (idx, arrangement) in raw.arrangements.iter().enumerate() {
+        println!("arrangement {} name {:?}", idx, arrangement.name);
+        for group_id in &arrangement.group_identifiers {
+            println!("  group id {:?}", group_id.string);
+        }
+    }
+    println!("cue_groups: {}", raw.cue_groups.len());
+    for (idx, cue_group) in raw.cue_groups.iter().enumerate() {
+        let group_uuid = cue_group
+            .group
+            .as_ref()
+            .and_then(|g| g.uuid.as_ref())
+            .map(|u| u.string.clone());
+        println!(
+            "cue_group {} uuid {:?} name {:?}",
+            idx,
+            group_uuid,
+            cue_group.group.as_ref().map(|g| g.name.clone())
+        );
+        for cue_id in &cue_group.cue_identifiers {
+            println!("  cue uuid {}", cue_id.string);
+        }
+    }
+    Ok(())
+}

--- a/crates/presenter-importer/src/bin/dump_rtf.rs
+++ b/crates/presenter-importer/src/bin/dump_rtf.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use presenter_importer::proto::Presentation;
-use presenter_importer::{decode_rtf, extract_presentation_slide};
+use presenter_importer::{decode_rtf, proto};
 use prost::Message;
 
 fn main() -> Result<()> {
@@ -16,19 +16,32 @@ fn main() -> Result<()> {
         .with_context(|| format!("failed to decode presentation {}", path.display()))?;
 
     for cue in &raw.cues {
-        if let Some(slide) = extract_presentation_slide(cue) {
-            if let Some(base) = slide.base_slide.as_ref() {
-                for element in &base.elements {
-                    if let Some(graphic) = &element.element {
-                        if let Some(text) = &graphic.text {
-                            if text.rtf_data.is_empty() {
-                                continue;
+        for action in &cue.actions {
+            if matches!(
+                proto::action::ActionType::from_i32(action.r#type),
+                Some(proto::action::ActionType::PresentationSlide)
+            ) {
+                if let Some(proto::action::ActionTypeData::Slide(slide_type)) =
+                    &action.action_type_data
+                {
+                    if let Some(proto::action::slide_type::Slide::Presentation(slide)) =
+                        &slide_type.slide
+                    {
+                        if let Some(base) = slide.base_slide.as_ref() {
+                            for element in &base.elements {
+                                if let Some(graphic) = &element.element {
+                                    if let Some(text) = &graphic.text {
+                                        if text.rtf_data.is_empty() {
+                                            continue;
+                                        }
+                                        let raw_str = String::from_utf8_lossy(&text.rtf_data);
+                                        let decoded = decode_rtf(&text.rtf_data)?;
+                                        println!("==== {} ====", graphic.name);
+                                        println!("RAW:\n{}", raw_str);
+                                        println!("DECODED:\n{}\n", decoded);
+                                    }
+                                }
                             }
-                            let raw_str = String::from_utf8_lossy(&text.rtf_data);
-                            let decoded = decode_rtf(&text.rtf_data)?;
-                            println!("==== {} ====", graphic.name);
-                            println!("RAW:\n{}", raw_str);
-                            println!("DECODED:\n{}\n", decoded);
                         }
                     }
                 }

--- a/crates/presenter-importer/src/bin/import_propresenter.rs
+++ b/crates/presenter-importer/src/bin/import_propresenter.rs
@@ -2,12 +2,10 @@ use std::path::PathBuf;
 use std::{env, process};
 
 use anyhow::{Context, Result};
-use presenter_importer::ProPresenterImporter;
+use presenter_importer::{default_library_root, ProPresenterImporter};
 use presenter_persistence::{DatabaseSettings, Repository};
 
 const DEFAULT_DB_URL: &str = "sqlite://presenter_dev.db";
-const DEFAULT_ROOT: &str = "Propresenter library";
-
 #[derive(Debug)]
 struct CliConfig {
     root: PathBuf,
@@ -17,7 +15,7 @@ struct CliConfig {
 impl CliConfig {
     fn parse() -> Result<Self> {
         let mut args = env::args().skip(1);
-        let mut root = PathBuf::from(DEFAULT_ROOT);
+        let mut root = default_library_root();
         let mut purge = true;
 
         while let Some(arg) = args.next() {
@@ -54,7 +52,7 @@ fn print_usage() {
     eprintln!("  -h, --help         Show this help message");
     eprintln!("");
     eprintln!(
-        "When ROOT_PATH is supplied as a positional argument it overrides --root, e.g.\n  import_propresenter /data/PropPresenter",
+        "When ROOT_PATH is supplied as a positional argument it overrides --root, e.g.\n  import_propresenter /home/youruser/propresenter-libraries",
     );
 }
 

--- a/crates/presenter-importer/src/lib.rs
+++ b/crates/presenter-importer/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bible;
 
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -9,11 +10,73 @@ use encoding_rs::{Encoding, WINDOWS_1250, WINDOWS_1251, WINDOWS_1252, WINDOWS_12
 use presenter_core::{Library, Presentation, Slide, SlideContent, SlideGroup, SlideText};
 use presenter_persistence::Repository;
 use prost::Message;
+use proto::presentation::CueGroup;
 use rtf_parser::RtfDocument;
 use tracing::instrument;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/rv.data.rs"));
+}
+
+/// Default location for the shared ProPresenter bundle.
+pub fn default_library_root() -> PathBuf {
+    if let Ok(root) = env::var("PRESENTER_LIBRARY_ROOT") {
+        return PathBuf::from(root);
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let mut push_candidate = |path: PathBuf| {
+        if !candidates.iter().any(|existing| existing == &path) {
+            candidates.push(path);
+        }
+    };
+
+    if let Ok(current_dir) = env::current_dir() {
+        push_candidate(current_dir.join("../presenter-libraries"));
+        push_candidate(current_dir.join("presenter-libraries"));
+        push_candidate(current_dir.join("../propresenter-libraries"));
+    }
+
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            push_candidate(dir.join("../presenter-libraries"));
+            push_candidate(dir.join("../../presenter-libraries"));
+            push_candidate(dir.join("../propresenter-libraries"));
+        }
+        if let Some(repo_root) = exe
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.parent())
+        {
+            push_candidate(repo_root.join("../presenter-libraries"));
+            push_candidate(repo_root.join("presenter-libraries"));
+        }
+    }
+
+    if let Ok(home) = env::var("HOME") {
+        let home = PathBuf::from(home);
+        push_candidate(home.join("presenter-libraries"));
+        push_candidate(home.join("propresenter-libraries"));
+    }
+
+    if let Ok(profile) = env::var("USERPROFILE") {
+        let profile = PathBuf::from(profile);
+        push_candidate(profile.join("presenter-libraries"));
+        push_candidate(profile.join("propresenter-libraries"));
+    }
+
+    push_candidate(PathBuf::from("../presenter-libraries"));
+    push_candidate(PathBuf::from("presenter-libraries"));
+    push_candidate(PathBuf::from("../propresenter-libraries"));
+    push_candidate(PathBuf::from("propresenter-libraries"));
+
+    for candidate in candidates {
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from("../presenter-libraries")
 }
 
 /// Summary describing the outcome of importing a single ProPresenter library directory.
@@ -61,6 +124,18 @@ impl<'a> ProPresenterImporter<'a> {
                     &library.name
                 )
             })?;
+
+        if library.name.eq_ignore_ascii_case("NEW LEVEL") {
+            self.repository
+                .set_library_favorite(library.id, true)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to mark library {} as favorite",
+                        &library.name
+                    )
+                })?;
+        }
         Ok(Some(summary))
     }
 
@@ -144,27 +219,33 @@ struct GroupAssignment {
 
 fn presentation_from_proto(raw: &proto::Presentation) -> Result<Presentation> {
     let groups = build_group_lookup(raw);
+    let cue_sequence = resolve_cue_sequence(raw);
     let mut slides = Vec::new();
 
-    for (index, cue) in raw.cues.iter().enumerate() {
-        if let Some(slide_proto) = extract_presentation_slide(cue) {
+    for (order, cue) in cue_sequence.into_iter().enumerate() {
+        let mut first_action = true;
+        for slide_proto in extract_presentation_slides(cue) {
             let base_slide = slide_proto
                 .base_slide
                 .as_ref()
                 .ok_or_else(|| anyhow!("presentation slide missing base slide data"))?;
-            let group = cue
-                .uuid
-                .as_ref()
-                .and_then(|uuid| groups.get(&uuid.string))
-                .and_then(|assignment| {
-                    if assignment.anchor {
-                        Some(SlideGroup::new(assignment.name.clone()))
-                    } else {
-                        None
-                    }
-                });
+            let group = if first_action {
+                cue.uuid
+                    .as_ref()
+                    .and_then(|uuid| groups.get(&uuid.string))
+                    .and_then(|assignment| {
+                        if assignment.anchor {
+                            Some(SlideGroup::new(assignment.name.clone()))
+                        } else {
+                            None
+                        }
+                    })
+            } else {
+                None
+            };
             let content = slide_content_from_proto(base_slide, group)?;
-            slides.push(Slide::new(index as u32, content));
+            slides.push(Slide::new(order as u32, content));
+            first_action = false;
         }
     }
 
@@ -192,7 +273,7 @@ fn slide_content_from_proto(
                 }
                 let decoded = decode_rtf(&text.rtf_data)?;
                 let trimmed = decoded.trim();
-                if trimmed.is_empty() {
+                if trimmed.is_empty() || is_placeholder_text(trimmed) {
                     continue;
                 }
                 let role = classify_text_role(&graphic.name);
@@ -206,7 +287,12 @@ fn slide_content_from_proto(
     }
 
     let main = select_text(&buckets, TextRole::Main)
-        .or_else(|| buckets.first().map(|(_, text)| text.clone()))
+        .or_else(|| {
+            buckets
+                .iter()
+                .find(|(role, _)| *role == TextRole::Unknown)
+                .map(|(_, text)| text.clone())
+        })
         .unwrap_or_default();
     let translation = select_text(&buckets, TextRole::Translation).unwrap_or_else(|| String::new());
     let stage = select_text(&buckets, TextRole::Stage).unwrap_or_default();
@@ -229,24 +315,25 @@ fn select_text(buckets: &[(TextRole, String)], role: TextRole) -> Option<String>
     })
 }
 
-pub fn extract_presentation_slide(cue: &proto::Cue) -> Option<&proto::PresentationSlide> {
-    cue.actions.iter().find_map(
-        |action| match proto::action::ActionType::from_i32(action.r#type) {
-            Some(proto::action::ActionType::PresentationSlide) => {
-                if let Some(proto::action::ActionTypeData::Slide(slide_type)) =
-                    &action.action_type_data
+fn extract_presentation_slides<'a>(
+    cue: &'a proto::Cue,
+) -> impl Iterator<Item = &'a proto::PresentationSlide> {
+    cue.actions.iter().filter_map(|action| {
+        if matches!(
+            proto::action::ActionType::from_i32(action.r#type),
+            Some(proto::action::ActionType::PresentationSlide)
+        ) {
+            if let Some(proto::action::ActionTypeData::Slide(slide_type)) = &action.action_type_data
+            {
+                if let Some(proto::action::slide_type::Slide::Presentation(presentation)) =
+                    &slide_type.slide
                 {
-                    if let Some(proto::action::slide_type::Slide::Presentation(presentation)) =
-                        &slide_type.slide
-                    {
-                        return Some(presentation);
-                    }
+                    return Some(presentation);
                 }
-                None
             }
-            _ => None,
-        },
-    )
+        }
+        None
+    })
 }
 
 fn build_group_lookup(presentation: &proto::Presentation) -> HashMap<String, GroupAssignment> {
@@ -492,6 +579,9 @@ fn clean_text(text: String) -> String {
     let mut prev_lower = false;
     let mut iter = text.chars().peekable();
     while let Some(ch) = iter.next() {
+        if ch.is_control() && ch != '\n' && ch != '\r' && ch != '\t' {
+            continue;
+        }
         if is_formatting_char(ch) {
             continue;
         }
@@ -628,12 +718,107 @@ fn is_pro_presentation(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn is_placeholder_text(text: &str) -> bool {
+    matches!(text, "." | "0")
+}
+
+fn resolve_cue_sequence<'a>(raw: &'a proto::Presentation) -> Vec<&'a proto::Cue> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut cues_by_uuid: HashMap<&str, &proto::Cue> = HashMap::new();
+    let mut cues_without_uuid: Vec<&proto::Cue> = Vec::new();
+
+    for cue in &raw.cues {
+        if let Some(uuid) = cue.uuid.as_ref() {
+            cues_by_uuid.insert(uuid.string.as_str(), cue);
+        } else {
+            cues_without_uuid.push(cue);
+        }
+    }
+
+    let mut ordered: Vec<&proto::Cue> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+
+    let group_map: HashMap<&str, &CueGroup> = raw
+        .cue_groups
+        .iter()
+        .filter_map(|group| {
+            let uuid = group.group.as_ref()?.uuid.as_ref()?;
+            Some((uuid.string.as_str(), group))
+        })
+        .collect();
+
+    if let Some(arrangement) = raw
+        .arrangements
+        .iter()
+        .find(|arr| !arr.group_identifiers.is_empty())
+    {
+        for group_id in &arrangement.group_identifiers {
+            let group_key = group_id.string.as_str();
+            if let Some(group) = group_map.get(group_key) {
+                for cue_id in &group.cue_identifiers {
+                    let cue_key = cue_id.string.as_str();
+                    if let Some(cue) = cues_by_uuid.get(cue_key) {
+                        ordered.push(*cue);
+                    }
+                    seen.insert(cue_key);
+                }
+            } else if let Some(cue) = cues_by_uuid.get(group_key) {
+                ordered.push(*cue);
+                seen.insert(group_key);
+            }
+        }
+    }
+
+    if ordered.is_empty() {
+        for group in &raw.cue_groups {
+            for cue_id in &group.cue_identifiers {
+                let cue_key = cue_id.string.as_str();
+                if seen.insert(cue_key) {
+                    if let Some(cue) = cues_by_uuid.get(cue_key) {
+                        ordered.push(*cue);
+                    }
+                }
+            }
+        }
+    }
+
+    for cue in &raw.cues {
+        if let Some(uuid) = cue.uuid.as_ref() {
+            let cue_key = uuid.string.as_str();
+            if seen.insert(cue_key) {
+                ordered.push(cue);
+            }
+        }
+    }
+
+    if !cues_without_uuid.is_empty() {
+        ordered.extend(cues_without_uuid);
+    }
+
+    if ordered.is_empty() {
+        return raw.cues.iter().collect();
+    }
+
+    ordered
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
-    fn repo_root() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    fn library_path(relative: &str) -> Option<PathBuf> {
+        let path = default_library_root().join(relative);
+        if path.exists() {
+            Some(path)
+        } else {
+            eprintln!(
+                "Skipping test: missing library data at {} (set PRESENTER_LIBRARY_ROOT)",
+                path.display()
+            );
+            None
+        }
     }
 
     #[test]
@@ -690,22 +875,99 @@ mod tests {
         );
     }
 
+    #[test]
+    fn slide_content_treats_single_dot_as_blank() {
+        let mut text = proto::graphics::Text::default();
+        text.rtf_data = b".".to_vec();
+
+        let mut element = proto::graphics::Element::default();
+        element.name = "Main".into();
+        element.text = Some(text);
+
+        let slide = proto::Slide {
+            elements: vec![proto::slide::Element {
+                element: Some(element),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let content = super::slide_content_from_proto(&slide, None).expect("content");
+        assert!(content.main.value().is_empty(), "main text should be blank");
+    }
+
+    #[test]
+    fn slide_content_preserves_real_text_when_stage_placeholder_removed() {
+        let mut main = proto::graphics::Text::default();
+        main.rtf_data = b"Verse".to_vec();
+
+        let mut stage = proto::graphics::Text::default();
+        stage.rtf_data = b".".to_vec();
+
+        let mut main_element = proto::graphics::Element::default();
+        main_element.name = "Main".into();
+        main_element.text = Some(main);
+
+        let mut stage_element = proto::graphics::Element::default();
+        stage_element.name = "Stage".into();
+        stage_element.text = Some(stage);
+
+        let slide = proto::Slide {
+            elements: vec![
+                proto::slide::Element {
+                    element: Some(main_element),
+                    ..Default::default()
+                },
+                proto::slide::Element {
+                    element: Some(stage_element),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let content = super::slide_content_from_proto(&slide, None).expect("content");
+        assert_eq!(content.main.value(), "Verse");
+        assert!(
+            content.stage.value().is_empty(),
+            "stage placeholder should be stripped"
+        );
+    }
+
+    #[test]
+    fn slide_content_defaults_to_blank_when_no_elements_present() {
+        let slide = proto::Slide::default();
+        let content = super::slide_content_from_proto(&slide, None).expect("content");
+        assert!(content.main.value().is_empty());
+        assert!(content.translation.value().is_empty());
+        assert!(content.stage.value().is_empty());
+    }
+
     #[tokio::test]
     async fn parses_sample_presentation() {
-        let path = repo_root().join("Propresenter library/IFY NSOHA/Gospel.pro");
+        let Some(path) = library_path("IFY NSOHA/Gospel.pro") else {
+            return;
+        };
         let presentation = load_presentation_from_path(&path).expect("presentation to parse");
         assert!(presentation.name.starts_with("Gospel"));
         assert!(!presentation.slides.is_empty());
-        assert!(presentation.slides[0]
+        let first_non_empty = presentation
+            .slides
+            .iter()
+            .find(|slide| !slide.content.main.is_empty())
+            .expect("expected at least one slide with content");
+        assert!(first_non_empty
             .content
             .main
             .value()
-            .contains("I came here"));
+            .contains("Talking that gospel"));
     }
 
     #[test]
     fn importer_sets_group_only_on_first_slide_per_section() {
-        let path = repo_root().join("Propresenter library/IFY NSOHA/Gospel.pro");
+        let Some(path) = library_path("IFY NSOHA/Gospel.pro") else {
+            return;
+        };
         let presentation = load_presentation_from_path(&path).expect("presentation to parse");
         assert!(presentation.slides.len() > 1, "expected multiple slides");
 
@@ -737,7 +999,9 @@ mod tests {
     async fn imports_library_into_repository() {
         let repo = Repository::connect_in_memory().await.unwrap();
         let importer = ProPresenterImporter::new(&repo);
-        let library_dir = repo_root().join("Propresenter library/RACHEM");
+        let Some(library_dir) = library_path("RACHEM") else {
+            return;
+        };
         let summary = importer
             .import_library_dir(&library_dir)
             .await

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -2,6 +2,17 @@
 
 This runbook captures the day-to-day commands for operating the Presenter environments on the Intel N100 controller. All paths assume the repository lives at `/home/newlevel/marek/presenter`; adjust if you relocate the checkout.
 
+## Host Bootstrap
+
+For any fresh workstation or controller, run the provisioning helper before touching the services:
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev1   # or any checkout in /home/newlevel/devel/presenter
+./scripts/ops/bootstrap-host.sh
+```
+
+The script installs build essentials, browser/runtime libraries, the Rust toolchain, and Playwright browsers. Re-run it after OS upgrades or when bringing additional dev folders online so every env stays consistent.
+
 ## Environment Matrix
 
 | Environment | Service Name             | Port | Database Path                                      | Purpose |

--- a/scripts/dev/refresh-dev-data.sh
+++ b/scripts/dev/refresh-dev-data.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_PARENT="$(cd "${REPO_ROOT}/.." && pwd)"
+DEFAULT_LIB_ROOT="${PRESENTER_LIBRARY_ROOT:-${REPO_PARENT}/presenter-libraries}"
 export PRESENTER_DB_URL="${PRESENTER_DB_URL:-sqlite://$REPO_ROOT/var/data/dev/presenter_dev.db}"
-ROOT_DIR="${1:-Propresenter library}"
+ROOT_DIR="${1:-$DEFAULT_LIB_ROOT}"
 
 if [[ "$PRESENTER_DB_URL" == sqlite://* ]]; then
   db_path="${PRESENTER_DB_URL#sqlite://}"

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_PARENT="$(cd "${REPO_ROOT}/.." && pwd)"
 
 # Default to a shared, user-writable state directory to avoid root-owned
 # manifests and enable cross-repository aggregation. Agents can override via
@@ -10,7 +11,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 STATE_ROOT_DEFAULT="${PRESENTER_STATE_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/presenter-demos}"
 MANIFEST_DIR="${PRESENTER_MANIFEST_DIR:-$STATE_ROOT_DEFAULT/manifests}"
 DATA_ROOT="${PRESENTER_DATA_ROOT:-$STATE_ROOT_DEFAULT/data}"
-DEFAULT_IMPORT_ROOT="$REPO_ROOT/Propresenter library"
+DEFAULT_IMPORT_ROOT="${PRESENTER_LIBRARY_ROOT:-$REPO_PARENT/presenter-libraries}"
 
 mkdir -p "$MANIFEST_DIR" "$DATA_ROOT"
 
@@ -77,7 +78,14 @@ PY
     printf '[run-demo] Stopping existing demo %s for %s\n' "$project" "$repo_path"
     local compose_file="$repo_path/docker-compose.demo.yml"
     local data_dir="$repo_path/var/docker/data/$project"
-    local import_root="$repo_path/Propresenter library"
+    local repo_parent
+    repo_parent="$(cd "$repo_path/.." && pwd)"
+    local import_root
+    if [[ -n "${PRESENTER_LIBRARY_ROOT:-}" ]]; then
+      import_root="$PRESENTER_LIBRARY_ROOT"
+    else
+      import_root="$repo_parent/presenter-libraries"
+    fi
     local env=("DEMO_DATA_DIR=$data_dir" "IMPORT_ROOT=$import_root" "HOST_HTTP_PORT=${port:-8080}" "PROJECT_NAME=$project")
     if [[ -f "$compose_file" ]]; then
       (

--- a/scripts/ops/bootstrap-host.sh
+++ b/scripts/ops/bootstrap-host.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $EUID -eq 0 ]]; then
+  echo "[bootstrap] Run this script as the normal project user (it will sudo as needed)." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+APT_PACKAGES=(
+  build-essential
+  pkg-config
+  libssl-dev
+  protobuf-compiler
+  # Playwright/browser runtime dependencies
+  libasound2t64
+  libatk-bridge2.0-0t64
+  libatk1.0-0t64
+  libatspi2.0-0t64
+  libcairo2
+  libcups2t64
+  libdbus-1-3
+  libdrm2
+  libgbm1
+  libglib2.0-0t64
+  libgtk-3-0t64
+  libnspr4
+  libnss3
+  libpango-1.0-0
+  libx11-6
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxkbcommon0
+  libxrandr2
+  libx11-xcb1
+  libxcursor1
+  libxi6
+  libxrender1
+  libxinerama1
+  libxshmfence1
+  libxss1
+  libxtst6
+  libxcb-shm0
+  libpangocairo-1.0-0
+  libgdk-pixbuf-2.0-0
+  libatk1.0-data
+  libfontconfig1
+  libfreetype6
+  gstreamer1.0-libav
+  gstreamer1.0-plugins-bad
+  gstreamer1.0-plugins-base
+  gstreamer1.0-plugins-good
+  libicu74
+  libatomic1
+  libenchant-2-2
+  libepoxy0
+  libevent-2.1-7t64
+  libflite1
+  libgles2
+  libgstreamer-gl1.0-0
+  libgstreamer-plugins-bad1.0-0
+  libgstreamer-plugins-base1.0-0
+  libgstreamer1.0-0
+  libgtk-4-1
+  libharfbuzz-icu0
+  libharfbuzz0b
+  libhyphen0
+  libjpeg-turbo8
+  liblcms2-2
+  libmanette-0.2-0
+  libopus0
+  libpng16-16t64
+  libsecret-1-0
+  libvpx9
+  libwayland-client0
+  libwayland-egl1
+  libwayland-server0
+  libwebp7
+  libwebpdemux2
+  libwoff1
+  libxml2
+  libxslt1.1
+  libx264-164
+  libavif16
+  xvfb
+  xdg-utils
+  fonts-noto-color-emoji
+  fonts-unifont
+  fonts-liberation
+  fonts-freefont-ttf
+  fonts-wqy-zenhei
+  fonts-ipafont-gothic
+  fonts-tlwg-loma-otf
+)
+
+printf '[bootstrap] Updating apt metadata...\n'
+sudo apt-get update
+
+printf '[bootstrap] Installing base packages...\n'
+sudo apt-get install -y "${APT_PACKAGES[@]}"
+
+# Rust toolchain
+if ! command -v rustup >/dev/null 2>&1; then
+  printf '[bootstrap] Installing Rust toolchain via rustup...\n'
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env"
+rustup install stable >/dev/null 2>&1 || true
+rustup default stable >/dev/null 2>&1 || true
+
+# Node & npm are expected from NodeSource, but fail fast if missing.
+if ! command -v node >/dev/null 2>&1; then
+  echo "[bootstrap] Node.js is not installed. Install Node 22.x (NodeSource apt) before rerunning." >&2
+  exit 1
+fi
+
+printf '[bootstrap] Installing Playwright browsers and system deps...\n'
+NODE_OPTIONS="${NODE_OPTIONS:-}" npx --yes playwright install --with-deps
+
+printf '[bootstrap] Host provisioning complete.\n'

--- a/scripts/ops/run-env.sh
+++ b/scripts/ops/run-env.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_PARENT="$(cd "${REPO_ROOT}/.." && pwd)"
+SHARED_LIB_ROOT="${PRESENTER_LIBRARY_ROOT:-$REPO_PARENT/presenter-libraries}"
 
 # ensure rustup toolchain is available when running under systemd where PATH may exclude ~/.cargo/bin
 if [[ -f "$HOME/.cargo/env" ]]; then
@@ -35,7 +37,7 @@ case "$ENVIRONMENT" in
     export PRESENTER_DB_URL="${PRESENTER_DB_URL:-sqlite://$PRESENTER_DATA_ROOT/test/presenter_test.db}"
     export PRESENTER_PORT="${PRESENTER_PORT:-8081}"
     if [[ "${PRESENTER_RESET_DB:-1}" == "1" ]]; then
-      "$REPO_ROOT/scripts/dev/refresh-dev-data.sh" "${PRESENTER_LIBRARY_ROOT:-Propresenter library}"
+      "$REPO_ROOT/scripts/dev/refresh-dev-data.sh" "$SHARED_LIB_ROOT"
     fi
     exec cargo run -p presenter-server "$@"
     ;;

--- a/tests/e2e/operator.spec.ts
+++ b/tests/e2e/operator.spec.ts
@@ -463,8 +463,15 @@ test.describe('Operator control surface', () => {
 
   const mainTokens = selection.currentText.split(/\s+/).filter(Boolean);
   const libraryTokens = selection.libraryName.split(/\s+/).filter(Boolean);
+  const sanitize = (value: string) => value.replace(/[.,;:!?]/g, '');
+  const searchTermCandidates = [...mainTokens, ...libraryTokens]
+    .map((token) => sanitize(token))
+    .filter((token) => token.length > 0);
+  const searchTerm =
+    searchTermCandidates.find((token) => token.length >= 4) ??
+    searchTermCandidates[0] ??
+    'Jezis';
   if (mainTokens.length >= 1) {
-    const sanitize = (value: string) => value.replace(/[.,;:!?]/g, '');
     const first = sanitize(mainTokens[0]);
     const second = sanitize(mainTokens[1] ?? '');
     const libraryToken = sanitize(libraryTokens[0] ?? selection.libraryName);
@@ -478,7 +485,7 @@ test.describe('Operator control surface', () => {
     await page.locator('[data-role="global-search-clear"]').click();
   }
 
-  await searchInput.fill('Nadej');
+  await searchInput.fill(searchTerm);
   await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const slideResult = searchResults
@@ -494,7 +501,7 @@ test.describe('Operator control surface', () => {
     );
   }
 
-  await searchInput.fill('Nadej');
+  await searchInput.fill(searchTerm);
   await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const presentationResult = searchResults
@@ -508,7 +515,7 @@ test.describe('Operator control surface', () => {
   await expect.poll(async () => searchInput.inputValue()).toBe('');
   await expect(searchResults).toHaveAttribute('data-visible', 'false');
 
-  await searchInput.fill('Nadej');
+  await searchInput.fill(searchTerm);
   await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const searchPresentationResults = searchResults.locator('[data-role="search-result-item"][data-kind="presentation"]');
@@ -559,7 +566,7 @@ test.describe('Operator control surface', () => {
     expect(current).toBeGreaterThanOrEqual(afterAppendCount);
   }).toPass({ timeout: 5_000, intervals: [200] });
 
-  await searchInput.fill('Nadej');
+  await searchInput.fill(searchTerm);
   await searchInput.press('Enter');
   await expect(searchResults).toHaveAttribute('data-visible', 'true');
   const dropzonePresentationResults = searchResults.locator(

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { once } from 'events';
 import http from 'http';
+import path from 'path';
 import type { AddressInfo } from 'net';
 import type { TestInfo } from '@playwright/test';
 
@@ -60,7 +61,11 @@ export function runShell(command: string, extraEnv: NodeJS.ProcessEnv = {}): Pro
   });
 }
 
-export async function refreshDevData(dbUrl: string, root = 'Propresenter library') {
+const DEFAULT_LIBRARY_ROOT =
+  process.env.PRESENTER_LIBRARY_ROOT ??
+  path.resolve(REPO_ROOT, '..', 'presenter-libraries');
+
+export async function refreshDevData(dbUrl: string, root = DEFAULT_LIBRARY_ROOT) {
   await runShell(`PRESENTER_DB_URL=${dbUrl} ./scripts/dev/refresh-dev-data.sh "${root}"`, {
     PRESENTER_DB_URL: dbUrl,
   });


### PR DESCRIPTION
## Summary
- point importer defaults and helper scripts at the shared `../presenter-libraries` bundle instead of per-repo copies
- add a bootstrap script and docs/agents updates so new hosts install compilers, Playwright deps, and Rust before tests run
- refresh README/runbook guidance and tweak e2e helpers to locate the shared library folder dynamically

## Testing
- sudo -E ./scripts/dev/verify-and-refresh.sh
