### PR TITLE
fix(worship): rework worship operator slides UI (#215)

### DIFF
--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -55,7 +55,7 @@ pub use playlist::{Playlist, PlaylistEntry};
 pub use presentation::Presentation;
 pub use resolume::{ResolumeHost, ResolumeHostDraft, ResolumeHostValidationError};
 pub use search::{SearchMatchField, SearchResult, SearchResultKind};
-pub use slide::{ResolvedSlide, Slide, SlideContent, SlideGroup, SlideText};
+pub use slide::{resolve_sequence, ResolvedSlide, Slide, SlideContent, SlideGroup, SlideText};
 pub use stage_client::{StageClientSnapshot, StageClientStatus};
 pub use stage_display::{
     StageDisplayLayout, StageDisplaySlide, StageDisplaySnapshot, StagePlaylistEntry, StageState,

--- a/crates/presenter-importer/src/lib.rs
+++ b/crates/presenter-importer/src/lib.rs
@@ -266,7 +266,9 @@ fn presentation_from_proto(raw: &proto::Presentation) -> Result<Presentation> {
             } else {
                 None
             };
-            let content = slide_content_from_proto(base_slide, group)?;
+            let Some(content) = slide_content_from_proto(base_slide, group)? else {
+                continue;
+            };
             slides.push(Slide::new(order as u32, content));
             first_action = false;
         }
@@ -285,7 +287,7 @@ fn presentation_from_proto(raw: &proto::Presentation) -> Result<Presentation> {
 fn slide_content_from_proto(
     base_slide: &proto::Slide,
     group: Option<SlideGroup>,
-) -> Result<SlideContent> {
+) -> Result<Option<SlideContent>> {
     let mut buckets: Vec<(TextRole, String)> = Vec::new();
 
     for element in &base_slide.elements {
@@ -305,8 +307,10 @@ fn slide_content_from_proto(
         }
     }
 
-    if buckets.is_empty() {
-        buckets.push((TextRole::Main, String::new()));
+    // Skip slides that have no text content AND no group assignment
+    // (these are artifacts of ProPresenter slides with only placeholder elements).
+    if buckets.is_empty() && group.is_none() {
+        return Ok(None);
     }
 
     let main = select_text(&buckets, TextRole::Main)
@@ -320,12 +324,12 @@ fn slide_content_from_proto(
     let translation = select_text(&buckets, TextRole::Translation).unwrap_or_default();
     let stage = select_text(&buckets, TextRole::Stage).unwrap_or_default();
 
-    Ok(SlideContent::new(
+    Ok(Some(SlideContent::new(
         SlideText::new(main)?,
         SlideText::new(translation)?,
         SlideText::new(stage)?,
         group,
-    ))
+    )))
 }
 
 fn select_text(buckets: &[(TextRole, String)], role: TextRole) -> Option<String> {
@@ -555,7 +559,10 @@ mod tests {
             ..Default::default()
         };
 
-        let content = super::slide_content_from_proto(&slide, None).expect("content");
+        let group = Some(SlideGroup::new("Verse 1".to_string()));
+        let content = super::slide_content_from_proto(&slide, group)
+            .expect("result")
+            .expect("slide kept due to group");
         assert!(content.main.value().is_empty(), "main text should be blank");
     }
 
@@ -597,7 +604,9 @@ mod tests {
             ..Default::default()
         };
 
-        let content = super::slide_content_from_proto(&slide, None).expect("content");
+        let content = super::slide_content_from_proto(&slide, None)
+            .expect("result")
+            .expect("non-empty slide");
         assert_eq!(content.main.value(), "Verse");
         assert!(
             content.stage.value().is_empty(),
@@ -606,12 +615,24 @@ mod tests {
     }
 
     #[test]
-    fn slide_content_defaults_to_blank_when_no_elements_present() {
+    fn slide_content_returns_none_when_no_elements_and_no_group() {
         let slide = proto::Slide::default();
-        let content = super::slide_content_from_proto(&slide, None).expect("content");
-        assert!(content.main.value().is_empty());
-        assert!(content.translation.value().is_empty());
-        assert!(content.stage.value().is_empty());
+        let result = super::slide_content_from_proto(&slide, None).expect("result");
+        assert!(
+            result.is_none(),
+            "empty slide with no group should be skipped"
+        );
+    }
+
+    #[test]
+    fn slide_content_returns_some_when_empty_but_has_group() {
+        let slide = proto::Slide::default();
+        let group = Some(SlideGroup::new("Verse 1".to_string()));
+        let result = super::slide_content_from_proto(&slide, group).expect("result");
+        assert!(
+            result.is_some(),
+            "slide with group should be kept even if text is empty"
+        );
     }
 
     #[tokio::test]
@@ -797,7 +818,9 @@ mod tests {
             ..Default::default()
         };
 
-        let content = slide_content_from_proto(&slide, None).expect("content");
+        let content = slide_content_from_proto(&slide, None)
+            .expect("result")
+            .expect("non-empty slide");
         assert_eq!(content.main.value(), "Main lyrics");
         assert_eq!(content.translation.value(), "Translation text");
         assert_eq!(content.stage.value(), "Stage text");

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.13"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -23,6 +23,7 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
     "Blob",
     "DataTransfer",
+    "DomRect",
     "DomStringMap",
     "DomTokenList",
     "Document",

--- a/crates/presenter-ui/src/api/ndi.rs
+++ b/crates/presenter-ui/src/api/ndi.rs
@@ -40,10 +40,7 @@ pub async fn discover_ndi_sources() -> Result<Vec<NdiSourceDto>, ApiError> {
     get_json("/ndi/sources").await
 }
 
-pub async fn create_video_source(
-    label: &str,
-    ndi_name: &str,
-) -> Result<VideoSourceDto, ApiError> {
+pub async fn create_video_source(label: &str, ndi_name: &str) -> Result<VideoSourceDto, ApiError> {
     post_json(
         "/integrations/video-sources",
         &CreateVideoSourceRequest {
@@ -63,7 +60,11 @@ pub async fn activate_video_source(id: &str) -> Result<VideoSourceDto, ApiError>
 }
 
 pub async fn deactivate_video_sources() -> Result<(), ApiError> {
-    post_no_content("/integrations/video-sources/deactivate", &serde_json::json!({})).await
+    post_no_content(
+        "/integrations/video-sources/deactivate",
+        &serde_json::json!({}),
+    )
+    .await
 }
 
 pub async fn delete_video_source(id: &str) -> Result<(), ApiError> {

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -210,6 +210,10 @@ pub fn SlideList() -> impl IntoView {
     // Scroll active slide into view whenever the stage's current slide changes.
     // This covers all trigger sources: click, keyboard arrows, Ableton follow,
     // Companion, API — the visible list should always follow the stage.
+    //
+    // The `prev_id: Option<Option<String>>` signature is Leptos's convention:
+    // outer Option = "Effect has run before", inner Option = the previous return
+    // value. `prev_id.flatten()` collapses both into the actual prior slide id.
     {
         let stage_snapshot = ctx.stage_snapshot;
         Effect::new(move |prev_id: Option<Option<String>>| {
@@ -322,51 +326,20 @@ pub fn SlideList() -> impl IntoView {
                                     if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                         if let Some(card) = el.closest("[data-slide-id]").ok().flatten() {
                                             let target_id = card.get_attribute("data-slide-id").unwrap_or_default();
-                                            if target_id != dragged_id {
-                                                let pres = ctx.selected_presentation.get_untracked();
-                                                if let Some(p) = pres {
-                                                    let pres_id = p.id.to_string();
-                                                    let mut slide_ids: Vec<String> = p.slides.iter().map(|s| s.id.to_string()).collect();
-                                                    // Find ORIGINAL positions before removing the dragged slide.
-                                                    let orig_drag_pos = slide_ids.iter().position(|id| id == &dragged_id);
-                                                    let orig_target_pos = slide_ids.iter().position(|id| id == &target_id);
-
-                                                    if let (Some(drag_pos), Some(target_pos)) = (orig_drag_pos, orig_target_pos) {
-                                                        // Direction-based insertion: forward drags land AFTER
-                                                        // the target, backward drags land BEFORE the target.
-                                                        // This guarantees every drag visibly moves the slide.
-                                                        let forward = drag_pos < target_pos;
-
-                                                        // Remove from original position.
-                                                        slide_ids.remove(drag_pos);
-
-                                                        // After removal, target_pos shifts down by 1 if the
-                                                        // dragged slide was before it.
-                                                        let adjusted_target = if drag_pos < target_pos {
-                                                            target_pos - 1
-                                                        } else {
-                                                            target_pos
-                                                        };
-
-                                                        let insert_idx = if forward {
-                                                            adjusted_target + 1
-                                                        } else {
-                                                            adjusted_target
-                                                        };
-
-                                                        slide_ids.insert(insert_idx, dragged_id);
-
-                                                        let selected_pres = ctx.selected_presentation;
-                                                        leptos::task::spawn_local(async move {
-                                                            if let Ok(slides) = api::presentations::reorder_slides(&pres_id, slide_ids).await {
-                                                                selected_pres.update(|p| {
-                                                                    if let Some(pres) = p.as_mut() {
-                                                                        pres.slides = slides;
-                                                                    }
-                                                                });
-                                                            }
-                                                        });
-                                                    }
+                                            if let Some(p) = ctx.selected_presentation.get_untracked() {
+                                                let pres_id = p.id.to_string();
+                                                let ids: Vec<String> = p.slides.iter().map(|s| s.id.to_string()).collect();
+                                                if let Some(new_ids) = reorder_slide_ids(ids, &dragged_id, &target_id) {
+                                                    let selected_pres = ctx.selected_presentation;
+                                                    leptos::task::spawn_local(async move {
+                                                        if let Ok(slides) = api::presentations::reorder_slides(&pres_id, new_ids).await {
+                                                            selected_pres.update(|p| {
+                                                                if let Some(pres) = p.as_mut() {
+                                                                    pres.slides = slides;
+                                                                }
+                                                            });
+                                                        }
+                                                    });
                                                 }
                                             }
                                         }
@@ -943,6 +916,8 @@ pub fn SlideList() -> impl IntoView {
     }
 }
 
+/// Assumes a vertically scrolling container (`.operator__slides`). If the list
+/// ever becomes horizontally scrollable, this function needs a companion branch.
 fn scroll_slide_into_view(slide_id: &str) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -977,5 +952,94 @@ fn scroll_slide_into_view(slide_id: &str) {
         // If below viewport, scroll so element bottom is at container bottom.
         let delta = el_bottom - c_bottom;
         container.set_scroll_top((scroll_top + delta) as i32);
+    }
+}
+
+/// Pure reorder: given a slide id list and a drag/target pair, returns the new
+/// ordering, or `None` if the drag is a no-op (same id, missing ids).
+///
+/// Direction-based insertion: forward drags land AFTER the target, backward
+/// drags land BEFORE. This guarantees every distinct drag visibly moves the
+/// slide (the previous drop-position heuristic could be a no-op on forward
+/// drags into a target's upper half).
+fn reorder_slide_ids(
+    ids: Vec<String>,
+    dragged: &str,
+    target: &str,
+) -> Option<Vec<String>> {
+    if dragged == target {
+        return None;
+    }
+    let drag_pos = ids.iter().position(|id| id == dragged)?;
+    let target_pos = ids.iter().position(|id| id == target)?;
+    let forward = drag_pos < target_pos;
+    let mut new_ids = ids;
+    new_ids.remove(drag_pos);
+    // After removal, target_pos shifts down by 1 if the dragged slide was before it.
+    let adjusted_target = if forward { target_pos - 1 } else { target_pos };
+    let insert_idx = if forward {
+        adjusted_target + 1
+    } else {
+        adjusted_target
+    };
+    new_ids.insert(insert_idx, dragged.to_string());
+    Some(new_ids)
+}
+
+#[cfg(test)]
+mod reorder_tests {
+    use super::reorder_slide_ids;
+
+    fn ids(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn forward_drag_lands_after_target() {
+        // Drag "a" (pos 0) onto "d" (pos 3) → "a" ends up at pos 3.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "d").unwrap();
+        assert_eq!(result, ids(&["b", "c", "d", "a", "e"]));
+    }
+
+    #[test]
+    fn backward_drag_lands_on_target_position() {
+        // Drag "d" (pos 3) onto "a" (pos 0) → "d" ends up at pos 0.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "d", "a").unwrap();
+        assert_eq!(result, ids(&["d", "a", "b", "c", "e"]));
+    }
+
+    #[test]
+    fn adjacent_forward_swap() {
+        // Drag "b" onto "c" → "b" and "c" swap.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "b", "c").unwrap();
+        assert_eq!(result, ids(&["a", "c", "b", "d"]));
+    }
+
+    #[test]
+    fn adjacent_backward_swap() {
+        // Drag "c" onto "b" → "c" and "b" swap.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "c", "b").unwrap();
+        assert_eq!(result, ids(&["a", "c", "b", "d"]));
+    }
+
+    #[test]
+    fn same_id_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "a").is_none());
+    }
+
+    #[test]
+    fn missing_dragged_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "z", "a").is_none());
+    }
+
+    #[test]
+    fn missing_target_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "z").is_none());
+    }
+
+    #[test]
+    fn preserves_length() {
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "e").unwrap();
+        assert_eq!(result.len(), 5);
     }
 }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -219,9 +219,13 @@ pub fn SlideList() -> impl IntoView {
             if current_id != prev_id.flatten() {
                 if let Some(ref slide_id) = current_id {
                     let slide_id = slide_id.clone();
-                    let _ = gloo_timers::callback::Timeout::new(0, move || {
+                    // Use forget() so the timeout isn't cancelled by being dropped.
+                    // 0ms defers until after Leptos has flushed the DOM update that
+                    // sets is-active on the new card.
+                    gloo_timers::callback::Timeout::new(0, move || {
                         scroll_slide_into_view(&slide_id);
-                    });
+                    })
+                    .forget();
                 }
             }
             current_id
@@ -319,42 +323,50 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(card) = el.closest("[data-slide-id]").ok().flatten() {
                                             let target_id = card.get_attribute("data-slide-id").unwrap_or_default();
                                             if target_id != dragged_id {
-                                                // Determine whether to insert before or after the target
-                                                // based on whether the drop was in the upper or lower half
-                                                // of the target card's bounding box.
-                                                let insert_after = card
-                                                    .clone()
-                                                    .dyn_into::<web_sys::HtmlElement>()
-                                                    .ok()
-                                                    .map(|html_el| {
-                                                        let rect = html_el.get_bounding_client_rect();
-                                                        let drop_y = ev.client_y() as f64;
-                                                        let midpoint = rect.top() + rect.height() / 2.0;
-                                                        drop_y > midpoint
-                                                    })
-                                                    .unwrap_or(false);
-
                                                 let pres = ctx.selected_presentation.get_untracked();
                                                 if let Some(p) = pres {
                                                     let pres_id = p.id.to_string();
                                                     let mut slide_ids: Vec<String> = p.slides.iter().map(|s| s.id.to_string()).collect();
-                                                    if let Some(drag_pos) = slide_ids.iter().position(|id| id == &dragged_id) {
+                                                    // Find ORIGINAL positions before removing the dragged slide.
+                                                    let orig_drag_pos = slide_ids.iter().position(|id| id == &dragged_id);
+                                                    let orig_target_pos = slide_ids.iter().position(|id| id == &target_id);
+
+                                                    if let (Some(drag_pos), Some(target_pos)) = (orig_drag_pos, orig_target_pos) {
+                                                        // Direction-based insertion: forward drags land AFTER
+                                                        // the target, backward drags land BEFORE the target.
+                                                        // This guarantees every drag visibly moves the slide.
+                                                        let forward = drag_pos < target_pos;
+
+                                                        // Remove from original position.
                                                         slide_ids.remove(drag_pos);
-                                                    }
-                                                    if let Some(target_pos) = slide_ids.iter().position(|id| id == &target_id) {
-                                                        let insert_idx = if insert_after { target_pos + 1 } else { target_pos };
+
+                                                        // After removal, target_pos shifts down by 1 if the
+                                                        // dragged slide was before it.
+                                                        let adjusted_target = if drag_pos < target_pos {
+                                                            target_pos - 1
+                                                        } else {
+                                                            target_pos
+                                                        };
+
+                                                        let insert_idx = if forward {
+                                                            adjusted_target + 1
+                                                        } else {
+                                                            adjusted_target
+                                                        };
+
                                                         slide_ids.insert(insert_idx, dragged_id);
+
+                                                        let selected_pres = ctx.selected_presentation;
+                                                        leptos::task::spawn_local(async move {
+                                                            if let Ok(slides) = api::presentations::reorder_slides(&pres_id, slide_ids).await {
+                                                                selected_pres.update(|p| {
+                                                                    if let Some(pres) = p.as_mut() {
+                                                                        pres.slides = slides;
+                                                                    }
+                                                                });
+                                                            }
+                                                        });
                                                     }
-                                                    let selected_pres = ctx.selected_presentation;
-                                                    leptos::task::spawn_local(async move {
-                                                        if let Ok(slides) = api::presentations::reorder_slides(&pres_id, slide_ids).await {
-                                                            selected_pres.update(|p| {
-                                                                if let Some(pres) = p.as_mut() {
-                                                                    pres.slides = slides;
-                                                                }
-                                                            });
-                                                        }
-                                                    });
                                                 }
                                             }
                                         }
@@ -936,10 +948,34 @@ fn scroll_slide_into_view(slide_id: &str) {
         return;
     };
     let selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
-    if let Ok(Some(el)) = document.query_selector(&selector) {
-        let mut opts = web_sys::ScrollIntoViewOptions::new();
-        opts.behavior(web_sys::ScrollBehavior::Smooth);
-        opts.block(web_sys::ScrollLogicalPosition::Nearest);
-        el.scroll_into_view_with_scroll_into_view_options(&opts);
+    let Ok(Some(el)) = document.query_selector(&selector) else {
+        return;
+    };
+    // Compute scroll position on the container so the active slide is in view.
+    // Find the scrollable ancestor (.operator__slides).
+    let Ok(Some(container)) = el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let Ok(el_html) = el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let el_rect = el_html.get_bounding_client_rect();
+    let container_rect = container.get_bounding_client_rect();
+    let el_top = el_rect.top();
+    let el_bottom = el_rect.bottom();
+    let c_top = container_rect.top();
+    let c_bottom = container_rect.bottom();
+    let scroll_top = container.scroll_top() as f64;
+    // If above viewport, scroll so element top is at container top.
+    if el_top < c_top {
+        let delta = c_top - el_top;
+        container.set_scroll_top((scroll_top - delta) as i32);
+    } else if el_bottom > c_bottom {
+        // If below viewport, scroll so element bottom is at container bottom.
+        let delta = el_bottom - c_bottom;
+        container.set_scroll_top((scroll_top + delta) as i32);
     }
 }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -207,19 +207,16 @@ pub fn SlideList() -> impl IntoView {
     let ctx = use_ctx!(AppContext);
     let op = use_ctx!(OperatorState);
 
-    // Scroll active slide into view when follow mode is ON and stage changes
+    // Scroll active slide into view whenever the stage's current slide changes.
+    // This covers all trigger sources: click, keyboard arrows, Ableton follow,
+    // Companion, API — the visible list should always follow the stage.
     {
         let stage_snapshot = ctx.stage_snapshot;
-        let ableset_status = ctx.ableset_status;
         Effect::new(move |prev_id: Option<Option<String>>| {
             let current_id = stage_snapshot
                 .get()
                 .and_then(|s| s.current_slide_id.map(|id| id.to_string()));
-            let follow_on = ableset_status
-                .get_untracked()
-                .map(|s| s.follow_enabled)
-                .unwrap_or(true);
-            if follow_on && current_id != prev_id.flatten() {
+            if current_id != prev_id.flatten() {
                 if let Some(ref slide_id) = current_id {
                     let slide_id = slide_id.clone();
                     let _ = gloo_timers::callback::Timeout::new(0, move || {
@@ -322,6 +319,21 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(card) = el.closest("[data-slide-id]").ok().flatten() {
                                             let target_id = card.get_attribute("data-slide-id").unwrap_or_default();
                                             if target_id != dragged_id {
+                                                // Determine whether to insert before or after the target
+                                                // based on whether the drop was in the upper or lower half
+                                                // of the target card's bounding box.
+                                                let insert_after = card
+                                                    .clone()
+                                                    .dyn_into::<web_sys::HtmlElement>()
+                                                    .ok()
+                                                    .map(|html_el| {
+                                                        let rect = html_el.get_bounding_client_rect();
+                                                        let drop_y = ev.client_y() as f64;
+                                                        let midpoint = rect.top() + rect.height() / 2.0;
+                                                        drop_y > midpoint
+                                                    })
+                                                    .unwrap_or(false);
+
                                                 let pres = ctx.selected_presentation.get_untracked();
                                                 if let Some(p) = pres {
                                                     let pres_id = p.id.to_string();
@@ -330,7 +342,8 @@ pub fn SlideList() -> impl IntoView {
                                                         slide_ids.remove(drag_pos);
                                                     }
                                                     if let Some(target_pos) = slide_ids.iter().position(|id| id == &target_id) {
-                                                        slide_ids.insert(target_pos, dragged_id);
+                                                        let insert_idx = if insert_after { target_pos + 1 } else { target_pos };
+                                                        slide_ids.insert(insert_idx, dragged_id);
                                                     }
                                                     let selected_pres = ctx.selected_presentation;
                                                     leptos::task::spawn_local(async move {

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use presenter_core::{resolve_sequence, ResolvedSlide};
 use wasm_bindgen::JsCast;
 
 use crate::api;
@@ -373,37 +374,58 @@ pub fn SlideList() -> impl IntoView {
                     };
 
                     let pres_id = presentation.id.to_string();
-                    let slides = presentation.slides.clone();
+                    let raw_slides = presentation.slides.clone();
+                    let resolved: Vec<ResolvedSlide> = resolve_sequence(&raw_slides);
                     let is_live = mode == "live";
                     let is_edit = !is_live;
 
-                    let mut current_group: Option<String> = None;
+                    // Track previous effective_group to decide whether the current slide
+                    // is showing the group for the first time ("explicit") or inheriting
+                    // it ("inherited").
+                    let mut prev_effective: Option<String> = None;
 
-                    slides.into_iter().enumerate().map(|(i, slide)| {
-                        let slide_id = slide.id.to_string();
-                        let main_text = slide.content.main.value().to_string();
-                        let translation_text = slide.content.translation.value().to_string();
-                        let stage_text = slide.content.stage.value().to_string();
-                        let group_name = slide.content.group.as_ref().map(|g| g.name().to_string());
+                    raw_slides
+                        .iter()
+                        .cloned()
+                        .zip(resolved.into_iter())
+                        .enumerate()
+                        .map(|(i, (raw_slide, resolved_slide))| {
+                        let slide_id = resolved_slide.id.to_string();
+                        let main_text = resolved_slide.main.value().to_string();
+                        let translation_text = resolved_slide.translation.value().to_string();
+                        let stage_text = resolved_slide.stage.value().to_string();
 
-                        // Track inherited vs explicit group for placeholder
-                        let inherited_group = if group_name.is_none() {
-                            current_group.clone()
+                        // The explicit group for this slide (None if inherited).
+                        let explicit_group_name = raw_slide
+                            .content
+                            .group
+                            .as_ref()
+                            .map(|g| g.name().to_string());
+
+                        // The effective (inherited or explicit) group for display.
+                        let effective_group_name = resolved_slide
+                            .effective_group
+                            .as_ref()
+                            .map(|g| g.name().to_string());
+
+                        // Is this slide the first one showing this effective group?
+                        let group_is_new = effective_group_name != prev_effective;
+                        prev_effective = effective_group_name.clone();
+                        let group_inherited =
+                            effective_group_name.is_some() && !group_is_new;
+
+                        // Header badge: always render the effective group. Dim if inherited.
+                        let group_badge_text = effective_group_name.clone();
+                        let group_badge_inherited = group_inherited;
+
+                        // Edit-mode group input:
+                        // - value = explicit group (empty if this slide doesn't have one)
+                        // - placeholder = effective group (shows what would be inherited)
+                        let group_edit_value = explicit_group_name.clone().unwrap_or_default();
+                        let group_edit_placeholder = if explicit_group_name.is_none() {
+                            effective_group_name.clone().unwrap_or_default()
                         } else {
-                            None
-                        };
-
-                        let group_inherited = if group_name != current_group {
-                            current_group.clone_from(&group_name);
-                            false
-                        } else {
-                            group_name.is_some()
-                        };
-
-                        let show_group = if !group_inherited {
-                            group_name.clone()
-                        } else {
-                            None
+                            String::new()
                         };
 
                         // is_active is now computed reactively in the class= closure
@@ -430,15 +452,6 @@ pub fn SlideList() -> impl IntoView {
                         let slide_id_for_article = slide_id.clone();
                         let slide_index = i;
 
-                        let group_display = group_name.clone().unwrap_or_default();
-                        let group_placeholder = inherited_group.clone().unwrap_or_default();
-
-                        // Group label for per-slide display
-                        let group_label_text_live = group_name.clone().or_else(|| inherited_group.clone());
-                        let group_label_inherited_live = group_name.is_none() && inherited_group.is_some();
-                        let group_label_text_edit = group_label_text_live.clone();
-                        let group_label_inherited_edit = group_label_inherited_live;
-
                         let trigger = trigger_slide;
 
                         // Clone for drag
@@ -458,12 +471,9 @@ pub fn SlideList() -> impl IntoView {
                         let slide_id_class = slide_id.clone();
 
                         view! {
-                            {show_group.map(|g| view! {
-                                <div class="operator__slide-group" data-role="slide-group">{g}</div>
-                            })}
                             <article
                                 class=move || {
-                                    let mut c = "operator__slide-card stage-control__slide".to_string();
+                                    let mut c = "operator__slide-card operator__slide-card--worship".to_string();
                                     // Read stage_snapshot reactively HERE (in class closure)
                                     // so it only updates this element's class, not the entire view.
                                     let snap = ctx.stage_snapshot.get();
@@ -582,6 +592,16 @@ pub fn SlideList() -> impl IntoView {
                                             })}
                                         </span>
                                     </div>
+                                    {group_badge_text.clone().map(|g| {
+                                        let class = if group_badge_inherited {
+                                            "operator__slide-group operator__slide-group--inherited"
+                                        } else {
+                                            "operator__slide-group"
+                                        };
+                                        view! {
+                                            <span class=class data-role="slide-group">{g}</span>
+                                        }
+                                    })}
                                     {is_edit.then(|| {
                                         let pres_id_save = pres_id_edit.clone();
                                         let slide_id_save = slide_id_edit.clone();
@@ -681,14 +701,6 @@ pub fn SlideList() -> impl IntoView {
                                             >
                                                 {format!("Line exceeds {line_limit} characters")}
                                             </div>
-                                            {group_label_text_live.map(|g| {
-                                                let class = if group_label_inherited_live {
-                                                    "operator__slide-group-label operator__slide-group-label--inherited"
-                                                } else {
-                                                    "operator__slide-group-label"
-                                                };
-                                                view! { <div class=class data-role="slide-group-label">{g}</div> }
-                                            })}
                                         }.into_any()
                                     } else {
                                         // Create reactive warning signals for real-time updates
@@ -728,14 +740,6 @@ pub fn SlideList() -> impl IntoView {
                                             >
                                                 {format!("Line exceeds {line_limit} characters")}
                                             </div>
-                                            {group_label_text_edit.map(|g| {
-                                                let class = if group_label_inherited_edit {
-                                                    "operator__slide-group-label operator__slide-group-label--inherited"
-                                                } else {
-                                                    "operator__slide-group-label"
-                                                };
-                                                view! { <div class=class data-role="slide-group-label">{g}</div> }
-                                            })}
                                             <div class="operator__slide-editor">
                                                 <label>
                                                     <span>"Main"</span>
@@ -850,9 +854,9 @@ pub fn SlideList() -> impl IntoView {
                                                     <input
                                                         type="text"
                                                         data-field="group"
-                                                        prop:value=group_display.clone()
+                                                        prop:value=group_edit_value.clone()
                                                         // CRITICAL #8 fix: Show inherited group as placeholder
-                                                        placeholder=group_placeholder
+                                                        placeholder=group_edit_placeholder
                                                         on:blur={
                                                             let pres_id = pres_id_edit.clone();
                                                             let sid = slide_id_edit.clone();

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1251,23 +1251,6 @@ body.operator[data-mode="live"] .operator__line-limit {
   font-size: 0.95rem;
 }
 
-.operator__slide-group {
-  font-size: 0.68rem;
-  color: var(--operator-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  text-align: center;
-  margin-top: auto;
-  min-height: 1rem;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-}
-
-.operator__slide-group[data-hidden="true"] {
-  visibility: hidden;
-}
-
 .operator__slide-text.is-warning {
   color: #dc2626;
 }
@@ -1381,30 +1364,37 @@ body.operator[data-mode="live"] .operator__slide-handle {
   color: var(--operator-accent-dark);
   border-radius: 999px;
   padding: 0.15rem 0.6rem;
-  align-self: center;
-  grid-column: 1 / -1;
-  justify-self: center;
+  white-space: nowrap;
 }
 
-.operator__slide-group.is-inherited {
+.operator__slide-group--inherited {
   background: rgba(148, 163, 184, 0.15);
   color: var(--operator-muted);
+  opacity: 0.8;
 }
 
-.operator__slide-group-label {
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--operator-accent-dark);
-  text-align: center;
-  margin-top: auto;
-  padding-top: 0.25rem;
+/* Worship slide card variant — make edit textareas grow like bible */
+.operator__slide-card--worship .operator__slide-editor textarea {
+  field-sizing: content;
+  min-height: 2.5em;
+  max-height: none;
+  height: auto;
+  overflow-y: visible;
 }
 
-.operator__slide-group-label--inherited {
-  font-style: italic;
-  color: var(--operator-muted);
-  opacity: 0.7;
+/* Worship slide header layout — group badge inline with index and controls */
+.operator__slide-card--worship .operator__slide-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.operator__slide-card--worship .operator__slide-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
 }
 
 .operator__panel {

--- a/docs/superpowers/plans/2026-04-13-worship-operator-ui-rework.md
+++ b/docs/superpowers/plans/2026-04-13-worship-operator-ui-rework.md
@@ -1,0 +1,938 @@
+# Worship Operator UI Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the worship operator slides page to match the bible operator UI's polish — clean cards, proper group inheritance display, no junk text, no blank slides, responsive edit mode.
+
+**Architecture:** Surgical fixes in the existing `slide_list.rs` component — no full rewrite. Use `resolve_sequence()` from the data model to get `effective_group`, move the group badge INSIDE the card header, delete the phantom CSS class, resolve CSS conflicts, add `field-sizing: content` to worship textareas, and fix the importer to skip fully-empty slides.
+
+**Tech Stack:** Rust/Leptos WASM (presenter-ui), CSS, Rust (presenter-core, presenter-importer)
+
+**Spec:** `docs/superpowers/specs/2026-04-13-worship-operator-ui-rework-design.md`
+
+---
+
+## Context
+
+- **slide_list.rs** — 928-line worship slide component. Manual group tracking at lines 380-410, outside-card group `<div>` at line 462, phantom CSS class at line 466, inline group label at lines 684-691 and 731-738.
+- **slide.rs** — data model with `resolve_sequence(&[Slide]) -> Vec<ResolvedSlide>` that computes `effective_group`. Currently not used by worship UI.
+- **operator.css** — conflicting `.operator__slide-group` definitions at lines 1254-1265 and 1373-1391. No `operator__slide-card--worship` variant.
+- **importer/lib.rs:308-310** — creates a blank slide with empty main text when ProPresenter slides have no text elements.
+
+**Key files:**
+- `crates/presenter-ui/src/components/slide_list.rs`
+- `crates/presenter-core/src/slide.rs` — exports `ResolvedSlide`, needs to export `resolve_sequence`
+- `crates/presenter-core/src/lib.rs` — re-exports
+- `crates/presenter-ui/styles/operator.css` — lines 1080-1420
+- `crates/presenter-importer/src/lib.rs` — lines 240-330
+
+---
+
+## File Structure
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `crates/presenter-core/src/lib.rs` | Export `resolve_sequence` |
+| `crates/presenter-ui/src/components/slide_list.rs` | Use `resolve_sequence`, move group badge inside card header, remove phantom class, use `effective_group` |
+| `crates/presenter-ui/styles/operator.css` | Delete conflicting group CSS, add `operator__slide-card--worship` variant with `field-sizing: content`, fix group badge positioning |
+| `crates/presenter-importer/src/lib.rs` | Skip fully-empty slides in `presentation_from_proto` |
+
+---
+
+## Task 1: Export `resolve_sequence` from presenter-core
+
+**Files:**
+- Modify: `crates/presenter-core/src/lib.rs:58`
+
+- [ ] **Step 1: Update the re-export**
+
+In `crates/presenter-core/src/lib.rs`, change line 58:
+
+```rust
+pub use slide::{resolve_sequence, ResolvedSlide, Slide, SlideContent, SlideGroup, SlideText};
+```
+
+- [ ] **Step 2: Verify compiles**
+
+```bash
+cargo check -p presenter-core
+```
+
+Expected: Compiles with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/presenter-core/src/lib.rs
+git commit -m "refactor(core): export resolve_sequence for UI consumers (#215)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Skip Empty Slides in Importer
+
+**Files:**
+- Modify: `crates/presenter-importer/src/lib.rs:285-329`
+- Modify: `crates/presenter-importer/src/lib.rs:608-615` (existing test)
+
+- [ ] **Step 1: Update `slide_content_from_proto` to return `Option`**
+
+In `crates/presenter-importer/src/lib.rs`, replace the `slide_content_from_proto` function (lines 285-329) with:
+
+```rust
+fn slide_content_from_proto(
+    base_slide: &proto::Slide,
+    group: Option<SlideGroup>,
+) -> Result<Option<SlideContent>> {
+    let mut buckets: Vec<(TextRole, String)> = Vec::new();
+
+    for element in &base_slide.elements {
+        if let Some(graphic) = &element.element {
+            if let Some(text) = &graphic.text {
+                if text.rtf_data.is_empty() {
+                    continue;
+                }
+                let decoded = decode_rtf(&text.rtf_data)?;
+                let trimmed = decoded.trim();
+                if trimmed.is_empty() || is_placeholder_text(trimmed) {
+                    continue;
+                }
+                let role = classify_text_role(&graphic.name);
+                buckets.push((role, trimmed.to_string()));
+            }
+        }
+    }
+
+    // Skip slides that have no text content AND no group assignment
+    // (these are artifacts of ProPresenter slides with only placeholder elements).
+    if buckets.is_empty() && group.is_none() {
+        return Ok(None);
+    }
+
+    let main = select_text(&buckets, TextRole::Main)
+        .or_else(|| {
+            buckets
+                .iter()
+                .find(|(role, _)| *role == TextRole::Unknown)
+                .map(|(_, text)| text.clone())
+        })
+        .unwrap_or_default();
+    let translation = select_text(&buckets, TextRole::Translation).unwrap_or_default();
+    let stage = select_text(&buckets, TextRole::Stage).unwrap_or_default();
+
+    Ok(Some(SlideContent::new(
+        SlideText::new(main)?,
+        SlideText::new(translation)?,
+        SlideText::new(stage)?,
+        group,
+    )))
+}
+```
+
+- [ ] **Step 2: Update the caller to skip `None` results**
+
+In `crates/presenter-importer/src/lib.rs`, find the call site around line 269 and replace:
+
+```rust
+            let content = slide_content_from_proto(base_slide, group)?;
+            slides.push(Slide::new(order as u32, content));
+```
+
+with:
+
+```rust
+            let Some(content) = slide_content_from_proto(base_slide, group)? else {
+                continue;
+            };
+            slides.push(Slide::new(order as u32, content));
+```
+
+- [ ] **Step 3: Update existing tests that expect `SlideContent`**
+
+In `crates/presenter-importer/src/lib.rs`, the tests at lines 558, 600, 611, and 800 call `slide_content_from_proto(...).expect("content")` expecting `SlideContent`. Update them to expect `Option<SlideContent>`:
+
+Replace `super::slide_content_from_proto(&slide, None).expect("content")` with:
+```rust
+super::slide_content_from_proto(&slide, None)
+    .expect("content")
+    .expect("non-empty slide")
+```
+for tests that expect text content to exist.
+
+For the test `slide_content_defaults_to_blank_when_no_elements_present` (around line 609), rename and change the assertion to verify the slide is skipped:
+
+```rust
+    #[test]
+    fn slide_content_returns_none_when_no_elements_and_no_group() {
+        let slide = proto::Slide::default();
+        let result = super::slide_content_from_proto(&slide, None).expect("result");
+        assert!(result.is_none(), "empty slide with no group should be skipped");
+    }
+
+    #[test]
+    fn slide_content_returns_some_when_empty_but_has_group() {
+        let slide = proto::Slide::default();
+        let group = Some(SlideGroup::new("Verse 1".to_string()));
+        let result = super::slide_content_from_proto(&slide, group).expect("result");
+        assert!(
+            result.is_some(),
+            "slide with group should be kept even if text is empty"
+        );
+    }
+```
+
+- [ ] **Step 4: Run importer tests**
+
+```bash
+cargo test -p presenter-importer -- --nocapture
+```
+
+Expected: All tests pass including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-importer/src/lib.rs
+git commit -m "fix(importer): skip fully-empty slides with no group (#215)
+
+ProPresenter slides with only placeholder elements previously
+became blank slides in the worship operator UI. Now they are
+skipped unless they carry a group assignment (which would create
+an orphan otherwise).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Delete Conflicting Group CSS and Add Worship Card Variant
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/operator.css:1254-1265` (delete first `.operator__slide-group`)
+- Modify: `crates/presenter-ui/styles/operator.css:1373-1391` (adjust second `.operator__slide-group`)
+- Modify: `crates/presenter-ui/styles/operator.css` (add worship card variant)
+
+- [ ] **Step 1: Delete the first conflicting `.operator__slide-group` definition**
+
+In `crates/presenter-ui/styles/operator.css`, find the block around lines 1254-1265:
+
+```css
+.operator__slide-group {
+  font-size: 0.68rem;
+  color: var(--operator-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+  margin-top: auto;
+  min-height: 1rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+```
+
+Delete this entire block.
+
+- [ ] **Step 2: Adjust the second `.operator__slide-group` (the badge style)**
+
+In `crates/presenter-ui/styles/operator.css`, around line 1373-1391, find:
+
+```css
+.operator__slide-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(59, 124, 255, 0.16);
+  color: var(--operator-accent-dark);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  align-self: center;
+  grid-column: 1 / -1;
+  justify-self: center;
+}
+```
+
+Replace with:
+
+```css
+.operator__slide-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(59, 124, 255, 0.16);
+  color: var(--operator-accent-dark);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  white-space: nowrap;
+}
+
+.operator__slide-group--inherited {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--operator-muted);
+  opacity: 0.8;
+}
+```
+
+(Removed `grid-column`, `justify-self`, `align-self` — those assumed grid layout. Kept the pill appearance. Added `--inherited` variant.)
+
+- [ ] **Step 3: Delete the old `.is-inherited` rule**
+
+Still in `operator.css`, delete the `.operator__slide-group.is-inherited` block that follows the group block (replaced by the new `--inherited` modifier).
+
+- [ ] **Step 4: Add worship card variant with field-sizing**
+
+At the end of the slide-card section in `operator.css` (after the existing `.operator__slide-card` rules, before the `.operator__slide-group` block), add:
+
+```css
+/* Worship slide card variant — make edit textareas grow like bible */
+.operator__slide-card--worship .operator__slide-editor textarea {
+  field-sizing: content;
+  min-height: 2.5em;
+  max-height: none;
+  height: auto;
+  overflow-y: visible;
+}
+
+/* Worship slide header layout — group badge inline with index and controls */
+.operator__slide-card--worship .operator__slide-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.operator__slide-card--worship .operator__slide-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+```
+
+- [ ] **Step 5: Delete inline `.operator__slide-group-label` styles (no longer used)**
+
+Find the `.operator__slide-group-label` rules in `operator.css` (around lines 1394-1410). Delete them entirely — the inline label is being removed in Task 5 and the group badge in the header replaces it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/presenter-ui/styles/operator.css
+git commit -m "style(operator): fix conflicting group CSS, add worship card variant (#215)
+
+- Delete duplicate .operator__slide-group definition
+- Remove grid-based assumptions from group badge
+- Add .operator__slide-group--inherited modifier for dimmed state
+- Add .operator__slide-card--worship variant with field-sizing textareas
+- Delete unused .operator__slide-group-label styles
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Use `resolve_sequence` in `slide_list.rs`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:1-10` (imports)
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:376-407` (replace manual group tracking)
+
+- [ ] **Step 1: Import `resolve_sequence` and `ResolvedSlide`**
+
+In `crates/presenter-ui/src/components/slide_list.rs`, update imports at the top of the file. Replace the first few `use` lines (around lines 1-6) with:
+
+```rust
+use leptos::prelude::*;
+use presenter_core::{resolve_sequence, ResolvedSlide};
+use wasm_bindgen::JsCast;
+
+use crate::api;
+use crate::state::operator::OperatorState;
+use crate::state::AppContext;
+```
+
+- [ ] **Step 2: Replace manual group tracking with `resolve_sequence`**
+
+In `crates/presenter-ui/src/components/slide_list.rs`, find lines 376-407 (the `slides` variable and the manual group tracking). Replace:
+
+```rust
+                    let pres_id = presentation.id.to_string();
+                    let slides = presentation.slides.clone();
+                    let is_live = mode == "live";
+                    let is_edit = !is_live;
+
+                    let mut current_group: Option<String> = None;
+
+                    slides.into_iter().enumerate().map(|(i, slide)| {
+                        let slide_id = slide.id.to_string();
+                        let main_text = slide.content.main.value().to_string();
+                        let translation_text = slide.content.translation.value().to_string();
+                        let stage_text = slide.content.stage.value().to_string();
+                        let group_name = slide.content.group.as_ref().map(|g| g.name().to_string());
+
+                        // Track inherited vs explicit group for placeholder
+                        let inherited_group = if group_name.is_none() {
+                            current_group.clone()
+                        } else {
+                            None
+                        };
+
+                        let group_inherited = if group_name != current_group {
+                            current_group.clone_from(&group_name);
+                            false
+                        } else {
+                            group_name.is_some()
+                        };
+
+                        let show_group = if !group_inherited {
+                            group_name.clone()
+                        } else {
+                            None
+                        };
+```
+
+with:
+
+```rust
+                    let pres_id = presentation.id.to_string();
+                    let raw_slides = presentation.slides.clone();
+                    let resolved: Vec<ResolvedSlide> = resolve_sequence(&raw_slides);
+                    let is_live = mode == "live";
+                    let is_edit = !is_live;
+
+                    // Track previous effective_group to decide whether the current slide
+                    // is showing the group for the first time ("explicit") or inheriting
+                    // it ("inherited").
+                    let mut prev_effective: Option<String> = None;
+
+                    resolved.into_iter().enumerate().map(|(i, resolved_slide)| {
+                        let slide_id = resolved_slide.id.to_string();
+                        let main_text = resolved_slide.main.value().to_string();
+                        let translation_text = resolved_slide.translation.value().to_string();
+                        let stage_text = resolved_slide.stage.value().to_string();
+
+                        let effective_group_name = resolved_slide
+                            .effective_group
+                            .as_ref()
+                            .map(|g| g.name().to_string());
+
+                        // Is this slide's effective group inherited from the previous slide,
+                        // or is this the first slide showing this group?
+                        let group_is_new = effective_group_name != prev_effective;
+                        prev_effective = effective_group_name.clone();
+                        let group_inherited = effective_group_name.is_some() && !group_is_new;
+
+                        // The badge to render in the header (always the effective group).
+                        let group_badge_text = effective_group_name.clone();
+                        let group_badge_inherited = group_inherited;
+
+                        // For edit mode: the placeholder in the group input shows the
+                        // inherited group so the operator knows what the slide would
+                        // inherit if they leave the field blank.
+                        let group_placeholder = if resolved_slide
+                            .main
+                            .value()
+                            .is_empty() // best-effort: we no longer have raw slide.content.group
+                        {
+                            effective_group_name.clone().unwrap_or_default()
+                        } else {
+                            String::new()
+                        };
+```
+
+Note: the explicit group field is no longer directly available on `ResolvedSlide`. To keep the edit-mode group input working, we need access to the raw slide's explicit group. Task 5 handles this.
+
+- [ ] **Step 3: Verify compiles (will have unused variable warnings)**
+
+```bash
+cargo check -p presenter-ui --target wasm32-unknown-unknown
+```
+
+Expected: Compiles. There may be unused variable warnings for `group_name`, `inherited_group`, `show_group`, `group_display`, `group_label_text_live`, `group_label_inherited_live`, `group_label_text_edit`, `group_label_inherited_edit` — these will be cleaned up in later steps.
+
+- [ ] **Step 4: Do NOT commit yet** — this task leaves the code in a broken state. Tasks 5 and 6 fix the downstream references.
+
+---
+
+## Task 5: Pair Raw Slide With Resolved Slide, Fix Edit-Mode Group Input
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:376-407`
+
+The edit-mode textarea for the group field needs access to the raw slide's `content.group` (to distinguish "explicit" from "inherited"), so we need to iterate over both `raw_slides` and `resolved` in parallel.
+
+- [ ] **Step 1: Zip raw slides with resolved slides**
+
+Update the code block from Task 4 to pair raw and resolved:
+
+```rust
+                    let pres_id = presentation.id.to_string();
+                    let raw_slides = presentation.slides.clone();
+                    let resolved: Vec<ResolvedSlide> = resolve_sequence(&raw_slides);
+                    let is_live = mode == "live";
+                    let is_edit = !is_live;
+
+                    let mut prev_effective: Option<String> = None;
+
+                    raw_slides
+                        .iter()
+                        .cloned()
+                        .zip(resolved.into_iter())
+                        .enumerate()
+                        .map(|(i, (raw_slide, resolved_slide))| {
+                        let slide_id = resolved_slide.id.to_string();
+                        let main_text = resolved_slide.main.value().to_string();
+                        let translation_text = resolved_slide.translation.value().to_string();
+                        let stage_text = resolved_slide.stage.value().to_string();
+
+                        // The explicit group for this slide (None if inherited).
+                        let explicit_group_name = raw_slide
+                            .content
+                            .group
+                            .as_ref()
+                            .map(|g| g.name().to_string());
+
+                        // The effective (inherited or explicit) group for display.
+                        let effective_group_name = resolved_slide
+                            .effective_group
+                            .as_ref()
+                            .map(|g| g.name().to_string());
+
+                        // Is this slide the first one showing this effective group?
+                        let group_is_new = effective_group_name != prev_effective;
+                        prev_effective = effective_group_name.clone();
+                        let group_inherited =
+                            effective_group_name.is_some() && !group_is_new;
+
+                        // Header badge: always render the effective group. Dim if inherited.
+                        let group_badge_text = effective_group_name.clone();
+                        let group_badge_inherited = group_inherited;
+
+                        // Edit-mode group input:
+                        // - value = explicit group (empty if this slide doesn't have one)
+                        // - placeholder = effective group (shows what would be inherited)
+                        let group_edit_value = explicit_group_name.clone().unwrap_or_default();
+                        let group_edit_placeholder =
+                            if explicit_group_name.is_none() {
+                                effective_group_name.clone().unwrap_or_default()
+                            } else {
+                                String::new()
+                            };
+```
+
+- [ ] **Step 2: Verify compiles**
+
+```bash
+cargo check -p presenter-ui --target wasm32-unknown-unknown
+```
+
+Expected: Compiles. Warnings about unused legacy variables (`show_group`, `group_display`, etc.) are expected — they'll be removed in Task 6.
+
+---
+
+## Task 6: Move Group Badge Inside Card Header and Remove Inline Labels
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:460-484` (card open + outside-card group)
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:548-584` (header)
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:684-691` (live mode inline label)
+- Modify: `crates/presenter-ui/src/components/slide_list.rs:731-738` (edit mode inline label)
+
+- [ ] **Step 1: Remove the outside-card group `<div>` and fix the card class**
+
+In `crates/presenter-ui/src/components/slide_list.rs`, find the block around lines 460-484 that starts with the `view! {` after the closures:
+
+```rust
+                        view! {
+                            {show_group.map(|g| view! {
+                                <div class="operator__slide-group" data-role="slide-group">{g}</div>
+                            })}
+                            <article
+                                class=move || {
+                                    let mut c = "operator__slide-card stage-control__slide".to_string();
+```
+
+Replace with:
+
+```rust
+                        view! {
+                            <article
+                                class=move || {
+                                    let mut c = "operator__slide-card operator__slide-card--worship".to_string();
+```
+
+This removes the phantom `stage-control__slide` class and the outside-card group div.
+
+- [ ] **Step 2: Insert the group badge inside the header**
+
+Still in `slide_list.rs`, find the header around line 548:
+
+```rust
+                                <header class="operator__slide-header">
+                                    <div class="operator__slide-header-left">
+                                        // BLOCKER #5: Drag handle for reordering
+                                        {is_edit.then(|| {
+```
+
+Just before the `<div class="operator__slide-header-left">`, add the group badge. Update to:
+
+```rust
+                                <header class="operator__slide-header">
+                                    <div class="operator__slide-header-left">
+                                        // BLOCKER #5: Drag handle for reordering
+                                        {is_edit.then(|| {
+```
+
+Then find the end of the `operator__slide-header-left` div (around line 584, after the closing `</span>` and `</div>`). Add the badge after the closing div:
+
+```rust
+                                        <span class="operator__slide-index">
+                                            {i + 1}
+                                            {any_warning.then(|| view! {
+                                                <sup>"!"</sup>
+                                            })}
+                                        </span>
+                                    </div>
+                                    {group_badge_text.clone().map(|g| {
+                                        let class = if group_badge_inherited {
+                                            "operator__slide-group operator__slide-group--inherited"
+                                        } else {
+                                            "operator__slide-group"
+                                        };
+                                        view! {
+                                            <span class=class data-role="slide-group">{g}</span>
+                                        }
+                                    })}
+                                    {is_edit.then(|| {
+```
+
+- [ ] **Step 3: Remove the inline group label in live mode**
+
+In `crates/presenter-ui/src/components/slide_list.rs`, find the block around lines 684-691:
+
+```rust
+                                            {group_label_text_live.map(|g| {
+                                                let class = if group_label_inherited_live {
+                                                    "operator__slide-group-label operator__slide-group-label--inherited"
+                                                } else {
+                                                    "operator__slide-group-label"
+                                                };
+                                                view! { <div class=class data-role="slide-group-label">{g}</div> }
+                                            })}
+```
+
+Delete this entire block.
+
+- [ ] **Step 4: Remove the inline group label in edit mode**
+
+Find the same pattern around lines 731-738 (same block structure but for edit mode). Delete it.
+
+- [ ] **Step 5: Remove dead variables**
+
+Find and delete these variable assignments (around lines 433-440) that are no longer used:
+
+```rust
+                        let group_display = group_name.clone().unwrap_or_default();
+                        let group_placeholder = inherited_group.clone().unwrap_or_default();
+
+                        // Group label for per-slide display
+                        let group_label_text_live = group_name.clone().or_else(|| inherited_group.clone());
+                        let group_label_inherited_live = group_name.is_none() && inherited_group.is_some();
+                        let group_label_text_edit = group_label_text_live.clone();
+                        let group_label_inherited_edit = group_label_inherited_live;
+```
+
+- [ ] **Step 6: Update the edit-mode group input to use new variables**
+
+Find the group input in edit mode (around line 848). It currently uses `group_display` and `group_placeholder`. Update to use `group_edit_value` and `group_edit_placeholder`:
+
+```rust
+// Find: prop:value=group_display.clone()
+// Replace: prop:value=group_edit_value.clone()
+
+// Find: placeholder=group_placeholder.clone()
+// Replace: placeholder=group_edit_placeholder.clone()
+```
+
+- [ ] **Step 7: Verify compiles with no warnings**
+
+```bash
+cargo check -p presenter-ui --target wasm32-unknown-unknown
+```
+
+Expected: Compiles with zero warnings. If there are `unused variable` warnings, trace them back and remove the dead bindings.
+
+- [ ] **Step 8: Run clippy**
+
+```bash
+cargo clippy -p presenter-ui --target wasm32-unknown-unknown -- -D warnings -W clippy::all
+```
+
+Expected: No warnings.
+
+- [ ] **Step 9: Commit Tasks 4+5+6 together**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/slide_list.rs
+git commit -m "fix(worship-ui): use effective_group and move badge inside card (#215)
+
+- Use resolve_sequence() from data model instead of manual group tracking
+- Move group badge from outside the card into the header row
+- Remove phantom stage-control__slide CSS class
+- Replace with operator__slide-card--worship variant
+- Delete redundant inline .operator__slide-group-label
+- Edit-mode group input now shows explicit group as value and
+  inherited group as placeholder
+
+Closes #215.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: E2E Test for Worship Slides Rendering
+
+**Files:**
+- Create or modify: `tests/e2e/worship-operator-slides.spec.ts` (new file if not exists)
+
+- [ ] **Step 1: Write E2E test**
+
+Create `tests/e2e/worship-operator-slides.spec.ts`:
+
+```typescript
+/**
+ * Worship operator slides rendering tests (#215).
+ *
+ * Verifies the worship slides page displays cleanly:
+ * - No phantom CSS classes
+ * - Group badges inside cards (not floating outside)
+ * - Inherited groups shown with dimmed styling
+ * - No blank slides from empty ProPresenter slides
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 120_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("worship slides render without phantom class or outside-card groups", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.goto(`${baseURL}/ui/operator`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+
+  // Click first library (there's always a default one)
+  const firstLibrary = page.locator('[data-role="library-list"] li button').first();
+  await firstLibrary.click();
+
+  // Click first presentation
+  const firstPresentation = page.locator('[data-role="presentation-item"]').first();
+  await firstPresentation.click();
+
+  // Wait for slides to load
+  await page.waitForSelector('[data-slide-id]', { timeout: 10_000 });
+
+  // Check: no element has the phantom "stage-control__slide" class
+  const phantomCount = await page.locator(".stage-control__slide").count();
+  expect(phantomCount).toBe(0);
+
+  // Check: all slide cards have the worship variant class
+  const worshipCards = await page.locator(".operator__slide-card--worship").count();
+  expect(worshipCards).toBeGreaterThan(0);
+
+  // Check: all slide-group elements are INSIDE a slide card (not siblings)
+  const orphanGroups = await page
+    .locator('[data-role="slide-group"]')
+    .evaluateAll((elements) =>
+      elements.filter(
+        (el) => !el.closest(".operator__slide-card"),
+      ).length,
+    );
+  expect(orphanGroups).toBe(0);
+
+  // Check: no inline .operator__slide-group-label (should be removed)
+  const inlineLabels = await page.locator(".operator__slide-group-label").count();
+  expect(inlineLabels).toBe(0);
+
+  // Clean console
+  expect(consoleMessages).toEqual([]);
+});
+
+test("worship slide cards display inherited groups with dimmed styling", async ({ page }) => {
+  await page.goto(`${baseURL}/ui/operator`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+
+  // Click first library
+  await page.locator('[data-role="library-list"] li button').first().click();
+  // Click first presentation
+  await page.locator('[data-role="presentation-item"]').first().click();
+
+  await page.waitForSelector('[data-slide-id]', { timeout: 10_000 });
+
+  // Find any inherited group badge (the first slide with a group will be explicit,
+  // subsequent slides showing the same group will be --inherited)
+  const inheritedBadges = page.locator(".operator__slide-group--inherited");
+  const explicitBadges = page.locator(
+    ".operator__slide-group:not(.operator__slide-group--inherited)",
+  );
+
+  // If the presentation has groups, there should be at least one badge
+  const anyBadge = (await inheritedBadges.count()) + (await explicitBadges.count());
+  expect(anyBadge).toBeGreaterThanOrEqual(0); // may be 0 if no groups in this presentation
+});
+```
+
+- [ ] **Step 2: Run E2E test**
+
+```bash
+npm run test:playwright -- worship-operator-slides
+```
+
+Expected: Both tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/worship-operator-slides.spec.ts
+git commit -m "test(e2e): verify worship slides rendering (#215)
+
+Tests that the worship operator slides page renders cleanly:
+- No phantom stage-control__slide class
+- All group badges are inside slide cards (no orphans)
+- No inline .operator__slide-group-label elements
+- Zero console errors/warnings
+- Inherited group badges use --inherited modifier
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Local Verification, Push, CI, PR
+
+- [ ] **Step 1: Build locally and deploy to dev**
+
+```bash
+bash scripts/build-ui.sh
+cargo build -p presenter-server
+sudo systemctl stop presenter-dev
+sudo cp target/debug/presenter-server /opt/presenter-dev/presenter-server
+sudo systemctl start presenter-dev
+sleep 3
+curl -sf http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"..."}`
+
+- [ ] **Step 2: Visual check in browser**
+
+Open `http://10.77.8.134:8080/ui/operator` in a browser. Click a library, click a presentation. Verify:
+- Slide cards look clean (no floating group text)
+- Group badges appear in the header row of each card
+- Inherited groups are dimmed
+- No blank cards
+- Edit mode: textareas grow to fit content
+
+- [ ] **Step 3: Re-import if needed for the empty-slide fix**
+
+If the libraries on dev contain pre-imported blank slides, trigger a re-import to apply the new skip-empty logic:
+
+```bash
+# Skip unless the fix is not visible
+```
+
+- [ ] **Step 4: Run local checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test -p presenter-core -- resolve_sequence --nocapture
+cargo test -p presenter-importer -- --nocapture
+```
+
+Expected: All pass.
+
+- [ ] **Step 5: Push and monitor CI**
+
+```bash
+git push origin dev
+```
+
+Monitor until all jobs pass. Fix issues in ONE commit if needed.
+
+- [ ] **Step 6: Create PR**
+
+```bash
+gh pr create --title "fix(worship): rework worship operator slides UI to match bible UI (#215)" --body "$(cat <<'EOF'
+## Summary
+- Use \`resolve_sequence()\` from data model for group inheritance (no more manual tracking)
+- Move group badge from outside the card into the header row
+- Remove phantom \`stage-control__slide\` CSS class
+- Fix conflicting \`.operator__slide-group\` CSS
+- Add \`operator__slide-card--worship\` variant with \`field-sizing: content\` textareas
+- Skip fully-empty slides in ProPresenter importer
+
+Closes #215
+
+## Test plan
+- [ ] Visual: worship operator slides look clean on dev
+- [ ] No phantom classes in DOM
+- [ ] Group badges inside cards, not floating
+- [ ] Inherited groups dimmed
+- [ ] Edit mode textareas grow to fit content
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Phantom class gone | `document.querySelectorAll('.stage-control__slide').length === 0` |
+| Group badges inside cards | `document.querySelectorAll('[data-role="slide-group"]:not(.operator__slide-card *)').length === 0` |
+| Inherited groups dimmed | Visual check — repeated group names in second+ slides show as faded pills |
+| No blank slides | No cards with empty main/translation/stage AND no group |
+| Edit textareas grow | Switch to edit mode, type multiple lines, textarea expands |
+| Effective group propagates | A presentation with group "Verse 1" on slide 1 and no explicit groups on slides 2-3 shows "Verse 1" (dimmed) on all three |
+| No E2E regressions | `npm run test:playwright` passes |

--- a/docs/superpowers/specs/2026-04-13-worship-operator-ui-rework-design.md
+++ b/docs/superpowers/specs/2026-04-13-worship-operator-ui-rework-design.md
@@ -1,0 +1,139 @@
+# Worship Operator UI Rework Design
+
+> **Issue:** #215
+> **Date:** 2026-04-13
+
+## Problem
+
+The worship operator slides page looks like a "junk yard": random group text outside slides, groups missing on slides that should inherit, blank cards where slides should be, inconsistent styling. The bible operator UI is clean and polished by comparison. The user wants the worship UI to match the bible UI's quality.
+
+## Root Causes (from codebase exploration)
+
+1. **Phantom CSS class `stage-control__slide`** added to every worship card at `slide_list.rs:466`. No styles defined anywhere.
+2. **Group headers rendered outside slide cards** at `slide_list.rs:462` as sibling `<div>` elements instead of inside the `<article>`.
+3. **Group inheritance duplicated in UI** at `slide_list.rs:380-410` with manual state tracking. The data model already computes this via `resolve_sequence()` → `effective_group`, but worship doesn't use it.
+4. **Conflicting CSS** — two `.operator__slide-group` definitions at `operator.css:1254` and `:1373` with opposite layout assumptions.
+5. **Fixed textarea heights** — worship uses `rows="2"` while bible uses `field-sizing: content`.
+6. **Empty slides from importer** — `importer/lib.rs:309` creates slides with empty main text when a ProPresenter slide has no text elements. UI renders them as blank cards.
+7. **Monolithic 928-line component** vs bible's clean helper-function pattern.
+
+## Architecture
+
+Rewrite the worship slide list to match the bible slide list pattern:
+- Use `ResolvedSlide` (with `effective_group` already computed) instead of raw `Slide`
+- Split the monolithic `SlideList` into focused components and helper functions
+- Match bible's zone-based card structure (trigger-zone + select-zone)
+- Consistent CSS with no phantom classes
+
+## Changes
+
+### 1. Use `ResolvedSlide` Throughout the Worship UI
+
+**Current:** The worship UI receives `Vec<Slide>` via the state signal and manually tracks group inheritance in the render closure.
+
+**New:** Expose `ResolvedSlide` (or compute `effective_group` inline once per render). The data model's `resolve_sequence()` at `presenter-core/src/slide.rs:189-208` already propagates groups forward correctly — the UI just needs to call it.
+
+**Two approaches:**
+
+**Option A — Resolve in state layer (preferred):** The `slides` signal in `operator_context.rs` stores `Vec<ResolvedSlide>`. When fresh slides arrive from API/WebSocket, call `resolve_sequence()` once and store the result.
+
+**Option B — Resolve in view:** Call `resolve_sequence()` inside the render closure. Simpler diff, but recomputes on every re-render.
+
+I recommend **Option B** for this refactor — smaller blast radius, the compute is cheap (a single pass), and it keeps the signal type unchanged.
+
+### 2. Rewrite Slide Card Rendering
+
+Delete the monolithic per-slide closure (lines 380-906 in `slide_list.rs`). Replace with:
+
+**New helpers** (mirroring bible pattern):
+```rust
+fn worship_slide_body_view(
+    main: String,
+    translation: String,
+    stage: String,
+    group: Option<String>,
+    group_inherited: bool,
+) -> impl IntoView { ... }
+
+fn worship_slide_editor_view(
+    main_sig: RwSignal<String>,
+    trans_sig: RwSignal<String>,
+    stage_sig: RwSignal<String>,
+    group_sig: RwSignal<String>,
+    group_placeholder: String,
+) -> impl IntoView { ... }
+```
+
+**New component** `WorshipSlideCard` that takes a `ResolvedSlide` and renders:
+```
+<article class="operator__slide-card operator__slide-card--worship">
+  <header class="operator__slide-header">
+    <drag-handle />
+    <slide-index />
+    {group_badge}         // INSIDE the card, not before it
+    {edit-controls}
+  </header>
+  <section class="operator__slide-bodies">
+    {live_or_editor}
+  </section>
+</article>
+```
+
+The group badge is inside the header, not a sibling. Uses a single `.operator__slide-group` CSS class (the grid-based one, moved to inline-flex since it's not in a grid anymore).
+
+### 3. Fix Group Rendering
+
+**Remove:** The outside-the-card `<div class="operator__slide-group">` at `slide_list.rs:462`.
+
+**Remove:** The inline `.operator__slide-group-label` at `slide_list.rs:684-691` and `:731-738` (redundant — the header group badge now covers this).
+
+**Show group logic:**
+- If `effective_group` differs from previous slide's `effective_group` → show as "explicit" (bright)
+- If same as previous → show as "inherited" (dimmed) — so operator can still see what group the slide belongs to
+- If `None` → no badge
+
+**CSS:** Delete the conflicting `.operator__slide-group` at `operator.css:1254-1265`. Keep only the one at `:1373-1391` and adjust:
+- Change `display: inline-flex` to fit inside the card header
+- Remove `grid-column: 1 / -1` (not a grid)
+- Keep the inherited variant for dimmed state
+
+### 4. Fix Textareas in Edit Mode
+
+Add `operator__slide-card--worship` variant in CSS with `field-sizing: content` for textareas, matching the bible rule at `operator.css:1333`.
+
+### 5. Hide Empty Slides
+
+In the importer (`presenter-importer/src/lib.rs:308-310`), change the fallback: if all text buckets are empty, SKIP creating the slide entirely instead of creating a blank one.
+
+OR, safer: in the worship UI, filter `ResolvedSlide`s where all text fields are empty AND there's no group. Show a toast: "Hidden N empty slides from import" once per load.
+
+I recommend the importer fix — it's the root cause and affects all consumers of the data.
+
+### 6. Remove Phantom CSS Class
+
+Delete `stage-control__slide` from line 466. Replace with `operator__slide-card--worship` for variant styling hooks.
+
+### 7. Split `SlideList` File
+
+The file is 928 lines. Split:
+- `slide_list.rs` — top-level component (keeps pagination, selection state, drag-drop orchestration)
+- `worship_slide_card.rs` — the per-slide card component (new file, ~300 lines)
+- `worship_slide_helpers.rs` — shared view helpers (~150 lines)
+
+## Testing
+
+- **E2E Playwright:** Load a presentation known to have groups (e.g., `160 Ježiš je meno`), verify:
+  - All slides display (no blank cards)
+  - Slides with inherited groups show the group badge (dimmed)
+  - Slides with new groups show the badge (bright)
+  - No text appears outside slide cards
+  - Edit mode textareas grow to fit content
+- **Unit tests:** `resolve_sequence()` already has tests at `slide.rs:226-277`. Add UI-level tests for the new `worship_slide_body_view` helper.
+- **Visual regression:** Take screenshots before/after, verify the "junk yard" appearance is gone
+
+## Out of Scope
+
+- Live event broadcasting changes (worship slide trigger flow stays the same)
+- ProPresenter importer protocol changes (only fix the empty-slide fallback)
+- Worship playlist / library panel rework (only the slides page)
+- Worship live preview panel

--- a/tests/e2e/worship-operator-slides.spec.ts
+++ b/tests/e2e/worship-operator-slides.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Worship operator slides rendering tests (#215).
+ *
+ * Verifies the worship slides page displays cleanly:
+ * - No phantom stage-control__slide class
+ * - Group badges are inside slide cards (not floating outside)
+ * - No inline .operator__slide-group-label elements
+ * - Zero console errors/warnings
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 120_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+async function openFirstPresentation(page: import("@playwright/test").Page) {
+  await page.goto(`${baseURL}/ui/operator`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  // Click first library via JS (clicks can be intercepted by overlays)
+  await page.evaluate(() => {
+    const lib = document.querySelector(
+      '[data-role="library-list"] li button, .operator__library-card button',
+    ) as HTMLElement | null;
+    lib?.click();
+  });
+
+  // Wait for presentations to load
+  await page.waitForSelector('[data-role="presentation-item"]', {
+    timeout: 10_000,
+  });
+
+  // Click first presentation via JS
+  await page.evaluate(() => {
+    const item = document.querySelector(
+      '[data-role="presentation-item"]',
+    ) as HTMLElement | null;
+    if (item) {
+      item.scrollIntoView({ block: "center" });
+      const btn =
+        (item.querySelector('button, [role="button"]') as HTMLElement | null) ||
+        item;
+      btn.click();
+    }
+  });
+
+  // Wait for slides to load
+  await page.waitForSelector("[data-slide-id]", { timeout: 10_000 });
+}
+
+test("worship slides render without phantom class or outside-card groups", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await openFirstPresentation(page);
+
+  // No element has the phantom "stage-control__slide" class
+  const phantomCount = await page.locator(".stage-control__slide").count();
+  expect(phantomCount).toBe(0);
+
+  // All slide cards have the worship variant class
+  const worshipCards = await page
+    .locator(".operator__slide-card--worship")
+    .count();
+  expect(worshipCards).toBeGreaterThan(0);
+
+  // All slide-group elements are INSIDE a slide card (no orphans as siblings)
+  const orphanGroups = await page
+    .locator('[data-role="slide-group"]')
+    .evaluateAll(
+      (elements) =>
+        elements.filter((el) => !el.closest(".operator__slide-card")).length,
+    );
+  expect(orphanGroups).toBe(0);
+
+  // No inline .operator__slide-group-label (removed in #215)
+  const inlineLabels = await page
+    .locator(".operator__slide-group-label")
+    .count();
+  expect(inlineLabels).toBe(0);
+
+  // Clean console
+  expect(consoleMessages).toEqual([]);
+});
+
+test("worship slides use --inherited modifier for repeated groups", async ({
+  page,
+}) => {
+  await openFirstPresentation(page);
+
+  // Find presentations known to have multiple slides sharing a group.
+  // If the current presentation has groups, at least one badge must exist.
+  const anyBadge = await page.locator('[data-role="slide-group"]').count();
+  if (anyBadge === 0) {
+    // Skip gracefully if the test presentation has no groups.
+    return;
+  }
+
+  // If there are multiple slides in a group, the non-first ones should be inherited.
+  // We can't assert this without knowing the presentation structure, so we at least
+  // verify the inherited modifier class exists on at least one badge when duplicates
+  // are present.
+  const total = await page
+    .locator(".operator__slide-group, .operator__slide-group--inherited")
+    .count();
+  expect(total).toBeGreaterThan(0);
+});

--- a/tests/e2e/worship-operator-slides.spec.ts
+++ b/tests/e2e/worship-operator-slides.spec.ts
@@ -6,9 +6,10 @@
  * - Group badges are inside slide cards (not floating outside)
  * - No inline .operator__slide-group-label elements
  * - Zero console errors/warnings
+ * - Repeated groups render with the --inherited modifier
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   deriveTestConfig,
   refreshDevData,
@@ -34,40 +35,107 @@ test.afterAll(async () => {
   server = undefined;
 });
 
-async function openFirstPresentation(page: import("@playwright/test").Page) {
+type SelectionTarget = {
+  libraryId: string;
+  libraryName: string;
+  presentationId: string;
+  presentationName: string;
+  hasGroups: boolean;
+  hasRepeatedGroups: boolean;
+};
+
+/**
+ * Fetches /libraries and picks a worship presentation that exercises the
+ * rendering paths we care about. Prefers presentations where a group repeats
+ * (so the inherited modifier is provably in the DOM). Returns `null` if the
+ * corpus has no worship presentations with groups — the test will then fail
+ * loudly instead of silently passing.
+ */
+async function pickWorshipTarget(
+  page: Page,
+  { requiresRepeatedGroups }: { requiresRepeatedGroups: boolean },
+): Promise<SelectionTarget | null> {
+  return page.evaluate<SelectionTarget | null, { requiresRepeatedGroups: boolean }>(
+    async ({ requiresRepeatedGroups }) => {
+      const libs = await (await fetch("/libraries")).json();
+      let best: SelectionTarget | null = null;
+      for (const lib of libs) {
+        for (const p of lib.presentations ?? []) {
+          const slides = p.slides ?? [];
+          if (slides.length === 0) continue;
+          const groups = slides
+            .map((s: any) => s.content?.group?.name as string | undefined)
+            .filter((g: string | undefined): g is string => !!g);
+          const hasGroups = groups.length > 0;
+          const hasRepeatedGroups = new Set(groups).size < groups.length;
+          if (requiresRepeatedGroups && !hasRepeatedGroups) continue;
+          if (!requiresRepeatedGroups && !hasGroups) continue;
+          const candidate: SelectionTarget = {
+            libraryId: lib.id,
+            libraryName: lib.name,
+            presentationId: p.id,
+            presentationName: p.name,
+            hasGroups,
+            hasRepeatedGroups,
+          };
+          // Prefer larger presentations — more realistic worship content.
+          if (!best || slides.length > (best as any)._size) {
+            (candidate as any)._size = slides.length;
+            best = candidate;
+          }
+        }
+      }
+      return best;
+    },
+    { requiresRepeatedGroups },
+  );
+}
+
+/**
+ * Opens the operator UI, navigates to a specific library + presentation by id.
+ * Uses DOM clicks on data attributes rather than text matching.
+ */
+async function openPresentation(page: Page, target: SelectionTarget) {
   await page.goto(`${baseURL}/ui/operator`);
   await page.waitForSelector('body[data-wasm-ready="true"]', {
     timeout: 30_000,
   });
 
-  // Click first library via JS (clicks can be intercepted by overlays)
-  await page.evaluate(() => {
-    const lib = document.querySelector(
-      '[data-role="library-list"] li button, .operator__library-card button',
-    ) as HTMLElement | null;
-    lib?.click();
-  });
+  // Click the specific library card by id.
+  const libClicked = await page.evaluate((libId: string) => {
+    const cards = document.querySelectorAll<HTMLElement>(
+      `[data-role="library-list"] [data-library-id="${libId}"], [data-library-id="${libId}"]`,
+    );
+    if (cards.length === 0) return false;
+    const btn =
+      (cards[0].querySelector("button") as HTMLElement | null) ?? cards[0];
+    btn.click();
+    return true;
+  }, target.libraryId);
+  expect(libClicked, `library ${target.libraryName} not found in UI`).toBe(true);
 
-  // Wait for presentations to load
   await page.waitForSelector('[data-role="presentation-item"]', {
     timeout: 10_000,
   });
 
-  // Click first presentation via JS
-  await page.evaluate(() => {
-    const item = document.querySelector(
-      '[data-role="presentation-item"]',
-    ) as HTMLElement | null;
-    if (item) {
-      item.scrollIntoView({ block: "center" });
-      const btn =
-        (item.querySelector('button, [role="button"]') as HTMLElement | null) ||
-        item;
-      btn.click();
-    }
-  });
+  // Click the specific presentation by id.
+  const presClicked = await page.evaluate((presId: string) => {
+    const item = document.querySelector<HTMLElement>(
+      `[data-role="presentation-item"][data-presentation-id="${presId}"]`,
+    );
+    if (!item) return false;
+    item.scrollIntoView({ block: "center" });
+    const btn =
+      (item.querySelector("button, [role='button']") as HTMLElement | null) ??
+      item;
+    btn.click();
+    return true;
+  }, target.presentationId);
+  expect(
+    presClicked,
+    `presentation ${target.presentationName} not found in UI`,
+  ).toBe(true);
 
-  // Wait for slides to load
   await page.waitForSelector("[data-slide-id]", { timeout: 10_000 });
 }
 
@@ -81,7 +149,15 @@ test("worship slides render without phantom class or outside-card groups", async
     }
   });
 
-  await openFirstPresentation(page);
+  // Just need a worship presentation with any slides + groups — doesn't
+  // have to have repeated groups for this test.
+  const target = await pickWorshipTarget(page, { requiresRepeatedGroups: false });
+  expect(
+    target,
+    "test corpus has no worship presentations with groups — fixtures broken",
+  ).not.toBeNull();
+
+  await openPresentation(page, target!);
 
   // No element has the phantom "stage-control__slide" class
   const phantomCount = await page.locator(".stage-control__slide").count();
@@ -102,6 +178,10 @@ test("worship slides render without phantom class or outside-card groups", async
     );
   expect(orphanGroups).toBe(0);
 
+  // At least one group badge is rendered (the chosen presentation has groups).
+  const badges = await page.locator('[data-role="slide-group"]').count();
+  expect(badges).toBeGreaterThan(0);
+
   // No inline .operator__slide-group-label (removed in #215)
   const inlineLabels = await page
     .locator(".operator__slide-group-label")
@@ -115,22 +195,27 @@ test("worship slides render without phantom class or outside-card groups", async
 test("worship slides use --inherited modifier for repeated groups", async ({
   page,
 }) => {
-  await openFirstPresentation(page);
+  // This test specifically asserts inherited-group rendering, so it MUST
+  // open a presentation that has at least one repeated group. Fail loudly
+  // if no such fixture exists.
+  const target = await pickWorshipTarget(page, { requiresRepeatedGroups: true });
+  expect(
+    target,
+    "test corpus has no worship presentations with repeated groups — cannot assert inherited modifier",
+  ).not.toBeNull();
 
-  // Find presentations known to have multiple slides sharing a group.
-  // If the current presentation has groups, at least one badge must exist.
-  const anyBadge = await page.locator('[data-role="slide-group"]').count();
-  if (anyBadge === 0) {
-    // Skip gracefully if the test presentation has no groups.
-    return;
-  }
+  await openPresentation(page, target!);
 
-  // If there are multiple slides in a group, the non-first ones should be inherited.
-  // We can't assert this without knowing the presentation structure, so we at least
-  // verify the inherited modifier class exists on at least one badge when duplicates
-  // are present.
-  const total = await page
-    .locator(".operator__slide-group, .operator__slide-group--inherited")
+  // At least one inherited badge must be in the DOM, since by definition
+  // a repeated group means the 2nd+ occurrence is inherited.
+  const inheritedCount = await page
+    .locator(".operator__slide-group--inherited")
     .count();
-  expect(total).toBeGreaterThan(0);
+  expect(inheritedCount).toBeGreaterThan(0);
+
+  // And at least one NON-inherited badge (the first occurrence).
+  const nonInheritedCount = await page
+    .locator('.operator__slide-group:not(.operator__slide-group--inherited)')
+    .count();
+  expect(nonInheritedCount).toBeGreaterThan(0);
 });

--- a/tests/e2e/worship-operator-slides.spec.ts
+++ b/tests/e2e/worship-operator-slides.spec.ts
@@ -45,50 +45,51 @@ type SelectionTarget = {
 };
 
 /**
- * Fetches /libraries and picks a worship presentation that exercises the
- * rendering paths we care about. Prefers presentations where a group repeats
- * (so the inherited modifier is provably in the DOM). Returns `null` if the
- * corpus has no worship presentations with groups — the test will then fail
- * loudly instead of silently passing.
+ * Queries the server's /libraries endpoint directly (via Playwright's fetch,
+ * not in-page) and picks a worship presentation that exercises the rendering
+ * paths we care about. Returns `null` if the corpus has no suitable fixture —
+ * callers MUST fail loudly rather than silently pass.
  */
 async function pickWorshipTarget(
   page: Page,
   { requiresRepeatedGroups }: { requiresRepeatedGroups: boolean },
 ): Promise<SelectionTarget | null> {
-  return page.evaluate<SelectionTarget | null, { requiresRepeatedGroups: boolean }>(
-    async ({ requiresRepeatedGroups }) => {
-      const libs = await (await fetch("/libraries")).json();
-      let best: SelectionTarget | null = null;
-      for (const lib of libs) {
-        for (const p of lib.presentations ?? []) {
-          const slides = p.slides ?? [];
-          if (slides.length === 0) continue;
-          const groups = slides
-            .map((s: any) => s.content?.group?.name as string | undefined)
-            .filter((g: string | undefined): g is string => !!g);
-          const hasGroups = groups.length > 0;
-          const hasRepeatedGroups = new Set(groups).size < groups.length;
-          if (requiresRepeatedGroups && !hasRepeatedGroups) continue;
-          if (!requiresRepeatedGroups && !hasGroups) continue;
-          const candidate: SelectionTarget = {
-            libraryId: lib.id,
-            libraryName: lib.name,
-            presentationId: p.id,
-            presentationName: p.name,
-            hasGroups,
-            hasRepeatedGroups,
-          };
-          // Prefer larger presentations — more realistic worship content.
-          if (!best || slides.length > (best as any)._size) {
-            (candidate as any)._size = slides.length;
-            best = candidate;
-          }
-        }
+  const response = await page.request.get(`${baseURL}/libraries`);
+  expect(response.ok()).toBe(true);
+  const libs = (await response.json()) as any[];
+
+  type Candidate = SelectionTarget & { size: number };
+  let best: Candidate | null = null;
+
+  for (const lib of libs) {
+    for (const p of lib.presentations ?? []) {
+      const slides = p.slides ?? [];
+      if (slides.length === 0) continue;
+      const groups = slides
+        .map((s: any) => s.content?.group?.name as string | undefined)
+        .filter((g: string | undefined): g is string => !!g);
+      const hasGroups = groups.length > 0;
+      const hasRepeatedGroups = new Set(groups).size < groups.length;
+      if (requiresRepeatedGroups && !hasRepeatedGroups) continue;
+      if (!requiresRepeatedGroups && !hasGroups) continue;
+      const candidate: Candidate = {
+        libraryId: lib.id,
+        libraryName: lib.name,
+        presentationId: p.id,
+        presentationName: p.name,
+        hasGroups,
+        hasRepeatedGroups,
+        size: slides.length,
+      };
+      if (!best || candidate.size > best.size) {
+        best = candidate;
       }
-      return best;
-    },
-    { requiresRepeatedGroups },
-  );
+    }
+  }
+
+  if (!best) return null;
+  const { size: _size, ...target } = best;
+  return target;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Use \`resolve_sequence()\` from data model for group inheritance
- Move group badge from outside the card into the header row
- Remove phantom \`stage-control__slide\` CSS class
- Fix conflicting \`.operator__slide-group\` CSS definitions
- Add \`operator__slide-card--worship\` variant with \`field-sizing: content\` textareas
- Skip fully-empty slides in ProPresenter importer

Closes #215

## Test plan
- [x] Visual: verified worship operator slides render correctly on dev (group badges inside cards, dimmed for inherited)
- [x] E2E test: \`tests/e2e/worship-operator-slides.spec.ts\` verifies no phantom classes, no orphan groups
- [x] Rust tests: importer tests updated for new Option return type (31 passing)
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)