### PR TITLE
feat: fully separate bible from worship (#231)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "async-trait",
  "sea-orm",
  "sea-orm-migration",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/bible/mod.rs
+++ b/crates/presenter-core/src/bible/mod.rs
@@ -1,4 +1,5 @@
 mod canonical;
+mod presentation;
 mod reference;
 mod search;
 mod translation;
@@ -6,6 +7,7 @@ mod translation;
 pub use canonical::{
     canonical_book_by_code, canonical_book_by_name, canonical_book_by_number, BibleBookCanonical,
 };
+pub use presentation::{BiblePresentation, BiblePresentationSummary, BibleSlide};
 pub use reference::{BibleReference, BibleReferenceError};
 pub use translation::{
     BibleBookChapterSummary, BibleBroadcast, BibleIngestionBatch, BibleIngestionError,

--- a/crates/presenter-core/src/bible/mod.rs
+++ b/crates/presenter-core/src/bible/mod.rs
@@ -7,7 +7,7 @@ mod translation;
 pub use canonical::{
     canonical_book_by_code, canonical_book_by_name, canonical_book_by_number, BibleBookCanonical,
 };
-pub use presentation::{BiblePresentation, BiblePresentationSummary, BibleSlide};
+pub use presentation::{BiblePresentation, BiblePresentationSlide, BiblePresentationSummary};
 pub use reference::{BibleReference, BibleReferenceError};
 pub use translation::{
     BibleBookChapterSummary, BibleBroadcast, BibleIngestionBatch, BibleIngestionError,

--- a/crates/presenter-core/src/bible/presentation.rs
+++ b/crates/presenter-core/src/bible/presentation.rs
@@ -10,14 +10,14 @@ use crate::slide::{BibleSlideMetadata, SlideText};
 pub struct BiblePresentation {
     pub id: BiblePresentationId,
     pub name: String,
-    pub slides: Vec<BibleSlide>,
+    pub slides: Vec<BiblePresentationSlide>,
     pub created_at: DateTime<Utc>,
 }
 
 /// A single bible slide within a `BiblePresentation`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BibleSlide {
+pub struct BiblePresentationSlide {
     pub id: BibleSlideId,
     pub order: u32,
     pub main: SlideText,
@@ -75,5 +75,35 @@ mod tests {
         let json = serde_json::to_string(&pres).unwrap();
         assert!(json.contains(r#""createdAt""#));
         assert!(!json.contains(r#""created_at""#));
+    }
+
+    #[test]
+    fn bible_presentation_slide_serialization_uses_camel_case() {
+        let slide = BiblePresentationSlide {
+            id: BibleSlideId::from_uuid(Uuid::nil()),
+            order: 0,
+            main: SlideText::new("text").unwrap(),
+            main_reference: "John 3:16".to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        };
+        let json = serde_json::to_string(&slide).unwrap();
+        assert!(
+            json.contains(r#""mainReference""#),
+            "expected mainReference in {json}"
+        );
+        assert!(
+            json.contains(r#""secondaryReference""#),
+            "expected secondaryReference in {json}"
+        );
+        assert!(
+            !json.contains(r#""main_reference""#),
+            "should NOT contain snake_case main_reference"
+        );
+        assert!(
+            !json.contains(r#""secondary_reference""#),
+            "should NOT contain snake_case secondary_reference"
+        );
     }
 }

--- a/crates/presenter-core/src/bible/presentation.rs
+++ b/crates/presenter-core/src/bible/presentation.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::id::{BiblePresentationId, BibleSlideId};
+use crate::slide::{BibleSlideMetadata, SlideText};
+
+/// A user-curated collection of bible slides (e.g., for a sermon series).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BiblePresentation {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slides: Vec<BibleSlide>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A single bible slide within a `BiblePresentation`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BibleSlide {
+    pub id: BibleSlideId,
+    pub order: u32,
+    pub main: SlideText,
+    pub main_reference: String,
+    pub secondary: SlideText,
+    pub secondary_reference: String,
+    pub metadata: Option<BibleSlideMetadata>,
+}
+
+/// Lightweight summary of a bible presentation for list views.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BiblePresentationSummary {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slide_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn bible_presentation_id_roundtrips_uuid() {
+        let original = Uuid::new_v4();
+        let id = BiblePresentationId::from_uuid(original);
+        assert_eq!(id.into_uuid(), original);
+    }
+
+    #[test]
+    fn bible_slide_id_roundtrips_uuid() {
+        let original = Uuid::new_v4();
+        let id = BibleSlideId::from_uuid(original);
+        assert_eq!(id.into_uuid(), original);
+    }
+
+    #[test]
+    fn bible_presentation_id_serializes_as_uuid_string() {
+        let id = BiblePresentationId::from_uuid(
+            Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap(),
+        );
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, r#""01234567-89ab-cdef-0123-456789abcdef""#);
+    }
+
+    #[test]
+    fn bible_presentation_serialization_uses_camel_case() {
+        let pres = BiblePresentation {
+            id: BiblePresentationId::from_uuid(Uuid::nil()),
+            name: "Test".to_string(),
+            slides: vec![],
+            created_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        };
+        let json = serde_json::to_string(&pres).unwrap();
+        assert!(json.contains(r#""createdAt""#));
+        assert!(!json.contains(r#""created_at""#));
+    }
+}

--- a/crates/presenter-core/src/id.rs
+++ b/crates/presenter-core/src/id.rs
@@ -44,3 +44,5 @@ id_type!(PlaylistEntryId);
 id_type!(ResolumeHostId);
 id_type!(AndroidStageDisplayId);
 id_type!(VideoSourceId);
+id_type!(BiblePresentationId);
+id_type!(BibleSlideId);

--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -5,6 +5,11 @@
 )]
 
 //! Core domain models for the Presenter application.
+//!
+//! # Naming convention
+//! - Unprefixed types (`Library`, `Presentation`, `Slide`, `SlideContent`) mean WORSHIP.
+//! - Bible-prefixed types (`BiblePresentation`, `BibleSlide`) mean BIBLE.
+//! - Bible has no library wrapper — there is exactly one bible per system.
 
 pub mod ableset;
 pub mod android_stage_display;
@@ -34,13 +39,13 @@ pub use android_stage_display::{
     DEFAULT_ADB_PORT, DEFAULT_LAUNCH_COMPONENT,
 };
 pub use bible::{
-    BibleBroadcast, BiblePassage, BiblePreferences, BiblePreferencesDraft, BibleReference,
-    BibleSlideOutput, BibleTranslation,
+    BibleBroadcast, BiblePassage, BiblePreferences, BiblePreferencesDraft, BiblePresentation,
+    BiblePresentationSummary, BibleReference, BibleSlide, BibleSlideOutput, BibleTranslation,
 };
 pub use feature_flags::FeatureFlags;
 pub use id::{
-    AndroidStageDisplayId, LibraryId, PlaylistEntryId, PlaylistId, PresentationId, ResolumeHostId,
-    SlideId, VideoSourceId,
+    AndroidStageDisplayId, BiblePresentationId, BibleSlideId, LibraryId, PlaylistEntryId,
+    PlaylistId, PresentationId, ResolumeHostId, SlideId, VideoSourceId,
 };
 pub use library::{Library, LibrarySummary, PresentationSummary};
 pub use live::{InboundMessage, LiveEvent};

--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Naming convention
 //! - Unprefixed types (`Library`, `Presentation`, `Slide`, `SlideContent`) mean WORSHIP.
-//! - Bible-prefixed types (`BiblePresentation`, `BibleSlide`) mean BIBLE.
+//! - Bible-prefixed types (`BiblePresentation`, `BiblePresentationSlide`) mean BIBLE.
 //! - Bible has no library wrapper — there is exactly one bible per system.
 
 pub mod ableset;
@@ -40,7 +40,8 @@ pub use android_stage_display::{
 };
 pub use bible::{
     BibleBroadcast, BiblePassage, BiblePreferences, BiblePreferencesDraft, BiblePresentation,
-    BiblePresentationSummary, BibleReference, BibleSlide, BibleSlideOutput, BibleTranslation,
+    BiblePresentationSlide, BiblePresentationSummary, BibleReference, BibleSlideOutput,
+    BibleTranslation,
 };
 pub use feature_flags::FeatureFlags;
 pub use id::{

--- a/crates/presenter-migration/Cargo.toml
+++ b/crates/presenter-migration/Cargo.toml
@@ -15,4 +15,5 @@ tracing.workspace = true
 [dev-dependencies]
 sea-orm.workspace = true
 sea-orm-migration.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -2,6 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20250927_000001_create_core_tables;
 mod m20260408_000001_add_preach_limit;
+mod m20260410_000001_separate_bible;
 
 pub struct Migrator;
 
@@ -10,6 +11,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20250927_000001_create_core_tables::Migration),
             Box::new(m20260408_000001_add_preach_limit::Migration),
+            Box::new(m20260410_000001_separate_bible::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260410_000001_separate_bible.rs
+++ b/crates/presenter-migration/src/m20260410_000001_separate_bible.rs
@@ -89,6 +89,12 @@ impl MigrationTrait for Migration {
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
 
+        // NOTE: The bible library row deleted in up() step 4 is NOT restored here.
+        // Any data that was cascade-deleted (presentations + slides under that
+        // library) is permanently gone. This rollback only undoes the schema
+        // changes — re-adds the dropped columns and the dead category column,
+        // then drops the new bible_presentations and bible_slides tables.
+
         // Re-add the dropped columns to slides (with empty defaults).
         for (col, sql_type) in [
             ("bible_main", "text NOT NULL DEFAULT ''"),
@@ -154,6 +160,7 @@ async fn column_exists(
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+    use sea_orm_migration::MigrationTrait;
 
     use crate::{Migrator, MigratorTrait};
 
@@ -228,8 +235,14 @@ mod tests {
     #[tokio::test]
     async fn migration_is_idempotent() {
         let db: DatabaseConnection = Database::connect("sqlite::memory:").await.unwrap();
-        // Run migrations twice — second run should succeed (tables already exist)
+        // First run via the framework (creates the seaql_migrations tracking table)
         Migrator::up(&db, None).await.unwrap();
-        Migrator::up(&db, None).await.unwrap();
+        // Second run: call our migration's up() directly to actually exercise
+        // the IF NOT EXISTS / column_exists guards. Without this bypass, the
+        // framework would skip the second run because the migration is already
+        // recorded as applied.
+        let migration = super::Migration;
+        let manager = sea_orm_migration::SchemaManager::new(&db);
+        migration.up(&manager).await.unwrap();
     }
 }

--- a/crates/presenter-migration/src/m20260410_000001_separate_bible.rs
+++ b/crates/presenter-migration/src/m20260410_000001_separate_bible.rs
@@ -1,0 +1,235 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // 1. Create bible_presentations table (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE TABLE IF NOT EXISTS "bible_presentations" (
+                "id" varchar(36) NOT NULL PRIMARY KEY,
+                "name" varchar NOT NULL,
+                "created_at" timestamp_with_timezone_text NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )"#,
+        ))
+        .await?;
+
+        // 2. Create bible_slides table (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE TABLE IF NOT EXISTS "bible_slides" (
+                "id" varchar(36) NOT NULL PRIMARY KEY,
+                "presentation_id" varchar(36) NOT NULL,
+                "slide_order" integer NOT NULL,
+                "main_text" text NOT NULL,
+                "main_search" text NOT NULL DEFAULT '',
+                "main_reference" text NOT NULL,
+                "secondary_text" text NOT NULL DEFAULT '',
+                "secondary_search" text NOT NULL DEFAULT '',
+                "secondary_reference" text NOT NULL DEFAULT '',
+                "metadata_json" text,
+                FOREIGN KEY ("presentation_id") REFERENCES "bible_presentations"("id") ON DELETE CASCADE
+            )"#,
+        ))
+        .await?;
+
+        // 3. Index on presentation_id for slide lookups (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE INDEX IF NOT EXISTS "idx_bible_slides_presentation_id"
+               ON "bible_slides" ("presentation_id")"#,
+        ))
+        .await?;
+
+        // 4. Delete any existing bible library row + cascade-delete its
+        //    presentations and slides. User explicitly confirmed this is OK.
+        //    SQLite cascades through the existing FKs.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DELETE FROM "libraries" WHERE LOWER("name") = 'bible'"#,
+        ))
+        .await?;
+
+        // 5. Drop the dead category column from libraries (guarded).
+        if column_exists(db, "libraries", "category").await? {
+            db.execute(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                r#"ALTER TABLE "libraries" DROP COLUMN "category""#,
+            ))
+            .await?;
+        }
+
+        // 6. Drop the bible_* columns and the metadata_json column from slides.
+        for col in [
+            "bible_main",
+            "bible_main_search",
+            "bible_main_reference",
+            "bible_translation",
+            "bible_translation_search",
+            "bible_translation_reference",
+            "metadata_json",
+        ] {
+            if column_exists(db, "slides", col).await? {
+                db.execute(sea_orm::Statement::from_string(
+                    sea_orm::DatabaseBackend::Sqlite,
+                    format!(r#"ALTER TABLE "slides" DROP COLUMN "{col}""#),
+                ))
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Re-add the dropped columns to slides (with empty defaults).
+        for (col, sql_type) in [
+            ("bible_main", "text NOT NULL DEFAULT ''"),
+            ("bible_main_search", "text NOT NULL DEFAULT ''"),
+            ("bible_main_reference", "text NOT NULL DEFAULT ''"),
+            ("bible_translation", "text NOT NULL DEFAULT ''"),
+            ("bible_translation_search", "text NOT NULL DEFAULT ''"),
+            ("bible_translation_reference", "text NOT NULL DEFAULT ''"),
+            ("metadata_json", "text"),
+        ] {
+            if !column_exists(db, "slides", col).await? {
+                db.execute(sea_orm::Statement::from_string(
+                    sea_orm::DatabaseBackend::Sqlite,
+                    format!(r#"ALTER TABLE "slides" ADD COLUMN "{col}" {sql_type}"#),
+                ))
+                .await?;
+            }
+        }
+
+        // Re-add the dead category column.
+        if !column_exists(db, "libraries", "category").await? {
+            db.execute(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                r#"ALTER TABLE "libraries" ADD COLUMN "category" varchar(32) NOT NULL DEFAULT 'worship'"#,
+            ))
+            .await?;
+        }
+
+        // Drop the new bible tables.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DROP TABLE IF EXISTS "bible_slides""#,
+        ))
+        .await?;
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DROP TABLE IF EXISTS "bible_presentations""#,
+        ))
+        .await?;
+
+        Ok(())
+    }
+}
+
+async fn column_exists(
+    db: &impl sea_orm::ConnectionTrait,
+    table: &str,
+    column: &str,
+) -> Result<bool, DbErr> {
+    let row = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            format!(
+                "SELECT COUNT(*) as cnt FROM pragma_table_info('{table}') WHERE name='{column}'"
+            ),
+        ))
+        .await?;
+    Ok(row
+        .map(|r| r.try_get::<i32>("", "cnt").unwrap_or(0) > 0)
+        .unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+
+    use crate::{Migrator, MigratorTrait};
+
+    #[tokio::test]
+    async fn migration_runs_on_fresh_db() {
+        let db: DatabaseConnection = Database::connect("sqlite::memory:").await.unwrap();
+        Migrator::up(&db, None).await.unwrap();
+
+        // Verify bible_presentations table exists
+        let result = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='bible_presentations'",
+            ))
+            .await
+            .unwrap();
+        assert!(result.is_some(), "bible_presentations table should exist");
+
+        // Verify bible_slides table exists
+        let result = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='bible_slides'",
+            ))
+            .await
+            .unwrap();
+        assert!(result.is_some(), "bible_slides table should exist");
+
+        // Verify bible_* columns are gone from slides
+        let count_row = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) as cnt FROM pragma_table_info('slides') WHERE name LIKE 'bible_%'",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let cnt: i32 = count_row.try_get("", "cnt").unwrap();
+        assert_eq!(cnt, 0, "bible_* columns should be dropped from slides");
+
+        // Verify category column is gone from libraries
+        let cat_row = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) as cnt FROM pragma_table_info('libraries') WHERE name='category'",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let cat_cnt: i32 = cat_row.try_get("", "cnt").unwrap();
+        assert_eq!(
+            cat_cnt, 0,
+            "category column should be dropped from libraries"
+        );
+
+        // Verify metadata_json is gone from slides
+        let meta_row = db
+            .query_one(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) as cnt FROM pragma_table_info('slides') WHERE name='metadata_json'",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let meta_cnt: i32 = meta_row.try_get("", "cnt").unwrap();
+        assert_eq!(
+            meta_cnt, 0,
+            "metadata_json column should be dropped from slides"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_is_idempotent() {
+        let db: DatabaseConnection = Database::connect("sqlite::memory:").await.unwrap();
+        // Run migrations twice — second run should succeed (tables already exist)
+        Migrator::up(&db, None).await.unwrap();
+        Migrator::up(&db, None).await.unwrap();
+    }
+}

--- a/crates/presenter-persistence/src/entities.rs
+++ b/crates/presenter-persistence/src/entities.rs
@@ -122,15 +122,7 @@ pub mod slide {
         pub worship_stage: String,
         pub worship_stage_search: String,
         pub worship_group: Option<String>,
-        // Bible columns
-        pub bible_main: String,
-        pub bible_main_search: String,
-        pub bible_translation: String,
-        pub bible_translation_search: String,
-        pub bible_main_reference: String,
-        pub bible_translation_reference: String,
         pub created_at: DateTimeWithTimeZone,
-        pub metadata_json: Option<String>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -405,8 +397,79 @@ pub mod bible_passage {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod bible_presentation {
+    use super::bible_slide;
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "bible_presentations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub name: String,
+        pub created_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(has_many = "bible_slide::Entity")]
+        Slides,
+    }
+
+    impl Related<bible_slide::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Slides.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod bible_slide {
+    use super::bible_presentation;
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "bible_slides")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub presentation_id: String,
+        pub slide_order: i32,
+        pub main_text: String,
+        pub main_search: String,
+        pub main_reference: String,
+        pub secondary_text: String,
+        pub secondary_search: String,
+        pub secondary_reference: String,
+        pub metadata_json: Option<String>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "bible_presentation::Entity",
+            from = "Column::PresentationId",
+            to = "bible_presentation::Column::Id",
+            on_update = "Cascade",
+            on_delete = "Cascade"
+        )]
+        Presentation,
+    }
+
+    impl Related<bible_presentation::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Presentation.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub use app_settings::Entity as AppSettingsEntity;
 pub use bible_passage::Entity as BiblePassageEntity;
+pub use bible_presentation::Entity as BiblePresentationEntity;
+pub use bible_slide::Entity as BibleSlideEntity;
 pub use bible_translation::Entity as BibleTranslationEntity;
 pub use library::Entity as LibraryEntity;
 pub use playlist::Entity as PlaylistEntity;

--- a/crates/presenter-persistence/src/repository/bible.rs
+++ b/crates/presenter-persistence/src/repository/bible.rs
@@ -371,18 +371,35 @@ impl Repository {
             .all(&self.db)
             .await?;
 
+        #[derive(FromQueryResult)]
+        struct CountRow {
+            presentation_id: String,
+            slide_count: i64,
+        }
+
+        let count_rows: Vec<CountRow> = bible_slide::Entity::find()
+            .select_only()
+            .column(bible_slide::Column::PresentationId)
+            .column_as(Expr::col(bible_slide::Column::Id).count(), "slide_count")
+            .group_by(bible_slide::Column::PresentationId)
+            .into_model::<CountRow>()
+            .all(&self.db)
+            .await?;
+
+        let counts: std::collections::HashMap<String, usize> = count_rows
+            .into_iter()
+            .map(|r| (r.presentation_id, r.slide_count as usize))
+            .collect();
+
         let mut summaries = Vec::with_capacity(presentations.len());
         for model in presentations {
-            let count = bible_slide::Entity::find()
-                .filter(bible_slide::Column::PresentationId.eq(model.id.clone()))
-                .count(&self.db)
-                .await?;
+            let slide_count = counts.get(&model.id).copied().unwrap_or(0);
             let uuid = Uuid::parse_str(&model.id)
                 .map_err(|_| RepositoryError::InvalidUuid(model.id.clone()))?;
             summaries.push(BiblePresentationSummary {
                 id: BiblePresentationId::from_uuid(uuid),
                 name: model.name,
-                slide_count: count as usize,
+                slide_count,
             });
         }
         Ok(summaries)
@@ -551,7 +568,20 @@ fn model_to_bible_slide(model: bible_slide::Model) -> anyhow::Result<BiblePresen
     let uuid =
         Uuid::parse_str(&model.id).map_err(|_| RepositoryError::InvalidUuid(model.id.clone()))?;
     let metadata = match model.metadata_json.as_deref() {
-        Some(raw) if !raw.trim().is_empty() => serde_json::from_str::<BibleSlideMetadata>(raw).ok(),
+        Some(raw) if !raw.trim().is_empty() => {
+            match serde_json::from_str::<BibleSlideMetadata>(raw) {
+                Ok(meta) => Some(meta),
+                Err(err) => {
+                    tracing::warn!(
+                        slide_id = %model.id,
+                        error = %err,
+                        raw = %raw,
+                        "failed to deserialize bible slide metadata, returning None"
+                    );
+                    None
+                }
+            }
+        }
         _ => None,
     };
     let main = SlideText::new(model.main_text).map_err(RepositoryError::from)?;
@@ -630,14 +660,31 @@ mod presentation_tests {
     }
 
     #[tokio::test]
-    async fn list_bible_presentation_summaries_returns_all() {
+    async fn list_bible_presentation_summaries_returns_all_with_correct_counts() {
         let repo = fresh_repo().await;
         repo.create_bible_presentation("Bravo").await.unwrap();
-        repo.create_bible_presentation("Alpha").await.unwrap();
+        let alpha = repo.create_bible_presentation("Alpha").await.unwrap();
+
+        let slide_a = sample_slide("First", "Gen 1:1");
+        let slide_b = BiblePresentationSlide {
+            id: BibleSlideId::new(),
+            order: 1,
+            main: SlideText::new("Second").unwrap(),
+            main_reference: "Gen 1:2".to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        };
+        repo.replace_bible_presentation_slides(alpha.id, &[slide_a, slide_b])
+            .await
+            .unwrap();
+
         let list = repo.list_bible_presentation_summaries().await.unwrap();
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].name, "Alpha");
+        assert_eq!(list[0].slide_count, 2);
         assert_eq!(list[1].name, "Bravo");
+        assert_eq!(list[1].slide_count, 0);
     }
 
     #[tokio::test]
@@ -650,11 +697,34 @@ mod presentation_tests {
     }
 
     #[tokio::test]
-    async fn delete_bible_presentation_removes_it() {
+    async fn delete_bible_presentation_removes_it_and_cascades_slides() {
+        use crate::entities::bible_slide;
+        use sea_orm::{EntityTrait, PaginatorTrait, QueryFilter};
+
         let repo = fresh_repo().await;
         let p = repo.create_bible_presentation("Doomed").await.unwrap();
+        let slide = sample_slide("text", "Ref");
+        repo.replace_bible_presentation_slides(p.id, &[slide])
+            .await
+            .unwrap();
+
+        let count_before = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(p.id.to_string()))
+            .count(&repo.db)
+            .await
+            .unwrap();
+        assert_eq!(count_before, 1);
+
         repo.delete_bible_presentation(p.id).await.unwrap();
+
         assert!(repo.fetch_bible_presentation(p.id).await.unwrap().is_none());
+
+        let count_after = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(p.id.to_string()))
+            .count(&repo.db)
+            .await
+            .unwrap();
+        assert_eq!(count_after, 0, "FK cascade should have removed the slide");
     }
 
     #[tokio::test]

--- a/crates/presenter-persistence/src/repository/bible.rs
+++ b/crates/presenter-persistence/src/repository/bible.rs
@@ -747,6 +747,54 @@ mod presentation_tests {
     }
 
     #[tokio::test]
+    async fn bible_slide_metadata_round_trips_through_replace_and_fetch() {
+        use presenter_core::slide::{BibleSlideMetadata, BibleSlideVerseRef};
+
+        let repo = fresh_repo().await;
+        let p = repo
+            .create_bible_presentation("Metadata Test")
+            .await
+            .unwrap();
+
+        let metadata = BibleSlideMetadata {
+            translation_code: "en-kjv".to_string(),
+            secondary_translation_code: Some("sk-sevp".to_string()),
+            book: "John".to_string(),
+            book_code: Some("JHN".to_string()),
+            book_number: Some(43),
+            chapter: 3,
+            verses: vec![
+                BibleSlideVerseRef::new(16, 16),
+                BibleSlideVerseRef::new(17, 17),
+            ],
+            main_reference_label: Some("John 3:16-17".to_string()),
+            translation_reference_label: Some("Ján 3:16-17".to_string()),
+        };
+
+        let slide = BiblePresentationSlide {
+            id: BibleSlideId::new(),
+            order: 0,
+            main: SlideText::new("For God so loved the world").unwrap(),
+            main_reference: "John 3:16-17".to_string(),
+            secondary: SlideText::new("Lebo tak Boh miloval svet").unwrap(),
+            secondary_reference: "Ján 3:16-17".to_string(),
+            metadata: Some(metadata.clone()),
+        };
+
+        repo.replace_bible_presentation_slides(p.id, std::slice::from_ref(&slide))
+            .await
+            .unwrap();
+
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert_eq!(fetched.slides.len(), 1);
+        let fetched_slide = &fetched.slides[0];
+        assert_eq!(fetched_slide.metadata, Some(metadata));
+        assert_eq!(fetched_slide.main.value(), "For God so loved the world");
+        assert_eq!(fetched_slide.main_reference, "John 3:16-17");
+        assert_eq!(fetched_slide.secondary_reference, "Ján 3:16-17");
+    }
+
+    #[tokio::test]
     async fn append_bible_slides_preserves_order() {
         let repo = fresh_repo().await;
         let p = repo.create_bible_presentation("Test").await.unwrap();

--- a/crates/presenter-persistence/src/repository/bible.rs
+++ b/crates/presenter-persistence/src/repository/bible.rs
@@ -1,19 +1,25 @@
+use anyhow::anyhow;
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
-    TransactionTrait,
+    sea_query::Expr as SeaExpr, ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, TransactionTrait,
 };
 use tracing::instrument;
 
-use crate::entities::{bible_passage, bible_translation};
+use crate::entities::{bible_passage, bible_presentation, bible_slide, bible_translation};
 use presenter_core::{
     bible::{canonical_book_by_name, BibleIngestionBatch},
-    BiblePassage, BibleReference, BibleTranslation,
+    search::fold_query,
+    slide::BibleSlideMetadata,
+    BiblePassage, BiblePresentation, BiblePresentationId, BiblePresentationSlide,
+    BiblePresentationSummary, BibleReference, BibleSlideId, BibleTranslation, SlideText,
 };
 use sea_orm::Set;
+use uuid::Uuid;
 
 use super::util::{
-    sanitize_like_input, to_domain_passage, to_domain_translation, BIBLE_INSERT_CHUNK,
+    sanitize_like_input, to_domain_passage, to_domain_translation, RepositoryError,
+    BIBLE_INSERT_CHUNK,
 };
 use super::Repository;
 
@@ -352,5 +358,341 @@ impl Repository {
             .exec(&self.db)
             .await?;
         Ok(result.rows_affected)
+    }
+
+    // ── Bible presentations ────────────────────────────────────────
+
+    #[instrument(skip_all)]
+    pub async fn list_bible_presentation_summaries(
+        &self,
+    ) -> anyhow::Result<Vec<BiblePresentationSummary>> {
+        let presentations = bible_presentation::Entity::find()
+            .order_by_asc(bible_presentation::Column::Name)
+            .all(&self.db)
+            .await?;
+
+        let mut summaries = Vec::with_capacity(presentations.len());
+        for model in presentations {
+            let count = bible_slide::Entity::find()
+                .filter(bible_slide::Column::PresentationId.eq(model.id.clone()))
+                .count(&self.db)
+                .await?;
+            let uuid = Uuid::parse_str(&model.id)
+                .map_err(|_| RepositoryError::InvalidUuid(model.id.clone()))?;
+            summaries.push(BiblePresentationSummary {
+                id: BiblePresentationId::from_uuid(uuid),
+                name: model.name,
+                slide_count: count as usize,
+            });
+        }
+        Ok(summaries)
+    }
+
+    #[instrument(skip_all)]
+    pub async fn fetch_bible_presentation(
+        &self,
+        id: BiblePresentationId,
+    ) -> anyhow::Result<Option<BiblePresentation>> {
+        let id_str = id.to_string();
+        let Some(model) = bible_presentation::Entity::find_by_id(id_str.clone())
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let slide_models = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(id_str))
+            .order_by_asc(bible_slide::Column::SlideOrder)
+            .all(&self.db)
+            .await?;
+
+        let mut slides = Vec::with_capacity(slide_models.len());
+        for slide_model in slide_models {
+            slides.push(model_to_bible_slide(slide_model)?);
+        }
+
+        Ok(Some(BiblePresentation {
+            id,
+            name: model.name,
+            slides,
+            created_at: model.created_at.into(),
+        }))
+    }
+
+    #[instrument(skip_all)]
+    pub async fn create_bible_presentation(&self, name: &str) -> anyhow::Result<BiblePresentation> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("bible presentation name cannot be empty"));
+        }
+        let id = BiblePresentationId::new();
+        let now = Utc::now();
+        let active = bible_presentation::ActiveModel {
+            id: Set(id.to_string()),
+            name: Set(trimmed.to_string()),
+            created_at: Set(now.into()),
+        };
+        bible_presentation::Entity::insert(active)
+            .exec(&self.db)
+            .await?;
+
+        Ok(BiblePresentation {
+            id,
+            name: trimmed.to_string(),
+            slides: Vec::new(),
+            created_at: now,
+        })
+    }
+
+    #[instrument(skip_all)]
+    pub async fn rename_bible_presentation(
+        &self,
+        id: BiblePresentationId,
+        name: &str,
+    ) -> anyhow::Result<()> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("bible presentation name cannot be empty"));
+        }
+        let result = bible_presentation::Entity::update_many()
+            .col_expr(bible_presentation::Column::Name, SeaExpr::value(trimmed))
+            .filter(bible_presentation::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+        if result.rows_affected == 0 {
+            return Err(anyhow!("bible presentation not found"));
+        }
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn delete_bible_presentation(&self, id: BiblePresentationId) -> anyhow::Result<()> {
+        let result = bible_presentation::Entity::delete_by_id(id.to_string())
+            .exec(&self.db)
+            .await?;
+        if result.rows_affected == 0 {
+            return Err(anyhow!("bible presentation not found"));
+        }
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn replace_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BiblePresentationSlide],
+    ) -> anyhow::Result<()> {
+        let id_str = id.to_string();
+        let txn = self.db.begin().await?;
+
+        if bible_presentation::Entity::find_by_id(id_str.clone())
+            .one(&txn)
+            .await?
+            .is_none()
+        {
+            return Err(anyhow!("bible presentation not found"));
+        }
+
+        bible_slide::Entity::delete_many()
+            .filter(bible_slide::Column::PresentationId.eq(id_str.clone()))
+            .exec(&txn)
+            .await?;
+
+        for (index, slide) in slides.iter().enumerate() {
+            let mut normalized = slide.clone();
+            normalized.order = index as u32;
+            let active = bible_slide_to_active_model(&normalized, &id_str)?;
+            bible_slide::Entity::insert(active).exec(&txn).await?;
+        }
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn append_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BiblePresentationSlide],
+    ) -> anyhow::Result<BiblePresentation> {
+        let id_str = id.to_string();
+        let txn = self.db.begin().await?;
+
+        if bible_presentation::Entity::find_by_id(id_str.clone())
+            .one(&txn)
+            .await?
+            .is_none()
+        {
+            return Err(anyhow!("bible presentation not found"));
+        }
+
+        let existing_count = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(id_str.clone()))
+            .count(&txn)
+            .await? as u32;
+
+        for (index, slide) in slides.iter().enumerate() {
+            let mut normalized = slide.clone();
+            normalized.order = existing_count + index as u32;
+            let active = bible_slide_to_active_model(&normalized, &id_str)?;
+            bible_slide::Entity::insert(active).exec(&txn).await?;
+        }
+
+        txn.commit().await?;
+
+        self.fetch_bible_presentation(id)
+            .await?
+            .ok_or_else(|| anyhow!("bible presentation disappeared after append"))
+    }
+}
+
+fn model_to_bible_slide(model: bible_slide::Model) -> anyhow::Result<BiblePresentationSlide> {
+    let uuid =
+        Uuid::parse_str(&model.id).map_err(|_| RepositoryError::InvalidUuid(model.id.clone()))?;
+    let metadata = match model.metadata_json.as_deref() {
+        Some(raw) if !raw.trim().is_empty() => serde_json::from_str::<BibleSlideMetadata>(raw).ok(),
+        _ => None,
+    };
+    let main = SlideText::new(model.main_text).map_err(RepositoryError::from)?;
+    let secondary = SlideText::new(model.secondary_text).map_err(RepositoryError::from)?;
+    Ok(BiblePresentationSlide {
+        id: BibleSlideId::from_uuid(uuid),
+        order: model.slide_order.max(0) as u32,
+        main,
+        main_reference: model.main_reference,
+        secondary,
+        secondary_reference: model.secondary_reference,
+        metadata,
+    })
+}
+
+fn bible_slide_to_active_model(
+    slide: &BiblePresentationSlide,
+    presentation_id: &str,
+) -> anyhow::Result<bible_slide::ActiveModel> {
+    let metadata_json = match slide.metadata.as_ref() {
+        Some(meta) => Some(serde_json::to_string(meta)?),
+        None => None,
+    };
+    Ok(bible_slide::ActiveModel {
+        id: Set(slide.id.to_string()),
+        presentation_id: Set(presentation_id.to_string()),
+        slide_order: Set(slide.order as i32),
+        main_text: Set(slide.main.value().to_owned()),
+        main_search: Set(fold_query(slide.main.value())),
+        main_reference: Set(slide.main_reference.clone()),
+        secondary_text: Set(slide.secondary.value().to_owned()),
+        secondary_search: Set(fold_query(slide.secondary.value())),
+        secondary_reference: Set(slide.secondary_reference.clone()),
+        metadata_json: Set(metadata_json),
+    })
+}
+
+#[cfg(test)]
+mod presentation_tests {
+    use super::*;
+    use crate::repository::Repository;
+    use presenter_core::SlideText;
+
+    async fn fresh_repo() -> Repository {
+        Repository::connect_in_memory()
+            .await
+            .expect("in-memory repo")
+    }
+
+    fn sample_slide(main: &str, reference: &str) -> BiblePresentationSlide {
+        BiblePresentationSlide {
+            id: BibleSlideId::new(),
+            order: 0,
+            main: SlideText::new(main).unwrap(),
+            main_reference: reference.to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_and_fetch_bible_presentation() {
+        let repo = fresh_repo().await;
+        let created = repo.create_bible_presentation("My Sermon").await.unwrap();
+        assert_eq!(created.name, "My Sermon");
+        assert!(created.slides.is_empty());
+
+        let fetched = repo
+            .fetch_bible_presentation(created.id)
+            .await
+            .unwrap()
+            .expect("should exist");
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.name, "My Sermon");
+    }
+
+    #[tokio::test]
+    async fn list_bible_presentation_summaries_returns_all() {
+        let repo = fresh_repo().await;
+        repo.create_bible_presentation("Bravo").await.unwrap();
+        repo.create_bible_presentation("Alpha").await.unwrap();
+        let list = repo.list_bible_presentation_summaries().await.unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "Alpha");
+        assert_eq!(list[1].name, "Bravo");
+    }
+
+    #[tokio::test]
+    async fn rename_bible_presentation_updates_name() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Old").await.unwrap();
+        repo.rename_bible_presentation(p.id, "New").await.unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert_eq!(fetched.name, "New");
+    }
+
+    #[tokio::test]
+    async fn delete_bible_presentation_removes_it() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Doomed").await.unwrap();
+        repo.delete_bible_presentation(p.id).await.unwrap();
+        assert!(repo.fetch_bible_presentation(p.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn replace_bible_slides_overwrites_existing() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Test").await.unwrap();
+        let slide = sample_slide("For God so loved the world", "John 3:16");
+        repo.replace_bible_presentation_slides(p.id, &[slide])
+            .await
+            .unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert_eq!(fetched.slides.len(), 1);
+        assert_eq!(fetched.slides[0].main_reference, "John 3:16");
+
+        repo.replace_bible_presentation_slides(p.id, &[])
+            .await
+            .unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert!(fetched.slides.is_empty());
+    }
+
+    #[tokio::test]
+    async fn append_bible_slides_preserves_order() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Test").await.unwrap();
+        let slide_a = sample_slide("First", "Gen 1:1");
+        let slide_b = sample_slide("Second", "Gen 1:2");
+        repo.append_bible_presentation_slides(p.id, &[slide_a])
+            .await
+            .unwrap();
+        let result = repo
+            .append_bible_presentation_slides(p.id, &[slide_b])
+            .await
+            .unwrap();
+        assert_eq!(result.slides.len(), 2);
+        assert_eq!(result.slides[0].order, 0);
+        assert_eq!(result.slides[1].order, 1);
+        assert_eq!(result.slides[0].main_reference, "Gen 1:1");
+        assert_eq!(result.slides[1].main_reference, "Gen 1:2");
     }
 }

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -40,7 +40,7 @@ const OSC_SETTINGS_SINGLETON_ID: &str = "osc";
 const ABLESET_SETTINGS_SINGLETON_ID: &str = "ableset";
 #[derive(Debug, Clone)]
 pub struct Repository {
-    db: DatabaseConnection,
+    pub(crate) db: DatabaseConnection,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -231,89 +231,43 @@ impl Repository {
         presentation_id: PresentationId,
         slide_id: SlideId,
         content: &SlideContent,
-        metadata: Option<&presenter_core::slide::SlideMetadata>,
+        _metadata: Option<&presenter_core::slide::SlideMetadata>,
     ) -> anyhow::Result<()> {
-        let is_bible = metadata.and_then(|m| m.bible.as_ref()).is_some();
-        let metadata_json = metadata.map(|m| serde_json::to_string(m)).transpose()?;
-
-        let result = if is_bible {
-            slide_entity::Entity::update_many()
-                .col_expr(
-                    slide_entity::Column::BibleMain,
-                    Expr::value(content.main.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::BibleMainSearch,
-                    Expr::value(fold_query(content.main.value())),
-                )
-                .col_expr(
-                    slide_entity::Column::BibleTranslation,
-                    Expr::value(content.translation.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::BibleTranslationSearch,
-                    Expr::value(fold_query(content.translation.value())),
-                )
-                .col_expr(
-                    slide_entity::Column::BibleMainReference,
-                    Expr::value(content.stage.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::BibleTranslationReference,
-                    Expr::value(
-                        metadata
-                            .and_then(|m| m.bible.as_ref())
-                            .and_then(|b| b.translation_reference_label.clone())
-                            .unwrap_or_default(),
-                    ),
-                )
-                .col_expr(
-                    slide_entity::Column::MetadataJson,
-                    Expr::value(metadata_json),
-                )
-                .filter(slide_entity::Column::Id.eq(slide_id.to_string()))
-                .filter(slide_entity::Column::PresentationId.eq(presentation_id.to_string()))
-                .exec(&self.db)
-                .await?
-        } else {
-            slide_entity::Entity::update_many()
-                .col_expr(
-                    slide_entity::Column::WorshipMain,
-                    Expr::value(content.main.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipMainSearch,
-                    Expr::value(fold_query(content.main.value())),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipTranslate,
-                    Expr::value(content.translation.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipTranslateSearch,
-                    Expr::value(fold_query(content.translation.value())),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipStage,
-                    Expr::value(content.stage.value().to_owned()),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipStageSearch,
-                    Expr::value(fold_query(content.stage.value())),
-                )
-                .col_expr(
-                    slide_entity::Column::WorshipGroup,
-                    Expr::value(content.group.as_ref().map(|group| group.name().to_owned())),
-                )
-                .col_expr(
-                    slide_entity::Column::MetadataJson,
-                    Expr::value(metadata_json),
-                )
-                .filter(slide_entity::Column::Id.eq(slide_id.to_string()))
-                .filter(slide_entity::Column::PresentationId.eq(presentation_id.to_string()))
-                .exec(&self.db)
-                .await?
-        };
+        // Worship slides no longer carry metadata — bible slides live in a separate table.
+        // The metadata parameter is accepted for API compatibility but ignored.
+        let result = slide_entity::Entity::update_many()
+            .col_expr(
+                slide_entity::Column::WorshipMain,
+                Expr::value(content.main.value().to_owned()),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipMainSearch,
+                Expr::value(fold_query(content.main.value())),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipTranslate,
+                Expr::value(content.translation.value().to_owned()),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipTranslateSearch,
+                Expr::value(fold_query(content.translation.value())),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipStage,
+                Expr::value(content.stage.value().to_owned()),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipStageSearch,
+                Expr::value(fold_query(content.stage.value())),
+            )
+            .col_expr(
+                slide_entity::Column::WorshipGroup,
+                Expr::value(content.group.as_ref().map(|group| group.name().to_owned())),
+            )
+            .filter(slide_entity::Column::Id.eq(slide_id.to_string()))
+            .filter(slide_entity::Column::PresentationId.eq(presentation_id.to_string()))
+            .exec(&self.db)
+            .await?;
 
         if result.rows_affected == 0 {
             return Err(anyhow!(

--- a/crates/presenter-persistence/src/repository/search.rs
+++ b/crates/presenter-persistence/src/repository/search.rs
@@ -249,9 +249,7 @@ impl Repository {
             slide_condition = slide_condition
                 .add(slide_entity::Column::WorshipMain.contains(&ctx.trimmed))
                 .add(slide_entity::Column::WorshipTranslate.contains(&ctx.trimmed))
-                .add(slide_entity::Column::WorshipStage.contains(&ctx.trimmed))
-                .add(slide_entity::Column::BibleMain.contains(&ctx.trimmed))
-                .add(slide_entity::Column::BibleTranslation.contains(&ctx.trimmed));
+                .add(slide_entity::Column::WorshipStage.contains(&ctx.trimmed));
         }
         if ctx.has_tokens {
             let mut token_condition = Condition::all();
@@ -259,9 +257,7 @@ impl Repository {
                 let per_token = Condition::any()
                     .add(slide_entity::Column::WorshipMainSearch.contains(token.clone()))
                     .add(slide_entity::Column::WorshipTranslateSearch.contains(token.clone()))
-                    .add(slide_entity::Column::WorshipStageSearch.contains(token.clone()))
-                    .add(slide_entity::Column::BibleMainSearch.contains(token.clone()))
-                    .add(slide_entity::Column::BibleTranslationSearch.contains(token.clone()));
+                    .add(slide_entity::Column::WorshipStageSearch.contains(token.clone()));
                 token_condition = token_condition.add(per_token);
             }
             slide_condition = slide_condition.add(token_condition);
@@ -324,38 +320,13 @@ impl Repository {
             let presentation_id = PresentationId::from_uuid(parse_uuid(&presentation_model.id)?);
             let slide_id = SlideId::from_uuid(parse_uuid(&slide_model.id)?);
 
-            // Determine effective text fields (worship or Bible)
-            let is_bible = !slide_model.bible_main.is_empty();
-            let (eff_main, eff_main_search) = if is_bible {
-                (
-                    slide_model.bible_main.as_str(),
-                    slide_model.bible_main_search.as_str(),
-                )
-            } else {
-                (
-                    slide_model.worship_main.as_str(),
-                    slide_model.worship_main_search.as_str(),
-                )
-            };
-            let (eff_translation, eff_translation_search) = if is_bible {
-                (
-                    slide_model.bible_translation.as_str(),
-                    slide_model.bible_translation_search.as_str(),
-                )
-            } else {
-                (
-                    slide_model.worship_translate.as_str(),
-                    slide_model.worship_translate_search.as_str(),
-                )
-            };
-            let (eff_stage, eff_stage_search) = if is_bible {
-                ("", "")
-            } else {
-                (
-                    slide_model.worship_stage.as_str(),
-                    slide_model.worship_stage_search.as_str(),
-                )
-            };
+            // Worship slide text fields (bible slides live in a separate table).
+            let eff_main = slide_model.worship_main.as_str();
+            let eff_main_search = slide_model.worship_main_search.as_str();
+            let eff_translation = slide_model.worship_translate.as_str();
+            let eff_translation_search = slide_model.worship_translate_search.as_str();
+            let eff_stage = slide_model.worship_stage.as_str();
+            let eff_stage_search = slide_model.worship_stage_search.as_str();
 
             if ctx.has_tokens {
                 let combined = fold_query(&format!(

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -1,14 +1,11 @@
 use super::Repository;
 use chrono::{Duration, Utc};
 use presenter_core::{
-    bible::BibleIngestionBatch,
-    playlist::PlaylistEntryKind,
-    slide::{BibleSlideMetadata, SlideMetadata},
-    AndroidStageDisplayDraft, BiblePassage, BibleReference, BibleTranslation, CountdownTimer,
-    Library, LibraryId, OscSettingsDraft, PlaylistEntry, PlaylistEntryId, PreachTimer,
-    Presentation, PresentationId, ResolumeHostDraft, SearchResultKind, Slide, SlideContent,
-    SlideGroup, SlideId, SlideText, StageState, TimerState, TimersState, VelocityMode,
-    DEFAULT_ADB_PORT, DEFAULT_LAUNCH_COMPONENT,
+    bible::BibleIngestionBatch, playlist::PlaylistEntryKind, AndroidStageDisplayDraft,
+    BiblePassage, BibleReference, BibleTranslation, CountdownTimer, Library, LibraryId,
+    OscSettingsDraft, PlaylistEntry, PlaylistEntryId, PreachTimer, Presentation, PresentationId,
+    ResolumeHostDraft, SearchResultKind, Slide, SlideContent, SlideGroup, SlideId, SlideText,
+    StageState, TimerState, TimersState, VelocityMode, DEFAULT_ADB_PORT, DEFAULT_LAUNCH_COMPONENT,
 };
 
 fn sample_library() -> Library {
@@ -676,7 +673,7 @@ async fn app_setting_round_trip_set_get_delete() {
 // ── update_slide_content_with_metadata tests ────────────────────────
 
 #[tokio::test]
-async fn update_slide_content_with_metadata_persists_all_fields() {
+async fn update_slide_content_with_metadata_persists_worship_fields() {
     let repo = Repository::connect_in_memory().await.unwrap();
     let library = sample_library();
     let presentation = library.presentations[0].clone();
@@ -684,32 +681,15 @@ async fn update_slide_content_with_metadata_persists_all_fields() {
     repo.upsert_library(&library).await.unwrap();
 
     let new_content = SlideContent::new(
-        SlideText::new("John 3:16 text").unwrap(),
-        SlideText::new("Jan 3:16 text").unwrap(),
-        SlideText::new("Stage bible").unwrap(),
-        None,
+        SlideText::new("Updated main").unwrap(),
+        SlideText::new("Updated translation").unwrap(),
+        SlideText::new("Updated stage").unwrap(),
+        Some(SlideGroup::new("Verse 1")),
     );
 
-    let metadata = SlideMetadata::new().with_bible(BibleSlideMetadata {
-        translation_code: "en-kjv".to_string(),
-        secondary_translation_code: Some("cs-cep".to_string()),
-        book: "John".to_string(),
-        book_code: Some("JHN".to_string()),
-        book_number: Some(43),
-        chapter: 3,
-        verses: vec![presenter_core::slide::BibleSlideVerseRef::new(16, 16)],
-        main_reference_label: Some("John 3:16 (KJV)".to_string()),
-        translation_reference_label: Some("Jan 3:16 (CEP)".to_string()),
-    });
-
-    repo.update_slide_content_with_metadata(
-        presentation.id,
-        slide.id,
-        &new_content,
-        Some(&metadata),
-    )
-    .await
-    .unwrap();
+    repo.update_slide_content_with_metadata(presentation.id, slide.id, &new_content, None)
+        .await
+        .unwrap();
 
     let detail = repo
         .fetch_presentation_detail(presentation.id)
@@ -723,13 +703,11 @@ async fn update_slide_content_with_metadata_persists_all_fields() {
         .find(|s| s.id == slide.id)
         .expect("slide");
 
-    assert_eq!(updated.content.main.value(), "John 3:16 text");
-    assert_eq!(updated.content.translation.value(), "Jan 3:16 text");
-    // Verify metadata was persisted and loaded back
-    assert!(updated.metadata.is_some());
-    let meta = updated.metadata.as_ref().unwrap();
-    let bible = meta.bible.as_ref().expect("bible metadata");
-    assert_eq!(bible.translation_code, "en-kjv");
-    assert_eq!(bible.book, "John");
-    assert_eq!(bible.chapter, 3);
+    assert_eq!(updated.content.main.value(), "Updated main");
+    assert_eq!(updated.content.translation.value(), "Updated translation");
+    assert_eq!(updated.content.stage.value(), "Updated stage");
+    assert_eq!(
+        updated.content.group.as_ref().map(|g| g.name()),
+        Some("Verse 1")
+    );
 }

--- a/crates/presenter-persistence/src/repository/util.rs
+++ b/crates/presenter-persistence/src/repository/util.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
-use presenter_core::slide::SlideMetadata;
 use presenter_core::{
     bible::BibleReference,
     playlist::{MidiBinding, PlaylistEntryKind},
@@ -62,36 +61,14 @@ pub(super) fn sanitize_like_input(input: &str) -> String {
 }
 
 pub(super) fn to_domain_slide(model: slide_entity::Model) -> Result<Slide, RepositoryError> {
-    // Determine slide type: Bible slides have bible_main populated, worship slides use worship_main
-    let is_bible = !model.bible_main.is_empty();
-    let content = if is_bible {
-        SlideContent::new(
-            SlideText::new(model.bible_main)?,
-            SlideText::new(model.bible_translation)?,
-            SlideText::new(model.bible_main_reference.clone())?,
-            if model.bible_main_reference.is_empty() {
-                None
-            } else {
-                Some(SlideGroup::new(model.bible_main_reference))
-            },
-        )
-    } else {
-        SlideContent::new(
-            SlideText::new(model.worship_main)?,
-            SlideText::new(model.worship_translate)?,
-            SlideText::new(model.worship_stage)?,
-            model.worship_group.map(SlideGroup::new),
-        )
-    };
-    let mut slide = Slide::new(model.position as u32, content)
+    let content = SlideContent::new(
+        SlideText::new(model.worship_main)?,
+        SlideText::new(model.worship_translate)?,
+        SlideText::new(model.worship_stage)?,
+        model.worship_group.map(SlideGroup::new),
+    );
+    let slide = Slide::new(model.position as u32, content)
         .with_id(SlideId::from_uuid(parse_uuid(&model.id)?));
-    if let Some(raw) = model.metadata_json.as_deref() {
-        if !raw.trim().is_empty() {
-            if let Ok(meta) = serde_json::from_str::<SlideMetadata>(raw) {
-                slide = slide.with_metadata(Some(meta));
-            }
-        }
-    }
     Ok(slide)
 }
 pub(super) fn to_domain_playlist_entry(
@@ -359,8 +336,7 @@ pub(super) fn parse_timer_state(value: &str) -> Result<TimerState, RepositoryErr
     }
 }
 
-/// Builds a slide entity ActiveModel from a domain Slide.
-/// Determines whether to populate worship_* or bible_* columns based on metadata.
+/// Builds a worship slide entity ActiveModel from a domain Slide.
 pub(super) fn build_slide_active_model(
     slide: &Slide,
     presentation_id: &str,
@@ -368,73 +344,24 @@ pub(super) fn build_slide_active_model(
 ) -> slide_entity::ActiveModel {
     use sea_orm::Set;
 
-    let is_bible = slide
-        .metadata
-        .as_ref()
-        .and_then(|m| m.bible.as_ref())
-        .is_some();
-    let metadata_json = slide
-        .metadata
-        .as_ref()
-        .and_then(|m| serde_json::to_string(m).ok());
-
-    if is_bible {
-        slide_entity::ActiveModel {
-            id: Set(slide.id.to_string()),
-            presentation_id: Set(presentation_id.to_string()),
-            position: Set(position),
-            worship_main: Set(String::new()),
-            worship_main_search: Set(String::new()),
-            worship_translate: Set(String::new()),
-            worship_translate_search: Set(String::new()),
-            worship_stage: Set(String::new()),
-            worship_stage_search: Set(String::new()),
-            worship_group: Set(None),
-            bible_main: Set(slide.content.main.value().to_owned()),
-            bible_main_search: Set(presenter_core::search::fold_query(
-                slide.content.main.value(),
-            )),
-            bible_translation: Set(slide.content.translation.value().to_owned()),
-            bible_translation_search: Set(presenter_core::search::fold_query(
-                slide.content.translation.value(),
-            )),
-            bible_main_reference: Set(slide.content.stage.value().to_owned()),
-            bible_translation_reference: Set(slide
-                .metadata
-                .as_ref()
-                .and_then(|m| m.bible.as_ref())
-                .and_then(|b| b.translation_reference_label.clone())
-                .unwrap_or_default()),
-            created_at: Set(chrono::Utc::now().into()),
-            metadata_json: Set(metadata_json),
-        }
-    } else {
-        slide_entity::ActiveModel {
-            id: Set(slide.id.to_string()),
-            presentation_id: Set(presentation_id.to_string()),
-            position: Set(position),
-            worship_main: Set(slide.content.main.value().to_owned()),
-            worship_main_search: Set(presenter_core::search::fold_query(
-                slide.content.main.value(),
-            )),
-            worship_translate: Set(slide.content.translation.value().to_owned()),
-            worship_translate_search: Set(presenter_core::search::fold_query(
-                slide.content.translation.value(),
-            )),
-            worship_stage: Set(slide.content.stage.value().to_owned()),
-            worship_stage_search: Set(presenter_core::search::fold_query(
-                slide.content.stage.value(),
-            )),
-            worship_group: Set(slide.content.group.as_ref().map(|g| g.name().to_owned())),
-            bible_main: Set(String::new()),
-            bible_main_search: Set(String::new()),
-            bible_translation: Set(String::new()),
-            bible_translation_search: Set(String::new()),
-            bible_main_reference: Set(String::new()),
-            bible_translation_reference: Set(String::new()),
-            created_at: Set(chrono::Utc::now().into()),
-            metadata_json: Set(metadata_json),
-        }
+    slide_entity::ActiveModel {
+        id: Set(slide.id.to_string()),
+        presentation_id: Set(presentation_id.to_string()),
+        position: Set(position),
+        worship_main: Set(slide.content.main.value().to_owned()),
+        worship_main_search: Set(presenter_core::search::fold_query(
+            slide.content.main.value(),
+        )),
+        worship_translate: Set(slide.content.translation.value().to_owned()),
+        worship_translate_search: Set(presenter_core::search::fold_query(
+            slide.content.translation.value(),
+        )),
+        worship_stage: Set(slide.content.stage.value().to_owned()),
+        worship_stage_search: Set(presenter_core::search::fold_query(
+            slide.content.stage.value(),
+        )),
+        worship_group: Set(slide.content.group.as_ref().map(|g| g.name().to_owned())),
+        created_at: Set(chrono::Utc::now().into()),
     }
 }
 

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -1,6 +1,6 @@
 use crate::state::bible::BibleTriggerOverrides;
 use crate::state::AppState;
-use presenter_core::slide::{BibleSlideMetadata, SlideContent, SlideMetadata, SlideText};
+use presenter_core::slide::{SlideContent, SlideText};
 use presenter_core::{BibleReference, LibraryId, PresentationId, Slide, SlideId};
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -256,7 +256,7 @@ fn slide_to_json(s: &Slide) -> Value {
     })
 }
 
-fn make_slide(i: usize, s: &Value, is_bible: bool) -> Slide {
+fn make_slide(i: usize, s: &Value) -> Slide {
     let main_text = SlideText::new(s["main"].as_str().unwrap_or(""))
         .unwrap_or_else(|_| SlideText::new("").unwrap());
     let translation_text = SlideText::new(s["translation"].as_str().unwrap_or(""))
@@ -268,27 +268,7 @@ fn make_slide(i: usize, s: &Value, is_bible: bool) -> Slide {
         .map(presenter_core::slide::SlideGroup::new);
 
     let content = SlideContent::new(main_text, translation_text, stage_text, group);
-    let mut slide = Slide::new(i as u32, content);
-    if is_bible {
-        let ref_label = s["stage"].as_str().unwrap_or("").to_string();
-        let meta = SlideMetadata::new().with_bible(BibleSlideMetadata {
-            translation_code: String::new(),
-            secondary_translation_code: None,
-            book: String::new(),
-            book_code: None,
-            book_number: None,
-            chapter: 0,
-            verses: Vec::new(),
-            main_reference_label: if ref_label.is_empty() {
-                None
-            } else {
-                Some(ref_label)
-            },
-            translation_reference_label: None,
-        });
-        slide = slide.with_metadata(Some(meta));
-    }
-    slide
+    Slide::new(i as u32, content)
 }
 
 /// Execute a tool call against AppState and return (result_json, preview).
@@ -368,17 +348,10 @@ pub async fn execute_tool(
             let name_val = str_field(&args, "name")?;
             let slides_arr = args["slides"].as_array();
 
-            let libs = state.libraries().await?;
-            let is_bible = libs
-                .iter()
-                .find(|l| l.id == lib_id)
-                .map(|l| l.name.eq_ignore_ascii_case("bible"))
-                .unwrap_or(false);
-
             let slides: Option<Vec<Slide>> = slides_arr.map(|arr| {
                 arr.iter()
                     .enumerate()
-                    .map(|(i, s)| make_slide(i, s, is_bible))
+                    .map(|(i, s)| make_slide(i, s))
                     .collect()
             });
 
@@ -424,17 +397,8 @@ pub async fn execute_tool(
                 let translation = args["translation"].as_str().unwrap_or("").to_string();
                 let stage = args["stage"].as_str().unwrap_or("").to_string();
                 let group = args["group"].as_str().map(String::from);
-                let metadata = bible_metadata_for_presentation(state, pres_id, &stage).await;
                 state
-                    .update_slide_content(
-                        pres_id,
-                        slide.id,
-                        main,
-                        translation,
-                        stage,
-                        group,
-                        metadata,
-                    )
+                    .update_slide_content(pres_id, slide.id, main, translation, stage, group, None)
                     .await?;
             }
             let preview = format!("Added slide (now {} total)", slides.len());
@@ -451,9 +415,8 @@ pub async fn execute_tool(
             let translation = args["translation"].as_str().unwrap_or("").to_string();
             let stage = args["stage"].as_str().unwrap_or("").to_string();
             let group = args["group"].as_str().map(String::from);
-            let metadata = bible_metadata_for_presentation(state, pres_id, &stage).await;
             state
-                .update_slide_content(pres_id, slide_id, main, translation, stage, group, metadata)
+                .update_slide_content(pres_id, slide_id, main, translation, stage, group, None)
                 .await?;
             Ok((json!({"ok": true}).to_string(), "Updated slide".to_string()))
         }
@@ -673,108 +636,10 @@ fn uuid_field(args: &Value, field: &str) -> anyhow::Result<Uuid> {
     Uuid::parse_str(&s).map_err(|_| anyhow::anyhow!("{field} must be a valid UUID"))
 }
 
-/// Look up whether a presentation belongs to the Bible library.
-/// If so, return Bible metadata with the stage text as the reference label.
-async fn bible_metadata_for_presentation(
-    state: &AppState,
-    presentation_id: PresentationId,
-    stage: &str,
-) -> Option<SlideMetadata> {
-    let detail = state.presentation_detail(presentation_id).await.ok()??;
-    let (_lib_id, lib_name, _pres) = detail;
-    if !lib_name.eq_ignore_ascii_case("bible") {
-        return None;
-    }
-    let ref_label = stage.trim().to_string();
-    Some(SlideMetadata::new().with_bible(BibleSlideMetadata {
-        translation_code: String::new(),
-        secondary_translation_code: None,
-        book: String::new(),
-        book_code: None,
-        book_number: None,
-        chapter: 0,
-        verses: Vec::new(),
-        main_reference_label: if ref_label.is_empty() {
-            None
-        } else {
-            Some(ref_label)
-        },
-        translation_reference_label: None,
-    }))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::state::AppState;
-
-    #[tokio::test]
-    async fn create_presentation_in_bible_library_attaches_metadata() {
-        let state = AppState::in_memory().await.unwrap();
-
-        // Create a "Bible" library via the tool
-        let (result, _) = execute_tool("create_library", r#"{"name":"Bible"}"#, &state, 320)
-            .await
-            .unwrap();
-        let lib: Value = serde_json::from_str(&result).unwrap();
-        let lib_id = lib["id"].as_str().unwrap();
-
-        // Create a presentation with a slide that has a stage reference
-        let args = json!({
-            "library_id": lib_id,
-            "name": "John 3:16-17",
-            "slides": [
-                {"main": "For God so loved the world", "stage": "John 3:16"},
-                {"main": "For God did not send his Son", "stage": "John 3:17"}
-            ]
-        });
-        let (result, _) = execute_tool("create_presentation", &args.to_string(), &state, 320)
-            .await
-            .unwrap();
-        let pres: Value = serde_json::from_str(&result).unwrap();
-        let pres_id_str = pres["id"].as_str().unwrap();
-
-        // Fetch the presentation and verify slides have Bible metadata
-        let pres_id = PresentationId::from_uuid(Uuid::parse_str(pres_id_str).unwrap());
-        let detail = state.presentation_detail(pres_id).await.unwrap().unwrap();
-        let (_, lib_name, presentation) = detail;
-        assert_eq!(lib_name, "Bible");
-
-        for slide in &presentation.slides {
-            let meta = slide.metadata.as_ref().expect("slide should have metadata");
-            let bible = meta
-                .bible
-                .as_ref()
-                .expect("slide should have bible metadata");
-            assert!(
-                bible.main_reference_label.is_some(),
-                "slide {} should have a main_reference_label",
-                slide.order
-            );
-        }
-        assert_eq!(
-            presentation.slides[0]
-                .metadata
-                .as_ref()
-                .unwrap()
-                .bible
-                .as_ref()
-                .unwrap()
-                .main_reference_label,
-            Some("John 3:16".to_string())
-        );
-        assert_eq!(
-            presentation.slides[1]
-                .metadata
-                .as_ref()
-                .unwrap()
-                .bible
-                .as_ref()
-                .unwrap()
-                .main_reference_label,
-            Some("John 3:17".to_string())
-        );
-    }
 
     #[tokio::test]
     async fn create_presentation_in_non_bible_library_has_no_metadata() {
@@ -807,100 +672,5 @@ mod tests {
                 "non-Bible slide should not have metadata"
             );
         }
-    }
-
-    #[tokio::test]
-    async fn add_slide_to_bible_presentation_attaches_metadata() {
-        let state = AppState::in_memory().await.unwrap();
-
-        let (result, _) = execute_tool("create_library", r#"{"name":"Bible"}"#, &state, 320)
-            .await
-            .unwrap();
-        let lib: Value = serde_json::from_str(&result).unwrap();
-        let lib_id = lib["id"].as_str().unwrap();
-
-        let args = json!({
-            "library_id": lib_id,
-            "name": "Romans 8",
-            "slides": [{"main": "Initial verse", "stage": "Romans 8:1"}]
-        });
-        let (result, _) = execute_tool("create_presentation", &args.to_string(), &state, 320)
-            .await
-            .unwrap();
-        let pres: Value = serde_json::from_str(&result).unwrap();
-        let pres_id = pres["id"].as_str().unwrap();
-
-        // Add a slide via the add_slide tool
-        let add_args = json!({
-            "presentation_id": pres_id,
-            "main": "There is now no condemnation",
-            "stage": "Romans 8:2"
-        });
-        execute_tool("add_slide", &add_args.to_string(), &state, 320)
-            .await
-            .unwrap();
-
-        // Verify the added slide has Bible metadata
-        let pid = PresentationId::from_uuid(Uuid::parse_str(pres_id).unwrap());
-        let detail = state.presentation_detail(pid).await.unwrap().unwrap();
-        let (_, _, presentation) = detail;
-        let last_slide = presentation.slides.last().unwrap();
-        let bible = last_slide
-            .metadata
-            .as_ref()
-            .expect("added slide should have metadata")
-            .bible
-            .as_ref()
-            .expect("added slide should have bible metadata");
-        assert_eq!(bible.main_reference_label, Some("Romans 8:2".to_string()));
-    }
-
-    #[tokio::test]
-    async fn update_slide_in_bible_presentation_attaches_metadata() {
-        let state = AppState::in_memory().await.unwrap();
-
-        let (result, _) = execute_tool("create_library", r#"{"name":"Bible"}"#, &state, 320)
-            .await
-            .unwrap();
-        let lib: Value = serde_json::from_str(&result).unwrap();
-        let lib_id = lib["id"].as_str().unwrap();
-
-        let args = json!({
-            "library_id": lib_id,
-            "name": "Psalm 23",
-            "slides": [{"main": "The Lord is my shepherd", "stage": "Psalm 23:1"}]
-        });
-        let (result, _) = execute_tool("create_presentation", &args.to_string(), &state, 320)
-            .await
-            .unwrap();
-        let pres: Value = serde_json::from_str(&result).unwrap();
-        let pres_id = pres["id"].as_str().unwrap();
-
-        // Fetch to get the slide ID
-        let pid = PresentationId::from_uuid(Uuid::parse_str(pres_id).unwrap());
-        let detail = state.presentation_detail(pid).await.unwrap().unwrap();
-        let slide_id = detail.2.slides[0].id.to_string();
-
-        // Update the slide with a new reference
-        let update_args = json!({
-            "presentation_id": pres_id,
-            "slide_id": slide_id,
-            "main": "Updated text",
-            "stage": "Psalm 23:2"
-        });
-        execute_tool("update_slide", &update_args.to_string(), &state, 320)
-            .await
-            .unwrap();
-
-        // Verify metadata was updated
-        let detail = state.presentation_detail(pid).await.unwrap().unwrap();
-        let bible = detail.2.slides[0]
-            .metadata
-            .as_ref()
-            .expect("updated slide should have metadata")
-            .bible
-            .as_ref()
-            .expect("updated slide should have bible metadata");
-        assert_eq!(bible.main_reference_label, Some("Psalm 23:2".to_string()));
     }
 }

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -82,8 +82,12 @@ pub fn build_router(state: AppState) -> Router {
             post(bible::append_bible_presentation_handler),
         )
         .route(
+            "/bible/presentations/{id}/slides/reorder",
+            post(bible::reorder_bible_presentation_slides),
+        )
+        .route(
             "/bible/presentations/{id}/slides/{slide_id}",
-            patch(bible::update_bible_slide),
+            patch(bible::update_bible_slide).delete(bible::delete_bible_presentation_slide),
         )
         .route(
             "/bible/presentations/{id}/slides/{slide_id}/trigger",

--- a/crates/presenter-server/src/router/bible.rs
+++ b/crates/presenter-server/src/router/bible.rs
@@ -828,3 +828,58 @@ pub(super) async fn append_bible_presentation_handler(
         .await?;
     Ok(Json(bible_presentation_to_detail(&presentation)))
 }
+
+/// DELETE /bible/presentations/{id}/slides/{slide_id}
+///
+/// Deletes a single slide from a bible presentation and returns the updated
+/// presentation detail.
+#[instrument(skip_all)]
+pub(super) async fn delete_bible_presentation_slide(
+    State(state): State<AppState>,
+    axum::extract::Path((presentation_id, slide_id)): axum::extract::Path<(String, String)>,
+) -> Result<Json<BiblePresentationDetailDto>, AppError> {
+    let pres_uuid = presentation_id
+        .parse::<uuid::Uuid>()
+        .map_err(|_| AppError::bad_request_message("Invalid presentation ID"))?;
+    let slide_uuid = slide_id
+        .parse::<uuid::Uuid>()
+        .map_err(|_| AppError::bad_request_message("Invalid slide ID"))?;
+
+    let presentation = state
+        .delete_bible_slide(
+            BiblePresentationId::from_uuid(pres_uuid),
+            BibleSlideId::from_uuid(slide_uuid),
+        )
+        .await?;
+    Ok(Json(bible_presentation_to_detail(&presentation)))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ReorderBibleSlidesRequest {
+    pub(super) slide_ids: Vec<String>,
+}
+
+/// POST /bible/presentations/{id}/slides/reorder
+///
+/// Reorders slides in a bible presentation according to the supplied ID list
+/// and returns the updated presentation detail.
+#[instrument(skip_all)]
+pub(super) async fn reorder_bible_presentation_slides(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
+    Json(payload): Json<ReorderBibleSlidesRequest>,
+) -> Result<Json<BiblePresentationDetailDto>, AppError> {
+    let mut slide_ids = Vec::with_capacity(payload.slide_ids.len());
+    for raw in payload.slide_ids {
+        let uuid = raw
+            .parse::<uuid::Uuid>()
+            .map_err(|_| AppError::bad_request_message("Invalid slide ID"))?;
+        slide_ids.push(BibleSlideId::from_uuid(uuid));
+    }
+
+    let presentation = state
+        .reorder_bible_slides(BiblePresentationId::from_uuid(id), slide_ids)
+        .await?;
+    Ok(Json(bible_presentation_to_detail(&presentation)))
+}

--- a/crates/presenter-server/src/router/bible.rs
+++ b/crates/presenter-server/src/router/bible.rs
@@ -9,8 +9,9 @@ use axum::{
 use chrono::Utc;
 use presenter_core::slide::SlideMetadata;
 use presenter_core::{
-    BiblePassage, BiblePreferences, BiblePreferencesDraft, BibleReference, BibleSlideOutput,
-    BibleTranslation, Slide,
+    BiblePassage, BiblePreferences, BiblePreferencesDraft, BiblePresentation, BiblePresentationId,
+    BiblePresentationSlide, BibleReference, BibleSlideId, BibleSlideOutput, BibleTranslation,
+    Slide, SlideText,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -370,7 +371,7 @@ pub(super) async fn trigger_presentation_slide(
         .parse::<uuid::Uuid>()
         .map_err(|_| AppError::bad_request_message("Invalid presentation ID"))?;
     let presentation = state
-        .bible_presentation_detail(presenter_core::PresentationId::from_uuid(pres_uuid))
+        .bible_presentation_detail(BiblePresentationId::from_uuid(pres_uuid))
         .await?
         .ok_or_else(|| AppError::not_found("Presentation not found"))?;
 
@@ -380,34 +381,18 @@ pub(super) async fn trigger_presentation_slide(
     let slide = presentation
         .slides
         .iter()
-        .find(|s| s.id == presenter_core::SlideId::from_uuid(slide_uuid))
+        .find(|s| s.id == BibleSlideId::from_uuid(slide_uuid))
         .ok_or_else(|| AppError::not_found("Slide not found in presentation"))?;
 
-    let main_reference = slide
-        .metadata
-        .as_ref()
-        .and_then(|m| m.bible.as_ref())
-        .and_then(|b| b.main_reference_label.clone())
-        .unwrap_or_default();
-
-    let secondary_reference = slide
-        .metadata
-        .as_ref()
-        .and_then(|m| m.bible.as_ref())
-        .and_then(|b| b.translation_reference_label.clone())
-        .unwrap_or_default();
-
-    let bible_translation_text = slide.content.translation.value().to_string();
-
     let output = BibleSlideOutput::new(
-        slide.content.main.value().to_string(),
-        main_reference,
-        bible_translation_text,
-        secondary_reference,
+        slide.main.value().to_string(),
+        slide.main_reference.clone(),
+        slide.secondary.value().to_string(),
+        slide.secondary_reference.clone(),
         Utc::now(),
     );
 
-    let meta = slide.metadata.as_ref().and_then(|m| m.bible.as_ref());
+    let meta = slide.metadata.as_ref();
     let (verse_start, verse_end) = meta
         .and_then(|m| m.verse_span())
         .map(|(s, e)| (Some(s), Some(e)))
@@ -499,7 +484,35 @@ pub(super) struct BibleSlideDto {
     bible_translation_reference: String,
 }
 
-fn bible_slide_to_dto(slide: &Slide) -> Result<BibleSlideDto, AppError> {
+/// Convert a stored `BiblePresentationSlide` (from the bible repository) to
+/// the wire DTO. The DTO field names remain unchanged to preserve wire
+/// compatibility with the existing frontend.
+fn bible_slide_to_dto(slide: &BiblePresentationSlide) -> BibleSlideDto {
+    // Wrap the structured `BibleSlideMetadata` into the legacy `SlideMetadata`
+    // envelope the frontend expects: `{ metadata: { bible: { ... } } }`.
+    let metadata = slide.metadata.as_ref().map(|bible_meta| {
+        let mut sm = SlideMetadata::new();
+        sm.bible = Some(bible_meta.clone());
+        sm
+    });
+
+    BibleSlideDto {
+        id: slide.id.to_string(),
+        order: slide.order,
+        bible_main: slide.main.value().to_string(),
+        bible_translation: slide.secondary.value().to_string(),
+        metadata,
+        bible_main_reference: slide.main_reference.clone(),
+        bible_translation_reference: slide.secondary_reference.clone(),
+    }
+}
+
+/// Convert a generated worship `Slide` (from `compose_bible_slides`) to the
+/// wire DTO. The composer currently stores the reference label in
+/// `content.stage` and the structured metadata inside `metadata.bible`. This
+/// conversion is used only by the `/bible/resolve` preview endpoint and the
+/// `resolve_bible_slides` AI tool — neither persists these slides.
+fn generated_slide_to_dto(slide: &Slide) -> BibleSlideDto {
     let metadata = slide.metadata.clone();
     let (main_reference, translation_reference) = metadata
         .as_ref()
@@ -512,7 +525,7 @@ fn bible_slide_to_dto(slide: &Slide) -> Result<BibleSlideDto, AppError> {
         })
         .unwrap_or_default();
 
-    Ok(BibleSlideDto {
+    BibleSlideDto {
         id: slide.id.to_string(),
         order: slide.order,
         bible_main: slide.content.main.value().to_string(),
@@ -520,7 +533,7 @@ fn bible_slide_to_dto(slide: &Slide) -> Result<BibleSlideDto, AppError> {
         metadata,
         bible_main_reference: main_reference,
         bible_translation_reference: translation_reference,
-    })
+    }
 }
 
 #[instrument(skip_all)]
@@ -582,10 +595,7 @@ pub(super) async fn resolve_bible_slides(
             character_limit,
         )
         .await?;
-    let mut slide_dtos = Vec::with_capacity(slides.len());
-    for slide in slides {
-        slide_dtos.push(bible_slide_to_dto(&slide)?);
-    }
+    let slide_dtos: Vec<BibleSlideDto> = slides.iter().map(generated_slide_to_dto).collect();
     Ok(Json(BibleResolveResponse {
         main_translation,
         secondary_translation,
@@ -641,74 +651,36 @@ pub(super) struct BibleSlideInput {
     metadata: Option<SlideMetadata>,
 }
 
-fn request_slide_to_domain(input: BibleSlideInput) -> Result<Slide, AppError> {
-    let content = presenter_core::SlideContent::new(
-        presenter_core::SlideText::new(&input.bible_main)
-            .map_err(|e| AppError::bad_request_message(e.to_string()))?,
-        presenter_core::SlideText::new(&input.bible_translation)
-            .map_err(|e| AppError::bad_request_message(e.to_string()))?,
-        presenter_core::SlideText::new(&input.bible_main_reference)
-            .map_err(|e| AppError::bad_request_message(e.to_string()))?,
-        if input.bible_main_reference.is_empty() {
-            None
-        } else {
-            Some(presenter_core::SlideGroup::new(&input.bible_main_reference))
-        },
-    );
-    let mut slide = Slide::new(0, content);
-    // Build metadata with reference labels
-    let metadata = match input.metadata {
-        Some(mut meta) => {
-            if let Some(ref mut bible) = meta.bible {
-                if bible.main_reference_label.is_none() && !input.bible_main_reference.is_empty() {
-                    bible.main_reference_label = Some(input.bible_main_reference.clone());
-                }
-                if bible.translation_reference_label.is_none()
-                    && !input.bible_translation_reference.is_empty()
-                {
-                    bible.translation_reference_label =
-                        Some(input.bible_translation_reference.clone());
-                }
-            }
-            Some(meta)
-        }
-        None if !input.bible_main_reference.is_empty() => Some(SlideMetadata::new().with_bible(
-            presenter_core::slide::BibleSlideMetadata {
-                translation_code: String::new(),
-                secondary_translation_code: None,
-                book: String::new(),
-                book_code: None,
-                book_number: None,
-                chapter: 0,
-                verses: Vec::new(),
-                main_reference_label: Some(input.bible_main_reference.clone()),
-                translation_reference_label: if input.bible_translation_reference.is_empty() {
-                    None
-                } else {
-                    Some(input.bible_translation_reference.clone())
-                },
-            },
-        )),
-        None => None,
-    };
-    if let Some(meta) = metadata {
-        slide = slide.with_metadata(Some(meta));
-    }
-    Ok(slide)
+fn request_slide_to_domain(input: BibleSlideInput) -> Result<BiblePresentationSlide, AppError> {
+    let main = SlideText::new(&input.bible_main)
+        .map_err(|e| AppError::bad_request_message(e.to_string()))?;
+    let secondary = SlideText::new(&input.bible_translation)
+        .map_err(|e| AppError::bad_request_message(e.to_string()))?;
+
+    // Unwrap the structured bible metadata from the legacy wire envelope
+    // (`{ metadata: { bible: { ... } } }`) — the frontend still sends it in
+    // that shape for backwards compatibility.
+    let metadata = input.metadata.and_then(|m| m.bible);
+
+    Ok(BiblePresentationSlide {
+        id: BibleSlideId::new(),
+        // The repository assigns the final order on insert; zero here is a
+        // placeholder.
+        order: 0,
+        main,
+        main_reference: input.bible_main_reference,
+        secondary,
+        secondary_reference: input.bible_translation_reference,
+        metadata,
+    })
 }
 
-fn bible_presentation_to_detail(
-    presentation: &presenter_core::Presentation,
-) -> Result<BiblePresentationDetailDto, AppError> {
-    let mut slides = Vec::with_capacity(presentation.slides.len());
-    for slide in &presentation.slides {
-        slides.push(bible_slide_to_dto(slide)?);
-    }
-    Ok(BiblePresentationDetailDto {
+fn bible_presentation_to_detail(presentation: &BiblePresentation) -> BiblePresentationDetailDto {
+    BiblePresentationDetailDto {
         id: presentation.id.to_string(),
         name: presentation.name.clone(),
-        slides,
-    })
+        slides: presentation.slides.iter().map(bible_slide_to_dto).collect(),
+    }
 }
 
 #[instrument(skip_all)]
@@ -716,19 +688,14 @@ pub(super) async fn list_bible_presentations(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<BiblePresentationSummaryDto>>, AppError> {
     let summaries = state.list_bible_presentations().await?;
-    let mut result = Vec::with_capacity(summaries.len());
-    for summary in summaries {
-        let slide_count = state
-            .bible_presentation_detail(summary.id)
-            .await?
-            .map(|presentation| presentation.slides.len())
-            .unwrap_or(0);
-        result.push(BiblePresentationSummaryDto {
-            id: summary.id.to_string(),
-            name: summary.name,
-            slide_count,
-        });
-    }
+    let result = summaries
+        .into_iter()
+        .map(|s| BiblePresentationSummaryDto {
+            id: s.id.to_string(),
+            name: s.name,
+            slide_count: s.slide_count,
+        })
+        .collect();
     Ok(Json(result))
 }
 
@@ -742,8 +709,7 @@ pub(super) async fn create_bible_presentation_handler(
         return Err(AppError::bad_request_message("name cannot be empty"));
     }
     let presentation = state.create_bible_presentation(name).await?;
-    let dto = bible_presentation_to_detail(&presentation)?;
-    Ok(Json(dto))
+    Ok(Json(bible_presentation_to_detail(&presentation)))
 }
 
 #[instrument(skip_all)]
@@ -752,11 +718,10 @@ pub(super) async fn get_bible_presentation(
     axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
 ) -> Result<Json<BiblePresentationDetailDto>, AppError> {
     let presentation = state
-        .bible_presentation_detail(presenter_core::PresentationId::from_uuid(id))
+        .bible_presentation_detail(BiblePresentationId::from_uuid(id))
         .await?
         .ok_or_else(|| AppError::not_found("presentation not found"))?;
-    let dto = bible_presentation_to_detail(&presentation)?;
-    Ok(Json(dto))
+    Ok(Json(bible_presentation_to_detail(&presentation)))
 }
 
 #[instrument(skip_all)]
@@ -770,7 +735,7 @@ pub(super) async fn rename_bible_presentation_handler(
         return Err(AppError::bad_request_message("name cannot be empty"));
     }
     state
-        .rename_bible_presentation(presenter_core::PresentationId::from_uuid(id), name)
+        .rename_bible_presentation(BiblePresentationId::from_uuid(id), name)
         .await?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -781,7 +746,7 @@ pub(super) async fn delete_bible_presentation_handler(
     axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
 ) -> Result<axum::http::StatusCode, AppError> {
     state
-        .delete_presentation(presenter_core::PresentationId::from_uuid(id))
+        .delete_bible_presentation(BiblePresentationId::from_uuid(id))
         .await?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -797,9 +762,10 @@ pub(super) struct UpdateBibleSlideRequest {
 }
 
 /// PATCH /bible/presentations/{id}/slides/{slide_id}
-/// Updates a Bible slide's content (main, translation) and metadata references
-/// (main_reference_label, translation_reference_label). Also writes mainReference
-/// to content.stage for Resolume compatibility (transparent to UI). Does NOT touch group.
+///
+/// Updates a Bible slide's text and reference labels. The structured bible
+/// metadata (book, chapter, verses, translation code) is preserved from the
+/// existing slide — the UI only edits text and reference labels.
 #[instrument(skip_all)]
 pub(super) async fn update_bible_slide(
     State(state): State<AppState>,
@@ -813,90 +779,35 @@ pub(super) async fn update_bible_slide(
         .parse::<uuid::Uuid>()
         .map_err(|_| AppError::bad_request_message("Invalid slide ID"))?;
 
-    let pres_id = presenter_core::PresentationId::from_uuid(pres_uuid);
-    let s_id = presenter_core::SlideId::from_uuid(slide_uuid);
+    let pres_id = BiblePresentationId::from_uuid(pres_uuid);
+    let s_id = BibleSlideId::from_uuid(slide_uuid);
 
-    // Look up the existing slide to preserve its metadata structure and group
+    // Preserve the existing structured metadata (book, chapter, verses, etc.)
+    // — the UI only edits text and reference labels, not the structured data.
     let presentation = state
         .bible_presentation_detail(pres_id)
         .await?
         .ok_or_else(|| AppError::not_found("Presentation not found"))?;
-
     let existing_slide = presentation
         .slides
         .iter()
         .find(|s| s.id == s_id)
         .ok_or_else(|| AppError::not_found("Slide not found in presentation"))?;
-
-    // Build updated metadata: preserve existing bible metadata but update reference labels
-    let updated_metadata = {
-        let mut meta = existing_slide
-            .metadata
-            .clone()
-            .unwrap_or_else(SlideMetadata::new);
-        if let Some(ref mut bible) = meta.bible {
-            bible.main_reference_label = if payload.bible_main_reference.is_empty() {
-                None
-            } else {
-                Some(payload.bible_main_reference.clone())
-            };
-            bible.translation_reference_label = if payload.bible_translation_reference.is_empty() {
-                None
-            } else {
-                Some(payload.bible_translation_reference.clone())
-            };
-        }
-        // If there's no bible metadata at all but references are provided, we still store them
-        if meta.bible.is_none()
-            && (!payload.bible_main_reference.is_empty()
-                || !payload.bible_translation_reference.is_empty())
-        {
-            meta.bible = Some(presenter_core::slide::BibleSlideMetadata {
-                translation_code: String::new(),
-                secondary_translation_code: None,
-                book: String::new(),
-                book_code: None,
-                book_number: None,
-                chapter: 0,
-                verses: Vec::new(),
-                main_reference_label: if payload.bible_main_reference.is_empty() {
-                    None
-                } else {
-                    Some(payload.bible_main_reference.clone())
-                },
-                translation_reference_label: if payload.bible_translation_reference.is_empty() {
-                    None
-                } else {
-                    Some(payload.bible_translation_reference.clone())
-                },
-            });
-        }
-        Some(meta)
-    };
-
-    // Stage stores the main reference for Resolume compatibility
-    let stage_value = payload.bible_main_reference.clone();
-
-    // Group stores reference label for grouping
-    let existing_group = if stage_value.is_empty() {
-        None
-    } else {
-        Some(stage_value.clone())
-    };
+    let existing_metadata = existing_slide.metadata.clone();
 
     let updated = state
-        .update_slide_content(
+        .update_bible_slide(
             pres_id,
             s_id,
             payload.bible_main,
+            payload.bible_main_reference,
             payload.bible_translation,
-            stage_value,
-            existing_group,
-            updated_metadata,
+            payload.bible_translation_reference,
+            existing_metadata,
         )
         .await?;
 
-    bible_slide_to_dto(&updated).map(Json)
+    Ok(Json(bible_slide_to_dto(&updated)))
 }
 
 #[instrument(skip_all)]
@@ -913,8 +824,7 @@ pub(super) async fn append_bible_presentation_handler(
         slides.push(request_slide_to_domain(input)?);
     }
     let presentation = state
-        .append_bible_presentation_slides(presenter_core::PresentationId::from_uuid(id), slides)
+        .append_bible_presentation_slides(BiblePresentationId::from_uuid(id), slides)
         .await?;
-    let dto = bible_presentation_to_detail(&presentation)?;
-    Ok(Json(dto))
+    Ok(Json(bible_presentation_to_detail(&presentation)))
 }

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -236,19 +236,101 @@ impl AppState {
         id: BiblePresentationId,
         new_slides: Vec<BiblePresentationSlide>,
     ) -> anyhow::Result<BiblePresentation> {
-        // Filter out empty placeholder slides (empty main text and empty reference)
-        let filtered: Vec<BiblePresentationSlide> = new_slides
-            .into_iter()
-            .filter(|s| !s.main.value().is_empty() || !s.main_reference.is_empty())
-            .collect();
+        // Note: empty slides are permitted — the operator UI's "add empty
+        // slide" button intentionally creates placeholder slides that the
+        // operator fills in by editing text in place.
         let presentation = self
             .repository
-            .append_bible_presentation_slides(id, &filtered)
+            .append_bible_presentation_slides(id, &new_slides)
             .await?;
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation.id.to_string(),
         });
         Ok(presentation)
+    }
+
+    /// Delete a single slide from a bible presentation. Implemented via
+    /// fetch + modify + replace_all — bible presentation slide counts are
+    /// small (typically a few to a few dozen), so read-modify-write is fine.
+    pub async fn delete_bible_slide(
+        &self,
+        presentation_id: BiblePresentationId,
+        slide_id: BibleSlideId,
+    ) -> anyhow::Result<BiblePresentation> {
+        let mut presentation = self
+            .repository
+            .fetch_bible_presentation(presentation_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+
+        let before = presentation.slides.len();
+        presentation.slides.retain(|s| s.id != slide_id);
+        if presentation.slides.len() == before {
+            return Err(anyhow::anyhow!("slide not found in presentation"));
+        }
+
+        self.repository
+            .replace_bible_presentation_slides(presentation_id, &presentation.slides)
+            .await?;
+
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: presentation_id.to_string(),
+        });
+
+        // Re-fetch to get the normalized orders assigned by replace_all.
+        self.repository
+            .fetch_bible_presentation(presentation_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation disappeared after delete"))
+    }
+
+    /// Reorder slides in a bible presentation by providing the desired slide
+    /// ID sequence. Missing IDs are dropped; unknown IDs are ignored.
+    pub async fn reorder_bible_slides(
+        &self,
+        presentation_id: BiblePresentationId,
+        slide_ids: Vec<BibleSlideId>,
+    ) -> anyhow::Result<BiblePresentation> {
+        let presentation = self
+            .repository
+            .fetch_bible_presentation(presentation_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+
+        // Build a lookup of existing slides by ID.
+        let mut by_id: HashMap<BibleSlideId, BiblePresentationSlide> = presentation
+            .slides
+            .iter()
+            .cloned()
+            .map(|s| (s.id, s))
+            .collect();
+
+        let mut reordered: Vec<BiblePresentationSlide> = Vec::with_capacity(by_id.len());
+        for id in slide_ids {
+            if let Some(slide) = by_id.remove(&id) {
+                reordered.push(slide);
+            }
+        }
+        // Append any slides not mentioned in the reorder list to preserve them.
+        for slide in presentation.slides {
+            if by_id.contains_key(&slide.id) {
+                reordered.push(slide.clone());
+                by_id.remove(&slide.id);
+            }
+        }
+
+        self.repository
+            .replace_bible_presentation_slides(presentation_id, &reordered)
+            .await?;
+
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: presentation_id.to_string(),
+        });
+
+        self.repository
+            .fetch_bible_presentation(presentation_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation disappeared after reorder"))
     }
 
     /// Replace a single slide within a bible presentation. Implemented via

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -220,7 +220,11 @@ impl AppState {
         id: BiblePresentationId,
         name: &str,
     ) -> anyhow::Result<()> {
-        self.repository.rename_bible_presentation(id, name).await
+        self.repository.rename_bible_presentation(id, name).await?;
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: id.to_string(),
+        });
+        Ok(())
     }
 
     pub async fn delete_bible_presentation(&self, id: BiblePresentationId) -> anyhow::Result<()> {

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -6,8 +6,9 @@ use crate::resolume::BibleUpdate;
 use chrono::Utc;
 use presenter_bible::BibleImportSummary;
 use presenter_core::{
-    BibleBroadcast, BiblePreferences, BibleReference, BibleSlideOutput, BibleTranslation,
-    Presentation, PresentationId, Slide,
+    slide::BibleSlideMetadata, BibleBroadcast, BiblePreferences, BiblePresentation,
+    BiblePresentationId, BiblePresentationSlide, BiblePresentationSummary, BibleReference,
+    BibleSlideId, BibleSlideOutput, BibleTranslation, Slide, SlideText,
 };
 use presenter_importer::bible::BibleIngestionService;
 use std::collections::HashMap;
@@ -195,48 +196,19 @@ impl AppState {
     }
 
     // Bible presentation methods
-    pub async fn list_bible_presentations(
-        &self,
-    ) -> anyhow::Result<Vec<presenter_core::PresentationSummary>> {
-        let libraries = self.repository.fetch_libraries().await?;
-        if let Some(bible_lib) = libraries
-            .into_iter()
-            .find(|l| l.name.eq_ignore_ascii_case("Bible"))
-        {
-            let summaries = bible_lib
-                .presentations
-                .into_iter()
-                .map(|p| presenter_core::PresentationSummary::new(p.id, p.name))
-                .collect();
-            Ok(summaries)
-        } else {
-            Ok(Vec::new())
-        }
+    pub async fn list_bible_presentations(&self) -> anyhow::Result<Vec<BiblePresentationSummary>> {
+        self.repository.list_bible_presentation_summaries().await
     }
 
     pub async fn bible_presentation_detail(
         &self,
-        id: PresentationId,
-    ) -> anyhow::Result<Option<Presentation>> {
-        let result = self.repository.fetch_presentation_detail(id).await?;
-        Ok(result.map(|(_, _, presentation)| presentation))
+        id: BiblePresentationId,
+    ) -> anyhow::Result<Option<BiblePresentation>> {
+        self.repository.fetch_bible_presentation(id).await
     }
 
-    pub async fn create_bible_presentation(&self, name: &str) -> anyhow::Result<Presentation> {
-        // Ensure a Bible library exists
-        let libraries = self.repository.fetch_libraries().await?;
-        let library = if let Some(existing) = libraries
-            .into_iter()
-            .find(|l| l.name.eq_ignore_ascii_case("Bible"))
-        {
-            existing
-        } else {
-            self.repository.create_library("Bible").await?
-        };
-        let (_lib_id, _lib_name, presentation) = self
-            .repository
-            .create_presentation(library.id, name, None)
-            .await?;
+    pub async fn create_bible_presentation(&self, name: &str) -> anyhow::Result<BiblePresentation> {
+        let presentation = self.repository.create_bible_presentation(name).await?;
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation.id.to_string(),
         });
@@ -245,41 +217,88 @@ impl AppState {
 
     pub async fn rename_bible_presentation(
         &self,
-        id: PresentationId,
+        id: BiblePresentationId,
         name: &str,
     ) -> anyhow::Result<()> {
-        self.repository.rename_presentation(id, name).await
+        self.repository.rename_bible_presentation(id, name).await
+    }
+
+    pub async fn delete_bible_presentation(&self, id: BiblePresentationId) -> anyhow::Result<()> {
+        self.repository.delete_bible_presentation(id).await?;
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: id.to_string(),
+        });
+        Ok(())
     }
 
     pub async fn append_bible_presentation_slides(
         &self,
-        id: PresentationId,
-        new_slides: Vec<Slide>,
-    ) -> anyhow::Result<Presentation> {
-        let (_, _, mut presentation) = self
+        id: BiblePresentationId,
+        new_slides: Vec<BiblePresentationSlide>,
+    ) -> anyhow::Result<BiblePresentation> {
+        // Filter out empty placeholder slides (empty main text and empty reference)
+        let filtered: Vec<BiblePresentationSlide> = new_slides
+            .into_iter()
+            .filter(|s| !s.main.value().is_empty() || !s.main_reference.is_empty())
+            .collect();
+        let presentation = self
             .repository
-            .fetch_presentation_detail(id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
-        // Filter out empty placeholder slides created by default
-        // (empty main, translation, and stage text)
-        presentation.slides.retain(|s| {
-            !s.content.main.value().is_empty()
-                || !s.content.translation.value().is_empty()
-                || !s.content.stage.value().is_empty()
-        });
-        let start_order = presentation.slides.len() as u32;
-        for (i, mut slide) in new_slides.into_iter().enumerate() {
-            slide.order = start_order + i as u32;
-            presentation.slides.push(slide);
-        }
-        self.repository
-            .replace_presentation_slides(id, &presentation.slides)
+            .append_bible_presentation_slides(id, &filtered)
             .await?;
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
-            presentation_id: id.to_string(),
+            presentation_id: presentation.id.to_string(),
         });
         Ok(presentation)
+    }
+
+    /// Replace a single slide within a bible presentation. Implemented via
+    /// fetch + modify + replace_all — bible presentation slide counts are
+    /// small (typically a few to a few dozen), so read-modify-write is fine.
+    pub async fn update_bible_slide(
+        &self,
+        presentation_id: BiblePresentationId,
+        slide_id: BibleSlideId,
+        main_text: String,
+        main_reference: String,
+        secondary_text: String,
+        secondary_reference: String,
+        metadata: Option<BibleSlideMetadata>,
+    ) -> anyhow::Result<BiblePresentationSlide> {
+        let mut presentation = self
+            .repository
+            .fetch_bible_presentation(presentation_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+
+        let main =
+            SlideText::new(main_text).map_err(|err| anyhow::anyhow!("invalid main text: {err}"))?;
+        let secondary = SlideText::new(secondary_text)
+            .map_err(|err| anyhow::anyhow!("invalid secondary text: {err}"))?;
+
+        let mut updated_slide: Option<BiblePresentationSlide> = None;
+        for slide in &mut presentation.slides {
+            if slide.id == slide_id {
+                slide.main = main.clone();
+                slide.main_reference = main_reference.clone();
+                slide.secondary = secondary.clone();
+                slide.secondary_reference = secondary_reference.clone();
+                slide.metadata = metadata.clone();
+                updated_slide = Some(slide.clone());
+                break;
+            }
+        }
+        let updated_slide =
+            updated_slide.ok_or_else(|| anyhow::anyhow!("slide not found in presentation"))?;
+
+        self.repository
+            .replace_bible_presentation_slides(presentation_id, &presentation.slides)
+            .await?;
+
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: presentation_id.to_string(),
+        });
+
+        Ok(updated_slide)
     }
 
     // Bible preferences (persisted via app_settings)

--- a/crates/presenter-server/src/state/broadcasting.rs
+++ b/crates/presenter-server/src/state/broadcasting.rs
@@ -9,11 +9,9 @@ use super::stage::{
     build_stage_snapshot, sanitize_song_title, stage_resolution_from_presentation, StageContext,
     StageResolution,
 };
-use presenter_core::bible::BibleSlideOutput;
-
 use super::AppState;
 use crate::live::LiveEvent;
-use crate::resolume::{BibleUpdate, StageUpdate};
+use crate::resolume::StageUpdate;
 
 impl AppState {
     pub(super) fn publish_stage_update(&self, snapshot: StageDisplaySnapshot) {
@@ -76,24 +74,6 @@ impl AppState {
             band_name: Some(band_name),
         };
         self.resolume_registry.stage_update(stage_update).await;
-
-        // If the current slide has a Bible reference in the `stage` field,
-        // also emit a BibleUpdate so Resolume #bible-reference-a/b clips
-        // show the actual reference instead of the library name.
-        if let Some(ref slide) = context.resolution.current {
-            if !slide.stage.is_empty() {
-                let bible_output = BibleSlideOutput {
-                    main_text: slide.main.clone(),
-                    main_reference: slide.stage.clone(),
-                    secondary_text: slide.translation.clone(),
-                    secondary_reference: String::new(),
-                    triggered_at: now,
-                };
-                self.resolume_registry
-                    .bible_update(BibleUpdate::from_slide_output(Some(bible_output)))
-                    .await;
-            }
-        }
 
         Ok(())
     }

--- a/crates/presenter-ui/src/api/bible.rs
+++ b/crates/presenter-ui/src/api/bible.rs
@@ -423,15 +423,14 @@ pub async fn update_bible_slide(
     .await
 }
 
-/// Delete a slide from a Bible presentation. Uses the generic presentations endpoint.
-/// Server: DELETE /presentations/{id}/slides/{slide_id}
+/// Delete a slide from a Bible presentation.
+/// Server: DELETE /bible/presentations/{id}/slides/{slide_id}
 pub async fn delete_presentation_slide(
     presentation_id: &str,
     slide_id: &str,
 ) -> Result<(), ApiError> {
-    // The generic endpoint returns Vec<Slide> but we just need success
-    let _slides: Vec<serde_json::Value> = super::delete_json(&format!(
-        "/presentations/{presentation_id}/slides/{slide_id}"
+    let _detail: BiblePresentationDetail = super::delete_json(&format!(
+        "/bible/presentations/{presentation_id}/slides/{slide_id}"
     ))
     .await?;
     Ok(())
@@ -443,14 +442,14 @@ struct ReorderSlidesRequest {
     slide_ids: Vec<String>,
 }
 
-/// Reorder slides in a Bible presentation. Uses the generic presentations endpoint.
-/// Server: POST /presentations/{id}/slides/reorder
+/// Reorder slides in a Bible presentation.
+/// Server: POST /bible/presentations/{id}/slides/reorder
 pub async fn reorder_presentation_slides(
     presentation_id: &str,
     slide_ids: Vec<String>,
 ) -> Result<(), ApiError> {
-    let _slides: Vec<serde_json::Value> = super::post_json(
-        &format!("/presentations/{presentation_id}/slides/reorder"),
+    let _detail: BiblePresentationDetail = super::post_json(
+        &format!("/bible/presentations/{presentation_id}/slides/reorder"),
         &ReorderSlidesRequest { slide_ids },
     )
     .await?;

--- a/crates/presenter-ui/src/pages/bible_slides.rs
+++ b/crates/presenter-ui/src/pages/bible_slides.rs
@@ -162,8 +162,8 @@ fn build_trigger_request(
         book_code: meta.and_then(|m| m.book_code.clone()),
         book_number: meta.and_then(|m| m.book_number),
         chapter: meta.and_then(|m| m.chapter),
-        verse_start: meta.and_then(|m| m.verse_start),
-        verse_end: meta.and_then(|m| m.verse_end),
+        verse_start: meta.and_then(|m| m.effective_verse_start()),
+        verse_end: meta.and_then(|m| m.effective_verse_end()),
     }
 }
 

--- a/docs/superpowers/plans/2026-04-10-bible-worship-separation.md
+++ b/docs/superpowers/plans/2026-04-10-bible-worship-separation.md
@@ -1,0 +1,2004 @@
+# Bible/Worship Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fully separate bible content from worship content at the storage, domain, repository, broadcasting, and AI-tools layers, eliminating field overloading and string-based type discrimination.
+
+**Architecture:** Add `bible_presentations` and `bible_slides` tables (no library wrapper since there's only one bible per system). Drop the bible_* columns from the worship `slides` table and the dead `category` column from `libraries`. Drop any existing bible library row outright (user explicitly OK with dropping the 2 production presentations). Add new `BiblePresentation` / `BibleSlide` Rust types with their own newtype IDs. Replace all `eq_ignore_ascii_case("Bible")` lookups with proper repository methods. Delete the broadcasting leak that emits `BibleUpdate` based on the worship `stage` field.
+
+**Tech Stack:** Rust (sea-orm, sea-orm-migration, axum, tokio), Leptos WASM (presenter-ui), Playwright E2E
+
+**Spec:** `docs/superpowers/specs/2026-04-10-bible-worship-separation-design.md`
+
+---
+
+## Context
+
+Issue #231: Bible and worship currently share storage and broadcasting code. Symptoms:
+
+1. **Bible library shows in worship UI list** (#227 — pre-existing since v0.1.2)
+2. **Field overloading**: worship `stage` field is reused for bible reference labels, causing worship slides with non-empty stage text to trigger spurious `BibleUpdate` broadcasts to Resolume
+3. **String matching** for type identification in 4 code locations (`state/bible.rs:204, 230`, `ai/tools.rs:375, 685`)
+4. **Dead `category` column** on `libraries` from an aborted earlier separation attempt
+
+User chose a **single big-bang PR** approach (per spec). Existing bible presentations on production are dropped (user confirmed).
+
+**Key existing code:**
+- `crates/presenter-migration/src/m20250927_000001_create_core_tables.rs` — original schema creating slides with 14 columns + dead category column
+- `crates/presenter-migration/src/m20260408_000001_add_preach_limit.rs` — example of an idempotent ALTER migration with `pragma_table_info` column-existence check
+- `crates/presenter-persistence/src/entities.rs:106-155` — `slide::Model` with 7 worship + 7 bible + metadata_json fields
+- `crates/presenter-persistence/src/repository/util.rs:66, 371` — `is_bible = !model.bible_main.is_empty()` content inspection
+- `crates/presenter-server/src/state/bible.rs:198-244` — string-based bible library lookups
+- `crates/presenter-server/src/state/broadcasting.rs:83-96` — the BibleUpdate-from-stage-field leak
+- `crates/presenter-server/src/ai/tools.rs:375, 685` — magic string checks
+- `crates/presenter-core/src/bible.rs` — currently empty / not present; will create
+
+---
+
+## File Structure
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `crates/presenter-migration/src/m20260410_000001_separate_bible.rs` | Schema migration: add bible_presentations + bible_slides tables, drop the bible library row, drop bible_* columns from slides, drop category column from libraries |
+| `crates/presenter-core/src/bible.rs` | Domain types: `BiblePresentation`, `BibleSlide`, `BiblePresentationId`, `BibleSlideId`, `BiblePresentationSummary` |
+| `crates/presenter-persistence/src/repository/bible.rs` | Repository methods for bible presentations and slides |
+| `crates/presenter-persistence/src/entities/bible_presentation.rs` (or inline in entities.rs) | sea-orm entity for `bible_presentations` |
+| `crates/presenter-persistence/src/entities/bible_slide.rs` (or inline in entities.rs) | sea-orm entity for `bible_slides` |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `crates/presenter-migration/src/lib.rs` | Register the new migration |
+| `crates/presenter-persistence/src/entities.rs` | Add `bible_presentation` and `bible_slide` entity modules; remove the 7 bible_* fields and `metadata_json` from `slide::Model` |
+| `crates/presenter-persistence/src/repository/mod.rs` | Re-export new bible methods |
+| `crates/presenter-persistence/src/repository/util.rs` | Drop the `is_bible` content inspection at lines 66 and 371; simplify worship slide conversion |
+| `crates/presenter-core/src/lib.rs` | Re-export `bible` module types; document the unprefixed-means-worship convention |
+| `crates/presenter-server/src/state/bible.rs` | Replace string-based library lookups (lines 198-244) with new repository methods; remove `create_bible_presentation`'s ensure-library branch |
+| `crates/presenter-server/src/state/broadcasting.rs` | Delete the BibleUpdate-from-stage-field leak (lines 83-96) |
+| `crates/presenter-server/src/router/bible.rs` | Update handlers to use new `BiblePresentation`/`BibleSlide` types |
+| `crates/presenter-server/src/ai/tools.rs` | Replace magic-string checks at lines 375 and 685 |
+| `tests/e2e/bible-presentation-append.spec.ts` | Verify still passing after changes |
+| `tests/e2e/bible-trigger-slide.spec.ts` | Verify still passing after changes |
+| New: regression test E2E file or new test in existing file | Worship library list does NOT contain Bible after a bible presentation is created |
+| `Cargo.toml` | Version bump 0.4.14 → 0.4.15 |
+
+---
+
+## Task 1: Schema Migration
+
+**Files:**
+- Create: `crates/presenter-migration/src/m20260410_000001_separate_bible.rs`
+- Modify: `crates/presenter-migration/src/lib.rs`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `crates/presenter-migration/src/m20260410_000001_separate_bible.rs` with this exact content:
+
+```rust
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // 1. Create bible_presentations table (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE TABLE IF NOT EXISTS "bible_presentations" (
+                "id" varchar(36) NOT NULL PRIMARY KEY,
+                "name" varchar NOT NULL,
+                "created_at" timestamp_with_timezone_text NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )"#,
+        ))
+        .await?;
+
+        // 2. Create bible_slides table (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE TABLE IF NOT EXISTS "bible_slides" (
+                "id" varchar(36) NOT NULL PRIMARY KEY,
+                "presentation_id" varchar(36) NOT NULL,
+                "slide_order" integer NOT NULL,
+                "main_text" text NOT NULL,
+                "main_search" text NOT NULL DEFAULT '',
+                "main_reference" text NOT NULL,
+                "secondary_text" text NOT NULL DEFAULT '',
+                "secondary_search" text NOT NULL DEFAULT '',
+                "secondary_reference" text NOT NULL DEFAULT '',
+                "metadata_json" text,
+                FOREIGN KEY ("presentation_id") REFERENCES "bible_presentations"("id") ON DELETE CASCADE
+            )"#,
+        ))
+        .await?;
+
+        // 3. Index on presentation_id for slide lookups (idempotent)
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"CREATE INDEX IF NOT EXISTS "idx_bible_slides_presentation_id"
+               ON "bible_slides" ("presentation_id")"#,
+        ))
+        .await?;
+
+        // 4. Delete any existing bible library row + cascade-delete its
+        //    presentations and slides. User explicitly confirmed this is OK.
+        //    SQLite cascades through the existing FKs.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DELETE FROM "libraries" WHERE LOWER("name") = 'bible'"#,
+        ))
+        .await?;
+
+        // 5. Drop the dead category column from libraries (guarded).
+        if column_exists(db, "libraries", "category").await? {
+            db.execute(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                r#"ALTER TABLE "libraries" DROP COLUMN "category""#,
+            ))
+            .await?;
+        }
+
+        // 6. Drop the bible_* columns and the metadata_json column from slides.
+        for col in [
+            "bible_main",
+            "bible_main_search",
+            "bible_main_reference",
+            "bible_translation",
+            "bible_translation_search",
+            "bible_translation_reference",
+            "metadata_json",
+        ] {
+            if column_exists(db, "slides", col).await? {
+                db.execute(sea_orm::Statement::from_string(
+                    sea_orm::DatabaseBackend::Sqlite,
+                    format!(r#"ALTER TABLE "slides" DROP COLUMN "{col}""#),
+                ))
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Re-add the dropped columns to slides (with empty defaults).
+        for (col, sql_type) in [
+            ("bible_main", "text NOT NULL DEFAULT ''"),
+            ("bible_main_search", "text NOT NULL DEFAULT ''"),
+            ("bible_main_reference", "text NOT NULL DEFAULT ''"),
+            ("bible_translation", "text NOT NULL DEFAULT ''"),
+            ("bible_translation_search", "text NOT NULL DEFAULT ''"),
+            ("bible_translation_reference", "text NOT NULL DEFAULT ''"),
+            ("metadata_json", "text"),
+        ] {
+            if !column_exists(db, "slides", col).await? {
+                db.execute(sea_orm::Statement::from_string(
+                    sea_orm::DatabaseBackend::Sqlite,
+                    format!(r#"ALTER TABLE "slides" ADD COLUMN "{col}" {sql_type}"#),
+                ))
+                .await?;
+            }
+        }
+
+        // Re-add the dead category column.
+        if !column_exists(db, "libraries", "category").await? {
+            db.execute(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                r#"ALTER TABLE "libraries" ADD COLUMN "category" varchar(32) NOT NULL DEFAULT 'worship'"#,
+            ))
+            .await?;
+        }
+
+        // Drop the new bible tables.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DROP TABLE IF EXISTS "bible_slides""#,
+        ))
+        .await?;
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            r#"DROP TABLE IF EXISTS "bible_presentations""#,
+        ))
+        .await?;
+
+        Ok(())
+    }
+}
+
+async fn column_exists(
+    db: &sea_orm::DatabaseConnection,
+    table: &str,
+    column: &str,
+) -> Result<bool, DbErr> {
+    let row = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            format!(
+                "SELECT COUNT(*) as cnt FROM pragma_table_info('{table}') WHERE name='{column}'"
+            ),
+        ))
+        .await?;
+    Ok(row
+        .map(|r| r.try_get::<i32>("", "cnt").unwrap_or(0) > 0)
+        .unwrap_or(false))
+}
+```
+
+- [ ] **Step 2: Register the migration**
+
+In `crates/presenter-migration/src/lib.rs`, add the new migration to the module list and `migrations()` vec:
+
+```rust
+pub use sea_orm_migration::prelude::*;
+
+mod m20250927_000001_create_core_tables;
+mod m20260408_000001_add_preach_limit;
+mod m20260410_000001_separate_bible;
+
+pub struct Migrator;
+
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![
+            Box::new(m20250927_000001_create_core_tables::Migration),
+            Box::new(m20260408_000001_add_preach_limit::Migration),
+            Box::new(m20260410_000001_separate_bible::Migration),
+        ]
+    }
+}
+```
+
+- [ ] **Step 3: Run cargo check on the migration crate**
+
+```bash
+cargo check -p presenter-migration 2>&1 | tail -10
+```
+
+Expected: clean build, no errors.
+
+- [ ] **Step 4: Test the migration against a fresh DB**
+
+```bash
+rm -f /tmp/migration-test.db
+PRESENTER_DB_URL=sqlite:///tmp/migration-test.db cargo run -p presenter-server -- --migrations-only 2>&1 | tail -20
+```
+
+If `--migrations-only` doesn't exist, instead:
+
+```bash
+rm -f /tmp/migration-test.db
+PRESENTER_DB_URL=sqlite:///tmp/migration-test.db timeout 5 cargo run -p presenter-server 2>&1 | grep -i 'migrat\|error' | head -10
+```
+
+Then verify the schema:
+
+```bash
+sqlite3 /tmp/migration-test.db "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name" | grep bible
+```
+
+Expected output includes `bible_presentations` and `bible_slides`. Should NOT include any "category" column on libraries:
+
+```bash
+sqlite3 /tmp/migration-test.db ".schema libraries" | grep -c category
+```
+
+Expected: `0`
+
+- [ ] **Step 5: Test the migration against a copy of the dev DB**
+
+```bash
+cp /opt/presenter-dev/presenter.db /tmp/migration-prod-copy.db
+PRESENTER_DB_URL=sqlite:///tmp/migration-prod-copy.db timeout 10 cargo run -p presenter-server 2>&1 | grep -iE 'migrat|error|fatal' | head -15
+```
+
+Expected: migration runs, server starts, no errors. Verify the bible library row is gone:
+
+```bash
+sqlite3 /tmp/migration-prod-copy.db "SELECT name FROM libraries WHERE LOWER(name) = 'bible'"
+```
+
+Expected: empty output.
+
+Verify bible_* columns are gone from slides:
+
+```bash
+sqlite3 /tmp/migration-prod-copy.db ".schema slides" | grep -c bible_
+```
+
+Expected: `0`
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-migration/src/m20260410_000001_separate_bible.rs crates/presenter-migration/src/lib.rs
+git commit -m "feat(migration): add separate_bible migration for #231
+
+Creates bible_presentations and bible_slides tables. Drops the
+dead category column from libraries. Drops the 7 bible_* columns
+and metadata_json from slides. Deletes any existing bible library
+row (user explicitly confirmed dropping the 2 production bible
+presentations).
+
+The migration is idempotent: tables use IF NOT EXISTS, column
+drops are guarded by pragma_table_info checks following the
+pattern from m20260408_000001_add_preach_limit."
+```
+
+---
+
+## Task 2: Bible Domain Types
+
+**Files:**
+- Create: `crates/presenter-core/src/bible.rs`
+- Modify: `crates/presenter-core/src/lib.rs`
+
+- [ ] **Step 1: Check what already exists in presenter-core for bible**
+
+```bash
+ls crates/presenter-core/src/ | grep -i bible
+```
+
+If `bible.rs` already exists, read it first to know what to extend. The existing module likely has `BibleSlideOutput`, `BibleSlideMetadata`, `BibleSlideVerseRef` etc. — leave those alone, just add the new types alongside.
+
+- [ ] **Step 2: Add the new types to `crates/presenter-core/src/bible.rs`**
+
+Append (or create) with the following content. Adjust imports if the file already exists:
+
+```rust
+use crate::slide::{SlideText, SlideTextError};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Identifier for a `BiblePresentation`. Distinct from `PresentationId` so
+/// the type system prevents mixing worship and bible IDs at API boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BiblePresentationId(pub Uuid);
+
+impl BiblePresentationId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for BiblePresentationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for BiblePresentationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Identifier for a `BibleSlide`. Distinct from `SlideId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BibleSlideId(pub Uuid);
+
+impl BibleSlideId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for BibleSlideId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for BibleSlideId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A user-curated collection of bible slides (e.g., for a sermon series).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BiblePresentation {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slides: Vec<BibleSlide>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A single bible slide within a `BiblePresentation`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BibleSlide {
+    pub id: BibleSlideId,
+    pub order: u32,
+    pub main: SlideText,
+    pub main_reference: String,
+    pub secondary: SlideText,
+    pub secondary_reference: String,
+    pub metadata: Option<BibleSlideMetadata>,
+}
+
+/// Lightweight summary of a bible presentation for list views.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BiblePresentationSummary {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slide_count: usize,
+}
+
+/// Bible-specific metadata stored as JSON in the database.
+///
+/// This carries reference info that worship slides do not have:
+/// translation codes, book/chapter/verse breakdown, etc.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BibleSlideMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub translation_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secondary_translation_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub book: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub book_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub book_number: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chapter: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verses: Vec<BibleSlideVerseRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub main_reference_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub translation_reference_label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BibleSlideVerseRef {
+    pub start: i32,
+    pub end: i32,
+}
+```
+
+**IMPORTANT:** If `BibleSlideMetadata` and `BibleSlideVerseRef` already exist in this file or in `crates/presenter-core/src/slide.rs`, do NOT redefine them — re-export the existing definitions instead. Use grep to check first:
+
+```bash
+grep -rn "struct BibleSlideMetadata\|struct BibleSlideVerseRef" crates/presenter-core/src/
+```
+
+If they exist elsewhere, use:
+
+```rust
+pub use crate::slide::{BibleSlideMetadata, BibleSlideVerseRef};
+```
+
+at the top of `bible.rs` instead of redefining.
+
+- [ ] **Step 3: Re-export from `crates/presenter-core/src/lib.rs`**
+
+Find the existing `pub mod bible;` (or similar) line. If `bible.rs` is a new module, add:
+
+```rust
+pub mod bible;
+```
+
+And re-export the new types alongside existing exports:
+
+```rust
+pub use bible::{
+    BiblePresentation, BiblePresentationId, BiblePresentationSummary, BibleSlide,
+    BibleSlideId, BibleSlideMetadata, BibleSlideVerseRef,
+};
+```
+
+**Convention comment:** add this near the top of `lib.rs`:
+
+```rust
+// Naming convention:
+// - Unprefixed types (Library, Presentation, Slide, SlideContent) mean WORSHIP.
+// - Bible-prefixed types (BiblePresentation, BibleSlide) mean BIBLE.
+// Bible has no library wrapper — there is exactly one bible per system.
+```
+
+- [ ] **Step 4: Add unit tests for the new ID types**
+
+In the same `bible.rs` file, append:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bible_presentation_id_roundtrips_uuid() {
+        let original = Uuid::new_v4();
+        let id = BiblePresentationId::from_uuid(original);
+        assert_eq!(id.as_uuid(), original);
+    }
+
+    #[test]
+    fn bible_slide_id_roundtrips_uuid() {
+        let original = Uuid::new_v4();
+        let id = BibleSlideId::from_uuid(original);
+        assert_eq!(id.as_uuid(), original);
+    }
+
+    #[test]
+    fn bible_presentation_id_serializes_as_uuid_string() {
+        let id = BiblePresentationId::from_uuid(
+            Uuid::parse_str("01234567-89ab-cdef-0123-456789abcdef").unwrap(),
+        );
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, r#""01234567-89ab-cdef-0123-456789abcdef""#);
+    }
+
+    #[test]
+    fn bible_presentation_serialization_uses_camel_case() {
+        let pres = BiblePresentation {
+            id: BiblePresentationId::from_uuid(Uuid::nil()),
+            name: "Test".to_string(),
+            slides: vec![],
+            created_at: chrono::DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        };
+        let json = serde_json::to_string(&pres).unwrap();
+        assert!(json.contains(r#""createdAt""#));
+        assert!(!json.contains(r#""created_at""#));
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cargo test -p presenter-core --lib bible:: 2>&1 | tail -15
+```
+
+Expected: 4 new tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-core/src/bible.rs crates/presenter-core/src/lib.rs
+git commit -m "feat(core): add BiblePresentation and BibleSlide domain types (#231)
+
+Adds BiblePresentation, BibleSlide, BiblePresentationId, BibleSlideId,
+and BiblePresentationSummary types to crates/presenter-core/src/bible.rs.
+The new IDs are newtype wrappers that are NOT compatible with the
+existing PresentationId/SlideId, so the type system prevents mixing
+worship and bible IDs at API boundaries.
+
+Documents the convention in lib.rs: unprefixed types mean worship,
+Bible-prefixed types mean bible. Bible has no library wrapper since
+there's exactly one bible per system.
+
+Includes 4 unit tests covering ID round-trip, JSON serialization,
+and camelCase output."
+```
+
+---
+
+## Task 3: Bible sea-orm Entities
+
+**Files:**
+- Modify: `crates/presenter-persistence/src/entities.rs`
+
+- [ ] **Step 1: Add bible_presentation entity module**
+
+In `crates/presenter-persistence/src/entities.rs`, add this module after the existing `bible_passage` module (around line 406):
+
+```rust
+pub mod bible_presentation {
+    use super::bible_slide;
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "bible_presentations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub name: String,
+        pub created_at: DateTimeWithTimeZone,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(has_many = "bible_slide::Entity")]
+        Slides,
+    }
+
+    impl Related<bible_slide::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Slides.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod bible_slide {
+    use super::bible_presentation;
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "bible_slides")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub presentation_id: String,
+        pub slide_order: i32,
+        pub main_text: String,
+        pub main_search: String,
+        pub main_reference: String,
+        pub secondary_text: String,
+        pub secondary_search: String,
+        pub secondary_reference: String,
+        pub metadata_json: Option<String>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "bible_presentation::Entity",
+            from = "Column::PresentationId",
+            to = "bible_presentation::Column::Id",
+            on_update = "Cascade",
+            on_delete = "Cascade"
+        )]
+        Presentation,
+    }
+
+    impl Related<bible_presentation::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Presentation.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+```
+
+- [ ] **Step 2: Re-export the new entities**
+
+Find the existing `pub use ... as ...Entity;` block (around line 408-415) and add:
+
+```rust
+pub use bible_presentation::Entity as BiblePresentationEntity;
+pub use bible_slide::Entity as BibleSlideEntity;
+```
+
+- [ ] **Step 3: Remove bible_* fields from `slide::Model`**
+
+Find `pub mod slide` (around line 106). Replace the entire `Model` struct definition (lines 110-134) so that the bible_* and metadata_json fields are removed:
+
+```rust
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "slides")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub presentation_id: String,
+        pub position: i32,
+        // Worship columns
+        pub worship_main: String,
+        pub worship_main_search: String,
+        pub worship_translate: String,
+        pub worship_translate_search: String,
+        pub worship_stage: String,
+        pub worship_stage_search: String,
+        pub worship_group: Option<String>,
+        pub created_at: DateTimeWithTimeZone,
+    }
+```
+
+- [ ] **Step 4: Build to find broken references**
+
+```bash
+cargo check -p presenter-persistence 2>&1 | tail -30
+```
+
+Expected: errors in `repository/util.rs` (and possibly other files) referencing the now-removed fields. **Do NOT fix these in this task** — they're handled in Task 4. Note the file/line of each error for reference.
+
+- [ ] **Step 5: Commit (allowing repository to be temporarily broken)**
+
+```bash
+cargo fmt --all
+git add crates/presenter-persistence/src/entities.rs
+git commit -m "feat(persistence): add bible_presentation/bible_slide entities, drop bible_* from slide (#231)
+
+Adds sea-orm entity definitions for bible_presentations and
+bible_slides tables. Removes the 7 bible_* fields and metadata_json
+from slide::Model since those columns are dropped by the new
+migration.
+
+This commit temporarily breaks repository/util.rs which still
+references the removed fields — fixed in the next task. Done as
+two commits so the entity change and the repo cleanup are
+reviewable independently."
+```
+
+**Note:** It's OK that this commit leaves the workspace not compiling. The next task fixes it. We commit anyway because the changes are independently meaningful.
+
+---
+
+## Task 4: Repository Cleanup + Bible Repository Methods
+
+**Files:**
+- Modify: `crates/presenter-persistence/src/repository/util.rs`
+- Create: `crates/presenter-persistence/src/repository/bible.rs`
+- Modify: `crates/presenter-persistence/src/repository/mod.rs`
+
+- [ ] **Step 1: Read util.rs to find all bible references**
+
+```bash
+grep -n "bible_\|is_bible\|metadata_json\|BibleSlide\|MetadataJson" crates/presenter-persistence/src/repository/util.rs
+```
+
+Make a list of every line that references bible-specific fields. These all need to be cleaned up.
+
+- [ ] **Step 2: Simplify `to_domain_slide` in util.rs**
+
+Around line 64, the current `to_domain_slide` function checks `is_bible = !model.bible_main.is_empty()` and branches on it. Replace the entire function so it ONLY handles worship slides:
+
+Open `crates/presenter-persistence/src/repository/util.rs`, find the `to_domain_slide` function and rewrite it. The function should:
+1. Take a `slide::Model` reference
+2. Build a `Slide` from the worship_* fields only
+3. NOT check `is_bible` and NOT touch any bible_* fields (which no longer exist)
+
+Concrete pattern (adapt to the actual surrounding code; read the current function before editing):
+
+```rust
+pub(crate) fn to_domain_slide(model: &slide::Model) -> anyhow::Result<Slide> {
+    let main = SlideText::new(&model.worship_main)
+        .map_err(|e| anyhow::anyhow!("invalid worship_main: {e}"))?;
+    let translation = SlideText::new(&model.worship_translate)
+        .map_err(|e| anyhow::anyhow!("invalid worship_translate: {e}"))?;
+    let stage = SlideText::new(&model.worship_stage)
+        .map_err(|e| anyhow::anyhow!("invalid worship_stage: {e}"))?;
+    let group = model
+        .worship_group
+        .as_ref()
+        .map(|name| SlideGroup::new(name.clone()))
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid worship_group: {e}"))?;
+    let content = SlideContent::new(main, translation, stage, group);
+    Ok(Slide {
+        id: SlideId::from_uuid(parse_uuid(&model.id)?),
+        order: model.position as u32,
+        content,
+    })
+}
+```
+
+The exact field initialization may vary based on the current `Slide` struct. **Read the current function before editing** and preserve any non-bible logic (e.g., metadata, timestamps, error handling) that exists.
+
+- [ ] **Step 3: Simplify `build_slide_active_model` in util.rs**
+
+Around line 371, the same file has `build_slide_active_model` which checks `is_bible` based on metadata. Replace it so it only writes worship_* columns. The function should:
+1. Take a `Slide` (worship slide)
+2. Build a `slide::ActiveModel` with worship_main, worship_main_search, worship_translate, worship_translate_search, worship_stage, worship_stage_search, worship_group set
+3. NOT touch any bible_* fields (they don't exist anymore)
+4. NOT touch metadata_json (column dropped)
+
+Read the current function first to preserve its non-bible behavior (id generation, search field computation, etc.).
+
+- [ ] **Step 4: Build to verify util.rs compiles**
+
+```bash
+cargo check -p presenter-persistence 2>&1 | tail -20
+```
+
+Expected: clean build OR errors only in OTHER files (state/bible.rs, etc.) that we'll fix in later tasks.
+
+If util.rs itself still has errors (e.g., unused imports), fix them before proceeding:
+
+```bash
+cargo check -p presenter-persistence 2>&1 | grep "src/repository/util.rs"
+```
+
+- [ ] **Step 5: Create bible.rs repository file**
+
+Create `crates/presenter-persistence/src/repository/bible.rs`:
+
+```rust
+use crate::entities::{bible_presentation, bible_slide};
+use crate::repository::Repository;
+use anyhow::{Context, Result};
+use chrono::Utc;
+use presenter_core::{
+    BiblePresentation, BiblePresentationId, BiblePresentationSummary, BibleSlide, BibleSlideId,
+    BibleSlideMetadata, SlideText,
+};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+
+impl Repository {
+    /// Returns lightweight summaries of all bible presentations, ordered by name.
+    pub async fn list_bible_presentation_summaries(
+        &self,
+    ) -> Result<Vec<BiblePresentationSummary>> {
+        let presentations = bible_presentation::Entity::find()
+            .order_by_asc(bible_presentation::Column::Name)
+            .all(&self.db)
+            .await
+            .context("listing bible presentations")?;
+
+        let mut summaries = Vec::with_capacity(presentations.len());
+        for p in presentations {
+            let slide_count = bible_slide::Entity::find()
+                .filter(bible_slide::Column::PresentationId.eq(&p.id))
+                .count(&self.db)
+                .await
+                .context("counting slides for bible presentation")?
+                as usize;
+            summaries.push(BiblePresentationSummary {
+                id: BiblePresentationId::from_uuid(parse_uuid(&p.id)?),
+                name: p.name,
+                slide_count,
+            });
+        }
+        Ok(summaries)
+    }
+
+    /// Fetches a single bible presentation with all its slides.
+    pub async fn fetch_bible_presentation(
+        &self,
+        id: BiblePresentationId,
+    ) -> Result<Option<BiblePresentation>> {
+        let id_str = id.to_string();
+        let Some(p) = bible_presentation::Entity::find_by_id(&id_str)
+            .one(&self.db)
+            .await
+            .context("fetching bible presentation")?
+        else {
+            return Ok(None);
+        };
+
+        let slide_models = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(&id_str))
+            .order_by_asc(bible_slide::Column::SlideOrder)
+            .all(&self.db)
+            .await
+            .context("fetching bible slides")?;
+
+        let mut slides = Vec::with_capacity(slide_models.len());
+        for m in slide_models {
+            slides.push(model_to_bible_slide(m)?);
+        }
+
+        Ok(Some(BiblePresentation {
+            id,
+            name: p.name,
+            slides,
+            created_at: p.created_at.with_timezone(&Utc),
+        }))
+    }
+
+    /// Creates a new empty bible presentation.
+    pub async fn create_bible_presentation(&self, name: &str) -> Result<BiblePresentation> {
+        let id = BiblePresentationId::new();
+        let now = Utc::now();
+        let model = bible_presentation::ActiveModel {
+            id: Set(id.to_string()),
+            name: Set(name.to_string()),
+            created_at: Set(now.into()),
+        };
+        model
+            .insert(&self.db)
+            .await
+            .context("creating bible presentation")?;
+        Ok(BiblePresentation {
+            id,
+            name: name.to_string(),
+            slides: vec![],
+            created_at: now,
+        })
+    }
+
+    /// Renames an existing bible presentation.
+    pub async fn rename_bible_presentation(
+        &self,
+        id: BiblePresentationId,
+        name: &str,
+    ) -> Result<()> {
+        let id_str = id.to_string();
+        let Some(model) = bible_presentation::Entity::find_by_id(&id_str)
+            .one(&self.db)
+            .await
+            .context("fetching bible presentation for rename")?
+        else {
+            return Err(anyhow::anyhow!("bible presentation not found"));
+        };
+        let mut active: bible_presentation::ActiveModel = model.into();
+        active.name = Set(name.to_string());
+        active
+            .update(&self.db)
+            .await
+            .context("renaming bible presentation")?;
+        Ok(())
+    }
+
+    /// Deletes a bible presentation and all its slides (cascade).
+    pub async fn delete_bible_presentation(&self, id: BiblePresentationId) -> Result<()> {
+        let id_str = id.to_string();
+        bible_presentation::Entity::delete_by_id(&id_str)
+            .exec(&self.db)
+            .await
+            .context("deleting bible presentation")?;
+        Ok(())
+    }
+
+    /// Replaces all slides on a bible presentation with the provided ones.
+    pub async fn replace_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BibleSlide],
+    ) -> Result<()> {
+        let id_str = id.to_string();
+
+        // Verify the presentation exists
+        let exists = bible_presentation::Entity::find_by_id(&id_str)
+            .one(&self.db)
+            .await
+            .context("checking bible presentation exists")?
+            .is_some();
+        if !exists {
+            return Err(anyhow::anyhow!("bible presentation not found"));
+        }
+
+        // Delete existing slides
+        bible_slide::Entity::delete_many()
+            .filter(bible_slide::Column::PresentationId.eq(&id_str))
+            .exec(&self.db)
+            .await
+            .context("clearing bible slides")?;
+
+        // Insert new slides
+        for slide in slides {
+            let active = bible_slide_to_active_model(slide, &id_str)?;
+            active
+                .insert(&self.db)
+                .await
+                .context("inserting bible slide")?;
+        }
+        Ok(())
+    }
+
+    /// Appends slides to an existing bible presentation. Returns the
+    /// updated presentation with all slides included.
+    pub async fn append_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BibleSlide],
+    ) -> Result<BiblePresentation> {
+        let id_str = id.to_string();
+
+        // Find current max order
+        let max_order = bible_slide::Entity::find()
+            .filter(bible_slide::Column::PresentationId.eq(&id_str))
+            .order_by_desc(bible_slide::Column::SlideOrder)
+            .one(&self.db)
+            .await
+            .context("finding max slide order")?
+            .map(|m| m.slide_order)
+            .unwrap_or(-1);
+
+        for (i, slide) in slides.iter().enumerate() {
+            let mut renumbered = slide.clone();
+            renumbered.order = (max_order + 1 + i as i32) as u32;
+            let active = bible_slide_to_active_model(&renumbered, &id_str)?;
+            active
+                .insert(&self.db)
+                .await
+                .context("appending bible slide")?;
+        }
+
+        self.fetch_bible_presentation(id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bible presentation disappeared"))
+    }
+}
+
+fn parse_uuid(s: &str) -> Result<uuid::Uuid> {
+    uuid::Uuid::parse_str(s).context("parsing UUID")
+}
+
+fn model_to_bible_slide(model: bible_slide::Model) -> Result<BibleSlide> {
+    let main = SlideText::new(&model.main_text)
+        .map_err(|e| anyhow::anyhow!("invalid main_text: {e}"))?;
+    let secondary = SlideText::new(&model.secondary_text)
+        .map_err(|e| anyhow::anyhow!("invalid secondary_text: {e}"))?;
+    let metadata: Option<BibleSlideMetadata> = model
+        .metadata_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .context("parsing bible slide metadata JSON")?;
+    Ok(BibleSlide {
+        id: BibleSlideId::from_uuid(parse_uuid(&model.id)?),
+        order: model.slide_order as u32,
+        main,
+        main_reference: model.main_reference,
+        secondary,
+        secondary_reference: model.secondary_reference,
+        metadata,
+    })
+}
+
+fn bible_slide_to_active_model(
+    slide: &BibleSlide,
+    presentation_id: &str,
+) -> Result<bible_slide::ActiveModel> {
+    let metadata_json = slide
+        .metadata
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .context("serializing bible slide metadata")?;
+    Ok(bible_slide::ActiveModel {
+        id: Set(slide.id.to_string()),
+        presentation_id: Set(presentation_id.to_string()),
+        slide_order: Set(slide.order as i32),
+        main_text: Set(slide.main.value().to_string()),
+        main_search: Set(normalize_search(slide.main.value())),
+        main_reference: Set(slide.main_reference.clone()),
+        secondary_text: Set(slide.secondary.value().to_string()),
+        secondary_search: Set(normalize_search(slide.secondary.value())),
+        secondary_reference: Set(slide.secondary_reference.clone()),
+        metadata_json: Set(metadata_json),
+    })
+}
+
+/// Lower-cased text for search indexing. Matches the convention used by
+/// the worship slide repository.
+fn normalize_search(text: &str) -> String {
+    text.to_lowercase()
+}
+```
+
+**IMPORTANT:** Look at how the existing worship `repository/slide.rs` (or `repository/util.rs`) computes the search field — it may use a more sophisticated normalization (diacritic stripping, etc.). If so, extract that helper into a shared location or call it from here. Don't reinvent.
+
+```bash
+grep -rn "search.*normalize\|normalize_search\|search_text\|fold_to_ascii" crates/presenter-persistence/src/repository/
+```
+
+If there's an existing helper, reuse it.
+
+- [ ] **Step 6: Register the new module in `repository/mod.rs`**
+
+Add `pub mod bible;` to `crates/presenter-persistence/src/repository/mod.rs` alongside the other repository submodule declarations.
+
+- [ ] **Step 7: Build the persistence crate**
+
+```bash
+cargo check -p presenter-persistence 2>&1 | tail -20
+```
+
+Expected: clean build.
+
+- [ ] **Step 8: Add unit tests for the bible repository methods**
+
+In `crates/presenter-persistence/src/repository/bible.rs`, append:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::Repository;
+    use sea_orm::Database;
+
+    async fn fresh_repo() -> Repository {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        // Run migrations
+        use presenter_migration::{Migrator, MigratorTrait};
+        Migrator::up(&db, None).await.unwrap();
+        Repository { db }
+    }
+
+    #[tokio::test]
+    async fn create_and_fetch_bible_presentation() {
+        let repo = fresh_repo().await;
+        let created = repo.create_bible_presentation("My Sermon").await.unwrap();
+        assert_eq!(created.name, "My Sermon");
+        assert!(created.slides.is_empty());
+
+        let fetched = repo
+            .fetch_bible_presentation(created.id)
+            .await
+            .unwrap()
+            .expect("should exist");
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.name, "My Sermon");
+    }
+
+    #[tokio::test]
+    async fn list_bible_presentation_summaries_returns_all() {
+        let repo = fresh_repo().await;
+        repo.create_bible_presentation("Bravo").await.unwrap();
+        repo.create_bible_presentation("Alpha").await.unwrap();
+        let list = repo.list_bible_presentation_summaries().await.unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "Alpha");
+        assert_eq!(list[1].name, "Bravo");
+    }
+
+    #[tokio::test]
+    async fn rename_bible_presentation_updates_name() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Old").await.unwrap();
+        repo.rename_bible_presentation(p.id, "New").await.unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert_eq!(fetched.name, "New");
+    }
+
+    #[tokio::test]
+    async fn delete_bible_presentation_removes_it() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Doomed").await.unwrap();
+        repo.delete_bible_presentation(p.id).await.unwrap();
+        assert!(repo.fetch_bible_presentation(p.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn replace_bible_slides_overwrites_existing() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Test").await.unwrap();
+        let slide = BibleSlide {
+            id: BibleSlideId::new(),
+            order: 0,
+            main: SlideText::new("For God so loved the world").unwrap(),
+            main_reference: "John 3:16".to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        };
+        repo.replace_bible_presentation_slides(p.id, &[slide.clone()])
+            .await
+            .unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert_eq!(fetched.slides.len(), 1);
+        assert_eq!(fetched.slides[0].main_reference, "John 3:16");
+
+        // Replace with empty slides clears them
+        repo.replace_bible_presentation_slides(p.id, &[])
+            .await
+            .unwrap();
+        let fetched = repo.fetch_bible_presentation(p.id).await.unwrap().unwrap();
+        assert!(fetched.slides.is_empty());
+    }
+
+    #[tokio::test]
+    async fn append_bible_slides_preserves_order() {
+        let repo = fresh_repo().await;
+        let p = repo.create_bible_presentation("Test").await.unwrap();
+        let slide_a = BibleSlide {
+            id: BibleSlideId::new(),
+            order: 0,
+            main: SlideText::new("First").unwrap(),
+            main_reference: "Gen 1:1".to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        };
+        let slide_b = BibleSlide {
+            id: BibleSlideId::new(),
+            order: 0,
+            main: SlideText::new("Second").unwrap(),
+            main_reference: "Gen 1:2".to_string(),
+            secondary: SlideText::new("").unwrap(),
+            secondary_reference: String::new(),
+            metadata: None,
+        };
+        repo.append_bible_presentation_slides(p.id, &[slide_a.clone()])
+            .await
+            .unwrap();
+        let result = repo
+            .append_bible_presentation_slides(p.id, &[slide_b.clone()])
+            .await
+            .unwrap();
+        assert_eq!(result.slides.len(), 2);
+        assert_eq!(result.slides[0].order, 0);
+        assert_eq!(result.slides[1].order, 1);
+        assert_eq!(result.slides[0].main_reference, "Gen 1:1");
+        assert_eq!(result.slides[1].main_reference, "Gen 1:2");
+    }
+}
+```
+
+**Note:** the test helper `fresh_repo` assumes `Repository` has a public `db` field. If it's private, use whatever constructor pattern the existing repository tests use. Check:
+
+```bash
+grep -rn "Repository {" crates/presenter-persistence/src/repository/ | head -5
+```
+
+- [ ] **Step 9: Run the new repository tests**
+
+```bash
+cargo test -p presenter-persistence repository::bible --lib 2>&1 | tail -20
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 10: Run the full persistence test suite to catch regressions**
+
+```bash
+cargo test -p presenter-persistence 2>&1 | tail -10
+```
+
+Expected: all tests pass (including pre-existing worship repository tests).
+
+- [ ] **Step 11: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-persistence/src/repository/util.rs crates/presenter-persistence/src/repository/bible.rs crates/presenter-persistence/src/repository/mod.rs
+git commit -m "feat(persistence): add bible repository methods, drop is_bible inspection (#231)
+
+- New repository/bible.rs with 7 methods:
+  list_bible_presentation_summaries, fetch_bible_presentation,
+  create_bible_presentation, rename_bible_presentation,
+  delete_bible_presentation, replace_bible_presentation_slides,
+  append_bible_presentation_slides
+
+- repository/util.rs: simplified to_domain_slide and
+  build_slide_active_model. Both now handle worship-only since the
+  bible_* columns are gone. Removed the is_bible content
+  inspection.
+
+- 6 new unit tests against an in-memory sqlite database covering
+  CRUD + replace + append for bible presentations and slides."
+```
+
+---
+
+## Task 5: State Layer — Replace String Lookups in bible.rs
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/bible.rs`
+
+- [ ] **Step 1: Read the current bible state file**
+
+```bash
+wc -l crates/presenter-server/src/state/bible.rs
+```
+
+If it's large, focus on these specific functions (find them by name):
+- `list_bible_presentations` (~line 198)
+- `bible_presentation_detail` (~line 217)
+- `create_bible_presentation` (~line 225)
+- `rename_bible_presentation` (~line 246)
+- `append_bible_presentation_slides` (~line 254)
+
+- [ ] **Step 2: Replace `list_bible_presentations`**
+
+Find the existing function (it does `repository.fetch_libraries().await?` then filters by name). Replace with:
+
+```rust
+pub async fn list_bible_presentations(
+    &self,
+) -> anyhow::Result<Vec<presenter_core::BiblePresentationSummary>> {
+    self.repository.list_bible_presentation_summaries().await
+}
+```
+
+The return type changes from `Vec<PresentationSummary>` to `Vec<BiblePresentationSummary>`. **This is a breaking change for callers** — note which callers exist:
+
+```bash
+grep -rn "list_bible_presentations" crates/presenter-server/src/
+```
+
+Update the router handler in `crates/presenter-server/src/router/bible.rs` to accept the new return type. The JSON shape should be similar (id, name, slide_count) so frontend should be unaffected — but verify by reading the existing handler.
+
+- [ ] **Step 3: Replace `bible_presentation_detail`**
+
+```rust
+pub async fn bible_presentation_detail(
+    &self,
+    id: presenter_core::BiblePresentationId,
+) -> anyhow::Result<Option<presenter_core::BiblePresentation>> {
+    self.repository.fetch_bible_presentation(id).await
+}
+```
+
+Note the parameter type change from `PresentationId` to `BiblePresentationId`. Update the router handler accordingly.
+
+- [ ] **Step 4: Replace `create_bible_presentation`**
+
+```rust
+pub async fn create_bible_presentation(
+    &self,
+    name: &str,
+) -> anyhow::Result<presenter_core::BiblePresentation> {
+    let presentation = self.repository.create_bible_presentation(name).await?;
+    self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+        presentation_id: presentation.id.to_string(),
+    });
+    Ok(presentation)
+}
+```
+
+The "ensure library exists" branch (lines 226-235 of the original) is GONE — there's no library wrapper anymore. The function is much simpler.
+
+- [ ] **Step 5: Replace `rename_bible_presentation`**
+
+```rust
+pub async fn rename_bible_presentation(
+    &self,
+    id: presenter_core::BiblePresentationId,
+    name: &str,
+) -> anyhow::Result<()> {
+    self.repository.rename_bible_presentation(id, name).await
+}
+```
+
+- [ ] **Step 6: Replace `append_bible_presentation_slides`**
+
+The existing function (~line 254) does some empty-slide filtering before appending. Preserve that logic but use the new types:
+
+```rust
+pub async fn append_bible_presentation_slides(
+    &self,
+    id: presenter_core::BiblePresentationId,
+    new_slides: Vec<presenter_core::BibleSlide>,
+) -> anyhow::Result<presenter_core::BiblePresentation> {
+    // Filter out empty placeholder slides (empty main and empty reference)
+    let filtered: Vec<_> = new_slides
+        .into_iter()
+        .filter(|s| !s.main.value().is_empty() || !s.main_reference.is_empty())
+        .collect();
+    let presentation = self
+        .repository
+        .append_bible_presentation_slides(id, &filtered)
+        .await?;
+    self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+        presentation_id: presentation.id.to_string(),
+    });
+    Ok(presentation)
+}
+```
+
+- [ ] **Step 7: Add a delete method if it doesn't already exist**
+
+```bash
+grep -n "delete_bible_presentation\|pub async fn delete" crates/presenter-server/src/state/bible.rs
+```
+
+If there's no `delete_bible_presentation` in state, add:
+
+```rust
+pub async fn delete_bible_presentation(
+    &self,
+    id: presenter_core::BiblePresentationId,
+) -> anyhow::Result<()> {
+    self.repository.delete_bible_presentation(id).await?;
+    self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+        presentation_id: id.to_string(),
+    });
+    Ok(())
+}
+```
+
+If it already exists, update its parameter type from `PresentationId` to `BiblePresentationId`.
+
+- [ ] **Step 8: Build to check for errors**
+
+```bash
+cargo check -p presenter-server 2>&1 | grep -A2 'error' | head -40
+```
+
+Expected errors will likely be in `router/bible.rs` calling these methods with the wrong types. Note the errors but don't fix them yet — that's Task 6.
+
+- [ ] **Step 9: Commit the state changes (knowing router is broken)**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/state/bible.rs
+git commit -m "refactor(state): replace string-based bible library lookups (#231)
+
+state/bible.rs now uses BiblePresentationId and the new repository
+methods directly. The 'find library named Bible' string match is
+gone. The 'ensure_library_exists' branch in create_bible_presentation
+is gone — there's no library wrapper anymore.
+
+This commit temporarily breaks router/bible.rs which still passes
+PresentationId to the renamed methods. Fixed in the next commit."
+```
+
+---
+
+## Task 6: Router — Update bible.rs Handlers
+
+**Files:**
+- Modify: `crates/presenter-server/src/router/bible.rs`
+
+- [ ] **Step 1: Read the current router file**
+
+```bash
+wc -l crates/presenter-server/src/router/bible.rs
+grep -n "pub.*async fn\|PresentationId\|SlideId" crates/presenter-server/src/router/bible.rs | head -30
+```
+
+Identify every handler that takes `Path<Uuid>` for a presentation ID and constructs `PresentationId::from_uuid`. They all need to use `BiblePresentationId` instead.
+
+Same for slide IDs — change `SlideId::from_uuid` to `BibleSlideId::from_uuid` where it's used in the bible context.
+
+- [ ] **Step 2: Update each handler one at a time**
+
+For each handler, the pattern is:
+- Change `PresentationId` → `BiblePresentationId`
+- Change `SlideId` → `BibleSlideId` (in bible-specific contexts)
+- Change `Vec<Slide>` → `Vec<BibleSlide>` for incoming slide payloads
+- Update the request DTO (the JSON body type) if it had bible-specific fields
+
+**IMPORTANT:** Read each handler carefully. The DTOs (request body structs) may have field names like `main_text`, `secondary_text`, `main_reference` that already match `BibleSlide`. If they're `Slide`-shaped instead, you may need to map them to `BibleSlide`.
+
+Example for the `create_bible_presentation` handler:
+
+```rust
+#[instrument(skip_all)]
+pub(crate) async fn create_bible_presentation(
+    State(state): State<AppState>,
+    Json(payload): Json<CreatePresentationRequest>,
+) -> Result<Json<BiblePresentationResponse>, AppError> {
+    let presentation = state.create_bible_presentation(&payload.name).await?;
+    Ok(Json(BiblePresentationResponse::from(presentation)))
+}
+```
+
+You may need to introduce or rename `BiblePresentationResponse` to make the API surface explicit. The wire JSON shape should remain the same as today (so the frontend is unaffected) — verify by checking the existing handler's response type.
+
+- [ ] **Step 3: Build until cargo check passes**
+
+```bash
+cargo check -p presenter-server 2>&1 | grep -A2 'error' | head -40
+```
+
+Iterate on router/bible.rs handlers until there are zero errors. **Do not edit files outside router/bible.rs in this task** — if you find errors elsewhere, that's a sign Task 5 needs revisiting.
+
+- [ ] **Step 4: Run the full server unit test suite**
+
+```bash
+cargo test -p presenter-server --lib 2>&1 | tail -20
+```
+
+Expected: all tests pass. Some bible-related tests may fail if their assertions used the old types — fix them by updating to `BiblePresentation` / `BibleSlide`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/router/bible.rs
+git commit -m "feat(router): wire bible router to new repository types (#231)
+
+Router handlers in router/bible.rs now use BiblePresentationId,
+BibleSlideId, and BiblePresentation/BibleSlide instead of the
+generic worship types. Wire JSON shape on the API is unchanged
+so the frontend continues to work without modification."
+```
+
+---
+
+## Task 7: Delete the Broadcasting Leak
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/broadcasting.rs`
+
+- [ ] **Step 1: Find the leak**
+
+Open `crates/presenter-server/src/state/broadcasting.rs` and locate the block at lines 83-96:
+
+```rust
+// If the current slide has a Bible reference in the `stage` field,
+// also emit a BibleUpdate so Resolume #bible-reference-a/b clips
+// show the actual reference instead of the library name.
+if let Some(ref slide) = context.resolution.current {
+    if !slide.stage.is_empty() {
+        let bible_output = BibleSlideOutput {
+            main_text: slide.main.clone(),
+            main_reference: slide.stage.clone(),
+            secondary_text: slide.translation.clone(),
+            secondary_reference: String::new(),
+            triggered_at: now,
+        };
+        self.resolume_registry
+            .bible_update(BibleUpdate::from_slide_output(Some(bible_output)))
+            .await;
+    }
+}
+```
+
+- [ ] **Step 2: Delete the entire block**
+
+Remove the lines exactly. Replace with NOTHING (no comment, no placeholder). The function `broadcast_stage_resolution` should end after the `stage_update` call without any bible-update logic.
+
+- [ ] **Step 3: Verify no other code in broadcasting.rs touches BibleUpdate from worship paths**
+
+```bash
+grep -n "BibleUpdate\|bible_update\|BibleSlideOutput" crates/presenter-server/src/state/broadcasting.rs
+```
+
+Expected: zero matches after the deletion. If anything else remains, evaluate whether it should also be removed.
+
+- [ ] **Step 4: Build**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -10
+```
+
+Expected: clean build. Unused imports may surface — clean them up.
+
+- [ ] **Step 5: Add a regression test**
+
+In `crates/presenter-server/src/state/tests.rs` (or wherever broadcasting tests live), add:
+
+```rust
+#[tokio::test]
+async fn broadcast_stage_resolution_does_not_emit_bible_update_for_worship_stage_text() {
+    // Regression for #231: previously, any worship slide with non-empty
+    // `stage` field would trigger a spurious BibleUpdate to Resolume.
+    let state = test_app_state_with_mock_resolume().await;
+
+    let resolution = StageResolution {
+        presentation_id: Some(PresentationId::new()),
+        presentation_name: Some("Test Song".to_string()),
+        library_name: Some("Worship".to_string()),
+        current_slide_id: None,
+        current: Some(StageDisplaySlide {
+            main: "Verse one".to_string(),
+            translation: "Verz jeden".to_string(),
+            stage: "Verse 1".to_string(), // Non-empty stage text — used to trigger leak
+            group: Some("Verse".to_string()),
+        }),
+        next_slide_id: None,
+        next: None,
+        current_index: Some(1),
+        total_slides: Some(5),
+        playlist_id: None,
+        playlist_name: None,
+        playlist_entries: None,
+    };
+
+    state.broadcast_stage_resolution(resolution).await.unwrap();
+
+    let resolume_calls = state.mock_resolume_registry.calls().await;
+    assert!(
+        resolume_calls.iter().all(|c| !matches!(c, ResolumeCall::BibleUpdate(_))),
+        "Worship stage broadcast should NOT emit BibleUpdate, got: {resolume_calls:?}"
+    );
+    assert!(
+        resolume_calls.iter().any(|c| matches!(c, ResolumeCall::StageUpdate(_))),
+        "Worship stage broadcast should emit StageUpdate"
+    );
+}
+```
+
+**IMPORTANT:** The mock infrastructure (`test_app_state_with_mock_resolume`, `mock_resolume_registry`, `ResolumeCall`) may not exist. Read the existing tests in `state/tests.rs` first to see what mock pattern is used. If the existing test pattern doesn't have a Resolume mock, you need to add one in this task. Check:
+
+```bash
+grep -rn "ResolumeRegistry\|mock_resolume\|MockResolume" crates/presenter-server/src/
+```
+
+If there's no existing mock, the test can be done at integration level instead — set up a real ResolumeRegistry but inject a fake host that records calls. Or skip this unit test and rely on the E2E test from Task 9.
+
+If you skip the unit test, document the skip in the commit message and ensure Task 9's E2E covers it.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cargo test -p presenter-server --lib 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/state/broadcasting.rs crates/presenter-server/src/state/tests.rs
+git commit -m "fix(broadcasting): delete BibleUpdate-from-stage-field leak (#231)
+
+The block in broadcast_stage_resolution that emitted a BibleUpdate
+whenever a worship slide had non-empty 'stage' text is removed.
+Worship slides with stage text now produce only StageUpdate, never
+BibleUpdate. Bible broadcasts only happen via the dedicated bible
+trigger code path in state/bible.rs.
+
+Adds a regression test asserting that worship stage broadcasts do
+not invoke the Resolume bible_update method."
+```
+
+---
+
+## Task 8: Replace Magic Strings in ai/tools.rs
+
+**Files:**
+- Modify: `crates/presenter-server/src/ai/tools.rs`
+
+- [ ] **Step 1: Read the two magic-string sites**
+
+```bash
+grep -n -B3 -A8 'eq_ignore_ascii_case("[Bb]ible")' crates/presenter-server/src/ai/tools.rs
+```
+
+Expected: two matches at approximately lines 375 and 685. Read the surrounding 10-15 lines of each to understand the intent.
+
+- [ ] **Step 2: Decide the replacement for each site**
+
+For each match, the question is: WHY is it checking if the library is "bible"? Common reasons:
+- "Skip bible libraries when listing worship libraries" → after the migration, bible libraries don't exist in `libraries`, so the check is trivially always false. **Delete the check entirely**.
+- "Special-case bible when generating slides" → the AI is creating slides into a library; if the target library is bible, do bible-specific work. **Replace with a parameter**: the caller should pass an explicit `target: SlideTarget::Worship | SlideTarget::Bible` enum.
+
+Read each site and decide which case applies. Report your decision in the commit message.
+
+- [ ] **Step 3: Implement the replacement at line ~375**
+
+Read the function containing line 375. If the check is "is this library bible?", and bible libraries no longer exist:
+
+- Delete the check (it was always going to be false post-migration)
+- Delete any branches that depended on the check being true
+- Update the function signature if it took a library specifically for bible/worship discrimination
+
+If the check was branching to call bible-specific code, replace with a direct call to the bible repository API:
+
+```rust
+let bible_summaries = state.list_bible_presentation_summaries().await?;
+// ... use bible_summaries instead of looking through worship libraries
+```
+
+- [ ] **Step 4: Implement the replacement at line ~685**
+
+Same approach as step 3 for the second site.
+
+- [ ] **Step 5: Build and test**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -10
+cargo test -p presenter-server --lib ai 2>&1 | tail -15
+```
+
+Expected: clean build, AI tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/ai/tools.rs
+git commit -m "refactor(ai): replace 'Bible' magic-string checks with proper API (#231)
+
+Both sites in ai/tools.rs that did
+  lib.name.eq_ignore_ascii_case('bible')
+have been replaced. After the migration there are no bible libraries
+in the libraries table, so the check is dead code. The bible-specific
+branches now call list_bible_presentation_summaries directly.
+
+Removes the last 'magic Bible string' references in the codebase.
+Combined with state/bible.rs, all 4 string-match locations identified
+in the design spec are gone."
+```
+
+---
+
+## Task 9: E2E Regression Tests
+
+**Files:**
+- Modify or create: `tests/e2e/bible-presentation-append.spec.ts` (or new file `tests/e2e/bible-worship-isolation.spec.ts`)
+
+- [ ] **Step 1: Add a regression test for #227 (Bible out of worship list)**
+
+Create `tests/e2e/bible-worship-isolation.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl, config.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+test("creating a bible presentation does not add a Bible library to the worship library list", async ({
+  request,
+}) => {
+  // Create a bible presentation via the bible API
+  const createResp = await request.post(
+    new URL("/bible/presentations", baseURL).toString(),
+    {
+      data: { name: "E2E Test Sermon" },
+    },
+  );
+  expect(createResp.ok()).toBe(true);
+
+  // Fetch the worship library summary
+  const libsResp = await request.get(
+    new URL("/libraries/summary", baseURL).toString(),
+  );
+  expect(libsResp.ok()).toBe(true);
+  const libs = (await libsResp.json()) as Array<{ name: string }>;
+
+  // Assert no library is named "Bible" (case-insensitive)
+  const bibleLibs = libs.filter(
+    (l) => l.name.toLowerCase() === "bible",
+  );
+  expect(bibleLibs).toHaveLength(0);
+});
+
+test("worship slide with stage text does not trigger bible Resolume update", async ({
+  request,
+}) => {
+  // This test asserts the broadcasting leak is fixed by checking that
+  // after triggering a worship slide that has non-empty stage text, the
+  // server does NOT broadcast a BibleSlide live event.
+  //
+  // We collect live events from the websocket. Worship stage broadcasts
+  // should produce a Stage event but never a BibleSlide event.
+  //
+  // (Implementation depends on the test harness — see existing
+  // ableton-osc.spec.ts or similar for the WebSocket subscription pattern.)
+  //
+  // If the WebSocket subscription pattern is too involved, this test can
+  // instead assert at the API level: after triggering a worship slide
+  // with stage text, /bible/active should still return null/empty.
+
+  const activeBefore = await request.get(
+    new URL("/bible/active", baseURL).toString(),
+  );
+  const beforeBody = activeBefore.ok() ? await activeBefore.json() : null;
+
+  // Set up a worship presentation with a slide that has non-empty stage text.
+  // This requires creating a library, presentation, slides, then triggering one.
+  // The exact API calls match the existing setup in stage-layout.spec.ts —
+  // copy that pattern.
+
+  // ... (setup code copied from stage-layout.spec.ts) ...
+
+  const activeAfter = await request.get(
+    new URL("/bible/active", baseURL).toString(),
+  );
+  const afterBody = activeAfter.ok() ? await activeAfter.json() : null;
+
+  // /bible/active should not have changed — the worship trigger didn't touch bible state
+  expect(afterBody).toEqual(beforeBody);
+});
+```
+
+**IMPORTANT:** The second test (broadcasting leak regression) needs the worship slide setup. Read `tests/e2e/stage-layout.spec.ts` for the pattern of creating a library + presentation + slides via the API and triggering one. Copy that pattern; do not invent.
+
+- [ ] **Step 2: Run the new tests locally**
+
+```bash
+npm run test:playwright -- bible-worship-isolation 2>&1 | tail -30
+```
+
+Expected: both tests pass against a server with the migration applied (Task 1).
+
+- [ ] **Step 3: Verify existing bible E2E tests still pass**
+
+```bash
+npm run test:playwright -- bible-presentation-append bible-trigger-slide 2>&1 | tail -30
+```
+
+Expected: existing tests pass on the new schema. If they fail, read the failure carefully — they may need updating for the new BiblePresentationId/BibleSlideId types in API responses.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/bible-worship-isolation.spec.ts
+git commit -m "test(e2e): add regression tests for bible/worship isolation (#231)
+
+Two new E2E tests:
+
+1. Creating a bible presentation does NOT add a Bible library row
+   to the worship /libraries/summary list. Regression guard for
+   #227 (the symptom of the coupling) — after the migration the
+   bible library row no longer exists at all.
+
+2. Triggering a worship slide with non-empty stage text does NOT
+   change /bible/active. Regression guard for the broadcasting
+   leak fixed in state/broadcasting.rs."
+```
+
+---
+
+## Task 10: Version Bump, Format, Push, Monitor CI
+
+- [ ] **Step 1: Bump the workspace version**
+
+In `Cargo.toml`, find:
+
+```toml
+[workspace.package]
+version = "0.4.14"
+```
+
+Change to:
+
+```toml
+[workspace.package]
+version = "0.4.15"
+```
+
+- [ ] **Step 2: Refresh Cargo.lock**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -3
+```
+
+This updates `Cargo.lock` with the new version.
+
+- [ ] **Step 3: Run all local quality checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test -p presenter-core -p presenter-persistence -p presenter-server 2>&1 | tail -20
+./scripts/dev/quality-check.sh --strict --against origin/main 2>&1 | grep -E 'fail|FAIL' | head -5
+```
+
+Expected: zero failures across all checks. Fix anything that breaks before pushing.
+
+- [ ] **Step 4: Sync with main**
+
+```bash
+git fetch origin
+git merge origin/main --no-edit
+```
+
+Resolve any conflicts (unlikely but possible).
+
+- [ ] **Step 5: Commit version bump**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.4.15"
+```
+
+- [ ] **Step 6: Push and monitor CI**
+
+```bash
+git push origin dev
+gh run list --branch dev --limit 3
+```
+
+Watch the run until ALL jobs reach a terminal state. The critical jobs to watch:
+- **Test** — unit tests including the new repository tests
+- **Build** — full release build
+- **Playwright E2E shards** — including the new bible-worship-isolation tests
+- **Migration test against prod DB** — `pipeline.yml:778-804` runs the migration on a copy of prod
+- **Deploy to Dev** — the dev server should now have the new schema
+
+If any job fails, run `gh run view <run-id> --log-failed`, fix the root cause in ONE commit, push ONCE, and monitor again.
+
+- [ ] **Step 7: Verify dev deployment**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.15"}`
+
+```bash
+sqlite3 /opt/presenter-dev/presenter.db ".schema bible_presentations"
+sqlite3 /opt/presenter-dev/presenter.db ".schema slides" | grep -c bible_
+sqlite3 /opt/presenter-dev/presenter.db "SELECT name FROM libraries WHERE LOWER(name) = 'bible'"
+```
+
+Expected:
+- bible_presentations table exists
+- 0 bible_* columns on slides
+- Empty result for bible library row
+
+- [ ] **Step 8: Open PR**
+
+```bash
+gh pr create --title "fix: fully separate bible from worship (#231)" --body-file - <<'EOF'
+## Summary
+
+Fully separates bible content from worship at every layer per the design spec at `docs/superpowers/specs/2026-04-10-bible-worship-separation-design.md`.
+
+### Schema
+- New `bible_presentations` and `bible_slides` tables
+- Dropped 7 `bible_*` columns + `metadata_json` from `slides`
+- Dropped dead `category` column from `libraries`
+- Dropped any existing bible library row (user explicitly confirmed this — the 2 production bible presentations are gone)
+
+### Domain
+- New `BiblePresentation`, `BibleSlide`, `BiblePresentationId`, `BibleSlideId` types
+- Existing `Library`, `Presentation`, `Slide` types now mean WORSHIP only
+
+### Repository
+- New `repository/bible.rs` with 7 methods (list/fetch/create/rename/delete/replace/append)
+- `repository/util.rs` simplified — no more `is_bible = !bible_main.is_empty()` content inspection
+
+### State / broadcasting
+- `state/bible.rs` uses the new repository methods, no string lookups
+- The `broadcast_stage_resolution` BibleUpdate-from-stage-field leak is DELETED (worship slides no longer trigger spurious bible Resolume broadcasts)
+
+### AI tools
+- Both magic-string `eq_ignore_ascii_case("Bible")` checks replaced with proper API calls
+
+### Tests
+- 4 new domain tests (`bible.rs` ID round-trip, JSON serialization)
+- 6 new repository tests (`repository/bible.rs` CRUD + replace + append against in-memory sqlite)
+- 2 new E2E tests (`bible-worship-isolation.spec.ts`):
+  - Creating a bible presentation does not add a Bible library to the worship list
+  - Triggering a worship slide with stage text does not change `/bible/active`
+- 1 new unit test for the broadcasting leak fix
+- All existing bible E2E tests continue to pass on the new schema
+
+## Verification
+- [x] Migration runs cleanly against a fresh DB
+- [x] Migration runs cleanly against a copy of prod DB (via dev pipeline step)
+- [x] Dev deployed v0.4.15, schema verified live
+- [x] CI fully green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 9: After PR is mergeable, wait for explicit user merge instruction**
+
+Per project policy, NEVER merge without explicit user instruction. Provide the PR URL and wait.
+
+---
+
+## Verification Checklist
+
+After PR merges to main and deploys to production:
+
+- [ ] `curl http://10.77.9.205/healthz` returns version 0.4.15
+- [ ] `curl http://10.77.9.205/libraries/summary | jq '.[] | select(.name | ascii_downcase == "bible")'` returns empty (no bible library in worship list)
+- [ ] Open `http://presenter.lan/ui/operator` Worship tab → no Bible row in library list
+- [ ] Open `http://presenter.lan/ui/bible` → Bible tab loads, can create a new bible presentation, can edit and trigger it
+- [ ] Trigger a worship slide that has non-empty stage text → Resolume bible clips do NOT change
+- [ ] Trigger a bible presentation → Resolume bible clips DO change
+- [ ] Existing E2E tests in `bible-presentation-append.spec.ts` and `bible-trigger-slide.spec.ts` pass on the new schema
+
+---
+
+## Risks Reminder
+
+- **Old binary against new schema:** If something needs to be rolled back, the old `slide::Model` references columns that no longer exist. **Rollback path:** restore the auto-backup taken in the dev pipeline `Backup database` step before deploy.
+- **Production data loss:** The 2 existing bible presentations on production are GONE after this deploys. User explicitly confirmed.
+- **Migration crashes mid-run:** All steps are idempotent. Tables use `IF NOT EXISTS`, the `DELETE` is naturally re-runnable, the `ALTER DROP COLUMN` is guarded by `pragma_table_info` checks. Crash + restart picks up where it left off.

--- a/docs/superpowers/specs/2026-04-10-bible-worship-separation-design.md
+++ b/docs/superpowers/specs/2026-04-10-bible-worship-separation-design.md
@@ -1,0 +1,252 @@
+# Bible/Worship Separation — Design Spec
+
+**Issue:** #231 — Fully separate bible and worship at the database, domain, repository, and broadcasting layers
+**Date:** 2026-04-10
+**Approach:** Single big-bang PR (per user direction)
+
+## Problem
+
+Bible and worship currently share storage, types, and broadcasting code. The coupling shows up in four ways:
+
+1. **Bible library leaks into worship UI list** (issue #227) — the operator sees a "Bible" library row in the worship library list
+2. **Field overloading** — the worship `stage` field is reused for bible reference labels, and any worship slide with non-empty `stage` text incorrectly triggers a `BibleUpdate` to Resolume
+3. **Per-type rules** — bible needs its own settings (character limits, default translation, etc.) but they live alongside worship
+4. **Per-type outputs** — bible should write to different Resolume parameters / different stage layouts than worship
+
+The root cause is that bible content is stored as a regular `Library` row named "Bible" with bible-specific columns (`bible_main`, `bible_main_reference`, etc.) on the same `slides` table as worship slides. There is no type discriminator anywhere — type is inferred by content inspection (`is_bible = !model.bible_main.is_empty()` at `repository/util.rs:66, 371`) and by string matching the library name in 4 places.
+
+A dead `category` column on `libraries` exists from an aborted earlier separation attempt but is never read.
+
+## Goal
+
+Fully separate bible from worship at every layer:
+- **Storage:** dedicated `bible_presentations` and `bible_slides` tables; the bible library wrapper is removed entirely (one bible per system)
+- **Domain:** separate `BiblePresentation` / `BibleSlide` types with their own newtype IDs
+- **Repository:** separate methods, no string matching
+- **Broadcasting:** worship stage updates never produce `BibleUpdate`
+- **UI:** worship library list never sees a bible row (because no such row exists)
+
+## Non-goals
+
+- Migrating existing bible content. The 2 bible presentations on production are dropped (user explicit decision).
+- Per-type stage layouts and per-type Resolume parameters beyond what already exists. Pain points 3 and 4 are addressed structurally — bible already has its own broadcast type (`BibleUpdate`) and its own preferences object (`BiblePreferences`) — by removing the cross-contamination, those existing structures actually start working as intended.
+- Multiple bible "libraries" or collections. There is exactly one bible per system; `bible_presentations` has no library_id.
+- Splitting into a separate sqlite file. Same database, separate tables.
+
+## Architecture
+
+### Schema (SQLite)
+
+New tables created by migration `m20260410_000001_separate_bible`:
+
+```sql
+CREATE TABLE IF NOT EXISTS bible_presentations (
+    id          varchar(36) NOT NULL PRIMARY KEY,
+    name        varchar     NOT NULL,
+    created_at  timestamp_with_timezone_text NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS bible_slides (
+    id                   varchar(36) NOT NULL PRIMARY KEY,
+    presentation_id      varchar(36) NOT NULL,
+    slide_order          integer     NOT NULL,
+    main_text            text        NOT NULL,
+    main_search          text        NOT NULL DEFAULT '',
+    main_reference       text        NOT NULL,
+    secondary_text       text        NOT NULL DEFAULT '',
+    secondary_search     text        NOT NULL DEFAULT '',
+    secondary_reference  text        NOT NULL DEFAULT '',
+    metadata_json        text,
+    FOREIGN KEY (presentation_id) REFERENCES bible_presentations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_bible_slides_presentation_id ON bible_slides(presentation_id);
+```
+
+The bible-specific metadata (book, chapter, verses, translation codes) is stored as JSON in `metadata_json` rather than normalized columns. This is pragmatic for an MVP — SQLite JSON functions handle the queries we currently need. Normalize later if/when we want to filter by individual metadata fields.
+
+Removed in the same migration:
+- `libraries.category` column (dead code from a previous separation attempt)
+- `slides.bible_main`, `slides.bible_main_search`, `slides.bible_main_reference`, `slides.bible_translation`, `slides.bible_translation_search`, `slides.bible_translation_reference`, `slides.metadata_json`
+- Any row in `libraries` where `LOWER(name) = 'bible'` (cascade-deletes its presentations and slides)
+
+### Domain types (`crates/presenter-core/src/bible.rs`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BiblePresentationId(Uuid);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BibleSlideId(Uuid);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BiblePresentation {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slides: Vec<BibleSlide>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BibleSlide {
+    pub id: BibleSlideId,
+    pub order: u32,
+    pub main: SlideText,
+    pub main_reference: String,
+    pub secondary: SlideText,
+    pub secondary_reference: String,
+    pub metadata: Option<BibleSlideMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BiblePresentationSummary {
+    pub id: BiblePresentationId,
+    pub name: String,
+    pub slide_count: usize,
+}
+```
+
+`BiblePresentationId` and `BibleSlideId` are new newtypes — they are NOT compatible with the existing `PresentationId` / `SlideId`, so the type system prevents accidentally mixing worship and bible IDs at API boundaries.
+
+The existing `Library`, `Presentation`, `Slide`, `SlideContent` types now mean **worship only**. They keep their unprefixed names; new convention documented in `crates/presenter-core/src/lib.rs`: "unprefixed = worship; `Bible*` = bible." `SlideContent` loses bible field accessors because the columns no longer exist on the `slides` table.
+
+### Repository (`crates/presenter-persistence/src/repository/bible.rs`)
+
+```rust
+impl Repository {
+    pub async fn list_bible_presentation_summaries(&self) -> Result<Vec<BiblePresentationSummary>>;
+    pub async fn fetch_bible_presentation(&self, id: BiblePresentationId) -> Result<Option<BiblePresentation>>;
+    pub async fn create_bible_presentation(&self, name: &str) -> Result<BiblePresentation>;
+    pub async fn rename_bible_presentation(&self, id: BiblePresentationId, name: &str) -> Result<()>;
+    pub async fn delete_bible_presentation(&self, id: BiblePresentationId) -> Result<()>;
+    pub async fn replace_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BibleSlide],
+    ) -> Result<()>;
+    pub async fn append_bible_presentation_slides(
+        &self,
+        id: BiblePresentationId,
+        slides: &[BibleSlide],
+    ) -> Result<BiblePresentation>;
+}
+```
+
+The existing `Repository::list_libraries`, `fetch_libraries`, etc. continue to mean worship-only — no Bible filtering needed because the bible library row no longer exists.
+
+`repository/util.rs` loses the `is_bible = !model.bible_main.is_empty()` content inspection at lines 66 and 371. Worship `to_domain_slide` and `build_slide_active_model` simplify because they no longer have to branch on type.
+
+### State layer
+
+`crates/presenter-server/src/state/bible.rs:198-244`: replace string-based library lookup with direct calls to the new `bible_presentations` repository methods.
+
+`crates/presenter-server/src/state/broadcasting.rs:83-96`: **delete the entire block** that emits `BibleUpdate` based on the worship slide's `stage` field. Worship stage broadcasts only emit `StageUpdate`. Bible broadcasts only happen via the dedicated `state/bible.rs` trigger code path.
+
+`crates/presenter-server/src/ai/tools.rs:375, 685`: replace `lib.name.eq_ignore_ascii_case("bible")` magic strings with proper API calls (call `list_bible_presentation_summaries` if you need to know about bible presentations; never reference the worship library list when looking for bible content).
+
+### API / router
+
+`crates/presenter-server/src/router/bible.rs` already exists with the full `/bible/*` route surface. Handlers get updated to use `BiblePresentation` / `BibleSlide` and the new repository methods. **No new routes, no removed routes** — the API surface is unchanged.
+
+### UI
+
+**No code changes needed.** After the migration, the bible library row is gone from the `libraries` table, so:
+- Worship `LibraryList` (`crates/presenter-ui/src/components/library_list.rs`) never sees Bible — fixes #227 implicitly
+- Bible UI continues to work via `/bible/*` endpoints
+- The two operator tabs (`<section data-view-panel="worship">` / `<section data-view-panel="bible">`) keep their existing wiring
+
+## Migration
+
+Single file: `crates/presenter-migration/src/m20260410_000001_separate_bible.rs`. Registered in `lib.rs` after the existing `m20260408_000001_add_preach_limit`.
+
+```rust
+async fn up() {
+    // 1. Create new tables (idempotent)
+    create_table_if_not_exists("bible_presentations");
+    create_table_if_not_exists("bible_slides");
+    create_index_if_not_exists("idx_bible_slides_presentation_id");
+
+    // 2. Drop the bible library row + cascade-delete its presentations/slides
+    DELETE FROM libraries WHERE LOWER(name) = 'bible';
+
+    // 3. Drop the now-unused bible_* columns from slides
+    ALTER TABLE slides DROP COLUMN bible_main;
+    ALTER TABLE slides DROP COLUMN bible_main_search;
+    ALTER TABLE slides DROP COLUMN bible_main_reference;
+    ALTER TABLE slides DROP COLUMN bible_translation;
+    ALTER TABLE slides DROP COLUMN bible_translation_search;
+    ALTER TABLE slides DROP COLUMN bible_translation_reference;
+    ALTER TABLE slides DROP COLUMN metadata_json;
+
+    // 4. Drop the dead category column from libraries
+    ALTER TABLE libraries DROP COLUMN category;
+}
+```
+
+**Idempotency:** `IF NOT EXISTS` for table creation. The `DELETE FROM libraries` is naturally idempotent (no rows to delete on re-run). The column drops are guarded by checking column existence first (sea-orm-migration patterns from the existing `m20260408_000001_add_preach_limit` migration).
+
+**SQLite version:** `ALTER TABLE DROP COLUMN` requires SQLite 3.35+ (released March 2021). All current sea-orm sqlite drivers are well above this.
+
+**Down migration:** Recreates the dropped columns and the empty bible library wrapper. **Lossy** — does not restore data. The down() exists for testing and hypothetical rollback, not for round-tripping production data.
+
+**Production safety:**
+- The dev pipeline takes a backup before deploy (`pipeline.yml:761-776`)
+- The dev pipeline tests migrations against a copy of the prod DB (`pipeline.yml:778-804`) — this catches schema-incompatibility errors before they touch dev, let alone prod
+- The user has explicitly confirmed dropping the 2 existing bible presentations on production
+
+## Tests
+
+### Unit (Rust)
+
+- **Repository:** create/read/update/delete/append for `bible_presentations` and `bible_slides` (covers all 7 new methods)
+- **Migration:** test that runs the new migration against a fresh database, verifies tables exist, verifies old columns are gone
+- **Migration on real schema:** test that runs against a copy of the existing schema (with bible library row + bible_* columns populated) and verifies the cleanup completes
+
+### Regression tests (the heart of this PR)
+
+- **Bible-out-of-worship-list:** integration test that creates a bible presentation via `POST /bible/presentations`, then calls `GET /libraries/summary`, asserts the response does NOT contain any library named "Bible"
+- **Broadcasting leak:** unit test that creates a worship slide with non-empty `stage` text, calls the broadcasting code path, asserts the resolume registry's `bible_update` was NOT invoked. This is the regression guard for the field-overloading bug.
+
+### E2E (Playwright)
+
+- Existing bible E2E tests (`bible-presentation-append.spec.ts`, `bible-trigger-slide.spec.ts`) should continue to pass — they create their own bible presentations via `/bible/presentations`, which now hits the new tables transparently.
+- New E2E test: navigate to worship operator, create a bible presentation in another tab, refresh worship operator, assert no Bible library appears in the library list.
+
+## Risks & Rollback
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Migration crashes mid-run | LOW | All steps idempotent. IF NOT EXISTS for tables, DELETE is naturally re-runnable, ALTER DROP is guarded by column existence check. Crash + restart = picks up where it left off. |
+| Old binary deployed against new schema | MEDIUM | Old binary's `slide::Model` references `bible_main` etc., would fail at startup. **Rollback path:** restore from the auto-backup taken in `Backup database` step before deploy. The dev DB also gets replaced from prod every deploy, so dev is never in a worse state than prod was. |
+| Production data loss | ACCEPTED | User explicitly confirmed dropping the 2 existing bible presentations. Backup is still taken. |
+| Companion / Bitfocus integration breaks | LOW | Companion API for bible already uses `/bible/*` routes. AI tool magic string checks get replaced with proper API calls in the same PR. |
+| ai/tools.rs magic string regression | LOW | Search-and-replace scope is small (2 references). Linter / `cargo check` catches it. |
+
+## Concrete file impact (~12 files)
+
+| File | Change |
+|------|--------|
+| `crates/presenter-migration/src/m20260410_000001_separate_bible.rs` | NEW: migration |
+| `crates/presenter-migration/src/lib.rs` | Register new migration |
+| `crates/presenter-persistence/src/entities.rs` | Add bible_presentation/bible_slide entities, drop bible_* columns from slide entity |
+| `crates/presenter-persistence/src/repository/bible.rs` | NEW: bible-specific repository methods |
+| `crates/presenter-persistence/src/repository/mod.rs` | Re-export bible methods |
+| `crates/presenter-persistence/src/repository/util.rs` | Drop is_bible content inspection (lines 66, 371) |
+| `crates/presenter-core/src/bible.rs` | Add BiblePresentation, BibleSlide, BiblePresentationId, BibleSlideId types |
+| `crates/presenter-core/src/lib.rs` | Export new types, document the unprefixed=worship convention |
+| `crates/presenter-server/src/state/bible.rs` | Replace string lookups (lines 198-244) with new repo methods |
+| `crates/presenter-server/src/state/broadcasting.rs` | Delete the BibleUpdate-from-stage-field leak (lines 83-96) |
+| `crates/presenter-server/src/router/bible.rs` | Update handlers to use new types |
+| `crates/presenter-server/src/ai/tools.rs` | Replace magic string checks (lines 375, 685) |
+| `tests/e2e/bible-presentation-append.spec.ts` etc. | Verify still passing; add new regression test for #227 |
+| `Cargo.toml` | Version bump 0.4.14 → 0.4.15 |
+
+## Verification checklist
+
+After deploy to production:
+- [ ] `/healthz` returns version 0.4.15
+- [ ] Worship library list does NOT contain "Bible"
+- [ ] Bible UI loads, can create/edit/trigger bible presentations via `/bible/presentations`
+- [ ] Trigger a worship slide with non-empty stage text → Resolume bible clips do NOT change
+- [ ] Trigger a bible presentation → Resolume bible clips DO change
+- [ ] Existing bible E2E tests pass on the new schema

--- a/tests/e2e/bible-worship-isolation.spec.ts
+++ b/tests/e2e/bible-worship-isolation.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("creating a Bible presentation does not add a Bible library to the worship library list", async ({
+  request,
+}) => {
+  // Regression for #227: previously bible content was stored as a Library row
+  // named "Bible" which leaked into the worship operator's library list. After
+  // the bible/worship separation migration, the bible library row no longer
+  // exists at all.
+
+  // Create a bible presentation via the dedicated bible API
+  const createResp = await request.post(
+    new URL("/bible/presentations", baseURL).toString(),
+    { data: { name: `Isolation Test ${Date.now()}` } },
+  );
+  expect(createResp.ok()).toBeTruthy();
+
+  // Fetch the worship library summary
+  const libsResp = await request.get(
+    new URL("/libraries/summary", baseURL).toString(),
+  );
+  expect(libsResp.ok()).toBeTruthy();
+  const libs = (await libsResp.json()) as Array<{ name: string }>;
+
+  // Assert NO library is named "Bible" (case-insensitive)
+  const bibleLibs = libs.filter(
+    (l) => l.name.toLowerCase() === "bible",
+  );
+  expect(bibleLibs).toHaveLength(0);
+});
+
+test("triggering a worship slide with non-empty stage text does not change /bible/active", async ({
+  request,
+}) => {
+  // Regression for the broadcasting leak deleted in Task 7. Previously, any
+  // worship slide with non-empty `stage` text triggered a spurious BibleUpdate
+  // to Resolume — hijacking the bible reference clips. This test asserts that
+  // /bible/active state is unaffected by worship stage broadcasts.
+
+  // Snapshot /bible/active before any worship action
+  const beforeResp = await request.get(
+    new URL("/bible/active", baseURL).toString(),
+  );
+  const beforeBody = beforeResp.ok() ? await beforeResp.json() : null;
+
+  // Create a worship library
+  const libResp = await request.post(
+    new URL("/libraries", baseURL).toString(),
+    { data: { name: `_Bible Isolation Test ${Date.now()}` } },
+  );
+  expect(libResp.ok()).toBeTruthy();
+  const lib: { id: string } = await libResp.json();
+
+  // Create a worship presentation containing a slide that has non-empty stage
+  // text. The `stage` field used to trigger a spurious BibleUpdate in the
+  // broadcasting layer that was deleted in Task 7.
+  const presResp = await request.post(
+    new URL(`/libraries/${lib.id}/presentations`, baseURL).toString(),
+    {
+      data: {
+        name: "Stage Text Trigger Test",
+        slides: [
+          {
+            main: "First line",
+            translation: "Translation",
+            stage: "John 3:16", // non-empty stage that previously triggered BibleUpdate
+            group: "Verse 1",
+          },
+        ],
+      },
+    },
+  );
+  expect(presResp.ok()).toBeTruthy();
+  const presData: {
+    presentation: { id: string; slides: Array<{ id: string }> };
+  } = await presResp.json();
+  const presentationId = presData.presentation.id;
+  const slideId = presData.presentation.slides[0].id;
+
+  // Trigger the slide via /stage/state — same path the operator UI uses
+  const triggerResp = await request.post(
+    new URL("/stage/state", baseURL).toString(),
+    {
+      data: {
+        presentationId,
+        currentSlideId: slideId,
+        nextSlideId: null,
+      },
+    },
+  );
+  expect(triggerResp.ok()).toBeTruthy();
+
+  // After the worship trigger, /bible/active should be unchanged
+  const afterResp = await request.get(
+    new URL("/bible/active", baseURL).toString(),
+  );
+  const afterBody = afterResp.ok() ? await afterResp.json() : null;
+
+  expect(afterBody).toEqual(beforeBody);
+});


### PR DESCRIPTION
## Summary

Fully separates bible content from worship at every layer per the design spec at `docs/superpowers/specs/2026-04-10-bible-worship-separation-design.md`.

### Schema (Task 1)
- New `bible_presentations` and `bible_slides` tables
- Dropped 7 `bible_*` columns + `metadata_json` from `slides`
- Dropped dead `category` column from `libraries`
- Dropped any existing bible library row outright (user explicitly confirmed)

### Domain types (Task 2)
- New `BiblePresentation`, `BiblePresentationSlide`, `BiblePresentationId`, `BibleSlideId`, `BiblePresentationSummary`
- New IDs are NOT type-compatible with `PresentationId`/`SlideId` — type system prevents accidental mixing
- The struct is named `BiblePresentationSlide` (not `BibleSlide`) to avoid colliding with `LiveEvent::BibleSlide`

### Persistence (Tasks 3-4)
- New sea-orm entities `bible_presentation` and `bible_slide`
- 7 new repository methods: `list_bible_presentation_summaries`, `fetch_bible_presentation`, `create_bible_presentation`, `rename_bible_presentation`, `delete_bible_presentation`, `replace_bible_presentation_slides`, `append_bible_presentation_slides`
- `list_bible_presentation_summaries` uses a single `GROUP BY` for slide counts (no N+1)
- Worship `repository/util.rs`, `presentation.rs`, `search.rs` cleaned up — no more `is_bible = !model.bible_main.is_empty()` content inspection
- 6 new in-memory sqlite unit tests for the bible repository methods

### Server state + router (Tasks 5-6)
- `state/bible.rs` uses the new repository methods directly
- `router/bible.rs` handlers wired to new types — wire JSON unchanged so frontend works without modification
- `delete_bible_presentation_handler` previously had a latent bug calling `state.delete_presentation` (worship delete) — now fixed
- `update_bible_slide` handler simplified ~60 lines — no more `SlideMetadata` wrapping for reference labels

### Broadcasting fix (Task 7)
- Deleted the leak in `broadcasting.rs:80-96` that emitted `BibleUpdate` for any worship slide with non-empty `stage` text
- Worship stage broadcasts now produce only `StageUpdate`

### AI tools cleanup (Task 8)
- All four `eq_ignore_ascii_case("Bible")` magic strings gone
- `bible_metadata_for_presentation` helper deleted (always returned None after migration)
- `make_slide` simplified — no more `is_bible` parameter
- 3 obsolete tests deleted that tested the legacy bible-as-worship-library flow

### Tests (Task 9)
- New `tests/e2e/bible-worship-isolation.spec.ts` with 2 regression tests:
  - Creating a bible presentation does NOT add a Bible library to `/libraries/summary`
  - Triggering a worship slide with non-empty `stage` text does NOT change `/bible/active`

### Local verification
- 156 unit tests pass (26 core + 32 persistence + 98 server), zero failures
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `quality-check.sh --strict` clean
- Migration tested against in-memory DB AND a copy of the dev DB

### Risks
- Old binary against new schema would crash. Rollback via the auto-backup taken in the dev pipeline `Backup database` step before deploy.
- The 2 existing bible presentations on production will be permanently dropped after this deploys (user explicitly confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
