### PR TITLE
ci(deploy): preserve database across deployments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,21 +75,37 @@ jobs:
             deploy-target:${{ env.DEPLOY_DIR }}/
           ssh deploy-target "chmod +x ${{ env.DEPLOY_DIR }}/presenter-server ${{ env.DEPLOY_DIR }}/import_propresenter ${{ env.DEPLOY_DIR }}/ingest_bibles"
 
-      - name: Import data (fresh database)
+      - name: Backup database
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'
           set -e
-          echo "Resetting database..."
-          rm -f /opt/presenter-dev/presenter.db /opt/presenter-dev/presenter.db-shm /opt/presenter-dev/presenter.db-wal
-          touch /opt/presenter-dev/presenter.db
+          DB_PATH="/opt/presenter-dev/presenter.db"
+          BACKUP_DIR="/opt/presenter-dev/backups"
+          mkdir -p "$BACKUP_DIR"
+          if [ -f "$DB_PATH" ] && [ -s "$DB_PATH" ]; then
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            cp "$DB_PATH" "${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+            echo "Database backed up to ${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+            ls -t "$BACKUP_DIR"/presenter-*.db 2>/dev/null | tail -n +6 | xargs -r rm --
+          else
+            echo "No existing database to back up"
+          fi
+          REMOTE_SCRIPT
 
-          echo "Importing ProPresenter libraries..."
-          PRESENTER_DB_URL=sqlite:///opt/presenter-dev/presenter.db \
-            /opt/presenter-dev/import_propresenter --root "/home/newlevel/devel/presenter/presenter-libraries"
-
-          echo "Importing Bible translations..."
-          PRESENTER_DB_URL=sqlite:///opt/presenter-dev/presenter.db \
-            /opt/presenter-dev/ingest_bibles
+      - name: Import data (first deploy only)
+        run: |
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          DB_PATH="/opt/presenter-dev/presenter.db"
+          if [ ! -f "$DB_PATH" ] || [ ! -s "$DB_PATH" ]; then
+            echo "First deploy detected - running initial import"
+            PRESENTER_DB_URL=sqlite:///opt/presenter-dev/presenter.db \
+              /opt/presenter-dev/import_propresenter --root "/home/newlevel/devel/presenter/presenter-libraries"
+            PRESENTER_DB_URL=sqlite:///opt/presenter-dev/presenter.db \
+              /opt/presenter-dev/ingest_bibles
+          else
+            echo "Existing database found - preserving user data"
+          fi
           REMOTE_SCRIPT
 
       - name: Deploy systemd service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,21 +75,37 @@ jobs:
             deploy-target:${{ env.DEPLOY_DIR }}/
           ssh deploy-target "chmod +x ${{ env.DEPLOY_DIR }}/presenter-server ${{ env.DEPLOY_DIR }}/import_propresenter ${{ env.DEPLOY_DIR }}/ingest_bibles"
 
-      - name: Import data (fresh database)
+      - name: Backup database
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'
           set -e
-          echo "Resetting database..."
-          rm -f /opt/presenter/presenter.db /opt/presenter/presenter.db-shm /opt/presenter/presenter.db-wal
-          touch /opt/presenter/presenter.db
+          DB_PATH="/opt/presenter/presenter.db"
+          BACKUP_DIR="/opt/presenter/backups"
+          mkdir -p "$BACKUP_DIR"
+          if [ -f "$DB_PATH" ] && [ -s "$DB_PATH" ]; then
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            cp "$DB_PATH" "${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+            echo "Database backed up to ${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+            ls -t "$BACKUP_DIR"/presenter-*.db 2>/dev/null | tail -n +6 | xargs -r rm --
+          else
+            echo "No existing database to back up"
+          fi
+          REMOTE_SCRIPT
 
-          echo "Importing ProPresenter libraries..."
-          PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \
-            /opt/presenter/import_propresenter --root "/opt/presenter/libraries"
-
-          echo "Importing Bible translations..."
-          PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \
-            /opt/presenter/ingest_bibles
+      - name: Import data (first deploy only)
+        run: |
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          DB_PATH="/opt/presenter/presenter.db"
+          if [ ! -f "$DB_PATH" ] || [ ! -s "$DB_PATH" ]; then
+            echo "First deploy detected - running initial import"
+            PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \
+              /opt/presenter/import_propresenter --root "/opt/presenter/libraries"
+            PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db \
+              /opt/presenter/ingest_bibles
+          else
+            echo "Existing database found - preserving user data"
+          fi
           REMOTE_SCRIPT
 
       - name: Deploy systemd service

--- a/.github/workflows/import-data.yml
+++ b/.github/workflows/import-data.yml
@@ -1,0 +1,134 @@
+name: Import Data
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          - production
+      import_type:
+        description: "What to import"
+        required: true
+        type: choice
+        options:
+          - all
+          - propresenter
+          - bibles
+      purge:
+        description: "Purge existing data before import (WARNING: destroys playlists)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: import-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  import:
+    name: Import Data (${{ inputs.environment }})
+    runs-on: self-hosted
+    steps:
+      - name: Set environment variables
+        id: env
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            echo "deploy_dir=/opt/presenter" >> "$GITHUB_OUTPUT"
+            echo "deploy_host=10.77.9.205" >> "$GITHUB_OUTPUT"
+            echo "service_name=presenter" >> "$GITHUB_OUTPUT"
+            echo "library_root=/opt/presenter/libraries" >> "$GITHUB_OUTPUT"
+            echo "ssh_key_secret=DEPLOY_SSH_KEY" >> "$GITHUB_OUTPUT"
+            echo "health_port=80" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_dir=/opt/presenter-dev" >> "$GITHUB_OUTPUT"
+            echo "deploy_host=10.77.8.134" >> "$GITHUB_OUTPUT"
+            echo "service_name=presenter-dev" >> "$GITHUB_OUTPUT"
+            echo "library_root=/home/newlevel/devel/presenter/presenter-libraries" >> "$GITHUB_OUTPUT"
+            echo "ssh_key_secret=DEPLOY_SSH_KEY_DEV" >> "$GITHUB_OUTPUT"
+            echo "health_port=8080" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_deploy
+          else
+            echo "${{ secrets.DEPLOY_SSH_KEY_DEV }}" > ~/.ssh/id_deploy
+          fi
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan ${{ steps.env.outputs.deploy_host }} >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<EOF
+          Host deploy-target
+              HostName ${{ steps.env.outputs.deploy_host }}
+              User newlevel
+              IdentityFile ~/.ssh/id_deploy
+          EOF
+
+      - name: Backup database
+        run: |
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          DB_PATH="${{ steps.env.outputs.deploy_dir }}/presenter.db"
+          BACKUP_DIR="${{ steps.env.outputs.deploy_dir }}/backups"
+          mkdir -p "$BACKUP_DIR"
+          if [ -f "$DB_PATH" ] && [ -s "$DB_PATH" ]; then
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            cp "$DB_PATH" "${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+            echo "Database backed up to ${BACKUP_DIR}/presenter-${TIMESTAMP}.db"
+          else
+            echo "No existing database to back up"
+          fi
+          REMOTE_SCRIPT
+
+      - name: Stop service
+        run: |
+          ssh deploy-target "if systemctl is-active --quiet ${{ steps.env.outputs.service_name }}; then sudo systemctl stop ${{ steps.env.outputs.service_name }}; echo 'Service stopped'; else echo 'Service not running'; fi"
+
+      - name: Import ProPresenter libraries
+        if: inputs.import_type == 'all' || inputs.import_type == 'propresenter'
+        run: |
+          KEEP_FLAG=""
+          if [ "${{ inputs.purge }}" != "true" ]; then
+            KEEP_FLAG="--keep"
+          fi
+          ssh deploy-target << REMOTE_SCRIPT
+          set -e
+          echo "Importing ProPresenter libraries (purge=${{ inputs.purge }})..."
+          PRESENTER_DB_URL=sqlite://${{ steps.env.outputs.deploy_dir }}/presenter.db \
+            ${{ steps.env.outputs.deploy_dir }}/import_propresenter \
+            --root "${{ steps.env.outputs.library_root }}" ${KEEP_FLAG}
+          REMOTE_SCRIPT
+
+      - name: Import Bible translations
+        if: inputs.import_type == 'all' || inputs.import_type == 'bibles'
+        run: |
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          echo "Importing Bible translations..."
+          PRESENTER_DB_URL=sqlite://${{ steps.env.outputs.deploy_dir }}/presenter.db \
+            ${{ steps.env.outputs.deploy_dir }}/ingest_bibles
+          REMOTE_SCRIPT
+
+      - name: Start service
+        run: |
+          ssh deploy-target "sudo systemctl start ${{ steps.env.outputs.service_name }}"
+
+      - name: Verify health
+        run: |
+          sleep 5
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          if systemctl is-active --quiet ${{ steps.env.outputs.service_name }}; then
+            echo "Service is running"
+            curl -sf http://localhost:${{ steps.env.outputs.health_port }}/healthz || echo "Warning: healthz check failed"
+          else
+            echo "Service failed to start"
+            sudo journalctl -u ${{ steps.env.outputs.service_name }} -n 50 --no-pager
+            exit 1
+          fi
+          REMOTE_SCRIPT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,15 +205,16 @@ docker compose down --timeout 5 && docker compose up -d
 
 ### Workflows
 
-| Workflow            | Trigger                   | Purpose                                         |
-| ------------------- | ------------------------- | ----------------------------------------------- |
-| `ci.yml`            | Push to `dev`/`main`, PRs | Format, lint, test, quality                     |
-| `e2e.yml`           | Push to `dev`/`main`, PRs | Playwright E2E tests                            |
-| `version-check.yml` | Push to `dev`/`main`, PRs | Validate version format                         |
-| `security.yml`      | Weekly + manual           | Vulnerability scanning                          |
-| `deploy-dev.yml`    | Push to `dev`             | Deploy dev binary via SSH to /opt/presenter-dev |
-| `deploy.yml`        | Push to `main`            | Deploy prod binary via SSH to /opt/presenter    |
-| `release.yml`       | GitHub Release published  | Build and upload release artifacts              |
+| Workflow            | Trigger                    | Purpose                                         |
+| ------------------- | -------------------------- | ----------------------------------------------- |
+| `ci.yml`            | Push to `dev`/`main`, PRs  | Format, lint, test, quality                     |
+| `e2e.yml`           | Push to `dev`/`main`, PRs  | Playwright E2E tests                            |
+| `version-check.yml` | Push to `dev`/`main`, PRs  | Validate version format                         |
+| `security.yml`      | Weekly + manual            | Vulnerability scanning                          |
+| `deploy-dev.yml`    | Push to `dev`              | Deploy dev binary via SSH to /opt/presenter-dev |
+| `deploy.yml`        | Push to `main`             | Deploy prod binary via SSH to /opt/presenter    |
+| `import-data.yml`   | Manual (workflow_dispatch) | Re-import ProPresenter/Bible data               |
+| `release.yml`       | GitHub Release published   | Build and upload release artifacts              |
 
 ### Monitoring CI
 
@@ -423,13 +424,31 @@ crates/
 
 ---
 
-## Database Policy (Pre-release)
+## Database Policy
+
+### Schema Changes (Pre-release)
 
 Schema is mutable during pre-release:
 
 1. **Never add incremental migrations** - Edit initial migration directly
-2. Rebuild SQLite from scratch after schema changes
-3. Keep `scripts/dev/refresh-dev-data.sh` up to date
+2. The server auto-migrates on startup via `Repository::connect()`
+3. For destructive schema changes, manually trigger the Import Data workflow after deploy
+
+### Deploy Safety
+
+- Deploys NEVER delete the database — only binaries and service files are updated
+- Database is backed up automatically before each deploy (5 retained in `backups/`)
+- First-time deploys auto-import; subsequent deploys preserve all user data
+- Data import is a separate, explicit "Import Data" workflow in GitHub Actions
+
+### Manual Import
+
+To re-import source data (ProPresenter libraries, Bibles):
+
+1. Go to Actions > "Import Data" > Run workflow
+2. Select environment (dev/production) and import type
+3. Default mode (`--keep`) preserves existing data
+4. `--purge` mode replaces all libraries (WARNING: destroys playlists via FK cascade)
 
 ---
 


### PR DESCRIPTION
## Summary

- Deploy workflows no longer wipe the SQLite database on every push — only binaries and service files are updated
- Database is automatically backed up before each deploy (5 most recent retained in `backups/`)
- First-time deploys still auto-import data; subsequent deploys preserve all user data (playlists, Bible preferences, timers, settings, favorites, stage state)
- New manual "Import Data" workflow (`workflow_dispatch`) allows explicit re-import with `--keep` (default) or `--purge` mode

## Test plan

- [x] CI green (all 4 workflows pass)
- [x] Dev deploy succeeded with new backup + conditional import steps
- [x] Dev environment healthy at http://10.77.8.134:8080/healthz
- [ ] Verify existing data preserved on dev: http://10.77.8.134:8080/ui/operator
- [ ] After merge, verify production deploy preserves data: http://10.77.9.205/ui/operator
- [ ] Test Import Data workflow on dev with `--keep` mode
- [ ] Verify backup files exist in `/opt/presenter-dev/backups/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)