### PR TITLE
fix(android-stage): restore kiosk auto-launch + test button (#245)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "axum",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,18 +2648,19 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "async-trait",
  "sea-orm",
  "sea-orm-migration",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -2674,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2695,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-migration/Cargo.toml
+++ b/crates/presenter-migration/Cargo.toml
@@ -11,6 +11,7 @@ sea-orm.workspace = true
 sea-orm-migration.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 sea-orm.workspace = true

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -7,6 +7,7 @@ mod m20260408_000001_add_preach_limit;
 mod m20260410_000001_separate_bible;
 mod m20260412_000001_bible_fts;
 mod m20260414_000001_bible_translation_digest;
+mod m20260414_000002_seed_android_stage_displays;
 
 pub struct Migrator;
 
@@ -18,6 +19,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260410_000001_separate_bible::Migration),
             Box::new(m20260412_000001_bible_fts::Migration),
             Box::new(m20260414_000001_bible_translation_digest::Migration),
+            Box::new(m20260414_000002_seed_android_stage_displays::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
+++ b/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
@@ -10,8 +10,7 @@ const SEED_ROWS: &[(&str, &str)] = &[
     ("Stage SD4", "sd4l.lan"),
 ];
 
-const DEFAULT_LAUNCH_COMPONENT: &str =
-    "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity";
+const DEFAULT_LAUNCH_COMPONENT: &str = "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity";
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {

--- a/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
+++ b/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
@@ -1,0 +1,62 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const SEED_ROWS: &[(&str, &str)] = &[
+    ("Stage SD1", "sd1l.lan"),
+    ("Stage SD2", "sd2l.lan"),
+    ("Stage SD3", "sd3l.lan"),
+    ("Stage SD4", "sd4l.lan"),
+];
+
+const DEFAULT_LAUNCH_COMPONENT: &str =
+    "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Only seed if the table is empty. If an operator has added any
+        // rows (even after deleting and re-adding), leave them alone.
+        let row = db
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) as cnt FROM android_stage_displays",
+            ))
+            .await?;
+
+        let count = row
+            .map(|r| r.try_get::<i32>("", "cnt").unwrap_or(0))
+            .unwrap_or(0);
+
+        if count > 0 {
+            return Ok(());
+        }
+
+        for (label, host) in SEED_ROWS {
+            let id = uuid::Uuid::new_v4().to_string();
+            db.execute(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Sqlite,
+                "INSERT INTO android_stage_displays \
+                 (id, label, host, port, launch_component, is_enabled, created_at, updated_at) \
+                 VALUES (?, ?, ?, 5555, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    id.into(),
+                    (*label).into(),
+                    (*host).into(),
+                    DEFAULT_LAUNCH_COMPONENT.into(),
+                ],
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // No-op. Do not delete operator data on rollback.
+        Ok(())
+    }
+}

--- a/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
+++ b/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs
@@ -3,6 +3,11 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
+/// Seed displays for the production presenter LAN. These hostnames are
+/// specific to our site; a deployment to a different site should delete
+/// these rows via the Settings UI and add their own. The `COUNT(*) > 0`
+/// guard in `up()` makes that delete-and-replace flow safe across future
+/// redeploys — once any operator row exists, the seed never runs again.
 const SEED_ROWS: &[(&str, &str)] = &[
     ("Stage SD1", "sd1l.lan"),
     ("Stage SD2", "sd2l.lan"),

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -110,6 +110,11 @@ impl Repository {
         &self.db
     }
 
+    #[cfg(test)]
+    pub fn connection_for_tests(&self) -> &DatabaseConnection {
+        &self.db
+    }
+
     #[instrument(skip_all)]
     pub async fn get_app_setting(&self, key: &str) -> anyhow::Result<Option<String>> {
         let result = app_settings::Entity::find_by_id(key.to_string())

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -252,10 +252,14 @@ async fn resolume_host_crud_round_trip() {
 #[tokio::test]
 async fn android_stage_display_crud_round_trip() {
     let repo = Repository::connect_in_memory().await.unwrap();
-    let draft = AndroidStageDisplayDraft::new("Stage Left", "sd1l.lan");
+
+    let initial = repo.list_android_stage_displays().await.unwrap();
+    let initial_count = initial.len();
+
+    let draft = AndroidStageDisplayDraft::new("Stage Left", "test-stage.invalid");
     let created = repo.create_android_stage_display(&draft).await.unwrap();
     assert_eq!(created.label, "Stage Left");
-    assert_eq!(created.host, "sd1l.lan");
+    assert_eq!(created.host, "test-stage.invalid");
     assert_eq!(created.port, DEFAULT_ADB_PORT);
     assert_eq!(
         created.launch_component,
@@ -264,9 +268,10 @@ async fn android_stage_display_crud_round_trip() {
     assert!(created.is_enabled);
 
     let displays = repo.list_android_stage_displays().await.unwrap();
-    assert_eq!(displays.len(), 1);
+    assert_eq!(displays.len(), initial_count + 1);
+    assert!(displays.iter().any(|d| d.id == created.id));
 
-    let updated_draft = AndroidStageDisplayDraft::new("Stage Right", "sd2l.lan")
+    let updated_draft = AndroidStageDisplayDraft::new("Stage Right", "test-stage2.invalid")
         .with_port(5566)
         .with_launch_component("com.example/.Main")
         .with_enabled(false);
@@ -275,14 +280,15 @@ async fn android_stage_display_crud_round_trip() {
         .await
         .unwrap();
     assert_eq!(updated.label, "Stage Right");
-    assert_eq!(updated.host, "sd2l.lan");
+    assert_eq!(updated.host, "test-stage2.invalid");
     assert_eq!(updated.port, 5566);
     assert_eq!(updated.launch_component, "com.example/.Main");
     assert!(!updated.is_enabled);
 
     repo.delete_android_stage_display(created.id).await.unwrap();
     let after_delete = repo.list_android_stage_displays().await.unwrap();
-    assert!(after_delete.is_empty());
+    assert_eq!(after_delete.len(), initial_count);
+    assert!(after_delete.iter().all(|d| d.id != created.id));
 }
 
 #[tokio::test]
@@ -709,5 +715,68 @@ async fn update_slide_content_with_metadata_persists_worship_fields() {
     assert_eq!(
         updated.content.group.as_ref().map(|g| g.name()),
         Some("Verse 1")
+    );
+}
+
+#[tokio::test]
+async fn seed_migration_populates_four_android_stage_displays_on_empty_table() {
+    let repo = Repository::connect_in_memory().await.unwrap();
+    let displays = repo.list_android_stage_displays().await.unwrap();
+    assert_eq!(displays.len(), 4, "seed should have inserted 4 displays");
+    let mut hosts: Vec<_> = displays.iter().map(|d| d.host.clone()).collect();
+    hosts.sort();
+    assert_eq!(
+        hosts,
+        vec![
+            "sd1l.lan".to_string(),
+            "sd2l.lan".to_string(),
+            "sd3l.lan".to_string(),
+            "sd4l.lan".to_string(),
+        ],
+        "seed hosts should be sd1l..sd4l",
+    );
+    for d in &displays {
+        assert_eq!(d.port, 5555);
+        assert_eq!(
+            d.launch_component,
+            "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity",
+        );
+        assert!(d.is_enabled, "seeded displays should be enabled");
+    }
+}
+
+#[tokio::test]
+async fn seed_migration_is_idempotent_when_rerun() {
+    use presenter_migration::{MigrationTrait, MigratorTrait};
+    use sea_orm_migration::SchemaManager;
+
+    let repo = Repository::connect_in_memory().await.unwrap();
+    // Initial connect ran migrations → 4 seed rows present.
+    assert_eq!(repo.list_android_stage_displays().await.unwrap().len(), 4);
+
+    // Operator adds a fifth display manually.
+    let draft = AndroidStageDisplayDraft::new("Operator Custom", "custom.invalid");
+    repo.create_android_stage_display(&draft).await.unwrap();
+    assert_eq!(repo.list_android_stage_displays().await.unwrap().len(), 5);
+
+    // Manually invoke the seed migration's `up()` a second time.
+    let connection = repo.connection_for_tests();
+    let schema = SchemaManager::new(connection);
+    let migration: Box<dyn MigrationTrait> = presenter_migration::Migrator::migrations()
+        .into_iter()
+        .find(|m| m.name() == "m20260414_000002_seed_android_stage_displays")
+        .expect("seed migration present in registry");
+    migration.up(&schema).await.expect("rerun seed");
+
+    // Row count stays at 5 — guard prevented re-insertion.
+    let displays = repo.list_android_stage_displays().await.unwrap();
+    assert_eq!(
+        displays.len(),
+        5,
+        "seed rerun must not insert duplicates once any row exists",
+    );
+    assert!(
+        displays.iter().any(|d| d.host == "custom.invalid"),
+        "operator's custom display must survive the rerun",
     );
 }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -409,7 +409,9 @@ mod tests {
         let err = registry.launch_now(unknown).await;
         assert!(err.is_err(), "launch_now must error on unknown id");
         assert!(
-            err.unwrap_err().to_string().contains("unknown android stage display"),
+            err.unwrap_err()
+                .to_string()
+                .contains("unknown android stage display"),
             "error message should identify the unknown-id case",
         );
     }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -238,6 +238,20 @@ async fn connect_and_launch(
 
     let adb_bin = adb_path.as_os_str();
 
+    // Clear any stale offline device entry from a previous attempt.
+    // ADB leaves stale entries after TV power cycles which then cause
+    // subsequent `-s serial` commands to fail until the daemon is restarted.
+    // Errors are intentionally ignored — the typical case is "not connected"
+    // which returns a non-zero exit code we don't care about.
+    let _ = timeout(
+        ADB_COMMAND_TIMEOUT,
+        Command::new(adb_bin)
+            .arg("disconnect")
+            .arg(&serial)
+            .output(),
+    )
+    .await;
+
     // Run adb connect
     let connect_result = timeout(
         ADB_COMMAND_TIMEOUT,

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -141,6 +141,25 @@ impl AndroidStageRegistry {
         }
     }
 
+    /// Tell the worker for `id` to run a launch immediately, bypassing the
+    /// 20-second tick. Returns an error if no such display exists or if the
+    /// display is currently disabled. The launch runs asynchronously — the
+    /// caller should poll `snapshot_for(id)` to observe the state change.
+    pub async fn launch_now(&self, id: AndroidStageDisplayId) -> anyhow::Result<()> {
+        let guard = self.displays.read().await;
+        let entry = guard
+            .get(&id)
+            .ok_or_else(|| anyhow!("unknown android stage display {id}"))?;
+        if !entry.config.is_enabled {
+            return Err(anyhow!("android stage display {id} is disabled"));
+        }
+        entry
+            .command_tx
+            .try_send(DeviceCommand::LaunchNow)
+            .map_err(|err| anyhow!("failed to enqueue launch for {id}: {err}"))?;
+        Ok(())
+    }
+
     fn spawn_display(&self, display: AndroidStageDisplay) -> DeviceEntry {
         let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
         let status = Arc::new(RwLock::new(if display.is_enabled {
@@ -374,5 +393,24 @@ fn truncate_error(message: &str) -> String {
         message.to_string()
     } else {
         format!("{}…", &message[..MAX_LEN - 1])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use presenter_core::AndroidStageDisplayId;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn launch_now_errors_on_unknown_id() {
+        let registry = AndroidStageRegistry::new();
+        let unknown = AndroidStageDisplayId::from_uuid(Uuid::new_v4());
+        let err = registry.launch_now(unknown).await;
+        assert!(err.is_err(), "launch_now must error on unknown id");
+        assert!(
+            err.unwrap_err().to_string().contains("unknown android stage display"),
+            "error message should identify the unknown-id case",
+        );
     }
 }

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -178,6 +178,10 @@ pub fn build_router(state: AppState) -> Router {
                 .delete(integrations::android_stage::delete_android_stage_display),
         )
         .route(
+            "/integrations/android-stage/displays/{id}/launch-now",
+            post(integrations::android_stage::launch_now_android_stage_display),
+        )
+        .route(
             "/integrations/osc/settings",
             get(integrations::osc::get_osc_settings).put(integrations::osc::update_osc_settings),
         )

--- a/crates/presenter-server/src/router/integrations/android_stage.rs
+++ b/crates/presenter-server/src/router/integrations/android_stage.rs
@@ -136,3 +136,15 @@ pub(crate) async fn delete_android_stage_display(
         .await?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
+
+#[instrument(skip_all)]
+pub(crate) async fn launch_now_android_stage_display(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<axum::http::StatusCode, AppError> {
+    state
+        .launch_now_android_stage_display(AndroidStageDisplayId::from_uuid(id))
+        .await
+        .map_err(|err| AppError::bad_request_message(err.to_string()))?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -213,7 +213,7 @@ async fn android_stage_display_endpoints_crud() {
     std::env::set_var("PRESENTER_ANDROID_ADB_BIN", "true");
     let app = build_router(AppState::in_memory().await.unwrap());
 
-    let list_empty = app
+    let list_initial = app
         .clone()
         .oneshot(
             Request::builder()
@@ -223,16 +223,17 @@ async fn android_stage_display_endpoints_crud() {
         )
         .await
         .unwrap();
-    assert_eq!(list_empty.status(), StatusCode::OK);
-    let empty_bytes = axum::body::to_bytes(list_empty.into_body(), usize::MAX)
+    assert_eq!(list_initial.status(), StatusCode::OK);
+    let initial_bytes = axum::body::to_bytes(list_initial.into_body(), usize::MAX)
         .await
         .unwrap();
-    let empty_displays: Vec<TestAndroidDisplayDto> = serde_json::from_slice(&empty_bytes).unwrap();
-    assert!(empty_displays.is_empty());
+    let initial_displays: Vec<TestAndroidDisplayDto> =
+        serde_json::from_slice(&initial_bytes).unwrap();
+    let initial_count = initial_displays.len();
 
     let create_body = json!({
         "label": "Stage Left",
-        "host": "sd1l.lan",
+        "host": "test-stage.invalid",
         "port": 5555,
         "launchComponent": "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity",
         "isEnabled": true
@@ -256,7 +257,7 @@ async fn android_stage_display_endpoints_crud() {
         .unwrap();
     let created: TestAndroidDisplayDto = serde_json::from_slice(&created_bytes).unwrap();
     assert_eq!(created.label, "Stage Left");
-    assert_eq!(created.host, "sd1l.lan");
+    assert_eq!(created.host, "test-stage.invalid");
     assert_eq!(created.port, 5555);
     assert_eq!(
         created.launch_component,
@@ -277,11 +278,12 @@ async fn android_stage_display_endpoints_crud() {
         .await
         .unwrap();
     let displays: Vec<TestAndroidDisplayDto> = serde_json::from_slice(&list_bytes).unwrap();
-    assert_eq!(displays.len(), 1);
+    assert_eq!(displays.len(), initial_count + 1);
+    assert!(displays.iter().any(|d| d.id == created.id));
 
     let update_body = json!({
         "label": "Stage Right",
-        "host": "sd2l.lan",
+        "host": "other-stage.invalid",
         "port": 5566,
         "launchComponent": "com.example/.Main",
         "isEnabled": false
@@ -308,7 +310,7 @@ async fn android_stage_display_endpoints_crud() {
         .unwrap();
     let updated: TestAndroidDisplayDto = serde_json::from_slice(&updated_bytes).unwrap();
     assert_eq!(updated.label, "Stage Right");
-    assert_eq!(updated.host, "sd2l.lan");
+    assert_eq!(updated.host, "other-stage.invalid");
     assert_eq!(updated.port, 5566);
     assert_eq!(updated.launch_component, "com.example/.Main");
     assert!(!updated.is_enabled);
@@ -343,7 +345,8 @@ async fn android_stage_display_endpoints_crud() {
         .unwrap();
     let after_delete_displays: Vec<TestAndroidDisplayDto> =
         serde_json::from_slice(&list_after_delete_bytes).unwrap();
-    assert!(after_delete_displays.is_empty());
+    assert_eq!(after_delete_displays.len(), initial_count);
+    assert!(after_delete_displays.iter().all(|d| d.id != created.id));
 }
 
 #[tokio::test]

--- a/crates/presenter-server/src/settings_script.js
+++ b/crates/presenter-server/src/settings_script.js
@@ -861,9 +861,12 @@
         throw new Error(await extractError(response));
       }
       showToast('Launch queued — refreshing status…', 'success');
+      // 600ms is typically enough for the worker to finish adb connect +
+      // am start and update its status snapshot. A reachable TV completes
+      // in ~130ms locally; add headroom for LAN latency and slow devices.
       setTimeout(() => {
         refreshAndroidDisplays(false);
-      }, 1500);
+      }, 600);
     } catch (error) {
       console.error('Failed to trigger android launch', error);
       showToast(error.message || 'Unable to trigger launch.', 'error');

--- a/crates/presenter-server/src/settings_script.js
+++ b/crates/presenter-server/src/settings_script.js
@@ -708,6 +708,7 @@
     ${warningDetail}
   </div>
   <div class="settings__list-actions">
+    <button type="button" class="settings__button settings__button--ghost" data-role="android-test" data-id="${normalized.id}">Test</button>
     <button type="button" class="settings__button settings__button--ghost" data-role="android-edit" data-id="${normalized.id}">Edit</button>
     <button type="button" class="settings__button settings__button--danger" data-role="android-delete" data-id="${normalized.id}">Delete</button>
   </div>
@@ -850,6 +851,25 @@
     }
   }
 
+  async function testAndroidDisplay(id) {
+    if (!id) return;
+    try {
+      const response = await fetch(`${ANDROID_API_ROOT}/${id}/launch-now`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        throw new Error(await extractError(response));
+      }
+      showToast('Launch queued — refreshing status…', 'success');
+      setTimeout(() => {
+        refreshAndroidDisplays(false);
+      }, 1500);
+    } catch (error) {
+      console.error('Failed to trigger android launch', error);
+      showToast(error.message || 'Unable to trigger launch.', 'error');
+    }
+  }
+
   async function deleteAndroidDisplay(id) {
     if (!id) return;
     const display = state.android.displays.find((item) => item.id === id);
@@ -886,6 +906,8 @@
       startAndroidEdit(id);
     } else if (target.dataset.role === 'android-delete') {
       await deleteAndroidDisplay(id);
+    } else if (target.dataset.role === 'android-test') {
+      await testAndroidDisplay(id);
     }
   }
 

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -118,6 +118,13 @@ impl AppState {
         self.sync_android_stage_displays().await
     }
 
+    pub async fn launch_now_android_stage_display(
+        &self,
+        id: AndroidStageDisplayId,
+    ) -> anyhow::Result<()> {
+        self.android_stage_registry.launch_now(id).await
+    }
+
     pub(super) async fn sync_android_stage_displays(&self) -> anyhow::Result<()> {
         let displays = self.repository.list_android_stage_displays().await?;
         self.android_stage_registry.set_displays(displays).await;

--- a/crates/presenter-server/src/ui/components/settings.rs
+++ b/crates/presenter-server/src/ui/components/settings.rs
@@ -411,6 +411,7 @@ pub fn AndroidStageSettingsCard(
                                     </p>
                                 }
                             });
+                            let display_id_test = display.id.clone();
                             let display_id_edit = display.id.clone();
                             let display_id_delete = display.id.clone();
                             view! {
@@ -436,6 +437,12 @@ pub fn AndroidStageSettingsCard(
                                         {warning_view}
                                     </div>
                                     <div class="settings__list-actions">
+                                        <button
+                                            type="button"
+                                            class="settings__button settings__button--ghost"
+                                            data-role="android-test"
+                                            data-id={display_id_test}
+                                        >"Test"</button>
                                         <button
                                             type="button"
                                             class="settings__button settings__button--ghost"

--- a/docs/superpowers/plans/2026-04-14-android-stage-resilience.md
+++ b/docs/superpowers/plans/2026-04-14-android-stage-resilience.md
@@ -1,0 +1,747 @@
+# Android Stage Launcher Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore working Android TV kiosk auto-launch on prod/dev by seeding the 4 known displays, hardening `adb connect` against stale state, and giving operators a one-click "Test" button.
+
+**Architecture:** Three surgical changes in one PR: (1) a one-time seed migration that inserts `sd1l..sd4l` into `android_stage_displays` when the table is empty, (2) `adb disconnect` before `adb connect` inside `connect_and_launch`, (3) a new `POST /integrations/android-stage/displays/{id}/launch-now` endpoint wired through state → registry → existing `DeviceCommand::LaunchNow`, with a "Test" button in the Settings UI.
+
+**Tech Stack:** Rust (axum, SeaORM, sea-orm-migration, tokio), Leptos SSR components, vanilla JS (`settings_script.js`).
+
+**Spec:** `docs/superpowers/specs/2026-04-14-android-stage-resilience-design.md`
+
+---
+
+## Context
+
+The existing `android_stage_displays` table lives in the initial migration `m20250927_000001_create_core_tables.rs:436-500`. It has columns `id TEXT PK`, `label TEXT NOT NULL UNIQUE`, `host TEXT NOT NULL`, `port INTEGER DEFAULT 5555`, `launch_component TEXT DEFAULT 'com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity'`, `is_enabled BOOLEAN DEFAULT TRUE`, `created_at/updated_at TIMESTAMP`.
+
+The launcher worker is at `crates/presenter-server/src/android_stage.rs`. Key facts:
+- `DeviceCommand::LaunchNow` already exists (line 66). The worker already handles it (line 206). We just need to expose a public method to send it.
+- `connect_and_launch` at line 225-314 runs `adb connect` then `adb shell am start`.
+- The worker ticks every 20s (`RETRY_INTERVAL`, line 17) and also fires `LaunchNow` on startup (line 167).
+- Registry methods currently exposed: `new`, `set_displays`, `snapshot`, `snapshot_for`, `spawn_display`.
+
+The state layer at `crates/presenter-server/src/state/integrations.rs:74-125` already has `list/create/update/delete_android_stage_display` and `sync_android_stage_displays`. We add one more method.
+
+The Settings UI has both SSR (`crates/presenter-server/src/ui/components/settings.rs:278-459`) and a JS client (`crates/presenter-server/src/settings_script.js:853-889`). The list gets re-rendered by JS after any mutation, so the "Test" button must be added to BOTH the SSR template and the JS template, plus an event delegation handler.
+
+**Working directory:** `/home/newlevel/devel/presenter/presenter-dev2`. **Branch:** dev. The recent Android stage code hasn't been touched in weeks; we can work confidently with the existing shape.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs` | **New** — one-time seed migration with `COUNT(*) = 0` guard |
+| `crates/presenter-migration/src/lib.rs` | Register the new migration as the last entry in `migrations()` |
+| `crates/presenter-server/src/android_stage.rs` | Add `adb disconnect` before `adb connect` in `connect_and_launch`; add pub `launch_now` method on `AndroidStageRegistry` |
+| `crates/presenter-server/src/state/integrations.rs` | Add `launch_now_android_stage_display(id)` method |
+| `crates/presenter-server/src/router/integrations/android_stage.rs` | Add `launch_now_android_stage_display` handler returning 204 |
+| `crates/presenter-server/src/router.rs` | Register `POST /integrations/android-stage/displays/{id}/launch-now` |
+| `crates/presenter-server/src/ui/components/settings.rs` | Add "Test" button in SSR template alongside Edit/Delete |
+| `crates/presenter-server/src/settings_script.js` | Add "Test" button to JS template + event handler + `testAndroidDisplay(id)` helper |
+
+---
+
+## Task 1: Seed Migration
+
+**Files:**
+- Create: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs`
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-migration/src/lib.rs`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs` with this exact content:
+
+```rust
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const SEED_ROWS: &[(&str, &str)] = &[
+    ("Stage SD1", "sd1l.lan"),
+    ("Stage SD2", "sd2l.lan"),
+    ("Stage SD3", "sd3l.lan"),
+    ("Stage SD4", "sd4l.lan"),
+];
+
+const DEFAULT_LAUNCH_COMPONENT: &str =
+    "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Only seed if the table is empty. If an operator has added any
+        // rows (even after deleting and re-adding), leave them alone.
+        let row = db
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT COUNT(*) as cnt FROM android_stage_displays",
+            ))
+            .await?;
+
+        let count = row
+            .map(|r| r.try_get::<i32>("", "cnt").unwrap_or(0))
+            .unwrap_or(0);
+
+        if count > 0 {
+            return Ok(());
+        }
+
+        for (label, host) in SEED_ROWS {
+            let id = uuid::Uuid::new_v4().to_string();
+            db.execute(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Sqlite,
+                "INSERT INTO android_stage_displays \
+                 (id, label, host, port, launch_component, is_enabled, created_at, updated_at) \
+                 VALUES (?, ?, ?, 5555, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    id.into(),
+                    (*label).into(),
+                    (*host).into(),
+                    DEFAULT_LAUNCH_COMPONENT.into(),
+                ],
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // No-op. Do not delete operator data on rollback.
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: Add `uuid` to presenter-migration deps if missing**
+
+Run:
+```bash
+grep '^uuid' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-migration/Cargo.toml
+```
+
+If the grep returns nothing, add `uuid = { version = "1", features = ["v4"] }` under `[dependencies]` in that Cargo.toml. If `uuid` is already there as a workspace dep, use `uuid.workspace = true`.
+
+- [ ] **Step 3: Register the migration**
+
+Edit `crates/presenter-migration/src/lib.rs`. It currently looks like:
+
+```rust
+pub use sea_orm_migration::prelude::*;
+
+pub mod bible_fts_triggers;
+
+mod m20250927_000001_create_core_tables;
+mod m20260408_000001_add_preach_limit;
+mod m20260410_000001_separate_bible;
+mod m20260412_000001_bible_fts;
+mod m20260414_000001_bible_translation_digest;
+
+pub struct Migrator;
+
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![
+            Box::new(m20250927_000001_create_core_tables::Migration),
+            Box::new(m20260408_000001_add_preach_limit::Migration),
+            Box::new(m20260410_000001_separate_bible::Migration),
+            Box::new(m20260412_000001_bible_fts::Migration),
+            Box::new(m20260414_000001_bible_translation_digest::Migration),
+        ]
+    }
+}
+```
+
+Add `mod m20260414_000002_seed_android_stage_displays;` below the last `mod` line, and append `Box::new(m20260414_000002_seed_android_stage_displays::Migration),` as the last element of the `vec!`.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check -p presenter-migration`
+Expected: compiles clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs crates/presenter-migration/src/lib.rs crates/presenter-migration/Cargo.toml
+git commit -m "feat(migration): seed known android stage displays when empty (#245)"
+```
+
+---
+
+## Task 2: Seed migration idempotency tests
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-persistence/src/repository/tests.rs` — append two new tests
+
+We put the tests in `presenter-persistence` because that crate already has in-memory DB helpers and exercises migrations via `Repository::connect_in_memory()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the existing test module in `crates/presenter-persistence/src/repository/tests.rs`:
+
+```rust
+    #[tokio::test]
+    async fn seed_migration_populates_four_android_stage_displays_on_empty_table() {
+        let repo = Repository::connect_in_memory().await.unwrap();
+        let displays = repo.list_android_stage_displays().await.unwrap();
+        assert_eq!(displays.len(), 4, "seed should have inserted 4 displays");
+        let hosts: Vec<_> = displays.iter().map(|d| d.host.clone()).collect();
+        let mut sorted = hosts.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec![
+                "sd1l.lan".to_string(),
+                "sd2l.lan".to_string(),
+                "sd3l.lan".to_string(),
+                "sd4l.lan".to_string(),
+            ],
+            "seed hosts should be sd1l..sd4l",
+        );
+        for d in &displays {
+            assert_eq!(d.port, 5555);
+            assert_eq!(
+                d.launch_component,
+                "com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity",
+            );
+            assert!(d.is_enabled, "seeded displays should be enabled");
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_migration_is_idempotent_when_rerun() {
+        use presenter_core::AndroidStageDisplayDraft;
+        use presenter_migration::{MigrationTrait, SchemaManager};
+
+        let repo = Repository::connect_in_memory().await.unwrap();
+
+        // The initial connect already ran migrations → 4 seed rows present.
+        assert_eq!(repo.list_android_stage_displays().await.unwrap().len(), 4);
+
+        // Operator manually adds a fifth display.
+        let draft = AndroidStageDisplayDraft::new(
+            "Operator Custom".to_string(),
+            "custom.lan".to_string(),
+        );
+        repo.create_android_stage_display(&draft).await.unwrap();
+        assert_eq!(repo.list_android_stage_displays().await.unwrap().len(), 5);
+
+        // Manually invoke the seed migration's `up()` again.
+        let connection = repo.connection_for_tests();
+        let schema = SchemaManager::new(connection);
+        let migration = presenter_migration::Migrator::migrations()
+            .into_iter()
+            .find(|m| m.name() == "m20260414_000002_seed_android_stage_displays")
+            .expect("seed migration present in registry");
+        migration.up(&schema).await.expect("rerun seed");
+
+        // Row count stays at 5 — guard prevented re-insertion.
+        let displays = repo.list_android_stage_displays().await.unwrap();
+        assert_eq!(
+            displays.len(),
+            5,
+            "seed rerun must not insert duplicates once any row exists",
+        );
+        assert!(
+            displays.iter().any(|d| d.host == "custom.lan"),
+            "operator's custom display must survive the rerun",
+        );
+    }
+```
+
+> **Note:** `Repository::connection_for_tests()` may not exist yet. If the first `cargo test` run fails with "no method named `connection_for_tests`", add a `#[cfg(test)] pub fn connection_for_tests(&self) -> &DatabaseConnection { &self.db }` method on `Repository` in `crates/presenter-persistence/src/repository/mod.rs` (search for the `impl Repository {` block near `connect_in_memory`). Commit that as a separate prep step if needed.
+
+- [ ] **Step 2: Run the tests to confirm they fail without Task 1 only if cargo test regressions happen**
+
+Run:
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo test -p presenter-persistence -- seed_migration --nocapture
+```
+Expected: both new tests PASS. The seed already landed via Task 1 (merged in the working branch), so the happy-path test should be green immediately. If the idempotency test fails on the `connection_for_tests` method, apply the note above and re-run.
+
+- [ ] **Step 3: Run the whole presenter-persistence suite to catch regressions**
+
+Run: `cargo test -p presenter-persistence`
+Expected: all tests pass. The existing `android_stage_display_crud_round_trip` test at `tests.rs:253` assumes an empty table; after Task 1 the initial state has 4 rows, so that test MAY need to be adjusted to compare against a **delta** rather than absolute counts. If it fails, read the test carefully and convert its `assert_eq!(displays.len(), N)` checks into `assert_eq!(displays.len(), 4 + N)` form. Commit that fix as part of this step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-persistence/src/repository/tests.rs crates/presenter-persistence/src/repository/mod.rs
+git commit -m "test(persistence): pin seed migration idempotency (#245)"
+```
+
+---
+
+## Task 3: `adb disconnect` before `adb connect` in the launcher
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/android_stage.rs` — inside `connect_and_launch`, just before the existing `adb connect` call (around line 241)
+
+- [ ] **Step 1: Add the `disconnect` call**
+
+Locate `connect_and_launch` in `android_stage.rs`. After the `let adb_bin = adb_path.as_os_str();` line and before `// Run adb connect`, insert:
+
+```rust
+    // Clear any stale offline device entry from a previous attempt.
+    // ADB leaves stale entries after TV power cycles which then cause
+    // subsequent `-s serial` commands to fail until the daemon is restarted.
+    // Errors are intentionally ignored — the typical case is "not connected"
+    // which returns a non-zero exit code we don't care about.
+    let _ = timeout(
+        ADB_COMMAND_TIMEOUT,
+        Command::new(adb_bin)
+            .arg("disconnect")
+            .arg(&serial)
+            .output(),
+    )
+    .await;
+```
+
+- [ ] **Step 2: Verify build and existing tests**
+
+Run:
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server
+cargo test -p presenter-server -- android_stage --nocapture
+```
+Expected: compile clean, android_stage tests pass (they don't exercise the worker loop against real adb, so this is a no-op at the test level — the change is behavioral at runtime).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/android_stage.rs
+git commit -m "fix(android-stage): adb disconnect before connect to clear stale state (#245)"
+```
+
+---
+
+## Task 4: `AndroidStageRegistry::launch_now` public method
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/android_stage.rs` — add a method on `impl AndroidStageRegistry`
+
+- [ ] **Step 1: Add the method**
+
+Locate the `impl AndroidStageRegistry { ... }` block (starts around line 70). Add this method after `snapshot_for` and before `spawn_display`:
+
+```rust
+    /// Tell the worker for `id` to run a launch immediately, bypassing the
+    /// 20-second tick. Returns an error if no such display exists or if the
+    /// display is currently disabled. The launch runs asynchronously — the
+    /// caller should poll `snapshot_for(id)` to observe the state change.
+    pub async fn launch_now(&self, id: AndroidStageDisplayId) -> anyhow::Result<()> {
+        let guard = self.displays.read().await;
+        let entry = guard
+            .get(&id)
+            .ok_or_else(|| anyhow!("unknown android stage display {id}"))?;
+        if !entry.config.is_enabled {
+            return Err(anyhow!("android stage display {id} is disabled"));
+        }
+        entry
+            .command_tx
+            .try_send(DeviceCommand::LaunchNow)
+            .map_err(|err| anyhow!("failed to enqueue launch for {id}: {err}"))?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 2: Add a unit test for the unknown-id error path**
+
+At the end of `crates/presenter-server/src/android_stage.rs`, add (or append to) a `#[cfg(test)] mod tests` block:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use presenter_core::AndroidStageDisplayId;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn launch_now_errors_on_unknown_id() {
+        let registry = AndroidStageRegistry::new();
+        let unknown = AndroidStageDisplayId::from_uuid(Uuid::new_v4());
+        let err = registry.launch_now(unknown).await;
+        assert!(err.is_err(), "launch_now must error on unknown id");
+        assert!(
+            err.unwrap_err().to_string().contains("unknown android stage display"),
+            "error message should identify the unknown-id case",
+        );
+    }
+}
+```
+
+This test deliberately avoids spawning a real worker (no `set_displays` call), so it doesn't touch `adb` at all. It only proves the unknown-id branch returns `Err`.
+
+If an existing `#[cfg(test)] mod tests` block is already at the bottom of the file, append the new test inside it instead of creating a second module.
+
+- [ ] **Step 3: Run the test and verify build**
+
+Run:
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo test -p presenter-server -- android_stage::tests::launch_now_errors_on_unknown_id --nocapture
+```
+Expected: test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/android_stage.rs
+git commit -m "feat(android-stage): expose launch_now on registry (#245)"
+```
+
+---
+
+## Task 5: State-layer `launch_now_android_stage_display`
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/integrations.rs` — append a method on `impl AppState`
+
+- [ ] **Step 1: Add the method**
+
+After the `delete_android_stage_display` method (around line 117), add:
+
+```rust
+    pub async fn launch_now_android_stage_display(
+        &self,
+        id: AndroidStageDisplayId,
+    ) -> anyhow::Result<()> {
+        self.android_stage_registry.launch_now(id).await
+    }
+```
+
+`AndroidStageDisplayId` is already imported at the top of the file.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check -p presenter-server`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/state/integrations.rs
+git commit -m "feat(state): add launch_now_android_stage_display passthrough (#245)"
+```
+
+---
+
+## Task 6: Router endpoint + wiring
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/router/integrations/android_stage.rs` — add handler
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/router.rs` — register route
+
+- [ ] **Step 1: Add the handler**
+
+Append to `crates/presenter-server/src/router/integrations/android_stage.rs` after `delete_android_stage_display`:
+
+```rust
+#[instrument(skip_all)]
+pub(crate) async fn launch_now_android_stage_display(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<axum::http::StatusCode, AppError> {
+    state
+        .launch_now_android_stage_display(AndroidStageDisplayId::from_uuid(id))
+        .await
+        .map_err(|err| AppError::bad_request(err.to_string()))?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+```
+
+All imports (`AndroidStageDisplayId`, `AppError`, `AppState`, `Path`, `State`, `Uuid`, `instrument`) are already present in that file.
+
+- [ ] **Step 2: Register the route**
+
+Open `crates/presenter-server/src/router.rs`. Find the existing block that registers `/integrations/android-stage/displays/{id}` with `.put(...)` and `.delete(...)` (around line 176-179). Immediately after that, add:
+
+```rust
+        .route(
+            "/integrations/android-stage/displays/{id}/launch-now",
+            post(integrations::android_stage::launch_now_android_stage_display),
+        )
+```
+
+`post` should already be imported from `axum::routing` at the top of `router.rs`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check -p presenter-server`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/router/integrations/android_stage.rs crates/presenter-server/src/router.rs
+git commit -m "feat(router): POST /android-stage/displays/{id}/launch-now (#245)"
+```
+
+---
+
+## Task 7: SSR "Test" button in settings.rs
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/ui/components/settings.rs` — add button to the Leptos template
+
+- [ ] **Step 1: Add the Test button**
+
+Locate the `<div class="settings__list-actions">` block inside `AndroidStageSettingsCard` (around line 438-451). Immediately BEFORE the existing Edit button, add the Test button so the action order is `[Test] [Edit] [Delete]`:
+
+```rust
+                                    <div class="settings__list-actions">
+                                        <button
+                                            type="button"
+                                            class="settings__button settings__button--ghost"
+                                            data-role="android-test"
+                                            data-id={display.id.clone()}
+                                        >"Test"</button>
+                                        <button
+                                            type="button"
+                                            class="settings__button settings__button--ghost"
+                                            data-role="android-edit"
+                                            data-id={display_id_edit}
+                                        >"Edit"</button>
+                                        <button
+                                            type="button"
+                                            class="settings__button settings__button--danger"
+                                            data-role="android-delete"
+                                            data-id={display_id_delete}
+                                        >"Delete"</button>
+                                    </div>
+```
+
+Note: `display.id.clone()` is used directly because the existing `display_id_edit` and `display_id_delete` locals are already consumed by the following buttons. We add a third local clone if the borrow checker complains — in that case, add `let display_id_test = display.id.clone();` alongside the existing edit/delete locals above the `view!` block.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check -p presenter-server`
+Expected: clean. If borrow-checker complains about `display.id.clone()` after move, apply the `display_id_test` workaround.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/ui/components/settings.rs
+git commit -m "feat(ui): add test launch button in android stage settings SSR (#245)"
+```
+
+---
+
+## Task 8: JS template "Test" button + click handler
+
+**Files:**
+- Modify: `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/settings_script.js` — update the android list template and add a click handler
+
+- [ ] **Step 1: Update the JS template**
+
+Find the android list item template around line 710-713:
+
+```javascript
+  <div class="settings__list-actions">
+    <button type="button" class="settings__button settings__button--ghost" data-role="android-edit" data-id="${normalized.id}">Edit</button>
+    <button type="button" class="settings__button settings__button--danger" data-role="android-delete" data-id="${normalized.id}">Delete</button>
+  </div>
+```
+
+Replace with:
+
+```javascript
+  <div class="settings__list-actions">
+    <button type="button" class="settings__button settings__button--ghost" data-role="android-test" data-id="${normalized.id}">Test</button>
+    <button type="button" class="settings__button settings__button--ghost" data-role="android-edit" data-id="${normalized.id}">Edit</button>
+    <button type="button" class="settings__button settings__button--danger" data-role="android-delete" data-id="${normalized.id}">Delete</button>
+  </div>
+```
+
+- [ ] **Step 2: Add the `testAndroidDisplay` helper**
+
+Insert this function immediately above `async function deleteAndroidDisplay(id) {` (around line 853):
+
+```javascript
+  async function testAndroidDisplay(id) {
+    if (!id) return;
+    try {
+      const response = await fetch(`${ANDROID_API_ROOT}/${id}/launch-now`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        throw new Error(await extractError(response));
+      }
+      showToast('Launch queued — refreshing status…', 'success');
+      setTimeout(() => {
+        refreshAndroidDisplays(false);
+      }, 1500);
+    } catch (error) {
+      console.error('Failed to trigger android launch', error);
+      showToast(error.message || 'Unable to trigger launch.', 'error');
+    }
+  }
+```
+
+- [ ] **Step 3: Wire up the click handler**
+
+In the android event delegation block (around line 885-889), extend the `if/else` chain:
+
+```javascript
+    if (target.dataset.role === 'android-edit') {
+      startAndroidEdit(id);
+    } else if (target.dataset.role === 'android-delete') {
+      await deleteAndroidDisplay(id);
+    } else if (target.dataset.role === 'android-test') {
+      await testAndroidDisplay(id);
+    }
+```
+
+- [ ] **Step 4: Verify JS is valid (no syntax errors)**
+
+Run:
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+node -e "new Function(require('fs').readFileSync('crates/presenter-server/src/settings_script.js', 'utf8'))" && echo "JS parses"
+```
+
+Expected: `JS parses`. If this prints a parse error, fix it before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/settings_script.js
+git commit -m "feat(ui): wire test launch button to launch-now endpoint (#245)"
+```
+
+---
+
+## Task 9: Version bump, fmt, clippy, push, monitor CI, verify on prod
+
+- [ ] **Step 1: Bump workspace version**
+
+Edit `Cargo.toml` at the workspace root — bump `[workspace.package].version` from `0.4.22` to `0.4.23` (whatever the current dev version is + 1 patch).
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server  # refresh Cargo.lock
+```
+
+- [ ] **Step 2: Local checks**
+
+```bash
+cargo fmt --all
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test --workspace
+```
+
+Fix any fmt drift, clippy warnings, or test failures before proceeding.
+
+- [ ] **Step 3: Commit version bump**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version for android stage resilience (#245)"
+```
+
+- [ ] **Step 4: Push and monitor dev pipeline**
+
+```bash
+git push origin dev
+gh run list --branch dev --workflow Pipeline --limit 3
+```
+
+Monitor the pipeline via `gh run view <id>` or the Monitor tool. When `Deploy to Dev` finishes, verify dev picked up the seed:
+
+```bash
+curl -sf http://10.77.8.134:8080/integrations/android-stage/displays | python3 -m json.tool
+```
+
+Expected: 4 entries with hosts `sd1l..sd4l.lan`, all enabled, with `status.state` = `running` (or `connecting` while the first tick is in flight).
+
+- [ ] **Step 5: Functional verification on dev**
+
+For at least one display (say the one backed by `sd1l.lan`):
+
+```bash
+# Grab its id from the list
+DISPLAY_ID=$(curl -sf http://10.77.8.134:8080/integrations/android-stage/displays | python3 -c "import json,sys; print([d['id'] for d in json.load(sys.stdin) if d['host']=='sd1l.lan'][0])")
+
+# Force a launch via the new endpoint
+curl -sf -X POST http://10.77.8.134:8080/integrations/android-stage/displays/$DISPLAY_ID/launch-now
+echo "HTTP $?"
+
+# Wait a moment, then check the TV
+sleep 2
+adb -s sd1l.lan:5555 shell "dumpsys activity activities | grep mResumedActivity"
+```
+
+Expected: the resumed activity contains `com.fullykiosk.videokiosk`. If it says `com.google.android.tvlauncher/.MainActivity`, something is still wrong — investigate before merging.
+
+- [ ] **Step 6: Create PR to main**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+gh pr create --base main --head dev --title "fix(android-stage): restore kiosk auto-launch + test button (#245)" --body "$(cat <<'EOF'
+## Summary
+
+- **Seed 4 known displays** (sd1l..sd4l) when the table is empty — one-time migration with a COUNT(*)=0 guard so operator edits survive reruns.
+- **adb disconnect before adb connect** in the launcher worker — clears stale offline device entries that ADB leaves behind after TV power cycles.
+- **"Test" button** on each display row in Settings → POST to a new /launch-now endpoint that tells the worker to launch immediately, bypassing the 20s retry tick.
+
+## Test plan
+
+- [x] Unit: seed populates 4 rows on empty table
+- [x] Unit: seed is idempotent when rerun against a non-empty table (operator edits preserved)
+- [x] Functional: dev deploy picks up the seed, `curl /integrations/android-stage/displays` returns 4 rows
+- [x] Functional: click Test on sd1l → status transitions within 2s → `adb shell dumpsys activity activities` shows FullyActivity foregrounded
+- [x] Functional: power-cycle sd1l and wait ≤20s → launcher auto-recovers via the new adb disconnect/connect sequence
+
+Closes #245.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: After user merges, verify on prod**
+
+Once the user merges the PR and the main deploy finishes:
+
+```bash
+curl -sf http://10.77.9.205/integrations/android-stage/displays | python3 -m json.tool
+```
+
+Expected: same 4 rows. If prod already had rows (operator had added them at some point that we couldn't find in backups), the seed skipped — still fine.
+
+Power on one of the TVs cold, wait up to 20 seconds, and confirm the kiosk is foregrounded. Optionally click "Test" in the UI to force a launch.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Seed migration idempotent | `cargo test -p presenter-persistence -- seed_migration` passes; the idempotency test proves a rerun doesn't duplicate |
+| 4 displays auto-created on empty DB | After deploy: `curl /integrations/android-stage/displays` returns 4 rows with sd1l..sd4l |
+| adb disconnect hardening | Read `connect_and_launch` at `crates/presenter-server/src/android_stage.rs` — disconnect call precedes connect |
+| Test button works | Click "Test" in Settings UI → toast → status panel shows updated `lastAttempt` within 2s |
+| Launch-now endpoint | `curl -X POST /integrations/android-stage/displays/<id>/launch-now` returns 204 |
+| End-to-end kiosk launch | `adb -s sd1l.lan:5555 shell dumpsys activity activities` shows FullyActivity after Test click |
+| CI green | Pipeline succeeds for dev and main |
+| Prod verified | `curl /integrations/android-stage/displays` on prod shows 4 rows; manual TV power-cycle test |

--- a/docs/superpowers/specs/2026-04-14-android-stage-resilience-design.md
+++ b/docs/superpowers/specs/2026-04-14-android-stage-resilience-design.md
@@ -1,0 +1,140 @@
+# Android Stage Launcher Resilience (#245)
+
+**Status:** Proposed
+**Date:** 2026-04-14
+**Issue:** #245
+
+## Problem
+
+Operators report that Android TV stage displays (`sd1l.lan` through `sd4l.lan`) boot to the Google TV home screen instead of the Fully Kiosk stage display app. The user "had it added on production" previously, but no backup from the last 3 days (prod + dev, 10 files total) contains a single row in `android_stage_displays`. The table exists from the initial migration, but it's empty.
+
+Diagnostics on 2026-04-14:
+- All 4 TVs are reachable on TCP port 5555.
+- Manual `adb connect sd1l.lan:5555 && adb shell am start -n com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity` launches the kiosk and the activity foregrounds on the TV.
+- Adding a display via the Settings UI on dev persists correctly: the row is created, the launcher worker fires within 130ms, `adb connect` + `am start` both succeed, and `dumpsys activity activities` confirms `FullyActivity` is resumed.
+- End-to-end the existing code works. The observable "bug" is that the table is empty.
+
+The feature is silent about its emptiness: the UI shows `0 Displays` with a fallback message, but no alert, log, or onboarding prompt nudges the operator to add them. If a migration or deploy event ever wipes the table, the feature appears broken with no signal.
+
+## Goals
+
+- The 4 known stage displays on the production LAN get re-added and stay added.
+- The launcher is more resilient to ADB's well-known stale-device behavior after TV power cycles.
+- Operators can verify a display works without waiting for the 20-second retry tick.
+
+Non-goals:
+- mDNS or Bonjour auto-discovery of Android TVs.
+- Dynamic registration (e.g., "any TV that connects once gets auto-added"). Too much magic for too little value.
+- Rewriting the retry loop. The 20s cadence is fine.
+
+## Architecture
+
+Three surgical changes:
+
+### 1. One-time seed migration
+
+New incremental migration `m20260414_000002_seed_android_stage_displays`. In `up()`:
+
+```sql
+SELECT COUNT(*) FROM android_stage_displays
+```
+
+If the count is `0`, insert 4 rows:
+
+| label      | host       | port | launch_component                                              | is_enabled |
+|------------|------------|------|---------------------------------------------------------------|------------|
+| Stage SD1  | sd1l.lan   | 5555 | com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity        | 1          |
+| Stage SD2  | sd2l.lan   | 5555 | com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity        | 1          |
+| Stage SD3  | sd3l.lan   | 5555 | com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity        | 1          |
+| Stage SD4  | sd4l.lan   | 5555 | com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity        | 1          |
+
+`created_at` / `updated_at` = current epoch millis. `id` = a UUID generated per row.
+
+**Crucially:** the seed only runs when the table is empty. If an operator later deletes all 4 displays, a subsequent deploy does NOT re-seed — the idempotency guard (`COUNT(*) = 0`) is what makes this safe. The migration still runs exactly once per SeaORM's migration tracking, but the INSERT path inside is guarded so it never overwrites operator intent.
+
+`down()` is a no-op. We don't want to delete operator data on rollback.
+
+### 2. `adb disconnect` before `adb connect` in the launcher worker
+
+In `crates/presenter-server/src/android_stage.rs::connect_and_launch`, before the existing `adb connect` call:
+
+```rust
+// Clear any stale offline device entry from a previous attempt.
+// ADB leaves stale entries after TV power cycles which then cause
+// subsequent `-s serial` commands to fail until the daemon is restarted.
+let _ = timeout(
+    ADB_COMMAND_TIMEOUT,
+    Command::new(adb_bin).arg("disconnect").arg(&serial).output(),
+)
+.await;
+```
+
+Errors from `disconnect` are intentionally ignored (the expected case is "not connected", which returns non-zero).
+
+### 3. "Test launch" button in Settings UI
+
+New endpoint `POST /integrations/android-stage/displays/{id}/launch-now`. Sends `DeviceCommand::LaunchNow` to the worker's command channel (already wired up). Returns `204 No Content` on enqueue. The response does NOT wait for the launch to complete — the UI polls the existing status snapshot for state transitions.
+
+New "Test" button in `crates/presenter-server/src/ui/components/settings.rs` on each display row. Click → POST → refresh status after 2 seconds → show updated state.
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `crates/presenter-migration/src/m20260414_000002_seed_android_stage_displays.rs` | **New** — one-time seed |
+| `crates/presenter-migration/src/lib.rs` | Register new migration |
+| `crates/presenter-server/src/android_stage.rs` | Add `adb disconnect` before `adb connect` in `connect_and_launch` |
+| `crates/presenter-server/src/router/integrations/android_stage.rs` | Add `launch_now_android_stage_display` handler |
+| `crates/presenter-server/src/router.rs` | Register POST route |
+| `crates/presenter-server/src/state/integrations.rs` | Add `launch_now_android_stage_display` method that sends `DeviceCommand::LaunchNow` to the registry |
+| `crates/presenter-server/src/android_stage.rs` | Add public `launch_now` method on `AndroidStageRegistry` |
+| `crates/presenter-server/src/ui/components/settings.rs` | Add "Test" button + click handler per display row |
+
+## Data Flow
+
+```
+Deploy → migration runs → if android_stage_displays empty → insert 4 rows
+Server boot → state::sync_android_stage_displays → registry.set_displays
+Registry → spawn worker per display → ticker every 20s
+Worker tick → adb disconnect → adb connect → am start → state = Running
+Operator clicks Test → POST /launch-now → state.launch_now → registry.launch_now →
+  tx.send(DeviceCommand::LaunchNow) → worker picks up → runs connect_and_launch immediately
+```
+
+## Error Handling
+
+- Seed migration failure: rolls back the transaction, deploy fails loudly. Expected 0% failure rate on a fresh or unchanged table.
+- `adb disconnect` failure: silently ignored. Expected case (device was never connected).
+- `adb connect` failure: existing behavior — record_error, worker retries next tick.
+- `launch-now` with unknown id: 404.
+- `launch-now` against a disabled display: returns 409 Conflict with a clear message, because the worker won't process `LaunchNow` when `!is_enabled`.
+
+## Testing
+
+### Unit tests (presenter-persistence / presenter-server)
+
+- Existing android stage display CRUD tests already cover the schema layer — not touched.
+- New test: `seed_inserts_four_displays_on_empty_table` — spin up an in-memory DB, run migrations, assert row count = 4 and all hosts match `sd1l..sd4l`.
+- New test: `seed_does_not_overwrite_existing_rows` — run migrations on a fresh in-memory DB (which triggers the seed and lands 4 rows). Manually insert a 5th display with a distinct label via the repository API. Invoke the seed migration's `up()` a second time directly (`Migration.up(&schema_manager).await`). Assert: row count stays at 5 (not 9), the custom row survives, no duplicate seed rows are inserted. This validates the `COUNT(*) = 0` guard.
+- New test: `launch_now_enqueues_command` — create a display, call `state.launch_now_android_stage_display(id)`, assert the mock worker received `DeviceCommand::LaunchNow`.
+
+### Manual verification on dev (after deploy)
+
+1. `curl http://10.77.8.134:8080/integrations/android-stage/displays` → expect 4 rows with `sd1l..sd4l`.
+2. Click Test on sd1l → watch `lastAttempt` bump and state transition to `running`.
+3. SSH to sd1l and run `dumpsys activity activities | grep mResumedActivity` → expect `FullyActivity`.
+4. Power-cycle sd1l via `adb reboot`, wait for it to come back, observe state recovery (should re-run within ~20s without operator intervention).
+
+### Manual verification on prod (after dev is green)
+
+Same 4 checks against `http://10.77.9.205`.
+
+## Open Questions
+
+None.
+
+## Future Work (out of scope)
+
+- Last-success age indicator in the Settings UI (e.g., "launched 3s ago" vs "launched 2h ago") — nice to have, not required for this fix.
+- Per-display custom launch component — current default works for all 4 TVs.
+- Automatic recovery if the TV is in a stuck app state (e.g., `am kill` + `am start` combo).

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -286,13 +286,14 @@ test('android stage launchers CRUD', async ({ page }) => {
   await page.goto(new URL('/ui/settings', baseURL).toString());
   await page.waitForLoadState('networkidle');
 
-  await expect(page.locator(selectors.androidList).first()).toContainText(
-    'No Android stage displays configured yet.'
-  );
+  // The seed migration adds 4 displays on a fresh DB — establish the baseline
+  // so we can write assertions relative to it instead of assuming an empty list.
+  const initialDisplays = await getAndroidDisplaysViaApi(page);
+  const initialCount = initialDisplays.length;
 
   const label = `Stage Display ${Date.now()}`;
   await page.fill(selectors.androidLabel, label);
-  await page.fill(selectors.androidHost, 'sd1l.lan');
+  await page.fill(selectors.androidHost, 'test-stage.invalid');
   await page.fill(selectors.androidPort, '5555');
   await page.fill(
     selectors.androidComponent,
@@ -303,48 +304,48 @@ test('android stage launchers CRUD', async ({ page }) => {
   await waitForToast(page, 'Added Android stage display.');
 
   const displaysAfterCreate = await getAndroidDisplaysViaApi(page);
-  expect(displaysAfterCreate).toHaveLength(1);
-  const created = displaysAfterCreate[0];
-  expect(created.label).toBe(label);
-  expect(created.host).toBe('sd1l.lan');
+  expect(displaysAfterCreate).toHaveLength(initialCount + 1);
+  const created = displaysAfterCreate.find((d) => d.label === label);
+  expect(created).toBeDefined();
+  expect(created!.host).toBe('test-stage.invalid');
   const androidListItem = page.locator(
-    `${selectors.androidList} li[data-id="${created.id}"]`
+    `${selectors.androidList} li[data-id="${created!.id}"]`
   );
   await expect(androidListItem).toContainText(label);
 
   // Edit display details.
-  await page.locator(`[data-role="android-edit"][data-id="${created.id}"]`).click();
+  await page.locator(`[data-role="android-edit"][data-id="${created!.id}"]`).click();
   const updatedLabel = `${label} Updated`;
   await page.fill(selectors.androidLabel, updatedLabel);
-  await page.fill(selectors.androidHost, 'sd2l.lan');
+  await page.fill(selectors.androidHost, 'other-stage.invalid');
   await page.fill(selectors.androidPort, '5566');
   await page.fill(selectors.androidComponent, 'com.example/.Main');
   await page.uncheck(selectors.androidEnabled);
   await page.click(selectors.androidSubmit);
   await waitForToast(page, 'Saved Android stage display.');
   await expect(androidListItem).toContainText(updatedLabel);
-  await expect(androidListItem).toContainText('sd2l.lan');
+  await expect(androidListItem).toContainText('other-stage.invalid');
 
   const displaysAfterUpdate = await getAndroidDisplaysViaApi(page);
-  expect(displaysAfterUpdate[0].label).toBe(updatedLabel);
-  expect(displaysAfterUpdate[0].host).toBe('sd2l.lan');
-  expect(displaysAfterUpdate[0].port).toBe(5566);
+  const updated = displaysAfterUpdate.find((d) => d.id === created!.id);
+  expect(updated).toBeDefined();
+  expect(updated!.label).toBe(updatedLabel);
+  expect(updated!.host).toBe('other-stage.invalid');
+  expect(updated!.port).toBe(5566);
   expect(
-    displaysAfterUpdate[0].launchComponent ?? displaysAfterUpdate[0].launch_component
+    updated!.launchComponent ?? updated!.launch_component
   ).toBe('com.example/.Main');
 
   // Delete the display.
   page.once('dialog', (dialog) => dialog.accept());
   await page
-    .locator(`[data-role="android-delete"][data-id="${created.id}"]`)
+    .locator(`[data-role="android-delete"][data-id="${created!.id}"]`)
     .click();
   await waitForToast(page, 'Deleted Android stage display.');
 
   const displaysAfterDelete = await getAndroidDisplaysViaApi(page);
-  expect(displaysAfterDelete).toHaveLength(0);
-  await expect(page.locator('[data-role="android-display-list"] [data-role="android-empty"]').first()).toHaveText(
-    'No Android stage displays configured yet.'
-  );
+  expect(displaysAfterDelete).toHaveLength(initialCount);
+  expect(displaysAfterDelete.find((d) => d.id === created!.id)).toBeUndefined();
 });
 
 test('companion settings reflect feature flags', async ({ page }) => {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -288,8 +288,11 @@ test('android stage launchers CRUD', async ({ page }) => {
 
   // The seed migration adds 4 displays on a fresh DB — establish the baseline
   // so we can write assertions relative to it instead of assuming an empty list.
+  // Lock in the seed's existence so a future regression that empties the table
+  // silently makes this test "pass" with a zero baseline.
   const initialDisplays = await getAndroidDisplaysViaApi(page);
   const initialCount = initialDisplays.length;
+  expect(initialCount).toBeGreaterThanOrEqual(4);
 
   const label = `Stage Display ${Date.now()}`;
   await page.fill(selectors.androidLabel, label);


### PR DESCRIPTION
## Summary

- **Seed 4 known displays** (sd1l..sd4l) when `android_stage_displays` is empty — one-time migration with a `COUNT(*) = 0` guard so operator edits survive reruns. Fresh/ empty DBs get 4 displays configured out of the box.
- **`adb disconnect` before `adb connect`** in the launcher worker — clears stale offline device entries that ADB leaves behind after TV power cycles. Makes recovery after a power-cycle reliable without needing to restart the service.
- **"Test" button** per display in Settings → `POST /integrations/android-stage/displays/{id}/launch-now` tells the worker to launch immediately, bypassing the 20s retry tick. Lets operators verify a device in <2s.

## Test plan

- [x] Unit: `seed_migration_populates_four_android_stage_displays_on_empty_table` — 4 rows with correct hosts, port, launch component, enabled
- [x] Unit: `seed_migration_is_idempotent_when_rerun` — operator edits survive a second migration up()
- [x] Unit: `launch_now_errors_on_unknown_id` — pins the unknown-id error branch
- [x] Router test: `android_stage_display_endpoints_crud` updated to handle seeded rows (reads `initial_count`, uses `test-stage.invalid` / `other-stage.invalid` to avoid collisions)
- [x] E2E: `android stage launchers CRUD` (Playwright) updated the same way
- [x] CI: all jobs green on dev pipeline (24414582528)
- [x] Functional: dev DB has 4 seeded rows with correct hosts, worker tick running, `POST /launch-now` returns 204 (dev @ 10.77.8.134)

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)