### PR TITLE
fix(deploy): add capability for binding to port 80

### DIFF
--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -17,8 +17,9 @@ Environment=PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db
 Environment=PRESENTER_LIBRARY_ROOT=/home/newlevel/devel/presenter/presenter-libraries
 Environment=RUST_LOG=info,tower_http=debug
 
-# Security hardening
-NoNewPrivileges=true
+# Security hardening - allow binding to port 80
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/opt/presenter


### PR DESCRIPTION
## Summary
- Replace `NoNewPrivileges=true` with `AmbientCapabilities=CAP_NET_BIND_SERVICE`
- Allows non-root service to bind to port 80

## Test plan
- [x] Service running locally on port 80
- [x] healthz endpoint responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)