### PR TITLE
fix(timer): rework countdown UX after operator feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.10"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/timer.rs
+++ b/crates/presenter-core/src/timer.rs
@@ -95,23 +95,6 @@ impl CountdownTimer {
         Ok(())
     }
 
-    /// Sets a new target while preserving the current timer state (Running/Paused).
-    /// `set_target_with_now` resets to Idle; this wrapper re-applies the prior state.
-    pub fn set_target_preserving_state(
-        &mut self,
-        target: DateTime<Utc>,
-        now: DateTime<Utc>,
-    ) -> Result<(), TimerError> {
-        let previous_state = self.state;
-        self.set_target_with_now(target, now)?;
-        match previous_state {
-            TimerState::Running => self.start(),
-            TimerState::Paused => self.state = TimerState::Paused,
-            _ => {}
-        }
-        Ok(())
-    }
-
     pub fn remaining(&self, now: DateTime<Utc>) -> Duration {
         let delta = self.target - now;
         if delta <= Duration::zero() {
@@ -265,7 +248,10 @@ impl TimersState {
     ) -> Result<(), TimerError> {
         match command {
             TimerCommand::SetCountdownTarget { target } => {
-                self.countdown.set_target_preserving_state(*target, now)?;
+                self.countdown.set_target_with_now(*target, now)?;
+                // Auto-start: setting a countdown target always activates it,
+                // regardless of source (operator UI, Companion, etc).
+                self.countdown.start();
             }
             TimerCommand::SetCountdownTargetLocal { hours, minutes } => {
                 let time = NaiveTime::from_hms_opt(*hours, *minutes, 0)
@@ -283,14 +269,18 @@ impl TimersState {
                     candidate
                 };
                 let target_utc = target_local.with_timezone(&Utc);
-                self.countdown
-                    .set_target_preserving_state(target_utc, now)?;
+                self.countdown.set_target_with_now(target_utc, now)?;
+                // Auto-start: setting a wall-clock target always activates the
+                // countdown so the operator never needs a separate Start step.
+                self.countdown.start();
             }
             TimerCommand::AdjustCountdownTarget { offset_minutes } => {
                 let new_target =
                     self.countdown.target + Duration::minutes(i64::from(*offset_minutes));
-                self.countdown
-                    .set_target_preserving_state(new_target, now)?;
+                self.countdown.set_target_with_now(new_target, now)?;
+                // Auto-start: ±5 min adjustments always leave the countdown
+                // running, even if it was previously idle/paused.
+                self.countdown.start();
             }
             TimerCommand::StartCountdown => {
                 if self.countdown.target <= now {
@@ -564,7 +554,7 @@ mod tests {
     }
 
     #[test]
-    fn set_countdown_target_local_converts_to_utc() {
+    fn set_countdown_target_local_converts_to_utc_and_auto_starts() {
         let now = Utc::now();
         let mut state = TimersState::default(now);
         let future_hour = (chrono::Local::now().hour() + 2) % 24;
@@ -578,7 +568,8 @@ mod tests {
             )
             .unwrap();
         assert!(state.countdown.target > now);
-        assert_eq!(state.countdown.state, TimerState::Idle);
+        // Auto-start: setting a wall-clock target always activates the countdown.
+        assert_eq!(state.countdown.state, TimerState::Running);
     }
 
     #[test]
@@ -609,7 +600,8 @@ mod tests {
     }
 
     #[test]
-    fn set_countdown_target_local_preserves_running_state() {
+    fn set_countdown_target_local_keeps_running_when_already_running() {
+        // After auto-start, setting a new target while already running stays running.
         let now = Utc::now();
         let mut state = TimersState::default(now);
         state.countdown.start();
@@ -690,7 +682,23 @@ mod tests {
     }
 
     #[test]
-    fn adjust_countdown_target_preserves_running_state() {
+    fn adjust_countdown_target_auto_starts_from_idle() {
+        let now = Utc::now();
+        let mut state = TimersState::default(now);
+        // Confirm precondition: default state is idle.
+        assert_eq!(state.countdown.state, TimerState::Idle);
+        state
+            .apply_command(
+                &TimerCommand::AdjustCountdownTarget { offset_minutes: 5 },
+                now,
+            )
+            .unwrap();
+        // ±5 min should auto-start the countdown.
+        assert_eq!(state.countdown.state, TimerState::Running);
+    }
+
+    #[test]
+    fn adjust_countdown_target_keeps_running_when_already_running() {
         let now = Utc::now();
         let mut state = TimersState::default(now);
         state.countdown.start();

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/timer_panel.rs
+++ b/crates/presenter-ui/src/components/timer_panel.rs
@@ -397,27 +397,37 @@ fn parse_time_input(input: &str) -> Option<(u32, u32)> {
     Some((h, m))
 }
 
+/// Parse a duration input written by the operator for the preach limit.
+///
+/// Accepted forms:
+/// - `"5"`     → 300 seconds (bare number = minutes)
+/// - `"45"`    → 2700 seconds
+/// - `"1:30"`  → 5400 seconds (hours:minutes)
+/// - `"1:00"`  → 3600 seconds
+///
+/// Note: single numbers mean MINUTES here (not hour-of-day like
+/// `parse_time_input`), because preach-limit is a duration, not a
+/// wall-clock time.
+///
+/// Returns `None` for invalid input. Minutes must be 0–59.
 fn parse_limit_input(input: &str) -> Option<u64> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let parts: Vec<&str> = trimmed.split(':').collect();
-    match parts.len() {
-        1 => {
-            let mins: u64 = parts[0].parse().ok()?;
-            Some(mins * 60)
+
+    if let Some((h_str, m_str)) = trimmed.split_once(':') {
+        let h: u64 = h_str.trim().parse().ok()?;
+        let m: u64 = m_str.trim().parse().ok()?;
+        if m > 59 {
+            return None;
         }
-        2 => {
-            let h: u64 = parts[0].trim().parse().ok()?;
-            let m: u64 = parts[1].trim().parse().ok()?;
-            if m > 59 {
-                return None;
-            }
-            Some(h * 3600 + m * 60)
-        }
-        _ => None,
+        return Some(h * 3600 + m * 60);
     }
+
+    // Bare number = minutes.
+    let mins: u64 = trimmed.parse().ok()?;
+    Some(mins * 60)
 }
 
 #[cfg(test)]
@@ -479,5 +489,37 @@ mod tests {
     fn parse_time_input_trims_whitespace() {
         assert_eq!(parse_time_input("  18  "), Some((18, 0)));
         assert_eq!(parse_time_input(" 1915 "), Some((19, 15)));
+    }
+
+    #[test]
+    fn parse_limit_input_bare_number_is_minutes() {
+        assert_eq!(parse_limit_input("5"), Some(300));
+        assert_eq!(parse_limit_input("45"), Some(2700));
+        assert_eq!(parse_limit_input("0"), Some(0));
+        // Not capped at 59 because bare number is minutes, not minutes-of-hour.
+        assert_eq!(parse_limit_input("90"), Some(5400));
+    }
+
+    #[test]
+    fn parse_limit_input_with_colon_is_hours_minutes() {
+        assert_eq!(parse_limit_input("1:30"), Some(5400));
+        assert_eq!(parse_limit_input("0:45"), Some(2700));
+        assert_eq!(parse_limit_input("2:00"), Some(7200));
+    }
+
+    #[test]
+    fn parse_limit_input_rejects_invalid() {
+        assert_eq!(parse_limit_input(""), None);
+        assert_eq!(parse_limit_input("   "), None);
+        assert_eq!(parse_limit_input("abc"), None);
+        assert_eq!(parse_limit_input("1:60"), None); // minutes > 59
+        assert_eq!(parse_limit_input("1:ab"), None);
+        assert_eq!(parse_limit_input("1:"), None);
+    }
+
+    #[test]
+    fn parse_limit_input_trims_whitespace() {
+        assert_eq!(parse_limit_input("  5  "), Some(300));
+        assert_eq!(parse_limit_input(" 1:30 "), Some(5400));
     }
 }

--- a/crates/presenter-ui/src/components/timer_panel.rs
+++ b/crates/presenter-ui/src/components/timer_panel.rs
@@ -171,11 +171,14 @@ pub fn TimerPanel() -> impl IntoView {
             .origin()
             .unwrap_or_default();
         let url = format!("{origin}/overlays/timer");
-        let window = crate::utils::window::window();
-        let clipboard = window.navigator().clipboard();
-        let _ = clipboard.write_text(&url);
-        toast_variant.set("success".to_string());
-        toast_message.set(Some("Timer overlay URL copied".to_string()));
+        let copied = copy_to_clipboard(&url);
+        if copied {
+            toast_variant.set("success".to_string());
+            toast_message.set(Some("Timer overlay URL copied".to_string()));
+        } else {
+            toast_variant.set("error".to_string());
+            toast_message.set(Some(format!("Could not copy. URL: {url}")));
+        }
     };
 
     view! {
@@ -291,6 +294,58 @@ pub fn TimerPanel() -> impl IntoView {
             </div>
         </div>
     }
+}
+
+/// Copy `text` to the system clipboard. Returns `true` on success.
+///
+/// Uses the legacy `document.execCommand('copy')` path because
+/// `navigator.clipboard.writeText()` is only available in secure
+/// contexts (HTTPS or localhost). The operator UI is served over plain
+/// HTTP on the LAN, so the modern API is `undefined` there.
+///
+/// `execCommand` is deprecated in web-sys (gated behind an unstable
+/// feature flag), so we call it dynamically through js_sys::Reflect.
+fn copy_to_clipboard(text: &str) -> bool {
+    use js_sys::{Function, Reflect};
+    use wasm_bindgen::{JsCast, JsValue};
+
+    let Some(document) = crate::utils::window::window().document() else {
+        return false;
+    };
+    let Ok(element) = document.create_element("textarea") else {
+        return false;
+    };
+    let Ok(textarea) = element.dyn_into::<web_sys::HtmlTextAreaElement>() else {
+        return false;
+    };
+    textarea.set_value(text);
+    // Position off-screen so the page doesn't scroll or flash visibly.
+    let _ = textarea.set_attribute(
+        "style",
+        "position:fixed;left:-9999px;top:0;opacity:0;pointer-events:none;",
+    );
+    let _ = textarea.set_attribute("readonly", "");
+    let Some(body) = document.body() else {
+        return false;
+    };
+    if body.append_child(&textarea).is_err() {
+        return false;
+    }
+    let _ = textarea.focus();
+    textarea.select();
+
+    // document.execCommand("copy") via reflection (web-sys gates the
+    // direct binding behind an unstable_apis feature flag).
+    let copied = (|| -> Option<bool> {
+        let exec_command = Reflect::get(&document, &"execCommand".into()).ok()?;
+        let func = exec_command.dyn_into::<Function>().ok()?;
+        let result = func.call1(&document, &JsValue::from_str("copy")).ok()?;
+        result.as_bool()
+    })()
+    .unwrap_or(false);
+
+    let _ = body.remove_child(&textarea);
+    copied
 }
 
 /// Parse a time-of-day input written by the operator.

--- a/crates/presenter-ui/src/components/timer_panel.rs
+++ b/crates/presenter-ui/src/components/timer_panel.rs
@@ -30,18 +30,6 @@ pub fn TimerPanel() -> impl IntoView {
         });
     };
 
-    let on_countdown_start = move |_| {
-        send_timer_cmd(TimerCommand::StartCountdown);
-    };
-
-    let on_countdown_pause = move |_| {
-        send_timer_cmd(TimerCommand::PauseCountdown);
-    };
-
-    let on_countdown_reset = move |_| {
-        send_timer_cmd(TimerCommand::ResetCountdown);
-    };
-
     // Focus/blur tracking for countdown input
     let on_countdown_focus = {
         let countdown_input_active = op.countdown_input_active;
@@ -258,12 +246,13 @@ pub fn TimerPanel() -> impl IntoView {
                     />
                 </label>
                 <p class="operator__timer-help">
-                    "Type HH:MM (or minutes only) and press Enter or Set to update while the timer runs."
+                    "Type the service start time and press Enter. Examples: "
+                    <code>"18"</code>" → 18:00, "
+                    <code>"830"</code>" → 8:30, "
+                    <code>"1915"</code>" → 19:15, "
+                    <code>"18:30"</code>" → 18:30. Setting a target starts the countdown automatically."
                 </p>
                 <div class="operator__timer-buttons">
-                    <button type="button" data-role="countdown-start" on:click=on_countdown_start>"Start"</button>
-                    <button type="button" data-role="countdown-pause" on:click=on_countdown_pause>"Pause"</button>
-                    <button type="button" data-role="countdown-reset" on:click=on_countdown_reset>"Reset"</button>
                     <button type="button" data-role="countdown-offset-minus" on:click=on_offset_minus>"-5 min"</button>
                     <button type="button" data-role="countdown-offset-plus" on:click=on_offset_plus>"+5 min"</button>
                 </div>
@@ -304,32 +293,53 @@ pub fn TimerPanel() -> impl IntoView {
     }
 }
 
+/// Parse a time-of-day input written by the operator.
+///
+/// Accepted forms (alarm-clock convention):
+/// - `"18"`        → 18:00 (1–2 digits = hour-of-day, minutes = 0)
+/// - `"8"`         → 08:00
+/// - `"830"`       → 08:30 (3 digits = H:MM)
+/// - `"1915"`      → 19:15 (4 digits = HH:MM)
+/// - `"18:30"`     → 18:30 (with colon)
+/// - `"8:05"`      → 08:05
+///
+/// Returns `None` for invalid input. Hours must be 0–23, minutes 0–59.
 fn parse_time_input(input: &str) -> Option<(u32, u32)> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let parts: Vec<&str> = trimmed.split(':').collect();
 
-    match parts.len() {
-        1 => {
-            // Single number: interpret as hours (e.g. "18" → 18:00)
-            let hours: u32 = parts[0].parse().ok()?;
-            if hours > 23 {
-                return None;
-            }
-            Some((hours, 0))
+    // Form with explicit colon: "H:MM" or "HH:MM"
+    if let Some((h_str, m_str)) = trimmed.split_once(':') {
+        let h: u32 = h_str.trim().parse().ok()?;
+        let m: u32 = m_str.trim().parse().ok()?;
+        if h > 23 || m > 59 {
+            return None;
         }
-        2 => {
-            let h: u32 = parts[0].trim().parse().ok()?;
-            let m: u32 = parts[1].trim().parse().ok()?;
-            if h > 23 || m > 59 {
-                return None;
-            }
-            Some((h, m))
-        }
-        _ => None,
+        return Some((h, m));
     }
+
+    // Compact digit-only form: "H", "HH", "HMM", "HHMM"
+    if !trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let (h, m) = match trimmed.len() {
+        1 | 2 => (trimmed.parse::<u32>().ok()?, 0),
+        3 => (
+            trimmed[..1].parse::<u32>().ok()?,
+            trimmed[1..].parse::<u32>().ok()?,
+        ),
+        4 => (
+            trimmed[..2].parse::<u32>().ok()?,
+            trimmed[2..].parse::<u32>().ok()?,
+        ),
+        _ => return None,
+    };
+    if h > 23 || m > 59 {
+        return None;
+    }
+    Some((h, m))
 }
 
 fn parse_limit_input(input: &str) -> Option<u64> {
@@ -352,5 +362,67 @@ fn parse_limit_input(input: &str) -> Option<u64> {
             Some(h * 3600 + m * 60)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_time_input_single_digit_hour() {
+        assert_eq!(parse_time_input("8"), Some((8, 0)));
+        assert_eq!(parse_time_input("0"), Some((0, 0)));
+    }
+
+    #[test]
+    fn parse_time_input_two_digit_hour() {
+        assert_eq!(parse_time_input("18"), Some((18, 0)));
+        assert_eq!(parse_time_input("23"), Some((23, 0)));
+        assert_eq!(parse_time_input("08"), Some((8, 0)));
+    }
+
+    #[test]
+    fn parse_time_input_three_digit_compact() {
+        // 3-digit form: H + MM
+        assert_eq!(parse_time_input("830"), Some((8, 30)));
+        assert_eq!(parse_time_input("905"), Some((9, 5)));
+        assert_eq!(parse_time_input("100"), Some((1, 0)));
+    }
+
+    #[test]
+    fn parse_time_input_four_digit_compact() {
+        // 4-digit form: HH + MM
+        assert_eq!(parse_time_input("1915"), Some((19, 15)));
+        assert_eq!(parse_time_input("1830"), Some((18, 30)));
+        assert_eq!(parse_time_input("0800"), Some((8, 0)));
+        assert_eq!(parse_time_input("2359"), Some((23, 59)));
+    }
+
+    #[test]
+    fn parse_time_input_with_colon() {
+        assert_eq!(parse_time_input("18:30"), Some((18, 30)));
+        assert_eq!(parse_time_input("8:05"), Some((8, 5)));
+        assert_eq!(parse_time_input("0:00"), Some((0, 0)));
+    }
+
+    #[test]
+    fn parse_time_input_rejects_invalid() {
+        assert_eq!(parse_time_input(""), None);
+        assert_eq!(parse_time_input("   "), None);
+        assert_eq!(parse_time_input("abc"), None);
+        assert_eq!(parse_time_input("25"), None); // hour > 23
+        assert_eq!(parse_time_input("24:00"), None);
+        assert_eq!(parse_time_input("1860"), None); // 18:60 invalid minutes
+        assert_eq!(parse_time_input("12:60"), None);
+        assert_eq!(parse_time_input("99999"), None); // 5 digits
+        assert_eq!(parse_time_input("18:"), None);
+        assert_eq!(parse_time_input("18:ab"), None);
+    }
+
+    #[test]
+    fn parse_time_input_trims_whitespace() {
+        assert_eq!(parse_time_input("  18  "), Some((18, 0)));
+        assert_eq!(parse_time_input(" 1915 "), Some((19, 15)));
     }
 }

--- a/tests/e2e/wasm-timers.spec.ts
+++ b/tests/e2e/wasm-timers.spec.ts
@@ -100,27 +100,81 @@ test.describe("WASM Operator Timer Tests", () => {
     await expect(errorToast).not.toBeVisible();
   });
 
-  test("countdown start button toggles timer", async ({ page }) => {
+  test("setting countdown target auto-starts the countdown", async ({
+    page,
+    request,
+  }) => {
     await navigateToTimers(page);
 
-    const startButton = page.locator('[data-role="countdown-start"]');
-    await expect(startButton).toBeVisible();
+    // Pick an hour at least 2 hours in the future so the test is stable
+    // even when run near hour boundaries.
+    const futureHour = (new Date().getHours() + 2) % 24;
+    const compactInput = String(futureHour).padStart(2, "0") + "00";
 
-    await startButton.click();
+    const countdownInput = page.locator('[data-role="countdown-target-input"]');
+    await countdownInput.fill(compactInput);
+    await countdownInput.press("Enter");
 
-    // Wait for API response
-    await page
-      .waitForResponse(
-        (resp) => resp.url().includes("/timers/") && resp.status() === 200,
-        { timeout: 5_000 },
-      )
-      .catch(() => {});
+    // After auto-start, the API should report the countdown as Running
+    // (not Idle) and the target should match what we typed.
+    await expect(async () => {
+      const response = await request.get(
+        new URL("/timers/overview", baseURL).toString(),
+        { timeout: 10_000 },
+      );
+      const data = await response.json();
+      expect(data.countdownToStart.state).toBe("running");
+      expect(data.countdownToStart.targetLocal).toMatch(
+        new RegExp(`^${String(futureHour).padStart(2, "0")}:00:00$`),
+      );
+    }).toPass({ timeout: 10_000, intervals: [500] });
+  });
 
-    // Should not show error
-    const errorToast = page.locator(
-      '[data-role="toast"][data-variant="error"]',
-    );
-    await expect(errorToast).not.toBeVisible();
+  test("countdown HHMM compact form sets correct target", async ({
+    page,
+    request,
+  }) => {
+    await navigateToTimers(page);
+
+    // Use 4-digit compact form: 1915 → 19:15
+    const countdownInput = page.locator('[data-role="countdown-target-input"]');
+    await countdownInput.fill("1915");
+    await countdownInput.press("Enter");
+
+    await expect(async () => {
+      const response = await request.get(
+        new URL("/timers/overview", baseURL).toString(),
+        { timeout: 10_000 },
+      );
+      const data = await response.json();
+      expect(data.countdownToStart.targetLocal).toBe("19:15:00");
+      expect(data.countdownToStart.state).toBe("running");
+    }).toPass({ timeout: 10_000, intervals: [500] });
+  });
+
+  test("countdown panel does not show Start/Pause/Reset buttons", async ({
+    page,
+  }) => {
+    await navigateToTimers(page);
+
+    // These were removed because wall-clock countdowns don't need them.
+    await expect(
+      page.locator('[data-role="countdown-start"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-role="countdown-pause"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-role="countdown-reset"]'),
+    ).toHaveCount(0);
+
+    // ±5 buttons stay
+    await expect(
+      page.locator('[data-role="countdown-offset-minus"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-role="countdown-offset-plus"]'),
+    ).toBeVisible();
   });
 
   test("countdown offset minus decreases by 5 minutes", async ({ page }) => {

--- a/tests/e2e/wasm-timers.spec.ts
+++ b/tests/e2e/wasm-timers.spec.ts
@@ -253,15 +253,48 @@ test.describe("WASM Operator Timer Tests", () => {
     await newPage.close();
   });
 
-  test("timer overlay URL can be copied", async ({ page }) => {
+  test("timer overlay URL can be copied via execCommand on HTTP", async ({
+    page,
+  }) => {
+    // This test guards the fix for the operator HTTP clipboard bug.
+    //
+    // Background: navigator.clipboard is undefined on plain HTTP (LAN
+    // access), so the old code silently failed. The fix uses
+    // document.execCommand('copy') with a temporary textarea. The
+    // existing toast-only check was insufficient because the old
+    // broken code ALSO set a success toast — it just never put
+    // anything on the clipboard.
+    //
+    // We can't read the system clipboard from a non-secure context,
+    // so instead we intercept document.execCommand and capture the
+    // selected textarea value at the moment of the copy call.
+
     await navigateToTimers(page);
+
+    // Install a spy on document.execCommand BEFORE clicking. The spy
+    // records the selected text and the command name, then delegates
+    // to the original implementation so the real path runs end-to-end.
+    await page.evaluate(() => {
+      const captured: { command?: string; selectedText?: string } = {};
+      const original = document.execCommand.bind(document);
+      // @ts-expect-error attaching for test inspection
+      window.__execCommandSpy = captured;
+      document.execCommand = function (command: string, ...rest: unknown[]) {
+        captured.command = command;
+        const active = document.activeElement;
+        if (active && active instanceof HTMLTextAreaElement) {
+          captured.selectedText = active.value;
+        }
+        // @ts-expect-error forwarding rest args
+        return original(command, ...rest);
+      };
+    });
 
     const copyButton = page.locator('[data-role="timer-overlay-copy"]');
     await expect(copyButton).toBeVisible();
-
     await copyButton.click();
 
-    // Should show success toast
+    // Success toast must appear (existing assertion)
     await page.waitForFunction(
       () => {
         const toast = document.querySelector('[data-role="toast"]');
@@ -269,6 +302,22 @@ test.describe("WASM Operator Timer Tests", () => {
       },
       { timeout: 3_000 },
     );
+
+    // Toast must be the SUCCESS variant, not the error fallback.
+    const toastVariant = await page
+      .locator('[data-role="toast"]')
+      .getAttribute("data-variant");
+    expect(toastVariant).toBe("success");
+
+    // The spy must have observed execCommand('copy') with the correct
+    // URL in the textarea. This is the part that genuinely regression-
+    // guards the HTTP clipboard fix.
+    const spy = await page.evaluate(
+      // @ts-expect-error reading the spy installed above
+      () => window.__execCommandSpy,
+    );
+    expect(spy?.command).toBe("copy");
+    expect(spy?.selectedText).toMatch(/\/overlays\/timer$/);
   });
 
   test("preach limit input sets and clears limit", async ({


### PR DESCRIPTION
## Summary

Operator-reported timer issues after deploying v0.4.11, plus a clipboard regression discovered during testing:

### 1. Typing time wrong
- `1915` did nothing (parser only accepted `HH` or `HH:MM`)
- Help text said "minutes only" so the operator typed numbers expecting minutes-from-now
- Fix: `parse_time_input` handles the alarm-clock convention: `8` → 08:00, `18` → 18:00, `830` → 08:30, `1915` → 19:15, `18:30` → 18:30
- Help text rewritten with concrete inline examples

### 2. Pause / Reset / Start buttons removed
- They don't fit a wall-clock countdown (target time arrives whether you pause or not)
- Companion API still exposes the commands so external integrations are unaffected

### 3. Auto-start
- Setting any countdown target now always activates the countdown
- Operator never needs to click Start
- Applied consistently across operator UI and Companion command path

### 4. Copy Overlay URL button (added during review)
- Was silently failing on plain HTTP because navigator.clipboard is undefined outside secure contexts
- Fix: legacy document.execCommand('copy') path with off-screen textarea
- Called dynamically through js_sys::Reflect
- Reports error toast with URL if even the legacy path fails

### 5. Code review findings addressed
- parse_limit_input refactored to match the cleaner parse_time_input style
- E2E test for Copy URL now genuinely regression-guards the HTTP clipboard fix by intercepting document.execCommand and asserting the URL was actually selected

## Verified end-to-end on dev (v0.4.14)
- Typed 1915 -> target 19:15:00, state running
- Typed 830 -> target 08:30:00, state running
- Start/Pause/Reset buttons removed from DOM
- Copy Overlay URL -> success toast on HTTP
- 11 parser unit tests pass (7 time + 4 limit)
- All 26 timer core tests pass
- All 3 Playwright E2E shards pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
