### PR TITLE
chore: bump version to 0.1.2 for main release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.1.2-dev.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2-dev.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump workspace version from `0.1.2-dev.1` to `0.1.2` for main branch release
- Fixes version check CI failure on main after PR #118 merge

## Test plan
- [ ] Version check passes (main expects clean `X.Y.Z`)
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)