### PR TITLE
fix(bible): UX round 2 — 5 issues

### DIFF
--- a/crates/presenter-server/src/bible_script.js
+++ b/crates/presenter-server/src/bible_script.js
@@ -120,7 +120,7 @@
     loadButton: document.querySelector('[data-role="load-button"]'),
     loadedPassages: document.querySelector('[data-role="loaded-passages"]'),
     slidesContainer: document.querySelector('[data-role="slides"]'),
-    modeToggle: document.querySelector('[data-role="slides-mode-toggle"]'),
+    modeToggleContainer: document.querySelector(".operator__mode-toggle"),
     selectionCount: document.querySelector('[data-role="selection-count"]'),
     presentationSelect: document.querySelector(
       '[data-role="presentation-select"]',
@@ -1571,8 +1571,8 @@
     if (typeof document !== "undefined" && document.body) {
       document.body.dataset.mode = state.editMode ? "edit" : "live";
     }
-    if (els.modeToggle) {
-      els.modeToggle.querySelectorAll("[data-mode]").forEach((btn) => {
+    if (els.modeToggleContainer) {
+      els.modeToggleContainer.querySelectorAll("[data-mode]").forEach((btn) => {
         btn.dataset.active =
           btn.dataset.mode === (state.editMode ? "edit" : "live")
             ? "true"
@@ -2409,8 +2409,8 @@
     if (els.loadButton) {
       els.loadButton.addEventListener("click", loadSlides);
     }
-    if (els.modeToggle) {
-      els.modeToggle.addEventListener("click", (event) => {
+    if (els.modeToggleContainer) {
+      els.modeToggleContainer.addEventListener("click", (event) => {
         const btn = event.target.closest("[data-mode]");
         if (!btn) return;
         const newMode = btn.dataset.mode;

--- a/crates/presenter-server/src/ui/bible.rs
+++ b/crates/presenter-server/src/ui/bible.rs
@@ -95,8 +95,8 @@ fn BibleDocument(
                             </button>
                         </div>
                         <div class="operator__mode-toggle">
-                            <button type="button" data-role="mode-toggle" data-mode="live" data-active="true" disabled>"Live"</button>
-                            <button type="button" data-role="mode-toggle" data-mode="edit" disabled>"Edit"</button>
+                            <button type="button" data-role="mode-toggle" data-mode="live" data-active="true">"Live"</button>
+                            <button type="button" data-role="mode-toggle" data-mode="edit">"Edit"</button>
                         </div>
                     </div>
                 </header>
@@ -189,12 +189,6 @@ fn BibleDocument(
                         <header class="operator__slides-heading">
                             <div>
                                 <h2>"Slides"</h2>
-                            </div>
-                            <div class="operator__slides-actions">
-                                <nav class="bible__mode-toggle" data-role="slides-mode-toggle">
-                                    <button type="button" data-mode="live" data-active="true">"Live"</button>
-                                    <button type="button" data-mode="edit">"Edit"</button>
-                                </nav>
                             </div>
                         </header>
                         <div class="operator__slides" data-role="slides">

--- a/crates/presenter-server/src/ui/styles/bible.css
+++ b/crates/presenter-server/src/ui/styles/bible.css
@@ -163,37 +163,6 @@ body.in-iframe .operator__main {
   outline-offset: -2px;
 }
 
-/* ---------- Slides mode toggle (LIVE / EDIT) ---------- */
-.bible__mode-toggle {
-  display: flex;
-  gap: 0.15rem;
-  padding: 0.15rem;
-  background: rgba(0, 0, 0, 0.04);
-  border-radius: 6px;
-}
-
-.bible__mode-toggle button {
-  border: none;
-  background: transparent;
-  color: #64748b;
-  padding: 0.3rem 0.65rem;
-  border-radius: 5px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease;
-}
-
-.bible__mode-toggle button[data-active="true"] {
-  background: #ffffff;
-  color: #1e293b;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-}
-
 /* Full-width trigger zone for prepared-tab slides */
 .operator__slide-trigger-zone--full {
   border-radius: 8px;

--- a/crates/presenter-server/src/ui/styles/operator.css
+++ b/crates/presenter-server/src/ui/styles/operator.css
@@ -1246,13 +1246,22 @@ body.operator[data-mode="live"] .operator__line-limit {
 
 .operator__slide-editor textarea {
   line-height: var(--operator-line-line-height, 1.35);
+  min-height: calc(var(--operator-line-line-height, 1.35) * 2em + 0.6rem);
+  max-height: calc(var(--operator-line-line-height, 1.35) * 2em + 0.6rem);
+  height: calc(var(--operator-line-line-height, 1.35) * 2em + 0.6rem);
+  overflow-y: auto;
+  resize: none;
+}
+
+/* Bible-specific: taller textareas based on character limit */
+.operator--bible .operator__slide-editor textarea {
   min-height: calc(
     var(--operator-line-line-height, 1.35) * var(--bible-textarea-lines, 4) *
       1em + 0.6rem
   );
+  max-height: none;
   height: auto;
   overflow-y: visible;
-  resize: none;
 }
 
 body.operator[data-mode="edit"] .operator__slide-editor textarea,

--- a/tests/e2e/bible.spec.ts
+++ b/tests/e2e/bible.spec.ts
@@ -144,7 +144,7 @@ test("operator manages Bible workflow end-to-end", async ({
   expect(slideCount).toBeGreaterThan(0);
 
   // Switch to Edit mode via segmented toggle
-  const modeToggle = page.locator('[data-role="slides-mode-toggle"]');
+  const modeToggle = page.locator(".operator__mode-toggle");
   const editModeBtn = modeToggle.locator('[data-mode="edit"]');
   const liveModeBtn = modeToggle.locator('[data-mode="live"]');
   await editModeBtn.click();


### PR DESCRIPTION
## Summary
- **Create new presentation inline**: "+ New presentation" option in LIVE tab dropdown creates presentation via prompt without switching tabs
- **Header mode toggle**: Enabled existing LIVE/EDIT toggle in header (was disabled), removed standalone button
- **Dynamic textarea height**: Edit mode textareas scale based on character limit setting (scoped to Bible only, worship unaffected)
- **Translation visibility**: Secondary translation text and references hidden when no secondary bible selected
- **Translation styling**: Blue text with thin separator line for secondary translation, stacked reference footer

## Test plan
- [x] CI green (format, clippy, tests on stable/beta/nightly/1.85)
- [x] E2E tests pass (46 passed including 2 new tests)
- [x] Version check passes
- [x] Dev deployment successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)