### PR TITLE
docs: add openspec project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,22 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->
+
 # Presenter Agent Handbook
 
 ## Purpose

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,456 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## TL;DR Quick Checklist
+
+- Search existing work: `openspec spec list --long`, `openspec list` (use `rg` only for full-text search)
+- Decide scope: new capability vs modify existing capability
+- Pick a unique `change-id`: kebab-case, verb-led (`add-`, `update-`, `remove-`, `refactor-`)
+- Scaffold: `proposal.md`, `tasks.md`, `design.md` (only if needed), and delta specs per affected capability
+- Write deltas: use `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`; include at least one `#### Scenario:` per requirement
+- Validate: `openspec validate [change-id] --strict` and fix issues
+- Request approval: Do not start implementation until proposal is approved
+
+## Three-Stage Workflow
+
+### Stage 1: Creating Changes
+Create proposal when you need to:
+- Add features or functionality
+- Make breaking changes (API, schema)
+- Change architecture or patterns  
+- Optimize performance (changes behavior)
+- Update security patterns
+
+Triggers (examples):
+- "Help me create a change proposal"
+- "Help me plan a change"
+- "Help me create a proposal"
+- "I want to create a spec proposal"
+- "I want to create a spec"
+
+Loose matching guidance:
+- Contains one of: `proposal`, `change`, `spec`
+- With one of: `create`, `plan`, `make`, `start`, `help`
+
+Skip proposal for:
+- Bug fixes (restore intended behavior)
+- Typos, formatting, comments
+- Dependency updates (non-breaking)
+- Configuration changes
+- Tests for existing behavior
+
+**Workflow**
+1. Review `openspec/project.md`, `openspec list`, and `openspec list --specs` to understand current context.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, optional `design.md`, and spec deltas under `openspec/changes/<id>/`.
+3. Draft spec deltas using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement.
+4. Run `openspec validate <id> --strict` and resolve any issues before sharing the proposal.
+
+### Stage 2: Implementing Changes
+Track these steps as TODOs and complete them one by one.
+1. **Read proposal.md** - Understand what's being built
+2. **Read design.md** (if exists) - Review technical decisions
+3. **Read tasks.md** - Get implementation checklist
+4. **Implement tasks sequentially** - Complete in order
+5. **Confirm completion** - Ensure every item in `tasks.md` is finished before updating statuses
+6. **Update checklist** - After all work is done, set every task to `- [x]` so the list reflects reality
+7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
+
+### Stage 3: Archiving Changes
+After deployment, create separate PR to:
+- Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
+- Update `specs/` if capabilities changed
+- Use `openspec archive [change] --skip-specs --yes` for tooling-only changes
+- Run `openspec validate --strict` to confirm the archived change passes checks
+
+## Before Any Task
+
+**Context Checklist:**
+- [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] Check pending changes in `changes/` for conflicts
+- [ ] Read `openspec/project.md` for conventions
+- [ ] Run `openspec list` to see active changes
+- [ ] Run `openspec list --specs` to see existing capabilities
+
+**Before Creating Specs:**
+- Always check if capability already exists
+- Prefer modifying existing specs over creating duplicates
+- Use `openspec show [spec]` to review current state
+- If request is ambiguous, ask 1–2 clarifying questions before scaffolding
+
+### Search Guidance
+- Enumerate specs: `openspec spec list --long` (or `--json` for scripts)
+- Enumerate changes: `openspec list` (or `openspec change list --json` - deprecated but available)
+- Show details:
+  - Spec: `openspec show <spec-id> --type spec` (use `--json` for filters)
+  - Change: `openspec show <change-id> --json --deltas-only`
+- Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" openspec/specs`
+
+## Quick Start
+
+### CLI Commands
+
+```bash
+# Essential commands
+openspec list                  # List active changes
+openspec list --specs          # List specifications
+openspec show [item]           # Display change or spec
+openspec diff [change]         # Show spec differences
+openspec validate [item]       # Validate changes or specs
+openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
+
+# Project management
+openspec init [path]           # Initialize OpenSpec
+openspec update [path]         # Update instruction files
+
+# Interactive mode
+openspec show                  # Prompts for selection
+openspec validate              # Bulk validation mode
+
+# Debugging
+openspec show [change] --json --deltas-only
+openspec validate [change] --strict
+```
+
+### Command Flags
+
+- `--json` - Machine-readable output
+- `--type change|spec` - Disambiguate items
+- `--strict` - Comprehensive validation
+- `--no-interactive` - Disable prompts
+- `--skip-specs` - Archive without spec updates
+- `--yes`/`-y` - Skip confirmation prompts (non-interactive archive)
+
+## Directory Structure
+
+```
+openspec/
+├── project.md              # Project conventions
+├── specs/                  # Current truth - what IS built
+│   └── [capability]/       # Single focused capability
+│       ├── spec.md         # Requirements and scenarios
+│       └── design.md       # Technical patterns
+├── changes/                # Proposals - what SHOULD change
+│   ├── [change-name]/
+│   │   ├── proposal.md     # Why, what, impact
+│   │   ├── tasks.md        # Implementation checklist
+│   │   ├── design.md       # Technical decisions (optional; see criteria)
+│   │   └── specs/          # Delta changes
+│   │       └── [capability]/
+│   │           └── spec.md # ADDED/MODIFIED/REMOVED
+│   └── archive/            # Completed changes
+```
+
+## Creating Change Proposals
+
+### Decision Tree
+
+```
+New request?
+├─ Bug fix restoring spec behavior? → Fix directly
+├─ Typo/format/comment? → Fix directly  
+├─ New feature/capability? → Create proposal
+├─ Breaking change? → Create proposal
+├─ Architecture change? → Create proposal
+└─ Unclear? → Create proposal (safer)
+```
+
+### Proposal Structure
+
+1. **Create directory:** `changes/[change-id]/` (kebab-case, verb-led, unique)
+
+2. **Write proposal.md:**
+```markdown
+## Why
+[1-2 sentences on problem/opportunity]
+
+## What Changes
+- [Bullet list of changes]
+- [Mark breaking changes with **BREAKING**]
+
+## Impact
+- Affected specs: [list capabilities]
+- Affected code: [key files/systems]
+```
+
+3. **Create spec deltas:** `specs/[capability]/spec.md`
+```markdown
+## ADDED Requirements
+### Requirement: New Feature
+The system SHALL provide...
+
+#### Scenario: Success case
+- **WHEN** user performs action
+- **THEN** expected result
+
+## MODIFIED Requirements
+### Requirement: Existing Feature
+[Complete modified requirement]
+
+## REMOVED Requirements
+### Requirement: Old Feature
+**Reason**: [Why removing]
+**Migration**: [How to handle]
+```
+If multiple capabilities are affected, create multiple delta files under `changes/[change-id]/specs/<capability>/spec.md`—one per capability.
+
+4. **Create tasks.md:**
+```markdown
+## 1. Implementation
+- [ ] 1.1 Create database schema
+- [ ] 1.2 Implement API endpoint
+- [ ] 1.3 Add frontend component
+- [ ] 1.4 Write tests
+```
+
+5. **Create design.md when needed:**
+Create `design.md` if any of the following apply; otherwise omit it:
+- Cross-cutting change (multiple services/modules) or a new architectural pattern
+- New external dependency or significant data model changes
+- Security, performance, or migration complexity
+- Ambiguity that benefits from technical decisions before coding
+
+Minimal `design.md` skeleton:
+```markdown
+## Context
+[Background, constraints, stakeholders]
+
+## Goals / Non-Goals
+- Goals: [...]
+- Non-Goals: [...]
+
+## Decisions
+- Decision: [What and why]
+- Alternatives considered: [Options + rationale]
+
+## Risks / Trade-offs
+- [Risk] → Mitigation
+
+## Migration Plan
+[Steps, rollback]
+
+## Open Questions
+- [...]
+```
+
+## Spec File Format
+
+### Critical: Scenario Formatting
+
+**CORRECT** (use #### headers):
+```markdown
+#### Scenario: User login success
+- **WHEN** valid credentials provided
+- **THEN** return JWT token
+```
+
+**WRONG** (don't use bullets or bold):
+```markdown
+- **Scenario: User login**  ❌
+**Scenario**: User login     ❌
+### Scenario: User login      ❌
+```
+
+Every requirement MUST have at least one scenario.
+
+### Requirement Wording
+- Use SHALL/MUST for normative requirements (avoid should/may unless intentionally non-normative)
+
+### Delta Operations
+
+- `## ADDED Requirements` - New capabilities
+- `## MODIFIED Requirements` - Changed behavior
+- `## REMOVED Requirements` - Deprecated features
+- `## RENAMED Requirements` - Name changes
+
+Headers matched with `trim(header)` - whitespace ignored.
+
+#### When to use ADDED vs MODIFIED
+- ADDED: Introduces a new capability or sub-capability that can stand alone as a requirement. Prefer ADDED when the change is orthogonal (e.g., adding "Slash Command Configuration") rather than altering the semantics of an existing requirement.
+- MODIFIED: Changes the behavior, scope, or acceptance criteria of an existing requirement. Always paste the full, updated requirement content (header + all scenarios). The archiver will replace the entire requirement with what you provide here; partial deltas will drop previous details.
+- RENAMED: Use when only the name changes. If you also change behavior, use RENAMED (name) plus MODIFIED (content) referencing the new name.
+
+Common pitfall: Using MODIFIED to add a new concern without including the previous text. This causes loss of detail at archive time. If you aren’t explicitly changing the existing requirement, add a new requirement under ADDED instead.
+
+Authoring a MODIFIED requirement correctly:
+1) Locate the existing requirement in `openspec/specs/<capability>/spec.md`.
+2) Copy the entire requirement block (from `### Requirement: ...` through its scenarios).
+3) Paste it under `## MODIFIED Requirements` and edit to reflect the new behavior.
+4) Ensure the header text matches exactly (whitespace-insensitive) and keep at least one `#### Scenario:`.
+
+Example for RENAMED:
+```markdown
+## RENAMED Requirements
+- FROM: `### Requirement: Login`
+- TO: `### Requirement: User Authentication`
+```
+
+## Troubleshooting
+
+### Common Errors
+
+**"Change must have at least one delta"**
+- Check `changes/[name]/specs/` exists with .md files
+- Verify files have operation prefixes (## ADDED Requirements)
+
+**"Requirement must have at least one scenario"**
+- Check scenarios use `#### Scenario:` format (4 hashtags)
+- Don't use bullet points or bold for scenario headers
+
+**Silent scenario parsing failures**
+- Exact format required: `#### Scenario: Name`
+- Debug with: `openspec show [change] --json --deltas-only`
+
+### Validation Tips
+
+```bash
+# Always use strict mode for comprehensive checks
+openspec validate [change] --strict
+
+# Debug delta parsing
+openspec show [change] --json | jq '.deltas'
+
+# Check specific requirement
+openspec show [spec] --json -r 1
+```
+
+## Happy Path Script
+
+```bash
+# 1) Explore current state
+openspec spec list --long
+openspec list
+# Optional full-text search:
+# rg -n "Requirement:|Scenario:" openspec/specs
+# rg -n "^#|Requirement:" openspec/changes
+
+# 2) Choose change id and scaffold
+CHANGE=add-two-factor-auth
+mkdir -p openspec/changes/$CHANGE/{specs/auth}
+printf "## Why\n...\n\n## What Changes\n- ...\n\n## Impact\n- ...\n" > openspec/changes/$CHANGE/proposal.md
+printf "## 1. Implementation\n- [ ] 1.1 ...\n" > openspec/changes/$CHANGE/tasks.md
+
+# 3) Add deltas (example)
+cat > openspec/changes/$CHANGE/specs/auth/spec.md << 'EOF'
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+Users MUST provide a second factor during login.
+
+#### Scenario: OTP required
+- **WHEN** valid credentials are provided
+- **THEN** an OTP challenge is required
+EOF
+
+# 4) Validate
+openspec validate $CHANGE --strict
+```
+
+## Multi-Capability Example
+
+```
+openspec/changes/add-2fa-notify/
+├── proposal.md
+├── tasks.md
+└── specs/
+    ├── auth/
+    │   └── spec.md   # ADDED: Two-Factor Authentication
+    └── notifications/
+        └── spec.md   # ADDED: OTP email notification
+```
+
+auth/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+...
+```
+
+notifications/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: OTP Email Notification
+...
+```
+
+## Best Practices
+
+### Simplicity First
+- Default to <100 lines of new code
+- Single-file implementations until proven insufficient
+- Avoid frameworks without clear justification
+- Choose boring, proven patterns
+
+### Complexity Triggers
+Only add complexity with:
+- Performance data showing current solution too slow
+- Concrete scale requirements (>1000 users, >100MB data)
+- Multiple proven use cases requiring abstraction
+
+### Clear References
+- Use `file.ts:42` format for code locations
+- Reference specs as `specs/auth/spec.md`
+- Link related changes and PRs
+
+### Capability Naming
+- Use verb-noun: `user-auth`, `payment-capture`
+- Single purpose per capability
+- 10-minute understandability rule
+- Split if description needs "AND"
+
+### Change ID Naming
+- Use kebab-case, short and descriptive: `add-two-factor-auth`
+- Prefer verb-led prefixes: `add-`, `update-`, `remove-`, `refactor-`
+- Ensure uniqueness; if taken, append `-2`, `-3`, etc.
+
+## Tool Selection Guide
+
+| Task | Tool | Why |
+|------|------|-----|
+| Find files by pattern | Glob | Fast pattern matching |
+| Search code content | Grep | Optimized regex search |
+| Read specific files | Read | Direct file access |
+| Explore unknown scope | Task | Multi-step investigation |
+
+## Error Recovery
+
+### Change Conflicts
+1. Run `openspec list` to see active changes
+2. Check for overlapping specs
+3. Coordinate with change owners
+4. Consider combining proposals
+
+### Validation Failures
+1. Run with `--strict` flag
+2. Check JSON output for details
+3. Verify spec file format
+4. Ensure scenarios properly formatted
+
+### Missing Context
+1. Read project.md first
+2. Check related specs
+3. Review recent archives
+4. Ask for clarification
+
+## Quick Reference
+
+### Stage Indicators
+- `changes/` - Proposed, not yet built
+- `specs/` - Built and deployed
+- `archive/` - Completed changes
+
+### File Purposes
+- `proposal.md` - Why and what
+- `tasks.md` - Implementation steps
+- `design.md` - Technical decisions
+- `spec.md` - Requirements and behavior
+
+### CLI Essentials
+```bash
+openspec list              # What's in progress?
+openspec show [item]       # View details
+openspec diff [change]     # What's changing?
+openspec validate --strict # Is it correct?
+openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
+```
+
+Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,68 @@
+# Project Context
+
+## Purpose
+Presenter is a monolithic, production-ready lyrics, Bible, timer, and stage display system built solely for our church services. It exists to give operators a fast, reliable control surface, keep every output (front-of-house, stage, broadcast) synchronized, and make service prep/import pipelines repeatable with minimal manual effort.
+
+## Tech Stack
+- Rust workspace with `presenter-core` (domain logic) and `presenter-server` (Axum/Tokio HTTP + WebSocket entrypoint).
+- SeaORM for persistence backed by SQLite in development/testing, with a forward path to Postgres in production.
+- Leptos-based UI surfaces (operator, tablet, Bible, settings, timer overlay) rendered from the server crate.
+- TypeScript + Playwright for end-to-end testing and frontend tooling (runs via Node.js 22.x).
+- Docker Engine 24+ with Compose V2 for isolated demos and the always-on gateway landing page.
+- Shared WebSocket channel (`/live/ws`) for live stage/operator synchronization and external device feeds.
+- OpenSpec CLI for proposal/spec workflow and structured change management.
+
+## Project Conventions
+
+### Code Style
+- Use rustfmt/clippy defaults; keep Rust source files under ~800 lines (hard cap 1,000) and functions under 60 lines by splitting features into focused modules.
+- Organize `presenter-server` feature-first: routers under `router/`, state handlers under `state/<feature>.rs`, and keep each Leptos page in `ui/{page}.rs`.
+- Store reusable styles in `ui/styles.rs` or static assets; keep per-surface inline styles below ~200 lines before extracting.
+- Reserve `mod.rs` files for orchestration/re-exports only; modules stay snake_case while types and components use PascalCase.
+- Add succinct comments only where behavior is non-obvious; rely on descriptive naming and tests for most documentation.
+
+### Architecture Patterns
+- Single monolithic Rust application optimized for in-house workflows; refactors prefer clean rebuilds over incremental compatibility layers.
+- `presenter-core` encapsulates domain models (songs, scripture, timers, stage layouts) with unit tests; `presenter-server` exposes HTTP/WebSocket APIs plus UI shells.
+- Feature-specific routers/state modules coordinate downstream clients (AbleSet, OSC, Resolume, Android stage app, Companion) while maintaining deterministic state snapshots for outputs.
+- Offline-ready caches, automatic backups, and sanitized ProPresenter import pipelines keep demos and operators consistent across devices.
+- Docker-managed demos (`run-demo.sh`) and the port-80 gateway provide branch-specific stacks; every change is validated and deployed through `verify-and-refresh.sh`.
+- Maintain three runtime tiers (development, testing, production); keep dev refreshed after each approved PR and gate production promotion on explicit sign-off with zero-downtime handoffs.
+- Capture architectural decisions as numbered ADRs and keep documentation in sync with behaviour after every change.
+
+### Testing Strategy
+- Follow TDD: add unit tests for pure Rust logic and Playwright E2E coverage for every user-visible workflow and cross-process side effect.
+- Primary verification command: `sudo -E ./scripts/dev/verify-and-refresh.sh` (runs `cargo test`, Playwright, rebuilds demo containers, and refreshes the gateway; must pass before reporting status).
+- Run suites individually with `cargo test` and `npm run test:playwright` for focused debugging—no `.only`/`.skip` committed.
+- Keep tests deterministic (fixed seeds, poll helpers instead of sleeps, animations disabled) and assert both UI interactions and downstream effects (stage layout updates, gateway card freshness, WebSocket broadcasts).
+- Recreate SQLite databases after schema edits and rerun import pipelines so dev/test/prod stay aligned.
+- Health checks within the suites must confirm the always-on gateway card updates (`data-updated-at`) and that stage/live WebSocket feeds respond within expected latency budgets.
+- Run `scripts/dev/quality-check.sh --against origin/main` frequently and `--strict` before merge; open questions or gaps become TODOs in `tasks.md` before implementation proceeds.
+
+### Git Workflow
+- Work exclusively on feature branches (`feature/<task>`); create a PR immediately after branching and update it continuously.
+- Never commit directly to `main`; agents do not merge PRs and must wait for user approval.
+- Keep commits small, descriptive, and single-purpose; push frequently so reviewers can follow progress.
+- Run `scripts/dev/quality-check.sh --against origin/main` regularly and `--strict` before merge; ensure working trees are clean before handing off.
+- Use OpenSpec proposals/tasks for any new capability, breaking change, or architecture shift; validate with `openspec validate <change-id> --strict` before coding.
+
+## Domain Context
+Presenter powers worship services with quick lyric selection, scripture lookup, timer management, and synchronized stage displays. Operators drive services from `/ui/operator`, assembling playlists/run sheets, triggering slides, adjusting timers, and monitoring what every output shows. Stage displays, Resolume layers, OBS overlays, and the tablet/stage apps subscribe to the same WebSocket feed, so layout changes (`POST /stage/layout`) and slide cues propagate instantly. Sanitized ProPresenter libraries live outside the repo (`../presenter-libraries`) and feed the import pipeline that populates every branch demo for consistent content. Stage profiles cover main stage, choir, and broadcast monitors, including automatic Android kiosk relaunch and latency/heartbeat indicators. AbleSet/OSC automation can pre-trigger playlists while operators retain manual override, and Resolume clip metadata is validated so A/B lane naming stays service-ready.
+
+## Important Constraints
+- Reliability, predictable behavior, and minimal operator friction take precedence over feature breadth; design every change for high-stakes live services.
+- Treat redesigns as greenfield efforts—remove or replace legacy artifacts rather than preserving compatibility with earlier drafts.
+- Maintain separate development, testing, and production installations; refresh the Docker demo and gateway after each change and never stop services you did not start.
+- Stick to Docker-managed demos (one per repo checkout) and ensure `run-gateway.sh` remains active on port 80.
+- Schema is still mutable pre-release: modify the initial migration directly, then rebuild databases and rerun import scripts instead of adding incremental migrations.
+- Avoid destructive Git commands (`reset --hard`, etc.) and respect existing local changes unless instructed otherwise.
+- Every code or asset change must finish with `sudo -E ./scripts/dev/verify-and-refresh.sh`, confirm the live demo via browser/curl, and document results before reporting progress.
+- Keep proposals/designs in OpenSpec up to date; archive completed changes only after deployment using `openspec archive`.
+
+## External Dependencies
+- Sanitized ProPresenter library exports that seed songs, scriptures, and playlists.
+- Media and control integrations: Resolume, OBS timer overlay, AbleSet/Ableton via OSC, Companion, and Android stage display clients.
+- Docker Engine + Compose, Node.js 22.x toolchain, and Playwright browsers (installed via `./scripts/ops/bootstrap-host.sh`).
+- SQLite for local storage with a planned move to Postgres via SeaORM in production deployments.
+- Android platform tools (ADB) for managing stage tablets via automation scripts.
+- Zerotier/LAN connectivity for remote gateway access during services and rehearsals.


### PR DESCRIPTION
## Summary
- add the managed OpenSpec instruction banner to `AGENTS.md` so assistants reach the spec playbook automatically
- check in the canonical OpenSpec instructions bundle under `openspec/AGENTS.md`
- document purpose, tech stack, conventions, and constraints for Presenter in `openspec/project.md`

## Testing
- `openspec validate --specs --strict`
- `cargo test`
- `npm run test:playwright`
- `npx playwright test tests/e2e/operator-playlist.spec.ts --project=chromium --grep "stage display status shows connection and latency"`
- `sudo -E ./scripts/dev/verify-and-refresh.sh`

## Definition of Done (Issue #41)
- [x] Ran `scripts/dev/quality-check.sh --strict` — result: PASS (advisory warnings only; backlog tracked in docs/quality/2025-10-roadmap.md)
- [x] Ran `sudo -E ./scripts/dev/verify-and-refresh.sh` — result: PASS
- [x] E2E includes user interaction + side-effects for changed surfaces (no functional changes; baseline suite + targeted rerun stayed green)
- [x] No `.only`/`.skip` in tests
- [x] File/function sizes within limits or refactor justified in PR notes (legacy overage called out in Quality Roadmap #44/#46)
- [x] ADR updated/added for non-obvious architectural choices (not needed for documentation-only update)
- [x] Gateway card fresh; operator UI reachable; Stage link present (verified via `sudo -E ./scripts/dev/verify-and-refresh.sh`)
- [x] No direct `playwright show-report` usage
- [x] Format & Lint pass (`cargo fmt --check`, `cargo clippy`) — enforced via quality script
- [x] No `unwrap`/`expect`/`panic!` in production sources
