### PR TITLE
feat(tablet): PWA-ready via Cloudflare Tunnel + LAN/WAN indicator (#218)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,7 +361,12 @@ jobs:
               -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
               deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
 
-          # 2. Write credentials JSON (short-lived)
+          # 2. Write credentials JSON (short-lived). Fail loudly if the
+          # matching secret isn't set — vars without creds can't work.
+          if [ -z "$CREDS" ]; then
+            echo "::error::CLOUDFLARED_CREDS_PROD secret is empty but CLOUDFLARED_TUNNEL_ID_PROD / _HOSTNAME_PROD vars are set. Register the credentials JSON in repo settings."
+            exit 1
+          fi
           printf '%s' "$CREDS" > /tmp/cf-creds.json
           chmod 600 /tmp/cf-creds.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -345,8 +345,8 @@ jobs:
           echo "Service: ${{ env.SERVICE_NAME }}"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
 
-      - name: Install & configure cloudflared (skipped if secret unset)
-        if: ${{ secrets.CLOUDFLARED_CREDS_PROD != '' && vars.CLOUDFLARED_TUNNEL_ID_PROD != '' && vars.CLOUDFLARED_HOSTNAME_PROD != '' }}
+      - name: Install & configure cloudflared (skipped if vars unset)
+        if: ${{ vars.CLOUDFLARED_TUNNEL_ID_PROD != '' && vars.CLOUDFLARED_HOSTNAME_PROD != '' }}
         env:
           TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PROD }}
           HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PROD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -344,3 +344,47 @@ jobs:
           echo "Version: $(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
           echo "Service: ${{ env.SERVICE_NAME }}"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
+
+      - name: Install & configure cloudflared (skipped if secret unset)
+        if: ${{ secrets.CLOUDFLARED_CREDS_PROD != '' && vars.CLOUDFLARED_TUNNEL_ID_PROD != '' && vars.CLOUDFLARED_HOSTNAME_PROD != '' }}
+        env:
+          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PROD }}
+          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PROD }}
+          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_PROD || '80' }}
+          CREDS: ${{ secrets.CLOUDFLARED_CREDS_PROD }}
+        run: |
+          set -euo pipefail
+
+          # 1. Render config.yml locally from the template
+          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
+              -e "s|__HOSTNAME__|$HOSTNAME|g" \
+              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
+              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
+
+          # 2. Write credentials JSON (short-lived)
+          printf '%s' "$CREDS" > /tmp/cf-creds.json
+          chmod 600 /tmp/cf-creds.json
+
+          # 3. Ship files to target
+          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
+          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
+          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
+          rm /tmp/cf-config.yml /tmp/cf-creds.json
+
+          # 4. Install + activate on target
+          ssh deploy-target "set -euo pipefail
+            if ! command -v cloudflared >/dev/null 2>&1; then
+              wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+              sudo dpkg -i /tmp/cf.deb
+              rm /tmp/cf.deb
+            fi
+            sudo mkdir -p /etc/cloudflared
+            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
+            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
+            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --now cloudflared
+            sudo systemctl restart cloudflared
+          "

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -957,8 +957,8 @@ jobs:
           echo "URL: http://10.77.8.134:8080"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
 
-      - name: Install & configure cloudflared (skipped if secret unset)
-        if: ${{ secrets.CLOUDFLARED_CREDS_DEV != '' && vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
+      - name: Install & configure cloudflared (skipped if vars unset)
+        if: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
         env:
           TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV }}
           HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_DEV }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -973,7 +973,12 @@ jobs:
               -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
               deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
 
-          # 2. Write credentials JSON (short-lived)
+          # 2. Write credentials JSON (short-lived). Fail loudly if the
+          # matching secret isn't set — vars without creds can't work.
+          if [ -z "$CREDS" ]; then
+            echo "::error::CLOUDFLARED_CREDS_DEV secret is empty but CLOUDFLARED_TUNNEL_ID_DEV / _HOSTNAME_DEV vars are set. Register the credentials JSON in repo settings."
+            exit 1
+          fi
           printf '%s' "$CREDS" > /tmp/cf-creds.json
           chmod 600 /tmp/cf-creds.json
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -957,6 +957,50 @@ jobs:
           echo "URL: http://10.77.8.134:8080"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
 
+      - name: Install & configure cloudflared (skipped if secret unset)
+        if: ${{ secrets.CLOUDFLARED_CREDS_DEV != '' && vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
+        env:
+          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV }}
+          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_DEV }}
+          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_DEV || '8080' }}
+          CREDS: ${{ secrets.CLOUDFLARED_CREDS_DEV }}
+        run: |
+          set -euo pipefail
+
+          # 1. Render config.yml locally from the template
+          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
+              -e "s|__HOSTNAME__|$HOSTNAME|g" \
+              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
+              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
+
+          # 2. Write credentials JSON (short-lived)
+          printf '%s' "$CREDS" > /tmp/cf-creds.json
+          chmod 600 /tmp/cf-creds.json
+
+          # 3. Ship files to target
+          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
+          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
+          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
+          rm /tmp/cf-config.yml /tmp/cf-creds.json
+
+          # 4. Install + activate on target
+          ssh deploy-target "set -euo pipefail
+            if ! command -v cloudflared >/dev/null 2>&1; then
+              wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+              sudo dpkg -i /tmp/cf.deb
+              rm /tmp/cf.deb
+            fi
+            sudo mkdir -p /etc/cloudflared
+            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
+            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
+            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --now cloudflared
+            sudo systemctl restart cloudflared
+          "
+
   # ============================================
   # Deploy Companion Plugin to both hosts
   # ============================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,3 +305,47 @@ jobs:
           echo "Release: ${{ github.event.release.tag_name }}"
           echo "Service: ${{ env.SERVICE_NAME }}"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
+
+      - name: Install & configure cloudflared (skipped if secret unset)
+        if: ${{ secrets.CLOUDFLARED_CREDS_PP != '' && vars.CLOUDFLARED_TUNNEL_ID_PP != '' && vars.CLOUDFLARED_HOSTNAME_PP != '' }}
+        env:
+          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PP }}
+          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PP }}
+          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_PP || '80' }}
+          CREDS: ${{ secrets.CLOUDFLARED_CREDS_PP }}
+        run: |
+          set -euo pipefail
+
+          # 1. Render config.yml locally from the template
+          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
+              -e "s|__HOSTNAME__|$HOSTNAME|g" \
+              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
+              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
+
+          # 2. Write credentials JSON (short-lived)
+          printf '%s' "$CREDS" > /tmp/cf-creds.json
+          chmod 600 /tmp/cf-creds.json
+
+          # 3. Ship files to target
+          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
+          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
+          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
+          rm /tmp/cf-config.yml /tmp/cf-creds.json
+
+          # 4. Install + activate on target
+          ssh deploy-target "set -euo pipefail
+            if ! command -v cloudflared >/dev/null 2>&1; then
+              wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+              sudo dpkg -i /tmp/cf.deb
+              rm /tmp/cf.deb
+            fi
+            sudo mkdir -p /etc/cloudflared
+            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
+            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
+            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --now cloudflared
+            sudo systemctl restart cloudflared
+          "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,8 +306,8 @@ jobs:
           echo "Service: ${{ env.SERVICE_NAME }}"
           ssh deploy-target "systemctl status ${{ env.SERVICE_NAME }} --no-pager" || true
 
-      - name: Install & configure cloudflared (skipped if secret unset)
-        if: ${{ secrets.CLOUDFLARED_CREDS_PP != '' && vars.CLOUDFLARED_TUNNEL_ID_PP != '' && vars.CLOUDFLARED_HOSTNAME_PP != '' }}
+      - name: Install & configure cloudflared (skipped if vars unset)
+        if: ${{ vars.CLOUDFLARED_TUNNEL_ID_PP != '' && vars.CLOUDFLARED_HOSTNAME_PP != '' }}
         env:
           TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PP }}
           HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PP }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,12 @@ jobs:
               -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
               deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
 
-          # 2. Write credentials JSON (short-lived)
+          # 2. Write credentials JSON (short-lived). Fail loudly if the
+          # matching secret isn't set — vars without creds can't work.
+          if [ -z "$CREDS" ]; then
+            echo "::error::CLOUDFLARED_CREDS_PP secret is empty but CLOUDFLARED_TUNNEL_ID_PP / _HOSTNAME_PP vars are set. Register the credentials JSON in repo settings."
+            exit 1
+          fi
           printf '%s' "$CREDS" > /tmp/cf-creds.json
           chmod 600 /tmp/cf-creds.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,11 +239,12 @@ crates/
 
 | Variable                      | Default                 | Purpose                 |
 | ----------------------------- | ----------------------- | ----------------------- |
-| `PRESENTER_PORT`              | 80                      | Server port             |
-| `PRESENTER_DB_URL`            | `sqlite://presenter.db` | Database connection     |
-| `PRESENTER_COMPANION_ENABLED` | 0                       | Enable Companion socket |
-| `PRESENTER_COMPANION_PORT`    | 18175                   | Companion listen port   |
-| `RUST_LOG`                    | `info,tower_http=debug` | Tracing filter          |
+| `PRESENTER_PORT`              | 80                      | Server port                                                          |
+| `PRESENTER_DB_URL`            | `sqlite://presenter.db` | Database connection                                                  |
+| `PRESENTER_COMPANION_ENABLED` | 0                       | Enable Companion socket                                              |
+| `PRESENTER_COMPANION_PORT`    | 18175                   | Companion listen port                                                |
+| `PRESENTER_LOCAL_PUBLIC_IP`   | unset                   | Church's public egress IP for LAN/WAN detection via Cloudflare Tunnel |
+| `RUST_LOG`                    | `info,tower_http=debug` | Tracing filter                                                       |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "axum",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "axum",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/config.rs
+++ b/crates/presenter-server/src/config.rs
@@ -14,6 +14,8 @@ pub struct ServerConfig {
     pub stage: StageConfig,
     #[allow(dead_code)] // Android stage feature in development
     pub android: AndroidConfig,
+    #[allow(dead_code)] // Consumed in Task 2 (AppState) — not yet wired
+    pub network: NetworkConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +64,7 @@ impl ServerConfig {
             osc: OscConfig::load(),
             stage: StageConfig::load(),
             android: AndroidConfig::load(),
+            network: NetworkConfig::load(),
         })
     }
 }
@@ -140,6 +143,25 @@ impl AndroidConfig {
     fn load() -> Self {
         let adb_path = env::var_os("PRESENTER_ANDROID_ADB_BIN");
         Self { adb_path }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NetworkConfig {
+    /// The church's outbound public IP as seen by Cloudflare.
+    /// Used by `/api/network-mode` to classify tunnel clients.
+    /// Optional — falls back to private-range heuristic when unset.
+    #[allow(dead_code)] // Consumed in Task 4 (/api/network-mode handler) — not yet wired
+    pub local_public_ip: Option<String>,
+}
+
+impl NetworkConfig {
+    fn load() -> Self {
+        let local_public_ip = env::var("PRESENTER_LOCAL_PUBLIC_IP")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        Self { local_public_ip }
     }
 }
 

--- a/crates/presenter-server/src/config.rs
+++ b/crates/presenter-server/src/config.rs
@@ -223,6 +223,31 @@ mod tests {
     }
 
     #[test]
+    fn network_config_parses_public_ip_trimming_whitespace_and_treating_empty_as_unset() {
+        let original = env::var("PRESENTER_LOCAL_PUBLIC_IP").ok();
+
+        env::remove_var("PRESENTER_LOCAL_PUBLIC_IP");
+        assert_eq!(NetworkConfig::load().local_public_ip, None);
+
+        env::set_var("PRESENTER_LOCAL_PUBLIC_IP", "");
+        assert_eq!(NetworkConfig::load().local_public_ip, None);
+
+        env::set_var("PRESENTER_LOCAL_PUBLIC_IP", "   ");
+        assert_eq!(NetworkConfig::load().local_public_ip, None);
+
+        env::set_var("PRESENTER_LOCAL_PUBLIC_IP", "  203.0.113.50  ");
+        assert_eq!(
+            NetworkConfig::load().local_public_ip,
+            Some("203.0.113.50".to_string())
+        );
+
+        match original {
+            Some(value) => env::set_var("PRESENTER_LOCAL_PUBLIC_IP", value),
+            None => env::remove_var("PRESENTER_LOCAL_PUBLIC_IP"),
+        }
+    }
+
+    #[test]
     fn duration_override_rejects_zero_and_invalid_values() {
         let original = env::var("PRESENTER_HEARTBEAT_INTERVAL_MS").ok();
         env::set_var("PRESENTER_HEARTBEAT_INTERVAL_MS", "1500");

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -3,6 +3,7 @@ mod bible;
 mod features;
 mod integrations;
 mod libraries;
+pub mod network_mode;
 mod playlists;
 mod presentations;
 mod search;

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -266,6 +266,10 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ai/proxy/stop", post(ai::proxy_stop))
         .route("/ai/proxy/login", post(ai::proxy_login))
         .route("/ai/proxy/complete-login", post(ai::proxy_complete_login))
+        .route(
+            "/api/network-mode",
+            get(network_mode::get_network_mode),
+        )
         .with_state(state)
 }
 

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -266,10 +266,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ai/proxy/stop", post(ai::proxy_stop))
         .route("/ai/proxy/login", post(ai::proxy_login))
         .route("/ai/proxy/complete-login", post(ai::proxy_complete_login))
-        .route(
-            "/api/network-mode",
-            get(network_mode::get_network_mode),
-        )
+        .route("/api/network-mode", get(network_mode::get_network_mode))
         .with_state(state)
 }
 

--- a/crates/presenter-server/src/router/network_mode.rs
+++ b/crates/presenter-server/src/router/network_mode.rs
@@ -1,0 +1,115 @@
+//! Network-mode classifier: determines whether a client is on the church LAN
+//! (direct or via tunnel-from-same-egress) or truly remote. Used by
+//! `GET /api/network-mode` and by the tablet UI's LAN/WAN pill.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use serde::Serialize;
+
+use crate::state::AppState;
+
+/// Classifies a client from request headers. Returns `"local"` or `"remote"`.
+///
+/// Rules:
+/// - No `CF-Connecting-IP` header → direct connection, not via tunnel → `local`.
+/// - `CF-Connecting-IP` matches `local_public_ip` → same egress IP as the server,
+///   so client is on the church LAN just using the tunnel URL → `local`.
+/// - Otherwise, if `local_public_ip` is set → `remote`.
+/// - Otherwise (no configured IP) → fall back to `is_private_ip` on the client IP.
+pub fn detect_network_mode(headers: &HeaderMap, local_public_ip: Option<&str>) -> &'static str {
+    let client_ip = headers
+        .get("cf-connecting-ip")
+        .or_else(|| headers.get("x-forwarded-for"))
+        .or_else(|| headers.get("x-real-ip"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string());
+
+    match (&client_ip, local_public_ip) {
+        (Some(client), Some(local)) if client == local => "local",
+        (Some(_), Some(_)) => "remote",
+        (None, _) => "local",
+        (Some(ip), None) if is_private_ip(ip) => "local",
+        (Some(_), None) => "remote",
+    }
+}
+
+/// Return true for IPs in private/loopback/link-local ranges.
+pub fn is_private_ip(ip: &str) -> bool {
+    ip.parse::<std::net::IpAddr>().is_ok_and(|addr| match addr {
+        std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local(),
+        std::net::IpAddr::V6(v6) => v6.is_loopback(),
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct NetworkModeResponse {
+    pub mode: String,
+}
+
+pub async fn get_network_mode(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Json<NetworkModeResponse> {
+    let mode = detect_network_mode(&headers, state.local_public_ip.as_deref());
+    Json(NetworkModeResponse {
+        mode: mode.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with(name: &str, value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        let key: axum::http::HeaderName = name.parse().unwrap();
+        h.insert(key, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn no_proxy_headers_is_local() {
+        let h = HeaderMap::new();
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+        assert_eq!(detect_network_mode(&h, None), "local");
+    }
+
+    #[test]
+    fn cf_connecting_ip_matching_configured_is_local() {
+        let h = headers_with("cf-connecting-ip", "203.0.113.50");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+    }
+
+    #[test]
+    fn cf_connecting_ip_different_from_configured_is_remote() {
+        let h = headers_with("cf-connecting-ip", "198.51.100.10");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "remote");
+    }
+
+    #[test]
+    fn x_forwarded_for_falls_through_to_classification() {
+        let h = headers_with("x-forwarded-for", "203.0.113.50, 10.0.0.1");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+    }
+
+    #[test]
+    fn no_configured_ip_falls_back_to_private_range() {
+        let h = headers_with("cf-connecting-ip", "10.77.9.50");
+        assert_eq!(detect_network_mode(&h, None), "local");
+
+        let h_public = headers_with("cf-connecting-ip", "198.51.100.10");
+        assert_eq!(detect_network_mode(&h_public, None), "remote");
+    }
+
+    #[test]
+    fn is_private_ip_handles_ranges() {
+        assert!(is_private_ip("10.1.2.3"));
+        assert!(is_private_ip("192.168.0.1"));
+        assert!(is_private_ip("172.20.30.40"));
+        assert!(is_private_ip("127.0.0.1"));
+        assert!(is_private_ip("::1"));
+        assert!(!is_private_ip("8.8.8.8"));
+        assert!(!is_private_ip("203.0.113.5"));
+        assert!(!is_private_ip("not-an-ip"));
+    }
+}

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -1761,3 +1761,49 @@ fn update_playlist_request_defaults_flags() {
     assert!(payload.name.is_none());
     assert!(payload.show_in_dashboard.is_none());
 }
+
+#[tokio::test]
+async fn network_mode_endpoint_returns_local_for_direct_request() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/network-mode")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["mode"], "local");
+}
+
+#[tokio::test]
+async fn network_mode_endpoint_returns_remote_with_foreign_cf_ip() {
+    // State without a configured local_public_ip → falls back to private-range check.
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/network-mode")
+                .header("CF-Connecting-IP", "198.51.100.10")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["mode"], "remote");
+}

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -98,6 +98,7 @@ pub struct AppState {
     ai_conversation: Arc<RwLock<Vec<ChatMessage>>>,
     ai_proxy: Arc<ProxyManager>,
     ndi_manager: Option<Arc<presenter_ndi::NdiManager>>,
+    pub local_public_ip: Arc<Option<String>>,
     #[cfg(test)]
     bible_ingestion_override: Option<std::sync::Arc<dyn TestBibleIngestion + Send + Sync>>,
 }
@@ -127,6 +128,7 @@ impl AppState {
             osc_bridge,
             ableset_bridge,
             heartbeat_config,
+            Arc::new(None),
         )
     }
 
@@ -140,6 +142,7 @@ impl AppState {
         osc_bridge: OscBridge,
         ableset_bridge: AbleSetBridge,
         heartbeat_config: StageHeartbeatConfig,
+        local_public_ip: Arc<Option<String>>,
     ) -> Self {
         let stage_connections = StageConnections::new();
         let default_layout = StageDisplayLayout::built_in()
@@ -176,6 +179,7 @@ impl AppState {
             ai_conversation: Arc::new(RwLock::new(Vec::new())),
             ai_proxy: Arc::new(ProxyManager::new(crate::ai::proxy::detect_deploy_dir())),
             ndi_manager,
+            local_public_ip,
             #[cfg(test)]
             bible_ingestion_override: None,
         };
@@ -329,6 +333,7 @@ impl AppState {
         let osc_bridge = OscBridge::new(&config.osc);
         let ableset_bridge = AbleSetBridge::new();
         let heartbeat_config = config.stage.heartbeat;
+        let local_public_ip = Arc::new(config.network.local_public_ip);
         let state = Self::new_with_heartbeat(
             repo,
             companion_token,
@@ -339,6 +344,7 @@ impl AppState {
             osc_bridge.clone(),
             ableset_bridge.clone(),
             heartbeat_config,
+            local_public_ip,
         );
         state.ensure_seed_library().await?;
         state.ensure_demo_playlist().await?;

--- a/crates/presenter-ui/src/api/mod.rs
+++ b/crates/presenter-ui/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod ai;
 pub mod bible;
 pub mod libraries;
 pub mod ndi;
+pub mod network;
 pub mod playlists;
 pub mod presentations;
 pub mod settings;

--- a/crates/presenter-ui/src/api/network.rs
+++ b/crates/presenter-ui/src/api/network.rs
@@ -1,0 +1,15 @@
+use serde::Deserialize;
+
+use super::{get_json, ApiError};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkModeDto {
+    pub mode: String,
+}
+
+/// Fetch `/api/network-mode`. Returns `"local"` or `"remote"` on success.
+pub async fn fetch_network_mode() -> Result<String, ApiError> {
+    let dto: NetworkModeDto = get_json("/api/network-mode").await?;
+    Ok(dto.mode)
+}

--- a/crates/presenter-ui/src/components/info_popover.rs
+++ b/crates/presenter-ui/src/components/info_popover.rs
@@ -1,0 +1,52 @@
+use leptos::prelude::*;
+
+#[component]
+pub fn InfoPopover(
+    /// "local" / "remote" / empty if not yet fetched.
+    network_mode: ReadSignal<String>,
+) -> impl IntoView {
+    let (open, set_open) = signal(false);
+
+    // Captured once at mount; these don't change during the session.
+    let version = env!("CARGO_PKG_VERSION");
+    let channel = option_env!("PRESENTER_BUILD_CHANNEL").unwrap_or("dev");
+    let hostname = web_sys::window()
+        .and_then(|w| w.location().host().ok())
+        .unwrap_or_default();
+
+    let reload = move |_| {
+        if let Some(w) = web_sys::window() {
+            let _ = w.location().reload();
+        }
+    };
+
+    view! {
+        <div class="info-popover-wrap">
+            <button
+                type="button"
+                class="info-button"
+                aria-label="Info"
+                data-role="info-button"
+                on:click=move |_| { let _ = set_open.try_update(|v| *v = !*v); }
+            >"\u{24D8}"</button>
+            <Show when=move || open.get() fallback=|| ()>
+                <div class="info-popover" data-role="info-popover">
+                    <dl>
+                        <dt>"Version"</dt>
+                        <dd>{format!("{version} ({channel})")}</dd>
+                        <dt>"Host"</dt>
+                        <dd>{hostname.clone()}</dd>
+                        <dt>"Network"</dt>
+                        <dd>{move || {
+                            let m = network_mode.get();
+                            if m == "local" { "LAN".to_string() }
+                            else if m == "remote" { "WAN".to_string() }
+                            else { "unknown".to_string() }
+                        }}</dd>
+                    </dl>
+                    <button type="button" class="info-popover__reload" on:click=reload>"Reload"</button>
+                </div>
+            </Show>
+        </div>
+    }
+}

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod header;
+pub mod info_popover;
 pub mod library_list;
 pub mod library_modal;
 pub mod modal;

--- a/crates/presenter-ui/src/pages/tablet.rs
+++ b/crates/presenter-ui/src/pages/tablet.rs
@@ -3,6 +3,7 @@ use presenter_core::{LiveEvent, TimerState, TimersOverview};
 use wasm_bindgen::JsCast;
 
 use crate::api::bible::{self, BibleSlideDto, BibleSlideMetaBible};
+use crate::components::info_popover::InfoPopover;
 use crate::state::tablet::TabletContext;
 use crate::ws::{self, WsState};
 
@@ -251,6 +252,7 @@ fn TabletTimerBar() -> impl IntoView {
                 }}
             </Show>
             <span class="tablet-timer-bar__state" data-role="timer-state">{state_label}</span>
+            <InfoPopover network_mode=network_mode />
         </div>
     }
 }

--- a/crates/presenter-ui/src/pages/tablet.rs
+++ b/crates/presenter-ui/src/pages/tablet.rs
@@ -226,10 +226,30 @@ fn TabletTimerBar() -> impl IntoView {
 
     let zone = move || ctx.timers.get().as_ref().map_or("neutral", compute_zone);
 
+    let (network_mode, set_network_mode) = leptos::prelude::signal(String::new());
+    leptos::task::spawn_local(async move {
+        if let Ok(mode) = crate::api::network::fetch_network_mode().await {
+            let _ = set_network_mode.try_set(mode);
+        }
+    });
+
     view! {
         <div class="tablet-timer-bar" data-zone=zone data-role="timer-bar">
             <span class="tablet-timer-bar__clock" data-role="timer-clock">{move || clock.get()}</span>
             <span class="tablet-timer-bar__elapsed" data-role="timer-elapsed">{elapsed_text}</span>
+            <Show when=move || !network_mode.get().is_empty() fallback=|| ()>
+                {move || {
+                    let mode = network_mode.get();
+                    let (class, label) = if mode == "local" {
+                        ("network-indicator network-indicator--local", "LAN")
+                    } else {
+                        ("network-indicator network-indicator--remote", "WAN")
+                    };
+                    view! {
+                        <span class=class data-role="network-indicator">{label}</span>
+                    }
+                }}
+            </Show>
             <span class="tablet-timer-bar__state" data-role="timer-state">{state_label}</span>
         </div>
     }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2708,3 +2708,84 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   color: var(--operator-text);
   font-size: 0.8rem;
 }
+
+/* Network mode indicator (LAN/WAN pill) */
+.network-indicator {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  margin: 0 0.35rem;
+}
+.network-indicator--local {
+  background: rgba(74, 222, 128, 0.18);
+  color: #22c55e;
+  border: 1px solid rgba(74, 222, 128, 0.4);
+}
+.network-indicator--remote {
+  background: rgba(124, 111, 255, 0.2);
+  color: #a094ff;
+  border: 1px solid rgba(124, 111, 255, 0.4);
+}
+
+/* Info button + popover */
+.info-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+.info-button {
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 50%;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.35rem;
+}
+.info-button:hover { background: rgba(148, 163, 184, 0.15); }
+.info-popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  min-width: 220px;
+  background: #1f2937;
+  color: #e5e7eb;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+  font-size: 0.85rem;
+}
+.info-popover dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 0.75rem;
+  margin: 0 0 0.5rem 0;
+}
+.info-popover dt {
+  font-weight: 600;
+  color: rgba(229, 231, 235, 0.7);
+}
+.info-popover dd { margin: 0; }
+.info-popover__reload {
+  appearance: none;
+  background: rgba(148, 163, 184, 0.15);
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+.info-popover__reload:hover { background: rgba(148, 163, 184, 0.25); }

--- a/deploy/cloudflared-config.yml.tmpl
+++ b/deploy/cloudflared-config.yml.tmpl
@@ -1,0 +1,8 @@
+tunnel: __TUNNEL_ID__
+credentials-file: /etc/cloudflared/__TUNNEL_ID__.json
+no-autoupdate: true
+
+ingress:
+  - hostname: __HOSTNAME__
+    service: http://localhost:__BACKEND_PORT__
+  - service: http_status:404

--- a/deploy/cloudflared.service
+++ b/deploy/cloudflared.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cloudflare Tunnel for presenter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/cloudflared tunnel --config /etc/cloudflared/config.yml run
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/cloudflare-tunnel-setup.md
+++ b/docs/cloudflare-tunnel-setup.md
@@ -1,0 +1,123 @@
+# Cloudflare Tunnel Setup
+
+One-off bootstrap for issue #218. Run once per instance (dev, prod, PP).
+
+The deploy workflows already contain an "Install & configure cloudflared" step that is a no-op until the operator registers the secrets and variables below. Once they exist, the next deploy activates the tunnel automatically.
+
+## Prerequisites
+
+- Cloudflare account with the `newlevel.media` zone.
+- Any machine with `cloudflared` installed to run the setup commands below. (The tunnel will run on the target machines — this is just for creation.)
+
+## Create the tunnel
+
+Install cloudflared locally if you haven't:
+
+```bash
+wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+sudo dpkg -i /tmp/cf.deb
+```
+
+Authenticate once (opens a browser):
+
+```bash
+cloudflared tunnel login
+```
+
+Create three tunnels + CNAMEs, one per instance:
+
+```bash
+cloudflared tunnel create presenter-dev
+cloudflared tunnel route dns presenter-dev presenter-dev.newlevel.media
+
+cloudflared tunnel create presenter-prod
+cloudflared tunnel route dns presenter-prod presenter.newlevel.media
+
+cloudflared tunnel create presenter-pp
+cloudflared tunnel route dns presenter-pp presenter-pp.newlevel.media
+```
+
+Each `cloudflared tunnel create` prints a Tunnel ID (UUID) and writes `~/.cloudflared/<tunnel-id>.json`. Keep both — you'll paste them into GitHub below.
+
+## Register GitHub secrets and variables
+
+For each environment in the repository (Settings → Environments → Dev / Prod / PP):
+
+**Secrets (encrypted):**
+
+| Name | Value |
+|------|-------|
+| `CLOUDFLARED_CREDS_DEV` / `_PROD` / `_PP` | Full contents of `~/.cloudflared/<tunnel-id>.json` |
+
+**Variables (plaintext):**
+
+| Name | Value |
+|------|-------|
+| `CLOUDFLARED_TUNNEL_ID_DEV` / `_PROD` / `_PP` | The Tunnel ID UUID printed by `cloudflared tunnel create` |
+| `CLOUDFLARED_HOSTNAME_DEV` / `_PROD` / `_PP` | `presenter-dev.newlevel.media` / `presenter.newlevel.media` / `presenter-pp.newlevel.media` |
+| `CLOUDFLARED_BACKEND_PORT_DEV` / `_PROD` / `_PP` | `8080` for dev, `80` for prod and PP |
+
+## Configure the church public IP
+
+The server uses `PRESENTER_LOCAL_PUBLIC_IP` to classify requests arriving via the tunnel as LAN (if the tunnel's `CF-Connecting-IP` matches this value) vs WAN (everything else).
+
+Get the church's outbound IP from any machine on the church LAN:
+
+```bash
+curl -s ifconfig.me
+```
+
+Set it in each presenter-server service's env file (e.g., `/etc/default/presenter-dev` or `/etc/systemd/system/presenter-dev.service.d/override.conf`):
+
+```
+PRESENTER_LOCAL_PUBLIC_IP=203.0.113.50
+```
+
+Restart the service. Verify from the same machine:
+
+```bash
+curl http://localhost:80/api/network-mode
+# → {"mode":"local"}
+```
+
+If `PRESENTER_LOCAL_PUBLIC_IP` is unset, the server falls back to the private-range heuristic (10.x / 172.16-31.x / 192.168.x + loopback → local). This is correct for direct LAN access but can't distinguish "on church LAN via tunnel" from "on WAN via tunnel" — both show up with a public `CF-Connecting-IP`.
+
+## Deploy + verify
+
+1. Trigger a deploy (push to dev / merge to main / create a GitHub Release for PP).
+2. The "Install & configure cloudflared" step activates the tunnel.
+3. From an external network (phone on cellular, not LAN), open `https://presenter-dev.newlevel.media` — page loads, "Add to home screen" installs the PWA as standalone.
+4. On the church LAN WiFi, reload the tablet — indicator should flip to `LAN`.
+
+## Troubleshooting
+
+**Tunnel not connecting**
+
+On the deploy target:
+
+```bash
+sudo systemctl status cloudflared
+sudo journalctl -u cloudflared -n 50
+sudo cloudflared tunnel info <tunnel-name>
+```
+
+**Wrong LAN/WAN label**
+
+Check `PRESENTER_LOCAL_PUBLIC_IP`:
+
+```bash
+systemctl show presenter-dev | grep Environment
+```
+
+The value must match what Cloudflare sees. Verify by checking `curl -s ifconfig.me` from the same machine.
+
+**Cert error in browser**
+
+The tunnel terminates HTTPS at Cloudflare's edge. If the browser shows a cert error, the request is not actually reaching Cloudflare — verify DNS. `dig presenter-dev.newlevel.media` should return a Cloudflare IP.
+
+## Notes
+
+- Tunnel credentials live at `/etc/cloudflared/<tunnel-id>.json` on each target, chmod 600, owned by root.
+- The tunnel runs as the `cloudflared.service` systemd unit and starts automatically on boot.
+- Each tunnel is tied to a single machine (one-to-one). The cross-machine tunnel-sharing setup is more complex and out of scope here.
+- Traffic is TLS end-to-end (Cloudflare ↔ cloudflared daemon ↔ localhost). No cert management in our code.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,11 +6,12 @@ All environment variables and feature flags for Presenter.
 
 ### Server
 
-| Variable           | Default                     | Description              |
-| ------------------ | --------------------------- | ------------------------ |
-| `PRESENTER_PORT`   | `80`                        | HTTP server port         |
-| `PRESENTER_DB_URL` | `sqlite://presenter_dev.db` | SQLite connection string |
-| `RUST_LOG`         | `info,tower_http=debug`     | Tracing filter           |
+| Variable                    | Default                     | Description                                                                                                                                                        |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PRESENTER_PORT`            | `80`                        | HTTP server port                                                                                                                                                   |
+| `PRESENTER_DB_URL`          | `sqlite://presenter_dev.db` | SQLite connection string                                                                                                                                           |
+| `RUST_LOG`                  | `info,tower_http=debug`     | Tracing filter                                                                                                                                                     |
+| `PRESENTER_LOCAL_PUBLIC_IP` | unset                       | Church's outbound public IP. When set, `/api/network-mode` classifies a tunnel request with matching `CF-Connecting-IP` as `local` (LAN). See `cloudflare-tunnel-setup.md`. |
 
 ### Companion Integration
 

--- a/docs/superpowers/plans/2026-04-16-pwa-via-cloudflare-tunnel.md
+++ b/docs/superpowers/plans/2026-04-16-pwa-via-cloudflare-tunnel.md
@@ -1,0 +1,1131 @@
+# PWA via Cloudflare Tunnel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve each presenter instance over HTTPS via a per-machine Cloudflare Tunnel so the tablet can install the PWA, and ship a LAN/WAN indicator pill + info popover in the tablet UI.
+
+**Architecture:** Three `cloudflared` daemons (one per instance) forward edge HTTPS → `localhost:80`. The server exposes `GET /api/network-mode` that classifies the client as local or remote from `CF-Connecting-IP` vs an operator-provided `PRESENTER_LOCAL_PUBLIC_IP`. The tablet UI adds a pill + info button based on the reaperiem pattern. No cert work in Rust, no TLS in the server, HTTP on LAN stays as-is.
+
+**Tech Stack:** Rust (axum, serde), Leptos WASM, Playwright, cloudflared (Cloudflare-managed), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-pwa-via-cloudflare-tunnel-design.md`
+
+---
+
+## Context
+
+The server already binds HTTP on `PRESENTER_PORT` (see `crates/presenter-server/src/config.rs:69-77`). `AppState::from_config` in `crates/presenter-server/src/state/mod.rs:285` wires the full config into the state. The tablet UI's `TabletTimerBar` lives in `crates/presenter-ui/src/pages/tablet.rs:194+` and currently renders `clock / elapsed / state` spans. E2E tests live under `tests/e2e/`.
+
+The reaperiem reference implementation lives at `zbynekdrlik/reaperiem`:
+- `iem-mixer/crates/iem-server/src/routes.rs:229-261` — `detect_network_mode` + `is_private_ip`
+- `iem-mixer/iem-ui/src/pages/mixer.rs:1346-1359` — network pill
+- `iem-mixer/iem-ui/style.css` — `.network-indicator.local/.remote` styles
+- `docs/cloudflare-tunnel-setup.md` — tunnel one-off setup steps
+
+**Working directory:** `/home/newlevel/devel/presenter/presenter-dev2`. **Branch:** dev.
+
+The bootstrap step (creating 3 tunnels + registering credentials as GitHub secrets) is a **one-off manual task** done by the operator once (Task 11 below). Until those secrets exist, the deploy workflow's cloudflared installation steps are no-ops — merging this PR before bootstrap is safe.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `crates/presenter-server/src/config.rs` | Add `PRESENTER_LOCAL_PUBLIC_IP` parsing in a new `NetworkConfig` section |
+| `crates/presenter-server/src/state/mod.rs` | Thread `local_public_ip: Option<String>` into `AppState` |
+| `crates/presenter-server/src/router/network_mode.rs` | **New** — `detect_network_mode`, `is_private_ip`, HTTP handler |
+| `crates/presenter-server/src/router/mod.rs` | Expose new module (likely `pub mod network_mode;`) |
+| `crates/presenter-server/src/router.rs` | Register `GET /api/network-mode` |
+| `crates/presenter-ui/src/api/network.rs` | **New** — `fetch_network_mode()` async helper |
+| `crates/presenter-ui/src/api/mod.rs` | `pub mod network;` |
+| `crates/presenter-ui/src/pages/tablet.rs` | Add network_mode signal, LAN/WAN pill, info button in TabletTimerBar |
+| `crates/presenter-ui/src/components/info_popover.rs` | **New** — reusable popover showing version/host/mode |
+| `crates/presenter-ui/src/components/mod.rs` | `pub mod info_popover;` |
+| `crates/presenter-ui/styles/operator.css` | Pill + popover CSS (tablet uses operator.css) |
+| `tests/e2e/tablet-network-indicator.spec.ts` | **New** — Playwright test |
+| `.github/workflows/pipeline.yml` | Deploy-dev adds cloudflared install step (idempotent, skip if secret missing) |
+| `.github/workflows/deploy.yml` | Deploy-prod same |
+| `.github/workflows/release.yml` | Deploy-PP same |
+| `deploy/cloudflared.service` | **New** — shared systemd unit template |
+| `deploy/cloudflared-config.yml.tmpl` | **New** — shared config template with `__HOSTNAME__` + `__PORT__` placeholders |
+| `docs/cloudflare-tunnel-setup.md` | **New** — one-off bootstrap instructions (ported + adapted from reaperiem) |
+| `docs/configuration.md` | Document `PRESENTER_LOCAL_PUBLIC_IP` |
+| `CLAUDE.md` | One-line note in the env-var table |
+
+---
+
+## Task 1: Add `PRESENTER_LOCAL_PUBLIC_IP` config
+
+**Files:**
+- Modify: `crates/presenter-server/src/config.rs`
+
+- [ ] **Step 1: Add `NetworkConfig` struct and loader**
+
+At the bottom of the struct list in `config.rs` (around line 54, after `AndroidConfig`), add:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct NetworkConfig {
+    /// The church's outbound public IP as seen by Cloudflare.
+    /// Used by `/api/network-mode` to classify tunnel clients.
+    /// Optional — falls back to private-range heuristic when unset.
+    pub local_public_ip: Option<String>,
+}
+
+impl NetworkConfig {
+    fn load() -> Self {
+        let local_public_ip = env::var("PRESENTER_LOCAL_PUBLIC_IP")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        Self { local_public_ip }
+    }
+}
+```
+
+Add `pub network: NetworkConfig,` to `ServerConfig` and wire `network: NetworkConfig::load(),` in `ServerConfig::load()`:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub http: HttpConfig,
+    pub database: DatabaseConfig,
+    pub companion: CompanionConfig,
+    pub osc: OscConfig,
+    pub stage: StageConfig,
+    #[allow(dead_code)]
+    pub android: AndroidConfig,
+    pub network: NetworkConfig,
+}
+
+impl ServerConfig {
+    pub fn load() -> Result<Self> {
+        Ok(Self {
+            http: HttpConfig::load()?,
+            database: DatabaseConfig::load(),
+            companion: CompanionConfig::load(),
+            osc: OscConfig::load(),
+            stage: StageConfig::load(),
+            android: AndroidConfig::load(),
+            network: NetworkConfig::load(),
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check -p presenter-server`
+Expected: clean. `state/mod.rs::from_config` destructures `config.database.url` etc. — we don't touch the existing fields so it still compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-server/src/config.rs
+git commit -m "feat(config): add PRESENTER_LOCAL_PUBLIC_IP for tunnel client classification (#218)"
+```
+
+---
+
+## Task 2: Thread `local_public_ip` into `AppState`
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/mod.rs`
+
+- [ ] **Step 1: Add field to `AppState`**
+
+Find the `AppState` struct definition (near the top of `state/mod.rs`). Add a field:
+
+```rust
+pub struct AppState {
+    // ...existing fields...
+    pub local_public_ip: Arc<Option<String>>,
+}
+```
+
+`Arc` is used so the state can be cheaply cloned into per-request extractors. `Arc` is already imported at the top of `state/mod.rs` via `use std::sync::Arc` (verify; if not, add it).
+
+- [ ] **Step 2: Populate it in `from_config`**
+
+In `state/mod.rs::from_config` (around line 285), after the existing body, add `local_public_ip: Arc::new(config.network.local_public_ip),` to the `Self { ... }` construction. If the state is built via a helper like `new_with_heartbeat`, add the param there too and forward it.
+
+If the construction goes through multiple layers, add a temp TODO with the exact location first (`grep -n "fn new" crates/presenter-server/src/state/mod.rs`) and keep the rename minimal.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cargo check -p presenter-server`
+Expected: clean. Existing handlers that take `State<AppState>` keep working.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-server/src/state/mod.rs
+git commit -m "feat(state): expose local_public_ip on AppState (#218)"
+```
+
+---
+
+## Task 3: `detect_network_mode` helper + unit tests (TDD)
+
+**Files:**
+- Create: `crates/presenter-server/src/router/network_mode.rs`
+- Modify: `crates/presenter-server/src/router/mod.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/presenter-server/src/router/network_mode.rs`:
+
+```rust
+//! Network-mode classifier: determines whether a client is on the church LAN
+//! (direct or via tunnel-from-same-egress) or truly remote. Used by
+//! `GET /api/network-mode` and by the tablet UI's LAN/WAN pill.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use serde::Serialize;
+
+use crate::state::AppState;
+
+/// Classifies a client from request headers. Returns `"local"` or `"remote"`.
+///
+/// Rules:
+/// - No `CF-Connecting-IP` header → direct connection, not via tunnel → `local`.
+/// - `CF-Connecting-IP` matches `local_public_ip` → same egress IP as the server,
+///   so client is on the church LAN just using the tunnel URL → `local`.
+/// - Otherwise, if `local_public_ip` is set → `remote`.
+/// - Otherwise (no configured IP) → fall back to `is_private_ip` on the client IP.
+pub fn detect_network_mode(headers: &HeaderMap, local_public_ip: Option<&str>) -> &'static str {
+    let client_ip = headers
+        .get("cf-connecting-ip")
+        .or_else(|| headers.get("x-forwarded-for"))
+        .or_else(|| headers.get("x-real-ip"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string());
+
+    match (&client_ip, local_public_ip) {
+        (Some(client), Some(local)) if client == local => "local",
+        (Some(_), Some(_)) => "remote",
+        (None, _) => "local",
+        (Some(ip), None) if is_private_ip(ip) => "local",
+        (Some(_), None) => "remote",
+    }
+}
+
+/// Return true for IPs in private/loopback/link-local ranges.
+pub fn is_private_ip(ip: &str) -> bool {
+    ip.parse::<std::net::IpAddr>().is_ok_and(|addr| match addr {
+        std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local(),
+        std::net::IpAddr::V6(v6) => v6.is_loopback(),
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct NetworkModeResponse {
+    pub mode: String,
+}
+
+pub async fn get_network_mode(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Json<NetworkModeResponse> {
+    let mode = detect_network_mode(&headers, state.local_public_ip.as_deref());
+    Json(NetworkModeResponse {
+        mode: mode.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with(name: &str, value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(name, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn no_proxy_headers_is_local() {
+        let h = HeaderMap::new();
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+        assert_eq!(detect_network_mode(&h, None), "local");
+    }
+
+    #[test]
+    fn cf_connecting_ip_matching_configured_is_local() {
+        let h = headers_with("cf-connecting-ip", "203.0.113.50");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+    }
+
+    #[test]
+    fn cf_connecting_ip_different_from_configured_is_remote() {
+        let h = headers_with("cf-connecting-ip", "198.51.100.10");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "remote");
+    }
+
+    #[test]
+    fn x_forwarded_for_falls_through_to_classification() {
+        let h = headers_with("x-forwarded-for", "203.0.113.50, 10.0.0.1");
+        assert_eq!(detect_network_mode(&h, Some("203.0.113.50")), "local");
+    }
+
+    #[test]
+    fn no_configured_ip_falls_back_to_private_range() {
+        let h = headers_with("cf-connecting-ip", "10.77.9.50");
+        assert_eq!(detect_network_mode(&h, None), "local");
+
+        let h_public = headers_with("cf-connecting-ip", "198.51.100.10");
+        assert_eq!(detect_network_mode(&h_public, None), "remote");
+    }
+
+    #[test]
+    fn is_private_ip_handles_ranges() {
+        assert!(is_private_ip("10.1.2.3"));
+        assert!(is_private_ip("192.168.0.1"));
+        assert!(is_private_ip("172.20.30.40"));
+        assert!(is_private_ip("127.0.0.1"));
+        assert!(is_private_ip("::1"));
+        assert!(!is_private_ip("8.8.8.8"));
+        assert!(!is_private_ip("203.0.113.5"));
+        assert!(!is_private_ip("not-an-ip"));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+Edit `crates/presenter-server/src/router/mod.rs`. Add `pub mod network_mode;` alongside the other `pub mod` lines.
+
+- [ ] **Step 3: Run the tests — expect PASS**
+
+Run:
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo test -p presenter-server -- network_mode --nocapture
+```
+Expected: 6 tests pass. The implementation lives in the same file so tests pass immediately (TDD "red" is implicit — without the code the file wouldn't compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-server/src/router/network_mode.rs crates/presenter-server/src/router/mod.rs
+git commit -m "feat(server): add detect_network_mode classifier with tests (#218)"
+```
+
+---
+
+## Task 4: Register `GET /api/network-mode` route
+
+**Files:**
+- Modify: `crates/presenter-server/src/router.rs`
+
+- [ ] **Step 1: Add the route**
+
+Find the router builder (`build_router` or similar). Near the Android stage routes we registered earlier (`router.rs:170-180`), add:
+
+```rust
+        .route(
+            "/api/network-mode",
+            get(router::network_mode::get_network_mode),
+        )
+```
+
+Adjust the module path to match the crate's conventions — if handlers are already imported via `integrations::...` elsewhere, use `network_mode::get_network_mode` with a `use crate::router::network_mode;` at the top.
+
+- [ ] **Step 2: Add a router-level integration test**
+
+Append to `crates/presenter-server/src/router/tests.rs`:
+
+```rust
+    #[tokio::test]
+    async fn network_mode_endpoint_returns_local_for_direct_request() {
+        let state = AppState::in_memory().await.unwrap();
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/network-mode")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mode"], "local");
+    }
+
+    #[tokio::test]
+    async fn network_mode_endpoint_returns_remote_with_foreign_cf_ip() {
+        // State without a configured local_public_ip → falls back to private-range check.
+        let state = AppState::in_memory().await.unwrap();
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/network-mode")
+                    .header("CF-Connecting-IP", "198.51.100.10")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mode"], "remote");
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p presenter-server -- network_mode --nocapture`
+Expected: all pass including the 2 new integration tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-server/src/router.rs crates/presenter-server/src/router/tests.rs
+git commit -m "feat(router): expose GET /api/network-mode (#218)"
+```
+
+---
+
+## Task 5: UI API client `fetch_network_mode`
+
+**Files:**
+- Create: `crates/presenter-ui/src/api/network.rs`
+- Modify: `crates/presenter-ui/src/api/mod.rs`
+
+- [ ] **Step 1: Create the client helper**
+
+Create `crates/presenter-ui/src/api/network.rs`:
+
+```rust
+use serde::Deserialize;
+
+use super::{get_json, ApiError};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkModeDto {
+    pub mode: String,
+}
+
+/// Fetch `/api/network-mode`. Returns `"local"` or `"remote"` on success.
+pub async fn fetch_network_mode() -> Result<String, ApiError> {
+    let dto: NetworkModeDto = get_json("/api/network-mode").await?;
+    Ok(dto.mode)
+}
+```
+
+If `get_json` or `ApiError` have different names/paths in the presenter-ui crate, adjust — grep for `pub async fn get_json` and `pub enum ApiError` (or `pub struct ApiError`) to find the actual API. The pattern should mirror `crates/presenter-ui/src/api/ndi.rs` which calls `get_json("/ndi/sources")`.
+
+- [ ] **Step 2: Register the module**
+
+Edit `crates/presenter-ui/src/api/mod.rs`. Add `pub mod network;` alongside the other `pub mod` declarations.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --lib`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/api/network.rs crates/presenter-ui/src/api/mod.rs
+git commit -m "feat(ui-api): add fetch_network_mode client helper (#218)"
+```
+
+---
+
+## Task 6: LAN/WAN pill in TabletTimerBar
+
+**Files:**
+- Modify: `crates/presenter-ui/src/pages/tablet.rs`
+
+- [ ] **Step 1: Add the signal and fetch-on-mount**
+
+Open `tablet.rs`. Inside `TabletTimerBar`'s function body (around line 194), after the existing `clock` signal and interval, add:
+
+```rust
+    let (network_mode, set_network_mode) = leptos::prelude::signal(String::new());
+    leptos::task::spawn_local(async move {
+        if let Ok(mode) = crate::api::network::fetch_network_mode().await {
+            let _ = set_network_mode.try_set(mode);
+        }
+    });
+```
+
+`spawn_local` is the existing pattern used elsewhere (e.g., `slide_list.rs:240`).
+
+- [ ] **Step 2: Render the pill**
+
+Replace the `view! { <div class="tablet-timer-bar" ... > ... </div> }` block's contents so the pill sits between the elapsed span and the state span. Use a `Show` component so the pill is hidden until the fetch returns:
+
+```rust
+    view! {
+        <div class="tablet-timer-bar" data-zone=zone data-role="timer-bar">
+            <span class="tablet-timer-bar__clock" data-role="timer-clock">{move || clock.get()}</span>
+            <span class="tablet-timer-bar__elapsed" data-role="timer-elapsed">{elapsed_text}</span>
+            <Show when=move || !network_mode.get().is_empty() fallback=|| ()>
+                {move || {
+                    let mode = network_mode.get();
+                    let (class, label) = if mode == "local" {
+                        ("network-indicator network-indicator--local", "LAN")
+                    } else {
+                        ("network-indicator network-indicator--remote", "WAN")
+                    };
+                    view! {
+                        <span class=class data-role="network-indicator">{label}</span>
+                    }
+                }}
+            </Show>
+            <span class="tablet-timer-bar__state" data-role="timer-state">{state_label}</span>
+        </div>
+    }
+```
+
+`Show` is already imported via `leptos::prelude::*` at the top of the file. If not, add `use leptos::prelude::Show;`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --lib`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/pages/tablet.rs
+git commit -m "feat(tablet): add LAN/WAN pill to timer bar (#218)"
+```
+
+---
+
+## Task 7: Info popover component + info button
+
+**Files:**
+- Create: `crates/presenter-ui/src/components/info_popover.rs`
+- Modify: `crates/presenter-ui/src/components/mod.rs`
+- Modify: `crates/presenter-ui/src/pages/tablet.rs`
+
+- [ ] **Step 1: Create the popover component**
+
+Create `crates/presenter-ui/src/components/info_popover.rs`:
+
+```rust
+use leptos::prelude::*;
+
+#[component]
+pub fn InfoPopover(
+    /// "local" / "remote" / empty if not yet fetched.
+    network_mode: Signal<String>,
+) -> impl IntoView {
+    let (open, set_open) = signal(false);
+
+    // Captured once at mount; these don't change during the session.
+    let version = env!("CARGO_PKG_VERSION");
+    let channel = option_env!("PRESENTER_BUILD_CHANNEL").unwrap_or("dev");
+    let hostname = web_sys::window()
+        .and_then(|w| w.location().host().ok())
+        .unwrap_or_default();
+
+    let reload = move |_| {
+        if let Some(w) = web_sys::window() {
+            let _ = w.location().reload();
+        }
+    };
+
+    view! {
+        <div class="info-popover-wrap">
+            <button
+                type="button"
+                class="info-button"
+                aria-label="Info"
+                data-role="info-button"
+                on:click=move |_| { let _ = set_open.try_update(|v| *v = !*v); }
+            >"\u{24D8}"</button>  // ⓘ
+            <Show when=move || open.get() fallback=|| ()>
+                <div class="info-popover" data-role="info-popover">
+                    <dl>
+                        <dt>"Version"</dt>
+                        <dd>{format!("{version} ({channel})")}</dd>
+                        <dt>"Host"</dt>
+                        <dd>{hostname.clone()}</dd>
+                        <dt>"Network"</dt>
+                        <dd>{move || {
+                            let m = network_mode.get();
+                            if m == "local" { "LAN".to_string() }
+                            else if m == "remote" { "WAN".to_string() }
+                            else { "unknown".to_string() }
+                        }}</dd>
+                    </dl>
+                    <button type="button" class="info-popover__reload" on:click=reload>"Reload"</button>
+                </div>
+            </Show>
+        </div>
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+Edit `crates/presenter-ui/src/components/mod.rs`. Add `pub mod info_popover;` alongside the others.
+
+- [ ] **Step 3: Wire the component into TabletTimerBar**
+
+In `crates/presenter-ui/src/pages/tablet.rs`, import the popover and place it inside the timer bar, AFTER the state span:
+
+```rust
+use crate::components::info_popover::InfoPopover;
+```
+
+Then inside the view, just before the closing `</div>` of `.tablet-timer-bar`:
+
+```rust
+            <InfoPopover network_mode=network_mode.into() />
+```
+
+`network_mode` is already in scope from Task 6. `.into()` converts the `ReadSignal<String>` to `Signal<String>`.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --lib`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/components/info_popover.rs crates/presenter-ui/src/components/mod.rs crates/presenter-ui/src/pages/tablet.rs
+git commit -m "feat(tablet): add info popover with version/host/mode + Reload (#218)"
+```
+
+---
+
+## Task 8: CSS for pill and popover
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/operator.css`
+
+- [ ] **Step 1: Append styles**
+
+Add to the END of `crates/presenter-ui/styles/operator.css`:
+
+```css
+/* Network mode indicator (LAN/WAN pill) */
+.network-indicator {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  margin: 0 0.35rem;
+}
+.network-indicator--local {
+  background: rgba(74, 222, 128, 0.18);
+  color: #22c55e;
+  border: 1px solid rgba(74, 222, 128, 0.4);
+}
+.network-indicator--remote {
+  background: rgba(124, 111, 255, 0.2);
+  color: #a094ff;
+  border: 1px solid rgba(124, 111, 255, 0.4);
+}
+
+/* Info button + popover */
+.info-popover-wrap {
+  position: relative;
+  display: inline-block;
+}
+.info-button {
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 50%;
+  width: 1.6rem;
+  height: 1.6rem;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.35rem;
+}
+.info-button:hover { background: rgba(148, 163, 184, 0.15); }
+.info-popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  min-width: 220px;
+  background: #1f2937;
+  color: #e5e7eb;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+  font-size: 0.85rem;
+}
+.info-popover dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 0.75rem;
+  margin: 0 0 0.5rem 0;
+}
+.info-popover dt {
+  font-weight: 600;
+  color: rgba(229, 231, 235, 0.7);
+}
+.info-popover dd { margin: 0; }
+.info-popover__reload {
+  appearance: none;
+  background: rgba(148, 163, 184, 0.15);
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+.info-popover__reload:hover { background: rgba(148, 163, 184, 0.25); }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/presenter-ui/styles/operator.css
+git commit -m "style(tablet): LAN/WAN pill + info popover styles (#218)"
+```
+
+---
+
+## Task 9: Playwright E2E test
+
+**Files:**
+- Create: `tests/e2e/tablet-network-indicator.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/e2e/tablet-network-indicator.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 60_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("tablet network indicator renders LAN for direct fetch", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await page.goto(`${baseURL}/ui/tablet`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+
+  const indicator = page.locator('[data-role="network-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 10_000 });
+  // Direct test client = no CF headers = local.
+  await expect(indicator).toHaveText("LAN");
+
+  // Info button opens popover with version and host.
+  const infoBtn = page.locator('[data-role="info-button"]');
+  await expect(infoBtn).toBeVisible();
+  await infoBtn.click();
+
+  const popover = page.locator('[data-role="info-popover"]');
+  await expect(popover).toBeVisible();
+  await expect(popover).toContainText("Version");
+  await expect(popover).toContainText("Host");
+  await expect(popover).toContainText("Network");
+  await expect(popover).toContainText("LAN");
+
+  expect(consoleMessages).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run locally (optional, if Playwright is installed)**
+
+Run: `npm run test:playwright -- tablet-network-indicator`
+Expected: test passes. If Playwright isn't set up locally, rely on CI — the spec will run via the existing `Playwright E2E` jobs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/tablet-network-indicator.spec.ts
+git commit -m "test(e2e): tablet LAN/WAN indicator + info popover (#218)"
+```
+
+---
+
+## Task 10: Deploy artifacts — `cloudflared.service` + config template
+
+**Files:**
+- Create: `deploy/cloudflared.service`
+- Create: `deploy/cloudflared-config.yml.tmpl`
+
+- [ ] **Step 1: Create the systemd unit template**
+
+Create `deploy/cloudflared.service`:
+
+```ini
+[Unit]
+Description=Cloudflare Tunnel for presenter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/cloudflared tunnel --config /etc/cloudflared/config.yml run
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 2: Create the config template**
+
+Create `deploy/cloudflared-config.yml.tmpl`:
+
+```yaml
+tunnel: __TUNNEL_ID__
+credentials-file: /etc/cloudflared/__TUNNEL_ID__.json
+no-autoupdate: true
+
+ingress:
+  - hostname: __HOSTNAME__
+    service: http://localhost:__BACKEND_PORT__
+  - service: http_status:404
+```
+
+Placeholders replaced by the deploy workflow: `__TUNNEL_ID__`, `__HOSTNAME__`, `__BACKEND_PORT__`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/cloudflared.service deploy/cloudflared-config.yml.tmpl
+git commit -m "feat(deploy): cloudflared systemd unit + config template (#218)"
+```
+
+---
+
+## Task 11: Deploy workflow — install cloudflared (all three targets)
+
+**Files:**
+- Modify: `.github/workflows/pipeline.yml` (deploy-dev)
+- Modify: `.github/workflows/deploy.yml` (deploy to prod)
+- Modify: `.github/workflows/release.yml` (deploy to PP)
+
+For each workflow, add a step that runs AFTER the existing deploy (service restart) and is conditional on the relevant secret being present.
+
+- [ ] **Step 1: Add the step to pipeline.yml (deploy-dev)**
+
+Locate the `deploy-dev` job near the end of `pipeline.yml`. After the final `systemctl start` step, add:
+
+```yaml
+      - name: Install & configure cloudflared (skipped if secret unset)
+        if: ${{ secrets.CLOUDFLARED_CREDS_DEV != '' && vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
+        env:
+          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV }}
+          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_DEV }}
+          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_DEV || '8080' }}
+        run: |
+          ssh deploy-target "set -euo pipefail
+            if ! command -v cloudflared >/dev/null 2>&1; then
+              wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+              sudo dpkg -i /tmp/cf.deb
+              rm /tmp/cf.deb
+            fi
+            sudo mkdir -p /etc/cloudflared
+            sudo tee /etc/cloudflared/config.yml >/dev/null <<'CFG'
+$(sed -e 's|__TUNNEL_ID__|'"$TUNNEL_ID"'|g' \
+      -e 's|__HOSTNAME__|'"$HOSTNAME"'|g' \
+      -e 's|__BACKEND_PORT__|'"$BACKEND_PORT"'|g' \
+      deploy/cloudflared-config.yml.tmpl)
+CFG
+          "
+          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
+          ssh deploy-target "sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service && sudo systemctl daemon-reload"
+
+          # Write credentials (short-lived in /tmp then move with sudo)
+          printf '%s' '${{ secrets.CLOUDFLARED_CREDS_DEV }}' > /tmp/cf-creds.json
+          chmod 600 /tmp/cf-creds.json
+          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
+          rm /tmp/cf-creds.json
+          ssh deploy-target "sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json && sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json && sudo chown root:root /etc/cloudflared/${TUNNEL_ID}.json"
+
+          ssh deploy-target "sudo systemctl enable --now cloudflared && sudo systemctl restart cloudflared"
+```
+
+**Note:** The heredoc with `sed` is tricky across SSH. If the one-liner proves fragile, generate the config locally first, then `scp` it to the target. The functional intent is: render `cloudflared-config.yml.tmpl` with the three env-substituted placeholders and place it at `/etc/cloudflared/config.yml` on the remote.
+
+Cleaner alternative that the implementer should use if the heredoc feels wrong:
+
+```yaml
+      - name: Install & configure cloudflared (skipped if secret unset)
+        if: ${{ secrets.CLOUDFLARED_CREDS_DEV != '' && vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
+        env:
+          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV }}
+          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_DEV }}
+          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_DEV || '8080' }}
+          CREDS: ${{ secrets.CLOUDFLARED_CREDS_DEV }}
+        run: |
+          set -euo pipefail
+          # 1. Render config.yml locally
+          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
+              -e "s|__HOSTNAME__|$HOSTNAME|g" \
+              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
+              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
+
+          # 2. Write credentials
+          printf '%s' "$CREDS" > /tmp/cf-creds.json
+          chmod 600 /tmp/cf-creds.json
+
+          # 3. Ship files
+          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
+          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
+          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
+          rm /tmp/cf-config.yml /tmp/cf-creds.json
+
+          # 4. Install + activate
+          ssh deploy-target "set -euo pipefail
+            if ! command -v cloudflared >/dev/null 2>&1; then
+              wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+              sudo dpkg -i /tmp/cf.deb
+              rm /tmp/cf.deb
+            fi
+            sudo mkdir -p /etc/cloudflared
+            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
+            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
+            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
+            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --now cloudflared
+            sudo systemctl restart cloudflared
+          "
+```
+
+Use the cleaner version. The `if:` guard means the step is a no-op until secrets are set.
+
+- [ ] **Step 2: Add the same step to deploy.yml (prod)**
+
+Same step, but with `CLOUDFLARED_CREDS_PROD`, `CLOUDFLARED_TUNNEL_ID_PROD`, `CLOUDFLARED_HOSTNAME_PROD`, `CLOUDFLARED_BACKEND_PORT_PROD` (default `80`). Append after the prod deploy's service restart.
+
+- [ ] **Step 3: Add the same step to release.yml (PP)**
+
+Same step, but with `CLOUDFLARED_CREDS_PP`, `CLOUDFLARED_TUNNEL_ID_PP`, `CLOUDFLARED_HOSTNAME_PP`, `CLOUDFLARED_BACKEND_PORT_PP` (default `80`). Append after the release's service restart.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/pipeline.yml .github/workflows/deploy.yml .github/workflows/release.yml
+git commit -m "ci: install + configure cloudflared on each deploy target (#218)"
+```
+
+---
+
+## Task 12: Bootstrap documentation
+
+**Files:**
+- Create: `docs/cloudflare-tunnel-setup.md`
+- Modify: `docs/configuration.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Write the bootstrap doc**
+
+Create `docs/cloudflare-tunnel-setup.md`:
+
+```markdown
+# Cloudflare Tunnel Setup
+
+One-off bootstrap for #218. Run once per instance (dev, prod, PP).
+
+## Prerequisites
+
+- Cloudflare account with `newlevel.media` zone.
+- Access to the target machine (SSH) to run `cloudflared tunnel login` **OR** use the Cloudflare dashboard.
+
+## Create the tunnel
+
+From any machine with cloudflared installed (or using the dashboard):
+
+```bash
+cloudflared tunnel login                          # opens browser, downloads cert.pem to ~/.cloudflared/
+cloudflared tunnel create presenter-dev           # prints a Tunnel ID (UUID) and writes <id>.json to ~/.cloudflared/
+cloudflared tunnel route dns presenter-dev presenter-dev.newlevel.media
+```
+
+Repeat for `presenter-prod` → `presenter.newlevel.media` and `presenter-pp` → `presenter-pp.newlevel.media`.
+
+## Register GitHub secrets and variables
+
+Per environment (Dev / Prod / PP) in **Settings → Environments → \<env\> → Add secret/variable**:
+
+**Secrets (encrypted):**
+- `CLOUDFLARED_CREDS_DEV` / `_PROD` / `_PP` — full contents of the `<tunnel-id>.json` file from `~/.cloudflared/`.
+
+**Variables (plaintext):**
+- `CLOUDFLARED_TUNNEL_ID_DEV` / `_PROD` / `_PP` — the Tunnel ID UUID.
+- `CLOUDFLARED_HOSTNAME_DEV` / `_PROD` / `_PP` — e.g., `presenter-dev.newlevel.media`.
+- `CLOUDFLARED_BACKEND_PORT_DEV` / `_PROD` / `_PP` — `8080` for dev, `80` for prod/PP.
+
+## Configure the church public IP
+
+Get it from any machine on the church LAN:
+
+```bash
+curl -s ifconfig.me
+```
+
+Set on each presenter-server install via the service env file (e.g., `/etc/default/presenter-dev`):
+
+```
+PRESENTER_LOCAL_PUBLIC_IP=203.0.113.50
+```
+
+Restart the service. Verify via `curl http://localhost:80/api/network-mode` (expect `{"mode":"local"}` from the same machine).
+
+## Verify
+
+1. Trigger a deploy. The new `Install & configure cloudflared` step activates the tunnel.
+2. On a phone over cellular, open `https://presenter-dev.newlevel.media` → page loads → "Add to home screen" installs as PWA.
+3. Tablet shows `WAN` pill (different public IP). On LAN WiFi, tablet shows `LAN` pill.
+```
+
+- [ ] **Step 2: Update docs/configuration.md**
+
+Add an entry for `PRESENTER_LOCAL_PUBLIC_IP` in the existing env var table. Find the table (it likely exists; grep for `PRESENTER_PORT` or `PRESENTER_DB_URL` to locate it):
+
+```markdown
+| `PRESENTER_LOCAL_PUBLIC_IP` | unset | Optional public IP of the church LAN's outbound gateway. Enables `LAN` vs `WAN` classification when traffic arrives via Cloudflare Tunnel. |
+```
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+In the env var table in `CLAUDE.md`, add:
+
+```markdown
+| `PRESENTER_LOCAL_PUBLIC_IP`   | unset                   | Church's public egress IP for LAN/WAN detection via Cloudflare Tunnel |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/cloudflare-tunnel-setup.md docs/configuration.md CLAUDE.md
+git commit -m "docs: cloudflare tunnel bootstrap + PRESENTER_LOCAL_PUBLIC_IP env (#218)"
+```
+
+---
+
+## Task 13: Version bump, fmt/clippy, push, monitor CI
+
+- [ ] **Step 1: Bump workspace version**
+
+Edit `Cargo.toml`:
+```
+[workspace.package]
+version = "0.4.25"
+```
+(or the next patch beyond whatever is on dev).
+
+Run `cargo check -p presenter-server` to refresh `Cargo.lock`.
+
+- [ ] **Step 2: Local checks**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test --workspace
+```
+
+Fix anything that surfaces.
+
+- [ ] **Step 3: Commit + push**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version for PWA via Cloudflare Tunnel (#218)"
+git push origin dev
+```
+
+- [ ] **Step 4: Monitor CI**
+
+```bash
+gh run list --branch dev --limit 3
+gh run view <pipeline-id>
+```
+
+Expected flow:
+- Format / Clippy / Test / Playwright E2E all pass
+- Deploy to Dev runs as usual
+- New cloudflared step is a no-op because secrets aren't set yet (by design)
+
+On a fully-green pipeline, open PR to `main`.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| `detect_network_mode` handles all 5 cases | `cargo test -p presenter-server -- network_mode` — 6 tests pass |
+| `GET /api/network-mode` returns JSON | router integration test (Task 4) |
+| Tablet pill renders | Playwright test (Task 9) |
+| Info popover shows version/host/mode | Playwright test (Task 9) |
+| CI green | all jobs succeed on dev |
+| Deploy step is no-op without secrets | Deploy logs show "Install & configure cloudflared" as skipped |
+| PWA installs after tunnel bootstrap | Manual on tablet — `https://presenter-pp.newlevel.media/ui/tablet` → Add to home screen → opens standalone |
+
+
+---
+
+## Self-Review Notes
+
+1. **Spec coverage:** All 10 spec bullet points have tasks — detect_network_mode (T3), endpoint (T4), env var (T1+T2), tablet pill (T6), info popover (T7), CSS (T8), E2E (T9), deploy (T10+T11), bootstrap docs (T12), version+CI (T13). ✓
+2. **Placeholder scan:** No "TBD"/"implement later". One intentional hedge in Task 11 ("If the heredoc proves fragile...") — kept because the cleaner alternative is also fully specified right there. ✓
+3. **Type consistency:** `detect_network_mode(&HeaderMap, Option<&str>) -> &'static str` used everywhere. `fetch_network_mode() -> Result<String, ApiError>` consistent between Task 5 and Task 6. `NetworkConfig::local_public_ip: Option<String>` consistent across Tasks 1-3. ✓

--- a/docs/superpowers/specs/2026-04-16-pwa-via-cloudflare-tunnel-design.md
+++ b/docs/superpowers/specs/2026-04-16-pwa-via-cloudflare-tunnel-design.md
@@ -1,0 +1,213 @@
+# PWA via Cloudflare Tunnel Design (#218, closes #221)
+
+**Status:** Proposed
+**Date:** 2026-04-16
+**Issues:** #218 (HTTPS for PWA), #221 (tablet PWA install — timer part already verified working)
+
+## Problem
+
+Chrome Android refuses to install a PWA over plain HTTP on a non-localhost origin. The current deploy serves presenter over HTTP on LAN IPs (`10.77.9.205`, `10.77.8.134`, companion-pp via Tailscale). "Add to home screen" creates a browser-tabbed shortcut, not a standalone PWA — the symptom reported on the tablet in #221.
+
+Rather than manage HTTPS certs ourselves, wrap each instance in a **Cloudflare Tunnel** that terminates HTTPS at Cloudflare's edge and forwards plaintext HTTP to `localhost`. This mirrors the working pattern in [`zbynekdrlik/reaperiem/docs/cloudflare-tunnel-setup.md`](https://github.com/zbynekdrlik/reaperiem/blob/main/docs/cloudflare-tunnel-setup.md).
+
+## Goals
+
+- `https://presenter.newlevel.media` (prod), `https://presenter-dev.newlevel.media`, `https://presenter-pp.newlevel.media` all serve the app via Cloudflare-managed HTTPS.
+- Tablet can install as standalone PWA from the HTTPS URL.
+- Existing LAN HTTP URLs keep working — operators on LAN continue to use `http://presenter.lan` at LAN latency.
+- UI shows whether the current client is on LAN or WAN (the reaperiem pattern), plus a small info popover with version + hostname + mode.
+
+## Non-goals
+
+- TLS in the Rust server itself. We do not bind 443 in `presenter-server`.
+- HTTPS on port 443 via Let's Encrypt. Tunnel does the cert work.
+- HTTP → HTTPS redirects. Both URLs coexist.
+- LAN/WAN indicator in the operator UI (scope kept to the tablet PWA target; operator can get it later).
+- Auto-detecting the church's public IP. Operator provides it via env var.
+
+## Architecture
+
+```
+[tablet on WiFi]  https://presenter-pp.newlevel.media
+                                  │
+                                  ▼
+                   Cloudflare edge (HTTPS termination)
+                                  │
+                                  ▼  (persistent outbound from host)
+                   cloudflared daemon on companion-pp.lan
+                                  │
+                                  ▼
+                   http://localhost:80 (presenter-server, unchanged)
+
+[operator on LAN]  http://presenter.lan           (unchanged, no tunnel)
+                   → presenter-server direct
+```
+
+### Cloudflare Tunnel per instance
+
+Three tunnels, one per machine, each with its own credentials JSON:
+
+| tunnel name       | hostname                         | host                  | backend             |
+|-------------------|----------------------------------|-----------------------|---------------------|
+| `presenter-prod`  | `presenter.newlevel.media`       | `presenter.lan` (10.77.9.205) | `http://localhost:80`   |
+| `presenter-dev`   | `presenter-dev.newlevel.media`   | `10.77.8.134`         | `http://localhost:8080` |
+| `presenter-pp`    | `presenter-pp.newlevel.media`    | `companion-pp.lan`    | `http://localhost:80`   |
+
+Each host runs `cloudflared.service` (systemd) with:
+
+```yaml
+# /etc/cloudflared/config.yml
+tunnel: <tunnel-id>
+credentials-file: /etc/cloudflared/<tunnel-id>.json
+no-autoupdate: true
+
+ingress:
+  - hostname: presenter-pp.newlevel.media
+    service: http://localhost:80
+  - service: http_status:404
+```
+
+The credentials JSON is per-tunnel and contains the tunnel secret. Stored as GitHub Actions secret per environment, written to `/etc/cloudflared/` by the deploy workflow with `chmod 600`.
+
+### DNS
+
+`cloudflared tunnel route dns <tunnel> <hostname>` creates a CNAME in Cloudflare pointing `presenter-pp.newlevel.media` at the tunnel's `<tunnel-id>.cfargotunnel.com`. We do this once per tunnel during setup.
+
+Because traffic routes through Cloudflare edge, these are proxied (orange-cloud) by design — no `grey-cloud / DNS-only` flag needed. RFC1918 private IPs are not involved; the tunnel is the public face.
+
+### Server-side: `detect_network_mode`
+
+Port the reaperiem pattern almost verbatim (`iem-mixer/crates/iem-server/src/routes.rs:229-261`) into `crates/presenter-server/src/router/network_mode.rs`:
+
+```rust
+pub fn detect_network_mode(
+    headers: &HeaderMap,
+    local_public_ip: &Option<String>,
+) -> &'static str {
+    let client_ip = headers.get("cf-connecting-ip")
+        .or_else(|| headers.get("x-forwarded-for"))
+        .or_else(|| headers.get("x-real-ip"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string());
+
+    match (&client_ip, local_public_ip) {
+        (Some(client), Some(local)) if client == local => "local",
+        (Some(_), Some(_)) => "remote",
+        (None, _) => "local",                                // direct LAN
+        (Some(ip), None) if is_private_ip(&ip) => "local",  // private range fallback
+        (Some(_), None) => "remote",
+    }
+}
+```
+
+**Rule summary:**
+- No `CF-Connecting-IP` header → direct LAN connection → `local`.
+- `CF-Connecting-IP` matches `PRESENTER_LOCAL_PUBLIC_IP` → client is on the same egress as the server → `local`.
+- Anything else → `remote`.
+
+Fallback (when `PRESENTER_LOCAL_PUBLIC_IP` isn't set) uses `IpAddr::is_private`/`is_loopback` so the check still works in dev environments.
+
+**Exposure:** `GET /api/network-mode` returning `{"mode": "local" | "remote"}`. Tablet UI calls it on mount.
+
+### Config
+
+New env var in `presenter-server`:
+- `PRESENTER_LOCAL_PUBLIC_IP`: the church's outbound public IP (e.g., `203.0.113.50`). Optional; falls back to private-range detection.
+
+Documented in `CLAUDE.md` and `docs/configuration.md`.
+
+### Tablet UI changes
+
+Add to the tablet timer bar component (`crates/presenter-ui/src/pages/tablet.rs` `TabletTimerBar`):
+
+1. **LAN/WAN pill** next to the existing clock / elapsed / state spans. One signal, updated once on mount via `GET /api/network-mode`. Two classes: `.network-indicator--local` (accent color) and `.network-indicator--remote` (different color).
+2. **Info button** (`ⓘ`) — small button next to the pill that opens a lightweight popover showing:
+   - Version (`env!("CARGO_PKG_VERSION")` available via `presenter-core`)
+   - Build channel (`dev` / `release`)
+   - Hostname (`window.location.hostname`)
+   - Network mode (duplicate of pill, useful in the popover for clarity)
+   - A button labelled "Reload" that does `location.reload()` (service worker drops cache)
+3. **PWA manifest:** no change. `start_url` is already relative (`/ui/tablet`), so installing from `https://presenter-pp.newlevel.media/ui/tablet` captures the correct origin into the installed PWA.
+
+### Deploy workflow changes
+
+New `install-cloudflared` step in each deploy job (dev, prod, PP), idempotent:
+
+```bash
+if ! command -v cloudflared &>/dev/null; then
+  wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
+  sudo dpkg -i /tmp/cf.deb
+  rm /tmp/cf.deb
+fi
+```
+
+Then write `/etc/cloudflared/config.yml` + credentials (from `CLOUDFLARED_CREDS_DEV` / `_PROD` / `_PP` secrets), create `/etc/systemd/system/cloudflared.service` if missing, `systemctl enable --now cloudflared`.
+
+The credentials JSON must NOT be committed. Stored in GitHub Environment Secrets, written at deploy time, `chmod 600`. Companion-pp currently uses the Tailscale `/etc/hosts` override — unchanged by this work.
+
+### Tunnel creation (one-time, manual)
+
+Before the first deploy can succeed, we:
+1. Create the three tunnels via `cloudflared tunnel create presenter-prod` etc. on any machine with Cloudflare auth cookie.
+2. Copy each resulting `<tunnel-id>.json` into the appropriate GitHub Environment Secret.
+3. Run `cloudflared tunnel route dns <name> <hostname>` once per tunnel to create the Cloudflare CNAME.
+
+The plan step for this is documented but not automated — this is a bootstrap one-off, tracked in a separate "one-time setup" task.
+
+## Data Flow
+
+```
+Tablet mount (/ui/tablet)
+  ↓
+fetch("/api/network-mode")  → server reads CF-Connecting-IP vs PRESENTER_LOCAL_PUBLIC_IP
+  ↓
+{ "mode": "local" | "remote" }
+  ↓
+Leptos signal network_mode
+  ↓
+LAN/WAN pill + info popover render reactively
+```
+
+## Error Handling
+
+- `cloudflared` can't reach Cloudflare → app still works on LAN via HTTP; HTTPS URL returns Cloudflare's "tunnel offline" page. Not a code bug.
+- `/api/network-mode` fetch fails on the tablet → pill just doesn't render (`Show when=!mode.is_empty()`), like reaperiem.
+- `PRESENTER_LOCAL_PUBLIC_IP` misconfigured → classifier falls back to private-range heuristic. Incorrect classification is cosmetic (wrong pill label), nothing breaks.
+- Credentials JSON missing at deploy time → deploy fails loudly; `cloudflared` refuses to start without them. No silent degraded state.
+
+## Testing
+
+- **Unit**: `detect_network_mode` — 6 tests covering the match arms (Some/Some match, Some/Some mismatch, None/_, Some/None private, Some/None public, IPv6 loopback).
+- **Unit**: `is_private_ip` — 4 tests (10.x, 192.168.x, 127.0.0.1, public IP).
+- **HTTP**: `GET /api/network-mode` returns JSON for both `local` and `remote` simulated header sets.
+- **E2E (Playwright)**: load `/ui/tablet`, assert `[data-role="network-indicator"]` is visible with either `LAN` or `WAN` text. Assert clicking `[data-role="info-button"]` reveals a popover with the version number.
+- **Manual**: tablet on 4G (different public IP from church) hits `https://presenter-pp.newlevel.media/ui/tablet`, sees `WAN` pill; PWA install option appears and works.
+- **Manual**: tablet on church WiFi hits `https://presenter-pp.newlevel.media/ui/tablet`, sees `LAN` pill (because CF-Connecting-IP matches church public IP).
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `crates/presenter-server/src/router/network_mode.rs` | **New** — `detect_network_mode`, `is_private_ip`, handler |
+| `crates/presenter-server/src/router.rs` | Register `GET /api/network-mode` |
+| `crates/presenter-server/src/config.rs` | Read `PRESENTER_LOCAL_PUBLIC_IP` env var |
+| `crates/presenter-server/src/state/mod.rs` | Expose `local_public_ip` on AppState |
+| `crates/presenter-ui/src/pages/tablet.rs` | Add network_mode signal + pill + info button |
+| `crates/presenter-ui/src/components/info_popover.rs` | **New** — reusable popover |
+| `crates/presenter-ui/src/api/mod.rs` (or similar) | `fetch_network_mode()` helper |
+| `crates/presenter-ui/styles/tablet.css` (and parent) | Pill + popover styles |
+| `.github/workflows/deploy.yml`, `pipeline.yml`, `release.yml` | Install cloudflared, write config + credentials |
+| `deploy/cloudflared-config.yml.tmpl` | **New** — template rendered by deploy |
+| `deploy/cloudflared.service` | **New** — systemd unit |
+| `docs/architecture.md`, `CLAUDE.md` | Note tunnel setup + env var |
+
+## Open Questions
+
+None at spec time. One bootstrap step (tunnel creation + secret registration) documented but not automated; tracked as a task item in the plan.
+
+## Future Work (out of scope)
+
+- Operator UI version/mode indicator (nice-to-have; operator is always on LAN).
+- Automatic public-IP detection via STUN so the env var isn't needed.
+- Multi-origin auth tokens (tunnel + direct LAN don't currently share session cookies — not an issue because session state is DB-backed, but worth noting).
+- Single shared tunnel with per-hostname ingress rules (vs 3 separate tunnels). Simpler to scale at the cost of tighter coupling across environments.

--- a/tests/e2e/tablet-network-indicator.spec.ts
+++ b/tests/e2e/tablet-network-indicator.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl, config.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+test("tablet network indicator renders LAN for direct fetch", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  // Wait for server readiness
+  await expect(async () => {
+    const response = await request.get(
+      new URL("/healthz", baseURL).toString(),
+      { timeout: 120_000 },
+    );
+    expect(response.ok()).toBeTruthy();
+  }).toPass({ timeout: 180_000 });
+
+  await page.goto(new URL("/ui/tablet", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  // Network indicator pill should be visible with "LAN" text.
+  // Test server has no CF headers and client is loopback → local (private-range fallback).
+  const indicator = page.locator('[data-role="network-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 10_000 });
+  await expect(indicator).toHaveText("LAN");
+
+  // Info button opens the info popover.
+  const infoBtn = page.locator('[data-role="info-button"]');
+  await expect(infoBtn).toBeVisible({ timeout: 5_000 });
+  await infoBtn.click();
+
+  const popover = page.locator('[data-role="info-popover"]');
+  await expect(popover).toBeVisible({ timeout: 5_000 });
+  await expect(popover).toContainText("Version");
+  await expect(popover).toContainText("Host");
+  await expect(popover).toContainText("Network");
+  await expect(popover).toContainText("LAN");
+
+  // Must have zero console errors/warnings throughout.
+  expect(consoleMessages).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- **Cloudflare Tunnel per instance** serves each presenter at `https://presenter{-dev,-pp,}.newlevel.media` so Chrome on Android accepts the origin as HTTPS and "Add to home screen" installs a real PWA (fixes the tablet symptom from #221).
- **No cert work in Rust.** `cloudflared` daemons forward edge HTTPS → localhost:80. LAN HTTP URLs keep working for low-latency operator use.
- **New `GET /api/network-mode`** classifies clients as `local` or `remote` via `CF-Connecting-IP` vs operator-provided `PRESENTER_LOCAL_PUBLIC_IP` (with a private-range fallback when unset).
- **LAN/WAN pill + ⓘ info popover** in the tablet timer bar, mirroring the pattern from `zbynekdrlik/reaperiem`.
- Deploy workflows install+configure cloudflared idempotently, gated on `vars.CLOUDFLARED_*` so the PR merges safely **before** the one-off Cloudflare bootstrap.

Closes #218. Unblocks the PWA symptom of #221.

## Test plan

- [x] Unit: 6 `detect_network_mode` tests + `is_private_ip` — covers private/public/loopback/v6, CF-IP match/mismatch, no-header direct
- [x] Router integration: 2 tests for `/api/network-mode` — direct → local, foreign CF-IP → remote
- [x] Playwright E2E: `tablet-network-indicator.spec.ts` asserts LAN pill + info popover + console clean
- [x] CI green on dev pipeline (24504876175)
- [x] Functional: `curl http://10.77.8.134:8080/api/network-mode` returns `{"mode":"local"}` — dev at `v0.4.25`
- [x] `actionlint` clean across all three workflows
- [ ] One-off: operator creates 3 tunnels + registers GitHub secrets/vars per `docs/cloudflare-tunnel-setup.md` — once that's done the next deploy activates tunnels and the tablet can install as PWA

## Follow-ups after merge

After this PR merges:
1. Operator runs `cloudflared tunnel login`, creates 3 tunnels (`presenter-dev`, `presenter-prod`, `presenter-pp`), runs `cloudflared tunnel route dns` for each.
2. Register `CLOUDFLARED_CREDS_*` secrets + `CLOUDFLARED_TUNNEL_ID_*` / `CLOUDFLARED_HOSTNAME_*` / `CLOUDFLARED_BACKEND_PORT_*` variables in GitHub Environment settings.
3. Set `PRESENTER_LOCAL_PUBLIC_IP` on each presenter-server install (get via `curl ifconfig.me` from church LAN).
4. Next deploy auto-activates tunnels → tablet installs PWA from `https://presenter-pp.newlevel.media/ui/tablet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)