### PR TITLE
feat: auto-detect public IP + shorter tunnel URLs + Rust 1.95 clippy fixes (#218)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -348,48 +348,20 @@ jobs:
       - name: Install & configure cloudflared (skipped if vars unset)
         if: ${{ vars.CLOUDFLARED_TUNNEL_ID_PROD != '' && vars.CLOUDFLARED_HOSTNAME_PROD != '' }}
         env:
-          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PROD }}
-          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PROD }}
-          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_PROD || '80' }}
-          CREDS: ${{ secrets.CLOUDFLARED_CREDS_PROD }}
+          TUNNEL_TOKEN: ${{ secrets.CLOUDFLARED_CREDS_PROD }}
         run: |
           set -euo pipefail
-
-          # 1. Render config.yml locally from the template
-          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
-              -e "s|__HOSTNAME__|$HOSTNAME|g" \
-              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
-              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
-
-          # 2. Write credentials JSON (short-lived). Fail loudly if the
-          # matching secret isn't set — vars without creds can't work.
-          if [ -z "$CREDS" ]; then
-            echo "::error::CLOUDFLARED_CREDS_PROD secret is empty but CLOUDFLARED_TUNNEL_ID_PROD / _HOSTNAME_PROD vars are set. Register the credentials JSON in repo settings."
+          if [ -z "$TUNNEL_TOKEN" ]; then
+            echo "::error::CLOUDFLARED_CREDS_PROD secret is empty. Register the tunnel token in repo settings."
             exit 1
           fi
-          printf '%s' "$CREDS" > /tmp/cf-creds.json
-          chmod 600 /tmp/cf-creds.json
-
-          # 3. Ship files to target
-          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
-          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
-          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
-          rm /tmp/cf-config.yml /tmp/cf-creds.json
-
-          # 4. Install + activate on target
           ssh deploy-target "set -euo pipefail
             if ! command -v cloudflared >/dev/null 2>&1; then
               wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
               sudo dpkg -i /tmp/cf.deb
               rm /tmp/cf.deb
             fi
-            sudo mkdir -p /etc/cloudflared
-            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
-            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
-            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
-            sudo systemctl daemon-reload
+            sudo cloudflared service uninstall 2>/dev/null || true
+            sudo cloudflared service install ${TUNNEL_TOKEN}
             sudo systemctl enable --now cloudflared
-            sudo systemctl restart cloudflared
           "

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -960,50 +960,22 @@ jobs:
       - name: Install & configure cloudflared (skipped if vars unset)
         if: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV != '' && vars.CLOUDFLARED_HOSTNAME_DEV != '' }}
         env:
-          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_DEV }}
-          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_DEV }}
-          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_DEV || '8080' }}
-          CREDS: ${{ secrets.CLOUDFLARED_CREDS_DEV }}
+          TUNNEL_TOKEN: ${{ secrets.CLOUDFLARED_CREDS_DEV }}
         run: |
           set -euo pipefail
-
-          # 1. Render config.yml locally from the template
-          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
-              -e "s|__HOSTNAME__|$HOSTNAME|g" \
-              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
-              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
-
-          # 2. Write credentials JSON (short-lived). Fail loudly if the
-          # matching secret isn't set — vars without creds can't work.
-          if [ -z "$CREDS" ]; then
-            echo "::error::CLOUDFLARED_CREDS_DEV secret is empty but CLOUDFLARED_TUNNEL_ID_DEV / _HOSTNAME_DEV vars are set. Register the credentials JSON in repo settings."
+          if [ -z "$TUNNEL_TOKEN" ]; then
+            echo "::error::CLOUDFLARED_CREDS_DEV secret is empty. Register the tunnel token in repo settings."
             exit 1
           fi
-          printf '%s' "$CREDS" > /tmp/cf-creds.json
-          chmod 600 /tmp/cf-creds.json
-
-          # 3. Ship files to target
-          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
-          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
-          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
-          rm /tmp/cf-config.yml /tmp/cf-creds.json
-
-          # 4. Install + activate on target
           ssh deploy-target "set -euo pipefail
             if ! command -v cloudflared >/dev/null 2>&1; then
               wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
               sudo dpkg -i /tmp/cf.deb
               rm /tmp/cf.deb
             fi
-            sudo mkdir -p /etc/cloudflared
-            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
-            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
-            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
-            sudo systemctl daemon-reload
+            sudo cloudflared service uninstall 2>/dev/null || true
+            sudo cloudflared service install ${TUNNEL_TOKEN}
             sudo systemctl enable --now cloudflared
-            sudo systemctl restart cloudflared
           "
 
   # ============================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,48 +309,20 @@ jobs:
       - name: Install & configure cloudflared (skipped if vars unset)
         if: ${{ vars.CLOUDFLARED_TUNNEL_ID_PP != '' && vars.CLOUDFLARED_HOSTNAME_PP != '' }}
         env:
-          TUNNEL_ID: ${{ vars.CLOUDFLARED_TUNNEL_ID_PP }}
-          HOSTNAME: ${{ vars.CLOUDFLARED_HOSTNAME_PP }}
-          BACKEND_PORT: ${{ vars.CLOUDFLARED_BACKEND_PORT_PP || '80' }}
-          CREDS: ${{ secrets.CLOUDFLARED_CREDS_PP }}
+          TUNNEL_TOKEN: ${{ secrets.CLOUDFLARED_CREDS_PP }}
         run: |
           set -euo pipefail
-
-          # 1. Render config.yml locally from the template
-          sed -e "s|__TUNNEL_ID__|$TUNNEL_ID|g" \
-              -e "s|__HOSTNAME__|$HOSTNAME|g" \
-              -e "s|__BACKEND_PORT__|$BACKEND_PORT|g" \
-              deploy/cloudflared-config.yml.tmpl > /tmp/cf-config.yml
-
-          # 2. Write credentials JSON (short-lived). Fail loudly if the
-          # matching secret isn't set — vars without creds can't work.
-          if [ -z "$CREDS" ]; then
-            echo "::error::CLOUDFLARED_CREDS_PP secret is empty but CLOUDFLARED_TUNNEL_ID_PP / _HOSTNAME_PP vars are set. Register the credentials JSON in repo settings."
+          if [ -z "$TUNNEL_TOKEN" ]; then
+            echo "::error::CLOUDFLARED_CREDS_PP secret is empty. Register the tunnel token in repo settings."
             exit 1
           fi
-          printf '%s' "$CREDS" > /tmp/cf-creds.json
-          chmod 600 /tmp/cf-creds.json
-
-          # 3. Ship files to target
-          scp /tmp/cf-config.yml deploy-target:/tmp/cf-config.yml
-          scp /tmp/cf-creds.json deploy-target:/tmp/cf-creds.json
-          scp deploy/cloudflared.service deploy-target:/tmp/cloudflared.service
-          rm /tmp/cf-config.yml /tmp/cf-creds.json
-
-          # 4. Install + activate on target
           ssh deploy-target "set -euo pipefail
             if ! command -v cloudflared >/dev/null 2>&1; then
               wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -O /tmp/cf.deb
               sudo dpkg -i /tmp/cf.deb
               rm /tmp/cf.deb
             fi
-            sudo mkdir -p /etc/cloudflared
-            sudo mv /tmp/cf-config.yml /etc/cloudflared/config.yml
-            sudo mv /tmp/cf-creds.json /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chown root:root /etc/cloudflared/config.yml /etc/cloudflared/${TUNNEL_ID}.json
-            sudo chmod 600 /etc/cloudflared/${TUNNEL_ID}.json
-            sudo mv /tmp/cloudflared.service /etc/systemd/system/cloudflared.service
-            sudo systemctl daemon-reload
+            sudo cloudflared service uninstall 2>/dev/null || true
+            sudo cloudflared service install ${TUNNEL_TOKEN}
             sudo systemctl enable --now cloudflared
-            sudo systemctl restart cloudflared
           "

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "axum",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/library.rs
+++ b/crates/presenter-core/src/library.rs
@@ -74,8 +74,7 @@ impl Library {
 
     pub fn add_presentation(&mut self, presentation: Presentation) -> Result<(), LibraryError> {
         self.presentations.push(presentation);
-        self.presentations
-            .sort_by_key(|p| p.name.to_lowercase());
+        self.presentations.sort_by_key(|p| p.name.to_lowercase());
         Ok(())
     }
 

--- a/crates/presenter-core/src/library.rs
+++ b/crates/presenter-core/src/library.rs
@@ -75,7 +75,7 @@ impl Library {
     pub fn add_presentation(&mut self, presentation: Presentation) -> Result<(), LibraryError> {
         self.presentations.push(presentation);
         self.presentations
-            .sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+            .sort_by_key(|p| p.name.to_lowercase());
         Ok(())
     }
 

--- a/crates/presenter-server/src/resolume/clip_map.rs
+++ b/crates/presenter-server/src/resolume/clip_map.rs
@@ -177,21 +177,13 @@ fn parse_clip_destinations(
         }
         "#bibleclear" => ClipKind::BibleClear,
         "#timer" => ClipKind::Timer,
-        "#song" => {
-            if tokens.get(index) == Some(&"name") {
-                index += 1;
-                ClipKind::SongName
-            } else {
-                return result;
-            }
+        "#song" if tokens.get(index) == Some(&"name") => {
+            index += 1;
+            ClipKind::SongName
         }
-        "#band" => {
-            if tokens.get(index) == Some(&"name") {
-                index += 1;
-                ClipKind::BandName
-            } else {
-                return result;
-            }
+        "#band" if tokens.get(index) == Some(&"name") => {
+            index += 1;
+            ClipKind::BandName
         }
         _ => return result,
     };
@@ -319,15 +311,13 @@ fn parse_transforms(tokens: &[&str]) -> Vec<TextTransform> {
     let mut transforms = Vec::new();
     for token in tokens {
         match *token {
-            "u" | "upper" => {
-                if !transforms.contains(&TextTransform::Uppercase) {
-                    transforms.push(TextTransform::Uppercase);
-                }
+            "u" | "upper" if !transforms.contains(&TextTransform::Uppercase) => {
+                transforms.push(TextTransform::Uppercase);
             }
-            "re" | "noenter" | "singleline" => {
-                if !transforms.contains(&TextTransform::RemoveLineBreaks) {
-                    transforms.push(TextTransform::RemoveLineBreaks);
-                }
+            "re" | "noenter" | "singleline"
+                if !transforms.contains(&TextTransform::RemoveLineBreaks) =>
+            {
+                transforms.push(TextTransform::RemoveLineBreaks);
             }
             _ => {}
         }

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -334,7 +334,7 @@ impl AppState {
         let ableset_bridge = AbleSetBridge::new();
         let heartbeat_config = config.stage.heartbeat;
         let local_public_ip = Arc::new(config.network.local_public_ip);
-        let state = Self::new_with_heartbeat(
+        let mut state = Self::new_with_heartbeat(
             repo,
             companion_token,
             companion_enabled,
@@ -369,6 +369,23 @@ impl AppState {
                 Ok(None) => {}
                 Err(err) => {
                     tracing::warn!(?err, "failed to query active video source on startup");
+                }
+            }
+        }
+
+        // Auto-detect public IP for LAN/WAN classification via Cloudflare Tunnel.
+        // Only runs if PRESENTER_LOCAL_PUBLIC_IP is not set (the env var is an
+        // optional override, not a requirement). Mirrors the reaperiem pattern.
+        if state.local_public_ip.is_none() {
+            match detect_public_ip().await {
+                Some(ip) => {
+                    tracing::info!(ip = %ip, "auto-detected public IP for LAN/WAN detection");
+                    state.local_public_ip = Arc::new(Some(ip));
+                }
+                None => {
+                    tracing::warn!(
+                        "could not auto-detect public IP; LAN/WAN detection will use private IP fallback"
+                    );
                 }
             }
         }
@@ -793,4 +810,34 @@ impl AppState {
         }
         Ok(())
     }
+}
+
+/// Auto-detect the server's public IP by querying external services.
+/// Tries multiple providers for reliability. Returns `None` if all fail
+/// (e.g., no internet on startup — LAN/WAN detection falls back to the
+/// private-range heuristic in that case).
+async fn detect_public_ip() -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .ok()?;
+    let services = [
+        "https://api.ipify.org",
+        "https://ifconfig.me/ip",
+        "https://icanhazip.com",
+    ];
+    for url in services {
+        match client.get(url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                if let Ok(ip) = resp.text().await {
+                    let ip = ip.trim().to_string();
+                    if !ip.is_empty() && ip.len() < 46 {
+                        return Some(ip);
+                    }
+                }
+            }
+            _ => continue,
+        }
+    }
+    None
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.19"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/cloudflare-tunnel-setup.md
+++ b/docs/cloudflare-tunnel-setup.md
@@ -57,30 +57,13 @@ For each environment in the repository (Settings → Environments → Dev / Prod
 | `CLOUDFLARED_HOSTNAME_DEV` / `_PROD` / `_PP` | `presenter-dev.newlevel.media` / `presenter.newlevel.media` / `presenter-pp.newlevel.media` |
 | `CLOUDFLARED_BACKEND_PORT_DEV` / `_PROD` / `_PP` | `8080` for dev, `80` for prod and PP |
 
-## Configure the church public IP
+## Public IP detection (automatic)
 
-The server uses `PRESENTER_LOCAL_PUBLIC_IP` to classify requests arriving via the tunnel as LAN (if the tunnel's `CF-Connecting-IP` matches this value) vs WAN (everything else).
+The server auto-detects its public IP at startup by querying `api.ipify.org` / `ifconfig.me` / `icanhazip.com` (tries all three for reliability). This is used to classify tunnel requests as LAN vs WAN: if `CF-Connecting-IP` matches the detected IP, the client is on the same network as the server.
 
-Get the church's outbound IP from any machine on the church LAN:
+**No manual configuration needed.** Works with dynamic IPs. If all three services are unreachable (no internet at startup), the server falls back to a private-range heuristic.
 
-```bash
-curl -s ifconfig.me
-```
-
-Set it in each presenter-server service's env file (e.g., `/etc/default/presenter-dev` or `/etc/systemd/system/presenter-dev.service.d/override.conf`):
-
-```
-PRESENTER_LOCAL_PUBLIC_IP=203.0.113.50
-```
-
-Restart the service. Verify from the same machine:
-
-```bash
-curl http://localhost:80/api/network-mode
-# → {"mode":"local"}
-```
-
-If `PRESENTER_LOCAL_PUBLIC_IP` is unset, the server falls back to the private-range heuristic (10.x / 172.16-31.x / 192.168.x + loopback → local). This is correct for direct LAN access but can't distinguish "on church LAN via tunnel" from "on WAN via tunnel" — both show up with a public `CF-Connecting-IP`.
+Optional override: set `PRESENTER_LOCAL_PUBLIC_IP` in the service env to force a specific IP instead of auto-detecting. This is only useful if auto-detection fails or you want to pin it for testing.
 
 ## Deploy + verify
 


### PR DESCRIPTION
## Summary

Follow-up to PR #248 (PWA via Cloudflare Tunnel):

- **Auto-detect public IP at startup** — queries `api.ipify.org` / `ifconfig.me` / `icanhazip.com` on boot (reaperiem pattern). No static IP env var needed, works with dynamic ISP IPs. `PRESENTER_LOCAL_PUBLIC_IP` kept as optional override only.
- **Shorter tunnel hostnames** — `prdev.newlevel.media`, `prsnv.newlevel.media`, `prpp.newlevel.media` (easy to type on mobile).
- **Simplified deploy step** — uses `cloudflared service install <token>` (remotely-managed tunnels) instead of config files + credentials JSON. Ingress rules managed via Cloudflare API.
- **Rust 1.95 clippy fixes** — `sort_by` → `sort_by_key`, `collapsible_match` guards in `clip_map.rs`.
- **Tunnel bootstrap done** — 3 tunnels created, DNS CNAMEs set, GitHub secrets+vars registered. `https://prdev.newlevel.media` verified live.

## Verified

- `https://prdev.newlevel.media/healthz` → `{"channel":"dev","status":"ok","version":"0.4.26"}`
- `/api/network-mode` via tunnel → `{"mode":"local"}` (auto-detected IP matches)
- CI green on pipeline 24632865674

🤖 Generated with [Claude Code](https://claude.com/claude-code)