### PR TITLE
fix(search): bible search crash on Slovak diacritics (#220)

### DIFF
--- a/crates/presenter-ui/src/components/search.rs
+++ b/crates/presenter-ui/src/components/search.rs
@@ -197,7 +197,12 @@ pub fn SearchResults() -> impl IntoView {
                                 let ref_label = hit.reference.to_human_readable();
                                 let text_preview = {
                                     let t = &hit.text;
-                                    if t.len() > 80 { format!("{}\u{2026}", &t[..80]) } else { t.clone() }
+                                    if t.chars().count() > 80 {
+                                        let end: usize = t.char_indices().nth(80).map(|(i, _)| i).unwrap_or(t.len());
+                                        format!("{}\u{2026}", &t[..end])
+                                    } else {
+                                        t.clone()
+                                    }
                                 };
                                 let book = hit.reference.book.clone();
                                 let book_code = hit.reference.book_code.clone();


### PR DESCRIPTION
## Summary
- Fix WASM panic when search results contain multi-byte Slovak characters (ž, á, č)
- Text preview truncation used byte index 80 which landed inside ž, causing panic
- Search was completely broken — showed "Searching..." forever with no results
- Fix uses char_indices() to find correct char boundary

**Hotfix already deployed to production** — search works now.

## Root cause
`&t[..80]` panics on multi-byte UTF-8. CI tests used English text (ASCII only) so the bug wasn't caught.

## Test plan
- [x] Verified: search "boh je" returns results instantly on dev
- [x] Verified: zero console errors
- [x] Verified: deployed to production, working

🤖 Generated with [Claude Code](https://claude.com/claude-code)