### PR TITLE
fix(ui): bible clear button + settings token alignment

### DIFF
--- a/crates/presenter-server/src/operator_script.js
+++ b/crates/presenter-server/src/operator_script.js
@@ -3256,6 +3256,24 @@
     }
   }
 
+  async function clearActiveBible() {
+    if (state.clearingSlide) return;
+    state.clearingSlide = true;
+    updateClearSlideAvailability();
+    try {
+      await apiFetch("/bible/clear", { method: "POST" });
+      state.activeBibleBroadcast = null;
+      renderStageStatus();
+      showToast("Bible broadcast cleared", "success");
+    } catch (error) {
+      console.error("Failed to clear bible broadcast", error);
+      showToast("Failed to clear bible broadcast", "error");
+    } finally {
+      state.clearingSlide = false;
+      updateClearSlideAvailability();
+    }
+  }
+
   function saveSlide(presentationId, slideId, card) {
     if (!presentationId || !slideId || !card) return;
     const mainInput = card.querySelector('[data-field="main"]');
@@ -5112,7 +5130,11 @@
       event.preventDefault();
       event.stopPropagation();
     }
-    clearActiveSlide();
+    if (state.view === "bible") {
+      clearActiveBible();
+    } else {
+      clearActiveSlide();
+    }
   }
 
   function handleSlidesClick(event) {

--- a/crates/presenter-server/src/ui/components/settings.rs
+++ b/crates/presenter-server/src/ui/components/settings.rs
@@ -264,6 +264,10 @@ pub fn ResolumeConnectionsCard(
                         <dt>"#band-name"</dt>
                         <dd>"Displays the library/band the current song belongs to."</dd>
                     </div>
+                    <div>
+                        <dt>"Suffixes: -u / -re"</dt>
+                        <dd>"Append -u to force uppercase and -re to collapse multi-line text into a single space-delimited line."</dd>
+                    </div>
                 </dl>
             </section>
         </section>

--- a/crates/presenter-server/src/ui/styles/settings.css
+++ b/crates/presenter-server/src/ui/styles/settings.css
@@ -463,6 +463,10 @@ body.in-iframe.settings .settings__card {
   grid-template-columns: minmax(160px, auto) 1fr;
 }
 
+.settings__legend dl > div {
+  display: contents;
+}
+
 .settings__legend dt {
   font-weight: 600;
   color: #cbd5f5;


### PR DESCRIPTION
## Summary
- Clear (broom) button now dispatches to `/bible/clear` when in Bible mode, instead of always clearing the worship stage
- Added `clearActiveBible()` function that resets `state.activeBibleBroadcast` and shows appropriate toast
- Fixed settings Clip Tokens `<dl>` grid alignment by adding `display: contents` to `<div>` wrappers
- Added missing "Suffixes: -u / -re" entry to the clip tokens legend

## Test plan
- [ ] Switch to Bible mode, trigger a passage, click broom → Bible broadcast clears (not worship slide)
- [ ] Switch to Worship mode, trigger a slide, click broom → worship slide clears (unchanged behavior)
- [ ] Open Settings → Resolume → Clip Tokens shows clean two-column alignment
- [ ] Verify "Suffixes: -u / -re" row is visible in the legend

🤖 Generated with [Claude Code](https://claude.com/claude-code)