### PR TITLE
feat(stage): worship-pp redesign, smart scaling, and runtime appearance settings

### DIFF
--- a/crates/presenter-server/src/companion/variables.rs
+++ b/crates/presenter-server/src/companion/variables.rs
@@ -26,6 +26,7 @@ impl CompanionVariableState {
             crate::live::LiveEvent::Bible { broadcast } => self.apply_bible(broadcast),
             crate::live::LiveEvent::BibleCleared => self.clear_bible(),
             crate::live::LiveEvent::StageLayout { code } => self.set_stage_layout_code(&code),
+            crate::live::LiveEvent::StageAppearance { .. } => false,
         }
     }
 

--- a/crates/presenter-server/src/live.rs
+++ b/crates/presenter-server/src/live.rs
@@ -1,3 +1,4 @@
+use crate::router::stage::StageAppearance;
 use crate::stage_connections::{StageClientSnapshot, StageConnections};
 use axum::extract::ws::{Message, WebSocket};
 use chrono::{DateTime, Utc};
@@ -57,13 +58,30 @@ enum InboundMessage {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)]
 pub enum LiveEvent {
-    Timers { overview: TimersOverview },
-    Stage { snapshot: StageDisplaySnapshot },
-    Heartbeat { id: Uuid, timestamp: DateTime<Utc> },
-    StageConnection { snapshot: StageClientSnapshot },
-    Bible { broadcast: BibleBroadcast },
+    Timers {
+        overview: TimersOverview,
+    },
+    Stage {
+        snapshot: StageDisplaySnapshot,
+    },
+    Heartbeat {
+        id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+    StageConnection {
+        snapshot: StageClientSnapshot,
+    },
+    Bible {
+        broadcast: BibleBroadcast,
+    },
     BibleCleared,
-    StageLayout { code: String },
+    StageLayout {
+        code: String,
+    },
+    StageAppearance {
+        layout: String,
+        appearance: StageAppearance,
+    },
 }
 
 pub async fn serve_websocket(hub: LiveHub, connections: StageConnections, socket: WebSocket) {

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -5,7 +5,7 @@ mod libraries;
 mod playlists;
 mod presentations;
 mod search;
-mod stage;
+pub(crate) mod stage;
 mod timers;
 mod ui_routes;
 use crate::state::AppState;
@@ -92,6 +92,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ui/tablet", get(ui_routes::tablet_ui))
         .route("/ui/bible", get(bible::bible_ui))
         .route("/ui/settings", get(ui_routes::settings_ui))
+        .route("/ui/stage-settings", get(ui_routes::stage_settings_ui))
         .route("/overlays/timer", get(ui_routes::timer_overlay))
         .route("/stage-displays", get(stage::list_stage_displays))
         .route(
@@ -106,6 +107,10 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route("/stage/state", post(stage::update_stage_state))
         .route("/stage/clear", post(stage::clear_stage_state))
+        .route(
+            "/stage/appearance/{layout}",
+            get(stage::get_stage_appearance).put(stage::update_stage_appearance),
+        )
         .route(
             "/integrations/resolume/hosts",
             get(integrations::resolume::list_resolume_hosts)

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::State,
+    extract::{Path, State},
     response::{IntoResponse, Response},
     Json,
 };
@@ -12,6 +12,65 @@ use axum::http::StatusCode;
 use presenter_core::{
     PlaylistId, PresentationId, SlideId, StageDisplayLayout, StageDisplaySnapshot,
 };
+
+/// Visual appearance settings for a stage display layout.
+///
+/// Each layout stores its own copy; unknown fields are ignored on
+/// deserialization so old clients survive schema additions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct StageAppearance {
+    pub body_padding_v: f32,
+    pub body_padding_h: f32,
+    pub current_max_font: f32,
+    pub next_max_font: f32,
+    pub next_ratio: f32,
+    pub group_font_size: f32,
+    pub lyrics_gap: f32,
+    pub next_padding_bottom: f32,
+    pub base_chars: u32,
+    pub min_font: f32,
+    // worship-pp specific
+    pub playlist_font_size: f32,
+    pub playlist_header_size: f32,
+    pub playlist_padding: f32,
+    pub slides_playlist_ratio: String,
+}
+
+impl Default for StageAppearance {
+    fn default() -> Self {
+        Self {
+            body_padding_v: 1.0,
+            body_padding_h: 2.0,
+            current_max_font: 120.0,
+            next_max_font: 80.0,
+            next_ratio: 0.8,
+            group_font_size: 1.6,
+            lyrics_gap: 0.5,
+            next_padding_bottom: 2.0,
+            base_chars: 25,
+            min_font: 12.0,
+            playlist_font_size: 1.3,
+            playlist_header_size: 1.1,
+            playlist_padding: 1.0,
+            slides_playlist_ratio: "7fr 3fr".to_string(),
+        }
+    }
+}
+
+impl StageAppearance {
+    /// Return sensible defaults per layout code.
+    pub fn default_for(layout: &str) -> Self {
+        match layout {
+            "worship-pp" => Self {
+                current_max_font: 100.0,
+                next_max_font: 64.0,
+                ..Self::default()
+            },
+            _ => Self::default(),
+        }
+    }
+}
 
 #[instrument(skip_all)]
 pub(super) async fn stage_display_selected_html(
@@ -145,5 +204,24 @@ pub(super) async fn clear_stage_state(
     State(state): State<AppState>,
 ) -> Result<StatusCode, AppError> {
     state.clear_stage().await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[instrument(skip_all)]
+pub(super) async fn get_stage_appearance(
+    State(state): State<AppState>,
+    Path(layout): Path<String>,
+) -> Result<Json<StageAppearance>, AppError> {
+    let appearance = state.get_stage_appearance(&layout).await?;
+    Ok(Json(appearance))
+}
+
+#[instrument(skip_all)]
+pub(super) async fn update_stage_appearance(
+    State(state): State<AppState>,
+    Path(layout): Path<String>,
+    Json(appearance): Json<StageAppearance>,
+) -> Result<StatusCode, AppError> {
+    state.set_stage_appearance(&layout, appearance).await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/presenter-server/src/router/ui_routes.rs
+++ b/crates/presenter-server/src/router/ui_routes.rs
@@ -49,6 +49,14 @@ pub(super) async fn settings_ui(
     Ok(html)
 }
 
+#[instrument(skip_all)]
+pub(super) async fn stage_settings_ui(
+    State(state): State<AppState>,
+) -> Result<axum::response::Html<String>, AppError> {
+    let html = ui::render_stage_settings_ui(&state).await?;
+    Ok(html)
+}
+
 pub(super) async fn tablet_ui(
     State(state): State<AppState>,
 ) -> Result<axum::response::Html<String>, AppError> {

--- a/crates/presenter-server/src/stage_ui.rs
+++ b/crates/presenter-server/src/stage_ui.rs
@@ -220,6 +220,51 @@ fn StageDisplayDocument(
   // Smart scaling: character-width based font sizing
   let measuredCharWidthPer100px = null;
 
+  // Configurable scaling parameters (updated by appearance settings)
+  const scalingConfig = {{
+    currentMaxFont: layout === 'worship-pp' ? 100 : 120,
+    nextMaxFont: layout === 'worship-pp' ? 64 : 80,
+    nextRatio: 0.8,
+    baseChars: 25,
+    minFont: 12,
+    groupFontSize: 1.6,
+  }};
+
+  const applyAppearance = (cfg) => {{
+    if (!cfg) return;
+    const b = document.body;
+    if (cfg.bodyPaddingV != null) b.style.setProperty('--body-pad-v', cfg.bodyPaddingV + 'vh');
+    if (cfg.bodyPaddingH != null) b.style.setProperty('--body-pad-h', cfg.bodyPaddingH + 'vw');
+    if (cfg.lyricsGap != null) b.style.setProperty('--lyrics-gap', cfg.lyricsGap + 'rem');
+    if (cfg.groupFontSize != null) b.style.setProperty('--group-font-size', cfg.groupFontSize + 'rem');
+    if (cfg.nextPaddingBottom != null) b.style.setProperty('--next-pad-bottom', cfg.nextPaddingBottom + 'vh');
+    if (cfg.playlistFontSize != null) b.style.setProperty('--playlist-font-size', cfg.playlistFontSize + 'rem');
+    if (cfg.playlistHeaderSize != null) b.style.setProperty('--playlist-header-size', cfg.playlistHeaderSize + 'rem');
+    if (cfg.playlistPadding != null) b.style.setProperty('--playlist-padding', cfg.playlistPadding + 'rem');
+    if (cfg.slidesPlaylistRatio != null) b.style.setProperty('--slides-playlist-ratio', cfg.slidesPlaylistRatio);
+
+    if (cfg.currentMaxFont != null) scalingConfig.currentMaxFont = cfg.currentMaxFont;
+    if (cfg.nextMaxFont != null) scalingConfig.nextMaxFont = cfg.nextMaxFont;
+    if (cfg.nextRatio != null) scalingConfig.nextRatio = cfg.nextRatio;
+    if (cfg.baseChars != null) scalingConfig.baseChars = cfg.baseChars;
+    if (cfg.minFont != null) scalingConfig.minFont = cfg.minFont;
+    if (cfg.groupFontSize != null) scalingConfig.groupFontSize = cfg.groupFontSize;
+
+    smartScaleLyrics(layout);
+  }};
+
+  const fetchAppearance = async () => {{
+    try {{
+      const resp = await fetch('/stage/appearance/' + encodeURIComponent(layout), {{ cache: 'no-store' }});
+      if (resp.ok) {{
+        const cfg = await resp.json();
+        applyAppearance(cfg);
+      }}
+    }} catch (err) {{
+      console.warn('Presenter appearance fetch failed', err);
+    }}
+  }};
+
   const measureCharWidth = () => {{
     if (measuredCharWidthPer100px !== null) return measuredCharWidthPer100px;
     const span = document.createElement('span');
@@ -243,11 +288,11 @@ fn StageDisplayDocument(
     }}
     if (longestLen === 0) longestLen = 1;
     const charW = measureCharWidth();
-    const baseFontPx = containerWidth / (25 * charW);
-    let fontPx = longestLen <= 25 ? baseFontPx : baseFontPx * (25 / longestLen);
+    const baseFontPx = containerWidth / (scalingConfig.baseChars * charW);
+    let fontPx = longestLen <= scalingConfig.baseChars ? baseFontPx : baseFontPx * (scalingConfig.baseChars / longestLen);
     fontPx *= ratio;
     if (maxPx && fontPx > maxPx) fontPx = maxPx;
-    fontPx = Math.max(12, fontPx);
+    fontPx = Math.max(scalingConfig.minFont, fontPx);
     element.style.fontSize = fontPx + 'px';
   }};
 
@@ -255,7 +300,7 @@ fn StageDisplayDocument(
     if (!element) return;
     const text = (element.textContent || '').trim();
     if (!text.length) return;
-    element.style.fontSize = '1.6rem';
+    element.style.fontSize = scalingConfig.groupFontSize + 'rem';
     element.style.maxWidth = Math.floor(containerWidth * 0.5) + 'px';
   }};
 
@@ -265,16 +310,16 @@ fn StageDisplayDocument(
         const container = document.querySelector('.stage__lyrics');
         if (!container) return;
         const w = container.clientWidth;
-        smartScaleElement(document.getElementById('current-text'), w, 1.0, 120);
-        smartScaleElement(document.getElementById('next-text'), w, 0.8, 80);
+        smartScaleElement(document.getElementById('current-text'), w, 1.0, scalingConfig.currentMaxFont);
+        smartScaleElement(document.getElementById('next-text'), w, scalingConfig.nextRatio, scalingConfig.nextMaxFont);
         smartScaleGroup(document.getElementById('current-group'), w);
         smartScaleGroup(document.getElementById('next-group'), w);
       }} else if (snapshotLayout === 'worship-pp') {{
         const container = document.querySelector('.stage__worship-pp-slides');
         if (!container) return;
         const w = container.clientWidth;
-        smartScaleElement(document.getElementById('current-main'), w, 1.0, 100);
-        smartScaleElement(document.getElementById('next-main'), w, 0.8, 64);
+        smartScaleElement(document.getElementById('current-main'), w, 1.0, scalingConfig.currentMaxFont);
+        smartScaleElement(document.getElementById('next-main'), w, scalingConfig.nextRatio, scalingConfig.nextMaxFont);
         smartScaleGroup(document.getElementById('current-group'), w);
         smartScaleGroup(document.getElementById('next-group'), w);
       }}
@@ -462,6 +507,7 @@ fn StageDisplayDocument(
       lastHeartbeatAt = Date.now();
       sendStagePresence();
       refreshFromServer();
+      fetchAppearance();
     }});
 
     ws.addEventListener('message', (event) => {{
@@ -473,6 +519,10 @@ fn StageDisplayDocument(
         }} else if (data.type === 'timers') {{
           currentSnapshot.timers = data.overview;
           applyTimers(currentSnapshot.timers);
+        }} else if (data.type === 'stage_appearance') {{
+          if (data.layout === layout && data.appearance) {{
+            applyAppearance(data.appearance);
+          }}
         }} else if (data.type === 'stage_layout' || data.type === 'StageLayout') {{
           const next =
             data.code || data.layoutCode || data.layout_code || '';
@@ -557,6 +607,7 @@ fn StageDisplayDocument(
   window.setInterval(checkHeartbeatTimeout, timeoutInterval);
 
   applyStage(currentSnapshot);
+  fetchAppearance();
   connectLive();
 
   document.addEventListener('visibilitychange', () => {{
@@ -831,7 +882,7 @@ fn format_hms(seconds: i64) -> String {
 
 const STAGE_STYLES: &str = r#"
 * { box-sizing: border-box; }
-body.stage { background: #000; color: #f8fafc; font-family: 'Inter', system-ui, sans-serif; margin: 0; min-height: 100vh; display: flex; align-items: stretch; justify-content: center; padding: 1vh 2vw; }
+body.stage { background: #000; color: #f8fafc; font-family: 'Inter', system-ui, sans-serif; margin: 0; min-height: 100vh; display: flex; align-items: stretch; justify-content: center; padding: var(--body-pad-v, 1vh) var(--body-pad-h, 2vw); }
 body.stage[data-output-stale="true"] .stage__body { opacity: 0.55; transition: opacity 0.25s ease; }
 body.stage[data-output-stale="true"] .stage__status { box-shadow: 0 12px 32px -18px rgba(248, 113, 113, 0.55); }
 body.stage[data-output-stale="true"] .stage__lyrics-current,
@@ -843,26 +894,26 @@ body.stage[data-live-state="reconnecting"] .stage__status-connection { color: #f
 body.stage[data-live-state="disconnected"] .stage__status-connection,
 body.stage[data-live-state="error"] .stage__status-connection { color: #f87171; }
 .stage__body { flex: 1; display: flex; align-items: stretch; justify-content: center; width: 100%; }
-.stage__lyrics { display: flex; flex-direction: column; justify-content: space-between; gap: 0.5rem; text-align: center; width: 100%; height: 100%; padding: 0; box-sizing: border-box; }
+.stage__lyrics { display: flex; flex-direction: column; justify-content: space-between; gap: var(--lyrics-gap, 0.5rem); text-align: center; width: 100%; height: 100%; padding: 0; box-sizing: border-box; }
 .stage__lyrics-current { font-size: 6.5rem; font-weight: 700; display: flex; flex-direction: column; gap: 0.3rem; align-items: center; justify-content: flex-start; letter-spacing: 0.04em; min-height: 0; }
 .stage__lyrics-current p { margin: 0; line-height: 1.06; white-space: pre-wrap; text-transform: none; max-width: 100%; }
-.stage__lyrics-next { font-size: 5.2rem; color: #cbd5f5; letter-spacing: 0.06em; display: flex; flex-direction: column; gap: 0.3rem; align-items: center; justify-content: center; padding-bottom: 2vh; }
+.stage__lyrics-next { font-size: 5.2rem; color: #cbd5f5; letter-spacing: 0.06em; display: flex; flex-direction: column; gap: 0.3rem; align-items: center; justify-content: center; padding-bottom: var(--next-pad-bottom, 2vh); }
 .stage__lyrics-next p { margin: 0; white-space: pre-wrap; text-transform: none; line-height: 1.1; max-width: 100%; }
 .stage__group-slot { min-height: 0; display: flex; align-items: center; justify-content: center; }
 .stage__group-slot:has([data-hidden="true"]) { display: none; }
 .stage__group-slot--next { justify-content: center; }
-.stage__worship-pp { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0.5rem; width: 100%; height: 100%; }
-.stage__worship-pp[data-has-playlist="true"] { grid-template-columns: minmax(0, 7fr) minmax(0, 3fr); }
-.stage__worship-pp-slides { display: flex; flex-direction: column; justify-content: space-between; gap: 0.5rem; min-height: 0; }
+.stage__worship-pp { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--lyrics-gap, 0.5rem); width: 100%; height: 100%; }
+.stage__worship-pp[data-has-playlist="true"] { grid-template-columns: var(--slides-playlist-ratio, minmax(0, 7fr) minmax(0, 3fr)); }
+.stage__worship-pp-slides { display: flex; flex-direction: column; justify-content: space-between; gap: var(--lyrics-gap, 0.5rem); min-height: 0; }
 .stage__worship-pp-current { flex: 1; font-size: 5.4rem; font-weight: 700; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; text-align: center; min-height: 0; }
 .stage__worship-pp-current p { margin: 0; line-height: 1.08; white-space: pre-wrap; max-width: 100%; }
-.stage__worship-pp-next { font-size: 3.2rem; color: #cbd5f5; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding-bottom: 2vh; }
+.stage__worship-pp-next { font-size: 3.2rem; color: #cbd5f5; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding-bottom: var(--next-pad-bottom, 2vh); }
 .stage__worship-pp-next p { margin: 0; white-space: pre-wrap; line-height: 1.1; max-width: 100%; }
-.stage__worship-pp-playlist { background: rgba(15, 23, 42, 0.55); border-radius: 0.8rem; padding: 1rem; overflow-y: auto; display: flex; flex-direction: column; }
+.stage__worship-pp-playlist { background: rgba(15, 23, 42, 0.55); border-radius: 0.8rem; padding: var(--playlist-padding, 1rem); overflow-y: auto; display: flex; flex-direction: column; }
 .stage__worship-pp[data-has-playlist="false"] .stage__worship-pp-playlist { display: none; }
-.stage__worship-pp-playlist h3 { font-size: 1.1rem; color: #38bdf8; letter-spacing: 0.1em; text-transform: uppercase; margin: 0 0 0.6rem 0; }
+.stage__worship-pp-playlist h3 { font-size: var(--playlist-header-size, 1.1rem); color: #38bdf8; letter-spacing: 0.1em; text-transform: uppercase; margin: 0 0 0.6rem 0; }
 .stage__worship-pp-playlist-list { list-style: none; padding: 0; margin: 0; }
-.stage__worship-pp-playlist-entry { padding: 0.45rem 0.8rem; border-radius: 0.4rem; font-size: 1.3rem; color: #94a3b8; transition: background 0.2s; }
+.stage__worship-pp-playlist-entry { padding: 0.45rem 0.8rem; border-radius: 0.4rem; font-size: var(--playlist-font-size, 1.3rem); color: #94a3b8; transition: background 0.2s; }
 .stage__worship-pp-playlist-entry[data-active="true"] { background: rgba(56, 189, 248, 0.2); color: #38bdf8; font-weight: 600; }
 .stage__worship-pp-playlist-entry[data-type="separator"] { font-size: 0.9rem; color: #475569; text-transform: uppercase; letter-spacing: 0.15em; padding: 0.6rem 0.8rem 0.2rem; }
 .stage__timer { text-align: center; width: 100%; }
@@ -870,7 +921,7 @@ body.stage[data-live-state="error"] .stage__status-connection { color: #f87171; 
 .stage__timer-label { font-size: 1.5rem; color: #94a3b8; letter-spacing: 0.3em; text-transform: uppercase; }
 .stage__timer--preach .stage__timer-value { color: #34d399; }
 .stage__timer--countdown .stage__timer-value { color: #38bdf8; }
-.stage__group { display: inline-flex; align-items: center; justify-content: center; padding: 0.25rem 1rem; background: rgba(56, 189, 248, 0.35); color: #38bdf8; border-radius: 999px; font-size: 1.6rem; letter-spacing: 0.18em; text-transform: uppercase; font-weight: 700; }
+.stage__group { display: inline-flex; align-items: center; justify-content: center; padding: 0.25rem 1rem; background: rgba(56, 189, 248, 0.35); color: #38bdf8; border-radius: 999px; font-size: var(--group-font-size, 1.6rem); letter-spacing: 0.18em; text-transform: uppercase; font-weight: 700; }
 .stage__group[data-hidden="true"] { display: none; }
 .stage__group--next { background: rgba(250, 204, 21, 0.3); color: #facc15; }
 .stage__meta { color: #cbd5f5; display: block; margin-top: 0.5rem; }

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -678,6 +678,33 @@ impl AppState {
         Ok(())
     }
 
+    // Stage appearance settings
+    pub async fn get_stage_appearance(
+        &self,
+        layout: &str,
+    ) -> anyhow::Result<crate::router::stage::StageAppearance> {
+        let key = format!("stage-appearance:{layout}");
+        match self.repository.get_app_setting(&key).await? {
+            Some(json) => Ok(serde_json::from_str(&json)?),
+            None => Ok(crate::router::stage::StageAppearance::default_for(layout)),
+        }
+    }
+
+    pub async fn set_stage_appearance(
+        &self,
+        layout: &str,
+        appearance: crate::router::stage::StageAppearance,
+    ) -> anyhow::Result<()> {
+        let key = format!("stage-appearance:{layout}");
+        let json = serde_json::to_string(&appearance)?;
+        self.repository.set_app_setting(&key, &json).await?;
+        self.live_hub.publish(LiveEvent::StageAppearance {
+            layout: layout.to_string(),
+            appearance,
+        });
+        Ok(())
+    }
+
     // Slide editing methods are in slides.rs
     // Timer methods are in timers.rs
     // Broadcasting methods are in broadcasting.rs

--- a/crates/presenter-server/src/ui/home.rs
+++ b/crates/presenter-server/src/ui/home.rs
@@ -34,6 +34,7 @@ fn HomeDocument() -> impl IntoView {
                             <li><a href="/ui/tablet">"Tablet UI"</a></li>
                             <li><a href="/ui/bible">"Bible Control"</a></li>
                             <li><a href="/ui/settings" target="_blank" rel="noopener">"Settings"</a></li>
+                            <li><a href="/ui/stage-settings" target="_blank" rel="noopener">"Stage Appearance"</a></li>
                         </ul>
                     </section>
                     <section class="home__section">

--- a/crates/presenter-server/src/ui/mod.rs
+++ b/crates/presenter-server/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod components;
 pub mod home;
 pub mod operator;
 pub mod settings;
+pub mod stage_settings;
 pub mod tablet;
 pub mod timer_overlay;
 
@@ -15,5 +16,6 @@ pub use bible::render_bible_ui;
 pub use home::render_home_ui;
 pub use operator::render_operator_ui;
 pub use settings::render_settings_ui;
+pub use stage_settings::render_stage_settings_ui;
 pub use tablet::render_tablet_ui;
 pub use timer_overlay::render_timer_overlay;

--- a/crates/presenter-server/src/ui/settings.rs
+++ b/crates/presenter-server/src/ui/settings.rs
@@ -160,6 +160,7 @@ fn SettingsDocument(
                     </div>
                     <nav class="settings__header-nav">
                         <a href="/" class="settings__link">"← Back to hub"</a>
+                        <a href="/ui/stage-settings" class="settings__link">"Stage Appearance →"</a>
                     </nav>
                 </header>
                 <main class="settings__main">

--- a/crates/presenter-server/src/ui/stage_settings.rs
+++ b/crates/presenter-server/src/ui/stage_settings.rs
@@ -1,0 +1,322 @@
+use crate::state::AppState;
+use axum::response::Html;
+use leptos::prelude::*;
+use reactive_graph::owner::Owner;
+
+use super::styles;
+use super::utils::json_safe;
+
+/// Render the stage appearance settings page.
+pub async fn render_stage_settings_ui(state: &AppState) -> anyhow::Result<Html<String>> {
+    let layouts = ["worship-snv", "worship-pp", "timer", "preach"];
+    let mut appearances = Vec::new();
+    for layout in &layouts {
+        let appearance = state.get_stage_appearance(layout).await?;
+        appearances.push((*layout, appearance));
+    }
+    let appearances_json = json_safe(
+        &appearances
+            .iter()
+            .map(|(code, app)| serde_json::json!({ "code": code, "appearance": app }))
+            .collect::<Vec<_>>(),
+    );
+
+    let owner = Owner::new_root(None);
+    let html = owner.with(|| {
+        view! {
+            <StageSettingsDocument appearances_json=appearances_json />
+        }
+        .into_view()
+        .to_html()
+    });
+
+    Ok(Html(format!("<!DOCTYPE html>{html}")))
+}
+
+#[component]
+fn StageSettingsDocument(appearances_json: String) -> impl IntoView {
+    let script = format!(
+        r#"(function() {{
+  const layouts = {appearances_json};
+  const layoutMap = {{}};
+  for (const entry of layouts) {{
+    layoutMap[entry.code] = entry.appearance;
+  }}
+
+  const defaults = {{
+    'worship-snv': {{
+      bodyPaddingV: 1, bodyPaddingH: 2, currentMaxFont: 120, nextMaxFont: 80,
+      nextRatio: 0.8, groupFontSize: 1.6, lyricsGap: 0.5, nextPaddingBottom: 2,
+      baseChars: 25, minFont: 12, playlistFontSize: 1.3, playlistHeaderSize: 1.1,
+      playlistPadding: 1, slidesPlaylistRatio: '7fr 3fr'
+    }},
+    'worship-pp': {{
+      bodyPaddingV: 1, bodyPaddingH: 2, currentMaxFont: 100, nextMaxFont: 64,
+      nextRatio: 0.8, groupFontSize: 1.6, lyricsGap: 0.5, nextPaddingBottom: 2,
+      baseChars: 25, minFont: 12, playlistFontSize: 1.3, playlistHeaderSize: 1.1,
+      playlistPadding: 1, slidesPlaylistRatio: '7fr 3fr'
+    }},
+    'timer': {{
+      bodyPaddingV: 1, bodyPaddingH: 2, currentMaxFont: 120, nextMaxFont: 80,
+      nextRatio: 0.8, groupFontSize: 1.6, lyricsGap: 0.5, nextPaddingBottom: 2,
+      baseChars: 25, minFont: 12, playlistFontSize: 1.3, playlistHeaderSize: 1.1,
+      playlistPadding: 1, slidesPlaylistRatio: '7fr 3fr'
+    }},
+    'preach': {{
+      bodyPaddingV: 1, bodyPaddingH: 2, currentMaxFont: 120, nextMaxFont: 80,
+      nextRatio: 0.8, groupFontSize: 1.6, lyricsGap: 0.5, nextPaddingBottom: 2,
+      baseChars: 25, minFont: 12, playlistFontSize: 1.3, playlistHeaderSize: 1.1,
+      playlistPadding: 1, slidesPlaylistRatio: '7fr 3fr'
+    }}
+  }};
+
+  let activeLayout = 'worship-snv';
+
+  const showTab = (code) => {{
+    activeLayout = code;
+    document.querySelectorAll('[data-role="layout-tab"]').forEach(btn => {{
+      btn.dataset.active = btn.dataset.layout === code ? 'true' : 'false';
+    }});
+    document.querySelectorAll('[data-role="layout-section"]').forEach(section => {{
+      section.dataset.visible = section.dataset.layout === code ? 'true' : 'false';
+    }});
+  }};
+
+  const populateSliders = (code) => {{
+    const cfg = layoutMap[code] || defaults[code] || defaults['worship-snv'];
+    const section = document.querySelector(`[data-role="layout-section"][data-layout="${{code}}"]`);
+    if (!section) return;
+    section.querySelectorAll('[data-param]').forEach(input => {{
+      const key = input.dataset.param;
+      if (key in cfg) {{
+        input.value = cfg[key];
+        const display = input.closest('.sa__slider-row')?.querySelector('[data-role="value-display"]');
+        if (display) display.textContent = cfg[key];
+      }}
+    }});
+  }};
+
+  const collectValues = (code) => {{
+    const section = document.querySelector(`[data-role="layout-section"][data-layout="${{code}}"]`);
+    if (!section) return {{}};
+    const result = {{}};
+    section.querySelectorAll('[data-param]').forEach(input => {{
+      const key = input.dataset.param;
+      if (input.type === 'text') {{
+        result[key] = input.value;
+      }} else {{
+        result[key] = parseFloat(input.value);
+      }}
+    }});
+    return result;
+  }};
+
+  const showToast = (message, isError) => {{
+    const toast = document.querySelector('[data-role="toast"]');
+    if (!toast) return;
+    toast.textContent = message;
+    toast.dataset.visible = 'true';
+    toast.dataset.state = isError ? 'error' : 'success';
+    clearTimeout(toast._timer);
+    toast._timer = setTimeout(() => {{ toast.dataset.visible = 'false'; }}, 3000);
+  }};
+
+  const saveCurrent = async () => {{
+    const code = activeLayout;
+    const values = collectValues(code);
+    try {{
+      const response = await fetch(`/stage/appearance/${{code}}`, {{
+        method: 'PUT',
+        headers: {{ 'Content-Type': 'application/json' }},
+        body: JSON.stringify(values),
+      }});
+      if (!response.ok) throw new Error(await response.text());
+      layoutMap[code] = values;
+      showToast('Saved ' + code + ' appearance', false);
+    }} catch (err) {{
+      showToast('Save failed: ' + err.message, true);
+    }}
+  }};
+
+  const resetCurrent = async () => {{
+    const code = activeLayout;
+    const def = defaults[code] || defaults['worship-snv'];
+    try {{
+      const response = await fetch(`/stage/appearance/${{code}}`, {{
+        method: 'PUT',
+        headers: {{ 'Content-Type': 'application/json' }},
+        body: JSON.stringify(def),
+      }});
+      if (!response.ok) throw new Error(await response.text());
+      layoutMap[code] = {{ ...def }};
+      populateSliders(code);
+      showToast('Reset ' + code + ' to defaults', false);
+    }} catch (err) {{
+      showToast('Reset failed: ' + err.message, true);
+    }}
+  }};
+
+  // Wire up tabs
+  document.querySelectorAll('[data-role="layout-tab"]').forEach(btn => {{
+    btn.addEventListener('click', () => {{
+      showTab(btn.dataset.layout);
+    }});
+  }});
+
+  // Wire up sliders
+  document.querySelectorAll('[data-param]').forEach(input => {{
+    input.addEventListener('input', () => {{
+      const display = input.closest('.sa__slider-row')?.querySelector('[data-role="value-display"]');
+      if (display) display.textContent = input.value;
+    }});
+  }});
+
+  // Wire up save/reset buttons
+  document.querySelectorAll('[data-role="save"]').forEach(btn => {{
+    btn.addEventListener('click', saveCurrent);
+  }});
+  document.querySelectorAll('[data-role="reset"]').forEach(btn => {{
+    btn.addEventListener('click', resetCurrent);
+  }});
+
+  // Initialize
+  for (const code of Object.keys(layoutMap)) {{
+    populateSliders(code);
+  }}
+  showTab('worship-snv');
+}})();"#,
+        appearances_json = appearances_json
+    );
+
+    view! {
+        <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <title>"Stage Appearance Settings"</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <style>{styles::SETTINGS}</style>
+                <style>{STAGE_SETTINGS_STYLES}</style>
+            </head>
+            <body class="settings">
+                <header class="settings__header">
+                    <div class="settings__header-title">
+                        <h1>"Stage Appearance Settings"</h1>
+                        <p>"Adjust visual parameters per stage layout. Changes are applied live."</p>
+                    </div>
+                    <nav class="settings__header-nav">
+                        <a href="/ui/settings" class="settings__link">"← Back to settings"</a>
+                    </nav>
+                </header>
+                <main class="settings__main">
+                    <nav class="sa__tabs" data-role="layout-tabs">
+                        <button data-role="layout-tab" data-layout="worship-snv" data-active="true" class="sa__tab">"worship-snv"</button>
+                        <button data-role="layout-tab" data-layout="worship-pp" data-active="false" class="sa__tab">"worship-pp"</button>
+                        <button data-role="layout-tab" data-layout="timer" data-active="false" class="sa__tab">"timer"</button>
+                        <button data-role="layout-tab" data-layout="preach" data-active="false" class="sa__tab">"preach"</button>
+                    </nav>
+                    {render_layout_section("worship-snv", true)}
+                    {render_layout_section("worship-pp", false)}
+                    {render_layout_section("timer", false)}
+                    {render_layout_section("preach", false)}
+                </main>
+                <div class="settings__toast" data-role="toast" data-visible="false"></div>
+                <script>{script}</script>
+            </body>
+        </html>
+    }
+}
+
+fn render_layout_section(layout_code: &str, visible: bool) -> impl IntoView {
+    let code = layout_code.to_string();
+    let vis = if visible { "true" } else { "false" };
+    let is_pp = layout_code == "worship-pp";
+
+    view! {
+        <section class="settings__card" data-role="layout-section" data-layout={code.clone()} data-visible={vis}>
+            {slider_row("bodyPaddingV", "Body Padding V", "vh", 0.0, 10.0, 0.5)}
+            {slider_row("bodyPaddingH", "Body Padding H", "vw", 0.0, 10.0, 0.5)}
+            {slider_row("currentMaxFont", "Current Max Font", "px", 20.0, 250.0, 1.0)}
+            {slider_row("nextMaxFont", "Next Max Font", "px", 20.0, 200.0, 1.0)}
+            {slider_row("nextRatio", "Next Ratio", "", 0.3, 1.0, 0.05)}
+            {slider_row("groupFontSize", "Group Font Size", "rem", 0.5, 4.0, 0.1)}
+            {slider_row("lyricsGap", "Lyrics Gap", "rem", 0.0, 3.0, 0.1)}
+            {slider_row("nextPaddingBottom", "Next Padding Bottom", "vh", 0.0, 10.0, 0.5)}
+            {slider_row("baseChars", "Base Chars", "", 10.0, 60.0, 1.0)}
+            {slider_row("minFont", "Min Font", "px", 6.0, 40.0, 1.0)}
+            {if is_pp {
+                Some(view! {
+                    <>
+                        {slider_row("playlistFontSize", "Playlist Font Size", "rem", 0.5, 4.0, 0.1)}
+                        {slider_row("playlistHeaderSize", "Playlist Header Size", "rem", 0.5, 3.0, 0.1)}
+                        {slider_row("playlistPadding", "Playlist Padding", "rem", 0.0, 4.0, 0.1)}
+                        <div class="sa__slider-row">
+                            <label class="sa__slider-label">"Slides/Playlist Ratio"</label>
+                            <input type="text" data-param="slidesPlaylistRatio" value="7fr 3fr" class="sa__text-input" />
+                        </div>
+                    </>
+                })
+            } else {
+                None
+            }}
+            <div class="sa__actions">
+                <button data-role="save" class="settings__button settings__button--primary">"Save"</button>
+                <button data-role="reset" class="settings__button settings__button--ghost">"Reset to Defaults"</button>
+            </div>
+        </section>
+    }
+}
+
+fn slider_row(
+    param: &str,
+    label: &str,
+    unit: &str,
+    min: f32,
+    max: f32,
+    step: f32,
+) -> impl IntoView {
+    let min_str = format_number(min);
+    let max_str = format_number(max);
+    let step_str = format_number(step);
+    let label_with_unit = if unit.is_empty() {
+        label.to_string()
+    } else {
+        format!("{label} ({unit})")
+    };
+
+    view! {
+        <div class="sa__slider-row">
+            <label class="sa__slider-label">{label_with_unit}</label>
+            <input
+                type="range"
+                data-param={param.to_string()}
+                min={min_str.clone()}
+                max={max_str.clone()}
+                step={step_str.clone()}
+                class="sa__slider"
+            />
+            <span data-role="value-display" class="sa__value-display">"0"</span>
+        </div>
+    }
+}
+
+fn format_number(value: f32) -> String {
+    if value == value.floor() {
+        format!("{}", value as i32)
+    } else {
+        format!("{value}")
+    }
+}
+
+const STAGE_SETTINGS_STYLES: &str = r#"
+.sa__tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
+.sa__tab { padding: 0.6rem 1.2rem; border: 1px solid #334155; border-radius: 0.5rem; background: transparent; color: #94a3b8; cursor: pointer; font-size: 0.9rem; transition: all 0.15s; }
+.sa__tab[data-active="true"] { background: #1e40af; color: #fff; border-color: #1e40af; }
+.sa__tab:hover { border-color: #60a5fa; }
+[data-role="layout-section"][data-visible="false"] { display: none; }
+.sa__slider-row { display: flex; align-items: center; gap: 1rem; padding: 0.5rem 0; }
+.sa__slider-label { min-width: 200px; font-size: 0.9rem; color: #cbd5e1; }
+.sa__slider { flex: 1; accent-color: #3b82f6; }
+.sa__value-display { min-width: 60px; text-align: right; font-variant-numeric: tabular-nums; color: #e2e8f0; font-size: 0.9rem; }
+.sa__text-input { flex: 1; padding: 0.4rem 0.8rem; background: #1e293b; border: 1px solid #334155; border-radius: 0.4rem; color: #e2e8f0; font-size: 0.9rem; }
+.sa__actions { display: flex; gap: 0.75rem; margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #1e293b; }
+"#;

--- a/tests/e2e/stage-appearance.spec.ts
+++ b/tests/e2e/stage-appearance.spec.ts
@@ -1,0 +1,349 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 600_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+test.describe("Stage Appearance Settings", () => {
+  test("settings page loads with layout tabs", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    await expect(page.locator("h1")).toHaveText("Stage Appearance Settings");
+    // Verify all four layout tabs are present
+    await expect(page.locator('[data-role="layout-tab"]')).toHaveCount(4);
+    await expect(
+      page.locator('[data-role="layout-tab"][data-layout="worship-snv"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-role="layout-tab"][data-layout="worship-pp"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-role="layout-tab"][data-layout="timer"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-role="layout-tab"][data-layout="preach"]'),
+    ).toBeVisible();
+    // worship-snv section should be visible by default
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="worship-snv"]'),
+    ).toHaveAttribute("data-visible", "true");
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="worship-pp"]'),
+    ).toHaveAttribute("data-visible", "false");
+  });
+
+  test("switching tabs shows correct layout section", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    // Click worship-pp tab
+    await page
+      .locator('[data-role="layout-tab"][data-layout="worship-pp"]')
+      .click();
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="worship-pp"]'),
+    ).toHaveAttribute("data-visible", "true");
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="worship-snv"]'),
+    ).toHaveAttribute("data-visible", "false");
+    // Click timer tab
+    await page.locator('[data-role="layout-tab"][data-layout="timer"]').click();
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="timer"]'),
+    ).toHaveAttribute("data-visible", "true");
+    await expect(
+      page.locator('[data-role="layout-section"][data-layout="worship-pp"]'),
+    ).toHaveAttribute("data-visible", "false");
+  });
+
+  test("sliders show default values for worship-snv", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    // Check default currentMaxFont for worship-snv is 120
+    const slider = page.locator(
+      '[data-role="layout-section"][data-layout="worship-snv"] [data-param="currentMaxFont"]',
+    );
+    await expect(slider).toHaveValue("120");
+    const display = slider.locator("..").locator('[data-role="value-display"]');
+    await expect(display).toHaveText("120");
+  });
+
+  test("worship-pp shows playlist-specific sliders", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    await page
+      .locator('[data-role="layout-tab"][data-layout="worship-pp"]')
+      .click();
+    // Playlist font size slider should exist
+    await expect(
+      page.locator(
+        '[data-role="layout-section"][data-layout="worship-pp"] [data-param="playlistFontSize"]',
+      ),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '[data-role="layout-section"][data-layout="worship-pp"] [data-param="slidesPlaylistRatio"]',
+      ),
+    ).toBeVisible();
+  });
+
+  test("timer layout does not show playlist sliders", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    await page.locator('[data-role="layout-tab"][data-layout="timer"]').click();
+    await expect(
+      page.locator(
+        '[data-role="layout-section"][data-layout="timer"] [data-param="playlistFontSize"]',
+      ),
+    ).toHaveCount(0);
+  });
+
+  test("save appearance via API and verify persistence", async ({ page }) => {
+    // Save custom appearance via the API
+    const response = await page.request.put(
+      `${baseURL}/stage/appearance/worship-snv`,
+      {
+        data: {
+          bodyPaddingV: 3.0,
+          bodyPaddingH: 4.0,
+          currentMaxFont: 90,
+          nextMaxFont: 60,
+          nextRatio: 0.7,
+          groupFontSize: 2.0,
+          lyricsGap: 1.0,
+          nextPaddingBottom: 3.0,
+          baseChars: 30,
+          minFont: 14,
+          playlistFontSize: 1.5,
+          playlistHeaderSize: 1.2,
+          playlistPadding: 1.5,
+          slidesPlaylistRatio: "6fr 4fr",
+        },
+      },
+    );
+    expect(response.status()).toBe(204);
+
+    // Verify retrieval
+    const getResponse = await page.request.get(
+      `${baseURL}/stage/appearance/worship-snv`,
+    );
+    expect(getResponse.status()).toBe(200);
+    const body = await getResponse.json();
+    expect(body.currentMaxFont).toBe(90);
+    expect(body.bodyPaddingV).toBe(3.0);
+    expect(body.baseChars).toBe(30);
+  });
+
+  test("save button persists slider changes", async ({ page }) => {
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    // Switch to worship-pp
+    await page
+      .locator('[data-role="layout-tab"][data-layout="worship-pp"]')
+      .click();
+
+    // Change a slider value
+    const slider = page.locator(
+      '[data-role="layout-section"][data-layout="worship-pp"] [data-param="currentMaxFont"]',
+    );
+    await slider.fill("85");
+
+    // Click save
+    await page
+      .locator(
+        '[data-role="layout-section"][data-layout="worship-pp"] [data-role="save"]',
+      )
+      .click();
+
+    // Verify toast appears
+    const toast = page.locator('[data-role="toast"]');
+    await expect(toast).toHaveAttribute("data-visible", "true");
+    await expect(toast).toContainText("Saved");
+
+    // Verify the value persisted via API
+    const getResponse = await page.request.get(
+      `${baseURL}/stage/appearance/worship-pp`,
+    );
+    const body = await getResponse.json();
+    expect(body.currentMaxFont).toBe(85);
+  });
+
+  test("reset button restores defaults", async ({ page }) => {
+    // First set a custom value
+    await page.request.put(`${baseURL}/stage/appearance/worship-pp`, {
+      data: {
+        bodyPaddingV: 5.0,
+        bodyPaddingH: 5.0,
+        currentMaxFont: 50,
+        nextMaxFont: 30,
+        nextRatio: 0.5,
+        groupFontSize: 3.0,
+        lyricsGap: 2.0,
+        nextPaddingBottom: 5.0,
+        baseChars: 40,
+        minFont: 20,
+        playlistFontSize: 2.5,
+        playlistHeaderSize: 2.0,
+        playlistPadding: 3.0,
+        slidesPlaylistRatio: "5fr 5fr",
+      },
+    });
+
+    await page.goto(`${baseURL}/ui/stage-settings`);
+    await page
+      .locator('[data-role="layout-tab"][data-layout="worship-pp"]')
+      .click();
+
+    // Click reset
+    await page
+      .locator(
+        '[data-role="layout-section"][data-layout="worship-pp"] [data-role="reset"]',
+      )
+      .click();
+
+    // Verify toast
+    const toast = page.locator('[data-role="toast"]');
+    await expect(toast).toHaveAttribute("data-visible", "true");
+    await expect(toast).toContainText("Reset");
+
+    // Verify default values via API
+    const getResponse = await page.request.get(
+      `${baseURL}/stage/appearance/worship-pp`,
+    );
+    const body = await getResponse.json();
+    expect(body.currentMaxFont).toBe(100); // worship-pp default
+    expect(body.nextMaxFont).toBe(64); // worship-pp default
+    expect(body.bodyPaddingV).toBe(1.0);
+  });
+
+  test("GET returns defaults for unknown layout", async ({ page }) => {
+    const response = await page.request.get(
+      `${baseURL}/stage/appearance/nonexistent`,
+    );
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    // Should get the generic defaults
+    expect(body.currentMaxFont).toBe(120);
+    expect(body.nextMaxFont).toBe(80);
+  });
+
+  test("stage display applies appearance CSS vars", async ({ page }) => {
+    // Set custom appearance
+    await page.request.put(`${baseURL}/stage/appearance/worship-snv`, {
+      data: {
+        bodyPaddingV: 5.0,
+        bodyPaddingH: 6.0,
+        currentMaxFont: 90,
+        nextMaxFont: 60,
+        nextRatio: 0.7,
+        groupFontSize: 2.0,
+        lyricsGap: 1.5,
+        nextPaddingBottom: 4.0,
+        baseChars: 30,
+        minFont: 14,
+        playlistFontSize: 1.3,
+        playlistHeaderSize: 1.1,
+        playlistPadding: 1.0,
+        slidesPlaylistRatio: "7fr 3fr",
+      },
+    });
+
+    // Open stage display (worship-snv is default layout)
+    await page.goto(`${baseURL}/stage`);
+    // Wait for appearance to be fetched and applied
+    await page.waitForTimeout(1500);
+
+    // Verify CSS custom properties are set on body
+    const bodyPadV = await page.evaluate(() =>
+      document.body.style.getPropertyValue("--body-pad-v"),
+    );
+    expect(bodyPadV).toBe("5vh");
+
+    const bodyPadH = await page.evaluate(() =>
+      document.body.style.getPropertyValue("--body-pad-h"),
+    );
+    expect(bodyPadH).toBe("6vw");
+
+    const lyricsGap = await page.evaluate(() =>
+      document.body.style.getPropertyValue("--lyrics-gap"),
+    );
+    expect(lyricsGap).toBe("1.5rem");
+  });
+
+  test("live appearance update via WebSocket", async ({ page, context }) => {
+    // Reset worship-snv to defaults first
+    await page.request.put(`${baseURL}/stage/appearance/worship-snv`, {
+      data: {
+        bodyPaddingV: 1.0,
+        bodyPaddingH: 2.0,
+        currentMaxFont: 120,
+        nextMaxFont: 80,
+        nextRatio: 0.8,
+        groupFontSize: 1.6,
+        lyricsGap: 0.5,
+        nextPaddingBottom: 2.0,
+        baseChars: 25,
+        minFont: 12,
+        playlistFontSize: 1.3,
+        playlistHeaderSize: 1.1,
+        playlistPadding: 1.0,
+        slidesPlaylistRatio: "7fr 3fr",
+      },
+    });
+
+    // Open stage display
+    await page.goto(`${baseURL}/stage`);
+    await page.waitForTimeout(1500);
+
+    // Verify initial CSS var
+    const initialPad = await page.evaluate(() =>
+      document.body.style.getPropertyValue("--body-pad-v"),
+    );
+    expect(initialPad).toBe("1vh");
+
+    // Now update via API (triggers WS broadcast)
+    const settingsPage = await context.newPage();
+    await settingsPage.request.put(`${baseURL}/stage/appearance/worship-snv`, {
+      data: {
+        bodyPaddingV: 8.0,
+        bodyPaddingH: 2.0,
+        currentMaxFont: 120,
+        nextMaxFont: 80,
+        nextRatio: 0.8,
+        groupFontSize: 1.6,
+        lyricsGap: 0.5,
+        nextPaddingBottom: 2.0,
+        baseChars: 25,
+        minFont: 12,
+        playlistFontSize: 1.3,
+        playlistHeaderSize: 1.1,
+        playlistPadding: 1.0,
+        slidesPlaylistRatio: "7fr 3fr",
+      },
+    });
+
+    // Wait for WebSocket to propagate
+    await page.waitForTimeout(1000);
+
+    // Verify the stage display received the update
+    const updatedPad = await page.evaluate(() =>
+      document.body.style.getPropertyValue("--body-pad-v"),
+    );
+    expect(updatedPad).toBe("8vh");
+
+    await settingsPage.close();
+  });
+});


### PR DESCRIPTION
## Summary
- **Worship-PP layout redesign** with playlist sidebar showing numbered entries, active highlighting, and auto-scroll
- **Smart text scaling** using character-width measurement for dynamic font sizing across all worship layouts
- **Runtime stage appearance settings** at `/ui/stage-settings` with per-layout sliders for all visual parameters (font sizes, padding, spacing, scaling caps, playlist sizing)
- Settings persisted to DB and broadcast live via WebSocket — stage displays update instantly without refresh
- CI/deploy: migrate dev environment to 10.77.8.134 with separate deploy key

### Key changes
- `StageAppearance` struct with GET/PUT `/stage/appearance/{layout}` API
- `LiveEvent::StageAppearance` variant for real-time push
- Stage CSS uses CSS custom properties with fallbacks
- `smartScaleElement` reads from configurable `scalingConfig`
- Playlist sidebar with entry numbering, separator support, active state tracking
- New `StagePlaylistEntry` core type with playlist name propagation

## Test plan
- [x] All Rust unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] E2E: `stage-worship-pp.spec.ts` — playlist sidebar rendering, numbering, active state, separators
- [x] E2E: `stage-appearance.spec.ts` — settings page tabs, slider defaults, API persistence, save/reset, CSS var application, live WebSocket propagation
- [x] All 5 CI workflows green (CI, E2E, Version Check, Security, PR Automation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)