### PR TITLE
ci(deploy): migrate production to new server 10.77.9.205

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,9 @@ env:
   CARGO_TERM_COLOR: always
   DEPLOY_DIR: /opt/presenter
   SERVICE_NAME: presenter
-  DEPLOY_HOST: 10.77.9.191
+  DEPLOY_HOST: 10.77.9.205
   DEPLOY_USER: newlevel
-  PRESENTER_LIBRARY_ROOT: /home/newlevel/devel/presenter/presenter-libraries
+  PRESENTER_LIBRARY_ROOT: /opt/presenter/libraries
 
 jobs:
   deploy:
@@ -85,7 +85,7 @@ jobs:
 
           echo "Importing ProPresenter libraries..."
           PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \
-            /opt/presenter/import_propresenter --root "/home/newlevel/devel/presenter/presenter-libraries"
+            /opt/presenter/import_propresenter --root "/opt/presenter/libraries"
 
           echo "Importing Bible translations..."
           PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ When a task is complete, **always** provide these links:
 
 - **Dev environment:** http://10.77.8.134:8080/ui/operator (verify healthy)
 - **PR to main:** GitHub PR URL (must be green and mergeable)
-- **Production environment:** http://10.77.9.191/ui/operator (verify healthy)
+- **Production environment:** http://10.77.9.205/ui/operator (verify healthy)
 
 ---
 
@@ -179,7 +179,7 @@ All workflows run on the Docker runners, providing:
 - 3 parallel runners for concurrent workflow execution
 - Reproducible environment (Docker image with Rust, Node.js, Playwright, Docker CLI)
 
-**Deploy workflows** use SSH to deploy binaries from runners to the application hosts (`10.77.9.191` for production, `10.77.8.134` for dev).
+**Deploy workflows** use SSH to deploy binaries from runners to the application hosts (`10.77.9.205` for production, `10.77.8.134` for dev).
 
 #### Runner Management
 
@@ -265,7 +265,7 @@ Two instances run on separate hosts:
 
 | Instance   | URL                     | Host        | Port | Service                 | Deploy Dir           | Branch |
 | ---------- | ----------------------- | ----------- | ---- | ----------------------- | -------------------- | ------ |
-| Production | http://10.77.9.191      | 10.77.9.191 | 80   | `presenter.service`     | `/opt/presenter`     | `main` |
+| Production | http://10.77.9.205      | 10.77.9.205 | 80   | `presenter.service`     | `/opt/presenter`     | `main` |
 | Dev        | http://10.77.8.134:8080 | 10.77.8.134 | 8080 | `presenter-dev.service` | `/opt/presenter-dev` | `dev`  |
 
 ```bash
@@ -511,14 +511,14 @@ cargo clippy --workspace --all-targets -- -D warnings -W clippy::all  # Must pas
 
 The user accesses the server from another machine on the same network. **Always provide LAN IP URLs, never localhost.**
 
-**Production LAN IP:** `10.77.9.191`
+**Production LAN IP:** `10.77.9.205`
 **Dev LAN IP:** `10.77.8.134`
 
 When providing URLs, use:
 
-- http://10.77.9.191/ui/operator (Production)
+- http://10.77.9.205/ui/operator (Production)
 - http://10.77.8.134:8080/ui/operator (Dev)
-- http://10.77.9.191/stage (Production stage)
+- http://10.77.9.205/stage (Production stage)
 - http://10.77.8.134:8080/stage (Dev stage)
 
 **Never use localhost** — always use the LAN IP.

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -14,7 +14,7 @@ RestartSec=5
 # Environment
 Environment=PRESENTER_PORT=80
 Environment=PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db
-Environment=PRESENTER_LIBRARY_ROOT=/home/newlevel/devel/presenter/presenter-libraries
+Environment=PRESENTER_LIBRARY_ROOT=/opt/presenter/libraries
 Environment=RUST_LOG=info,tower_http=debug
 
 # Security hardening - allow binding to port 80


### PR DESCRIPTION
## Summary
- Migrate production deploy workflow from old server (10.77.9.191) to new server (10.77.9.205) after disk-full crash
- Update `DEPLOY_HOST` and `PRESENTER_LIBRARY_ROOT` in deploy workflow and systemd service to use clean `/opt/presenter/libraries` layout
- Update all documentation references in CLAUDE.md

## Server Setup (already completed)
- SSH key auth configured on 10.77.9.205 (DEPLOY_SSH_KEY secret updated)
- Directory structure created: `/opt/presenter/{libraries,backups}`
- ProPresenter libraries copied to new server

## Test plan
- [x] All CI workflows green (CI, E2E, Version Check, Deploy Dev)
- [x] Dev environment healthy: http://10.77.8.134:8080/healthz
- [ ] Merge PR → deploy workflow deploys to 10.77.9.205
- [ ] Verify: `curl http://10.77.9.205/healthz`
- [ ] Verify UI: http://10.77.9.205/ui/operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)