### PR TITLE
feat(stage): worship-pp baseline + 5 rounds of polish + companion-pp deploy migration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1041,10 +1041,13 @@ jobs:
       - name: Deploy to companion-pp.lan
         run: |
           MODULE_DIR="/opt/companion/v4.1/modules/presenter"
-          echo "Deploying Companion plugin to companion-pp.lan..."
-          ssh companion-pp "mkdir -p $MODULE_DIR"
-          scp -r ops/companion/presenter/* companion-pp:$MODULE_DIR/
-          ssh companion-pp "cd $MODULE_DIR && npm install --omit=dev"
+          STAGE_DIR=$(ssh companion-pp "mktemp -d /tmp/companion-module-XXXXXX")
+          echo "Deploying Companion plugin to companion-pp.lan (staging: $STAGE_DIR)..."
+          scp -r ops/companion/presenter/* companion-pp:$STAGE_DIR/
+          ssh companion-pp "cd $STAGE_DIR && npm install --omit=dev"
+          # Stage-then-sudo-move so we don't need write access to /opt/companion
+          # as the SSH user. Mirrors the companion-snv step above.
+          ssh companion-pp "sudo rm -rf $MODULE_DIR && sudo mkdir -p $(dirname $MODULE_DIR) && sudo mv $STAGE_DIR $MODULE_DIR"
           echo "Restarting Companion on PP..."
           ssh companion-pp "docker restart companion"
           sleep 10

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1040,18 +1040,19 @@ jobs:
 
       - name: Deploy to companion-pp.lan
         run: |
-          MODULE_DIR="/opt/companion/v4.1/modules/presenter"
+          # companion-pp now runs the CompanionPi (Raspberry-Pi-style) build,
+          # not Docker. Modules go in --extra-module-path /opt/companion-module-dev,
+          # service is the systemd unit "companion", run as user "companion".
+          MODULE_DIR="/opt/companion-module-dev/presenter"
           STAGE_DIR=$(ssh companion-pp "mktemp -d /tmp/companion-module-XXXXXX")
           echo "Deploying Companion plugin to companion-pp.lan (staging: $STAGE_DIR)..."
           scp -r ops/companion/presenter/* companion-pp:$STAGE_DIR/
           ssh companion-pp "cd $STAGE_DIR && npm install --omit=dev"
-          # Stage-then-sudo-move so we don't need write access to /opt/companion
-          # as the SSH user. Mirrors the companion-snv step above.
-          ssh companion-pp "sudo rm -rf $MODULE_DIR && sudo mkdir -p $(dirname $MODULE_DIR) && sudo mv $STAGE_DIR $MODULE_DIR"
+          ssh companion-pp "sudo rm -rf $MODULE_DIR && sudo mkdir -p $(dirname $MODULE_DIR) && sudo mv $STAGE_DIR $MODULE_DIR && sudo chown -R companion:companion $MODULE_DIR"
           echo "Restarting Companion on PP..."
-          ssh companion-pp "docker restart companion"
-          sleep 10
-          ssh companion-pp "docker exec companion curl -sf http://127.0.0.1:8000 > /dev/null" || { echo "::error::Companion failed to restart on PP"; exit 1; }
+          ssh companion-pp "sudo systemctl restart companion"
+          sleep 5
+          ssh companion-pp "systemctl is-active companion" || { echo "::error::Companion failed to restart on PP"; exit 1; }
           echo "Companion plugin deployed to companion-pp.lan"
 
       - name: Show deployment info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.40"
+version = "0.4.41"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.37"
+version = "0.4.38"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.41"
+version = "0.4.42"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.42"
+version = "0.4.43"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.39"
+version = "0.4.40"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.35"
+version = "0.4.36"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.36"
+version = "0.4.37"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.38"
+version = "0.4.39"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/playlist.rs
+++ b/crates/presenter-core/src/playlist.rs
@@ -46,6 +46,11 @@ pub enum PlaylistEntryKind {
         presentation_id: PresentationId,
         #[serde(skip_serializing_if = "Option::is_none")]
         midi_binding: Option<MidiBinding>,
+        /// Display name resolved by the server when serializing the playlist
+        /// for the client. Stored as None internally; populated only on the
+        /// response path. See `enrich_playlist_with_names` in the server.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        presentation_name: Option<String>,
     },
     Separator {
         name: String,
@@ -126,6 +131,70 @@ impl Playlist {
 }
 
 #[cfg(test)]
+mod presentation_name_tests {
+    use super::*;
+    use crate::id::{PlaylistEntryId, PresentationId};
+
+    #[test]
+    fn presentation_entry_round_trips_presentation_name() {
+        let id = PlaylistEntryId::new();
+        let pres_id = PresentationId::new();
+        let entry = PlaylistEntry {
+            id,
+            kind: PlaylistEntryKind::Presentation {
+                presentation_id: pres_id,
+                midi_binding: None,
+                presentation_name: Some("My Song".to_string()),
+            },
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        // serde serializes struct variant fields with the rename_all from the enum,
+        // but flattening means field names come through as snake_case
+        assert!(
+            json.contains("\"presentation_name\":\"My Song\""),
+            "expected presentation_name field in JSON; got: {json}"
+        );
+        let parsed: PlaylistEntry = serde_json::from_str(&json).expect("deserialize");
+        match parsed.kind {
+            PlaylistEntryKind::Presentation {
+                presentation_name, ..
+            } => assert_eq!(presentation_name.as_deref(), Some("My Song")),
+            _ => panic!("expected Presentation"),
+        }
+    }
+
+    #[test]
+    fn presentation_entry_omits_name_when_none() {
+        let entry = PlaylistEntry {
+            id: PlaylistEntryId::new(),
+            kind: PlaylistEntryKind::Presentation {
+                presentation_id: PresentationId::new(),
+                midi_binding: None,
+                presentation_name: None,
+            },
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("presentation_name"),
+            "None should be skip_serializing_if; got: {json}"
+        );
+    }
+
+    #[test]
+    fn deserializing_legacy_payload_without_name_works() {
+        // Fields use snake_case (serde flatten with tagged enum preserves snake_case)
+        let json = r#"{"id":"00000000-0000-0000-0000-000000000001","type":"presentation","presentation_id":"00000000-0000-0000-0000-000000000002"}"#;
+        let parsed: PlaylistEntry = serde_json::from_str(json).expect("deserialize");
+        match parsed.kind {
+            PlaylistEntryKind::Presentation {
+                presentation_name, ..
+            } => assert_eq!(presentation_name, None),
+            _ => panic!("expected Presentation"),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::id::PresentationId;
@@ -158,6 +227,7 @@ mod tests {
                 kind: PlaylistEntryKind::Presentation {
                     presentation_id,
                     midi_binding: Some(MidiBinding::new(1).unwrap()),
+                    presentation_name: None,
                 },
             },
             PlaylistEntry {
@@ -165,6 +235,7 @@ mod tests {
                 kind: PlaylistEntryKind::Presentation {
                     presentation_id: PresentationId::new(),
                     midi_binding: Some(MidiBinding::new(1).unwrap()),
+                    presentation_name: None,
                 },
             },
         ];
@@ -183,6 +254,7 @@ mod tests {
                     kind: PlaylistEntryKind::Presentation {
                         presentation_id: first,
                         midi_binding: Some(MidiBinding::new(10).unwrap()),
+                        presentation_name: None,
                     },
                 },
                 PlaylistEntry {
@@ -190,6 +262,7 @@ mod tests {
                     kind: PlaylistEntryKind::Presentation {
                         presentation_id: PresentationId::new(),
                         midi_binding: None,
+                        presentation_name: None,
                     },
                 },
             ],

--- a/crates/presenter-core/src/tests.rs
+++ b/crates/presenter-core/src/tests.rs
@@ -36,6 +36,7 @@ fn library_and_playlist_share_ids_without_collision() {
                 kind: PlaylistEntryKind::Presentation {
                     presentation_id: first_presentation.id,
                     midi_binding: Some(crate::playlist::MidiBinding::new(1).unwrap()),
+                    presentation_name: None,
                 },
             },
             PlaylistEntry {
@@ -43,6 +44,7 @@ fn library_and_playlist_share_ids_without_collision() {
                 kind: PlaylistEntryKind::Presentation {
                     presentation_id: second_presentation.id,
                     midi_binding: Some(crate::playlist::MidiBinding::new(2).unwrap()),
+                    presentation_name: None,
                 },
             },
         ],

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -161,6 +161,7 @@ impl Repository {
                 PlaylistEntryKind::Presentation {
                     presentation_id,
                     midi_binding,
+                    ..
                 } => (
                     "presentation".to_string(),
                     Some(presentation_id.to_string()),

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -220,16 +220,32 @@ impl Repository {
         &self,
         playlist: &Playlist,
     ) -> anyhow::Result<HashMap<PresentationId, String>> {
-        let ids: Vec<String> = playlist
-            .entries
-            .iter()
-            .filter_map(|entry| match &entry.kind {
-                PlaylistEntryKind::Presentation {
+        self.fetch_presentation_names_for_playlists(std::slice::from_ref(playlist))
+            .await
+    }
+
+    /// Batched variant: collect all presentation_ids across the given
+    /// playlists and fetch their names in a single query. Used by the
+    /// list-playlists response path so we don't issue N queries for N
+    /// playlists.
+    #[instrument(skip_all)]
+    pub async fn fetch_presentation_names_for_playlists(
+        &self,
+        playlists: &[Playlist],
+    ) -> anyhow::Result<HashMap<PresentationId, String>> {
+        let mut ids: Vec<String> = Vec::new();
+        for playlist in playlists {
+            for entry in &playlist.entries {
+                if let PlaylistEntryKind::Presentation {
                     presentation_id, ..
-                } => Some(presentation_id.to_string()),
-                _ => None,
-            })
-            .collect();
+                } = &entry.kind
+                {
+                    ids.push(presentation_id.to_string());
+                }
+            }
+        }
+        ids.sort();
+        ids.dedup();
         if ids.is_empty() {
             return Ok(HashMap::new());
         }

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -340,6 +340,7 @@ async fn playlist_round_trip_with_separator() {
             kind: PlaylistEntryKind::Presentation {
                 presentation_id: presentation.id,
                 midi_binding: None,
+                presentation_name: None,
             },
         },
     ];

--- a/crates/presenter-persistence/src/repository/util.rs
+++ b/crates/presenter-persistence/src/repository/util.rs
@@ -106,6 +106,7 @@ pub(super) fn to_domain_playlist_entry(
             PlaylistEntryKind::Presentation {
                 presentation_id,
                 midi_binding,
+                presentation_name: None,
             }
         }
         other => return Err(RepositoryError::UnknownPlaylistEntryType(other.to_string())),

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -113,7 +113,9 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route(
             "/playlists/{id}",
-            patch(playlists::update_playlist).delete(playlists::delete_playlist),
+            get(playlists::get_playlist)
+                .patch(playlists::update_playlist)
+                .delete(playlists::delete_playlist),
         )
         .route(
             "/playlists/{id}/entries",

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -77,6 +77,18 @@ pub(super) async fn create_playlist(
 }
 
 #[instrument(skip_all)]
+pub(super) async fn get_playlist(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Playlist>, AppError> {
+    let playlist = state
+        .get_playlist(PlaylistId::from_uuid(id))
+        .await?
+        .ok_or_else(|| AppError::not_found("playlist not found"))?;
+    Ok(Json(playlist))
+}
+
+#[instrument(skip_all)]
 pub(super) async fn update_playlist(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -153,6 +153,7 @@ pub(super) async fn replace_playlist_entries(
                     kind: PlaylistEntryKind::Presentation {
                         presentation_id: PresentationId::from_uuid(presentation_id),
                         midi_binding: binding,
+                        presentation_name: None,
                     },
                 })
             }

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -58,7 +58,8 @@ pub(super) async fn list_playlists(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<Playlist>>, AppError> {
     let playlists = state.playlists().await?;
-    Ok(Json(playlists))
+    let enriched = state.enrich_playlists_with_names(playlists).await?;
+    Ok(Json(enriched))
 }
 
 #[instrument(skip_all)]
@@ -73,7 +74,9 @@ pub(super) async fn create_playlist(
     let playlist = state
         .create_playlist(name, payload.show_in_dashboard)
         .await?;
-    Ok(Json(playlist))
+    // Just-created has no entries, but enrich for response shape consistency.
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
 }
 
 #[instrument(skip_all)]
@@ -85,7 +88,8 @@ pub(super) async fn get_playlist(
         .get_playlist(PlaylistId::from_uuid(id))
         .await?
         .ok_or_else(|| AppError::not_found("playlist not found"))?;
-    Ok(Json(playlist))
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
 }
 
 #[instrument(skip_all)]
@@ -113,8 +117,8 @@ pub(super) async fn update_playlist(
         .into_iter()
         .find(|playlist| playlist.id == playlist_id)
         .ok_or_else(|| AppError::not_found("playlist not found"))?;
-
-    Ok(Json(updated))
+    let enriched = state.enrich_playlist_with_names(updated).await?;
+    Ok(Json(enriched))
 }
 
 #[instrument(skip_all)]
@@ -179,5 +183,6 @@ pub(super) async fn replace_playlist_entries(
     let playlist = state
         .replace_playlist_entries(PlaylistId::from_uuid(id), entries)
         .await?;
-    Ok(Json(playlist))
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
 }

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -1756,6 +1756,69 @@ fn mock_ingestion() -> std::sync::Arc<dyn crate::state::TestBibleIngestion + Sen
     std::sync::Arc::new(Mock)
 }
 
+#[tokio::test]
+async fn get_playlist_returns_playlist_when_present() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+
+    // Create a playlist
+    let create_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/playlists")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"GET test","showInDashboard":false}"#.to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_bytes = axum::body::to_bytes(create_resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&create_bytes).unwrap();
+    let id = created["id"].as_str().unwrap().to_string();
+
+    // GET it back
+    let get_resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/playlists/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_resp.status(), StatusCode::OK);
+    let get_bytes = axum::body::to_bytes(get_resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let fetched: serde_json::Value = serde_json::from_slice(&get_bytes).unwrap();
+    assert_eq!(fetched["id"].as_str().unwrap(), id);
+    assert_eq!(fetched["name"].as_str().unwrap(), "GET test");
+}
+
+#[tokio::test]
+async fn get_playlist_returns_404_when_missing() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/playlists/00000000-0000-0000-0000-000000000000")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
 #[test]
 fn update_playlist_request_defaults_flags() {
     let payload: UpdatePlaylistRequest = serde_json::from_str(r"{}").expect("deserialises");

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -15,8 +15,9 @@ use crate::router::libraries::CreateLibraryPresentationResponse;
 use crate::router::playlists::UpdatePlaylistRequest;
 use crate::router::presentations::PresentationDetailDto;
 use crate::router::stage::StageLayoutResponse;
-use presenter_core::Playlist;
+use presenter_core::playlist::PlaylistEntryKind;
 use presenter_core::TimersOverview;
+use presenter_core::{Playlist, PlaylistEntry, PlaylistEntryId};
 use presenter_core::{StageDisplayLayout, StageDisplaySnapshot};
 
 #[derive(Debug, Deserialize)]
@@ -1870,4 +1871,110 @@ async fn network_mode_endpoint_returns_remote_with_foreign_cf_ip() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["mode"], "remote");
+}
+
+#[tokio::test]
+async fn get_playlist_response_includes_presentation_name() {
+    let state = AppState::in_memory().await.unwrap();
+    // Seed: create one library + presentation
+    let library = state
+        .create_library("Test Library")
+        .await
+        .expect("create library");
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "My Song", None)
+        .await
+        .expect("create presentation");
+    // Create playlist with that presentation as an entry
+    let playlist = state
+        .create_playlist("Test Playlist", true)
+        .await
+        .expect("create playlist");
+    let entries = vec![PlaylistEntry {
+        id: PlaylistEntryId::new(),
+        kind: PlaylistEntryKind::Presentation {
+            presentation_id: presentation.id,
+            midi_binding: None,
+            presentation_name: None,
+        },
+    }];
+    state
+        .replace_playlist_entries(playlist.id, entries)
+        .await
+        .expect("replace entries");
+
+    let app = build_router(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/playlists/{}", playlist.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let entry = &body["entries"][0];
+    assert_eq!(entry["type"], "presentation");
+    assert_eq!(
+        entry["presentation_name"], "My Song",
+        "presentation_name must be present in playlist GET response"
+    );
+}
+
+#[tokio::test]
+async fn list_playlists_response_includes_presentation_names() {
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library("Lib").await.unwrap();
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "Track One", None)
+        .await
+        .unwrap();
+    let playlist = state.create_playlist("PL", true).await.unwrap();
+    state
+        .replace_playlist_entries(
+            playlist.id,
+            vec![PlaylistEntry {
+                id: PlaylistEntryId::new(),
+                kind: PlaylistEntryKind::Presentation {
+                    presentation_id: presentation.id,
+                    midi_binding: None,
+                    presentation_name: None,
+                },
+            }],
+        )
+        .await
+        .unwrap();
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/playlists")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let pl = body
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|pl| pl["name"] == "PL")
+        .expect("playlist named PL must be present");
+    assert_eq!(
+        pl["entries"][0]["presentation_name"], "Track One",
+        "presentation_name must be present in list response"
+    );
 }

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -190,6 +190,7 @@ impl AppState {
                 kind: PlaylistEntryKind::Presentation {
                     presentation_id: presentation.id,
                     midi_binding: None,
+                    presentation_name: None,
                 },
             })
             .collect();

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -110,6 +110,40 @@ impl AppState {
         self.repository.fetch_playlist_by_id(playlist_id).await
     }
 
+    /// Populate `presentation_name` on each `PlaylistEntryKind::Presentation`
+    /// entry. Idempotent — overwrites whatever was there.
+    pub async fn enrich_playlist_with_names(
+        &self,
+        mut playlist: presenter_core::Playlist,
+    ) -> anyhow::Result<presenter_core::Playlist> {
+        let names = self
+            .repository
+            .fetch_presentation_names_for_playlist(&playlist)
+            .await?;
+        for entry in playlist.entries.iter_mut() {
+            if let presenter_core::playlist::PlaylistEntryKind::Presentation {
+                presentation_id,
+                presentation_name,
+                ..
+            } = &mut entry.kind
+            {
+                *presentation_name = names.get(presentation_id).cloned();
+            }
+        }
+        Ok(playlist)
+    }
+
+    pub async fn enrich_playlists_with_names(
+        &self,
+        playlists: Vec<presenter_core::Playlist>,
+    ) -> anyhow::Result<Vec<presenter_core::Playlist>> {
+        let mut out = Vec::with_capacity(playlists.len());
+        for pl in playlists {
+            out.push(self.enrich_playlist_with_names(pl).await?);
+        }
+        Ok(out)
+    }
+
     pub async fn create_playlist(
         &self,
         name: &str,

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -133,15 +133,32 @@ impl AppState {
         Ok(playlist)
     }
 
+    /// Batched enrichment for the list-playlists response path. Collects
+    /// all presentation_ids across the given playlists and fetches their
+    /// names in a single DB query, then maps them back into each entry —
+    /// avoids the N+1 queries that the trivial loop-with-`enrich_playlist_with_names`
+    /// would do.
     pub async fn enrich_playlists_with_names(
         &self,
-        playlists: Vec<presenter_core::Playlist>,
+        mut playlists: Vec<presenter_core::Playlist>,
     ) -> anyhow::Result<Vec<presenter_core::Playlist>> {
-        let mut out = Vec::with_capacity(playlists.len());
-        for pl in playlists {
-            out.push(self.enrich_playlist_with_names(pl).await?);
+        let names = self
+            .repository
+            .fetch_presentation_names_for_playlists(&playlists)
+            .await?;
+        for playlist in playlists.iter_mut() {
+            for entry in playlist.entries.iter_mut() {
+                if let presenter_core::playlist::PlaylistEntryKind::Presentation {
+                    presentation_id,
+                    presentation_name,
+                    ..
+                } = &mut entry.kind
+                {
+                    *presentation_name = names.get(presentation_id).cloned();
+                }
+            }
         }
-        Ok(out)
+        Ok(playlists)
     }
 
     pub async fn create_playlist(

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -106,10 +106,7 @@ impl AppState {
         self.repository.list_playlists().await
     }
 
-    pub async fn get_playlist(
-        &self,
-        playlist_id: PlaylistId,
-    ) -> anyhow::Result<Option<Playlist>> {
+    pub async fn get_playlist(&self, playlist_id: PlaylistId) -> anyhow::Result<Option<Playlist>> {
         self.repository.fetch_playlist_by_id(playlist_id).await
     }
 

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -106,6 +106,13 @@ impl AppState {
         self.repository.list_playlists().await
     }
 
+    pub async fn get_playlist(
+        &self,
+        playlist_id: PlaylistId,
+    ) -> anyhow::Result<Option<Playlist>> {
+        self.repository.fetch_playlist_by_id(playlist_id).await
+    }
+
     pub async fn create_playlist(
         &self,
         name: &str,

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.33"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/api/playlists.rs
+++ b/crates/presenter-ui/src/api/playlists.rs
@@ -63,15 +63,16 @@ struct UpdateEntriesRequest {
 }
 
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum PlaylistEntryPayload {
     Presentation {
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "entryId")]
         entry_id: Option<String>,
+        #[serde(rename = "presentationId")]
         presentation_id: String,
     },
     Separator {
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "entryId")]
         entry_id: Option<String>,
         name: String,
     },
@@ -99,4 +100,68 @@ pub async fn add_presentation_to_playlist(
         presentation_id: presentation_id.to_string(),
     });
     replace_entries(playlist_id, entries).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presentation_entry_serializes_camelcase_fields() {
+        // Regression guard: serde's `rename_all = "camelCase"` on internally
+        // tagged enums (`tag = "type"`) does NOT rename inner-struct fields,
+        // only variant names. Without explicit `rename = "presentationId"`
+        // attributes, the WASM client sent `presentation_id` (snake_case)
+        // and the server rejected it with 422. Drag-drop into a playlist
+        // silently no-oped as a result.
+        let payload = PlaylistEntryPayload::Presentation {
+            entry_id: None,
+            presentation_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert!(
+            json.contains("\"presentationId\""),
+            "expected camelCase field; got: {json}"
+        );
+        assert!(
+            !json.contains("\"presentation_id\""),
+            "snake_case field leaked through: {json}"
+        );
+        assert!(
+            json.contains("\"type\":\"presentation\""),
+            "tag should be lowercase variant: {json}"
+        );
+    }
+
+    #[test]
+    fn presentation_entry_with_existing_id_renames_entry_id() {
+        let payload = PlaylistEntryPayload::Presentation {
+            entry_id: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()),
+            presentation_id: "00000000-0000-0000-0000-000000000002".to_string(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert!(
+            json.contains("\"entryId\""),
+            "expected camelCase entryId; got: {json}"
+        );
+        assert!(
+            !json.contains("\"entry_id\""),
+            "snake_case entry_id leaked through: {json}"
+        );
+    }
+
+    #[test]
+    fn separator_entry_serializes_with_renamed_entry_id() {
+        let payload = PlaylistEntryPayload::Separator {
+            entry_id: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()),
+            name: "section".to_string(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert!(json.contains("\"entryId\""), "got: {json}");
+        assert!(!json.contains("\"entry_id\""), "got: {json}");
+        assert!(
+            json.contains("\"type\":\"separator\""),
+            "tag should be lowercase variant: {json}"
+        );
+    }
 }

--- a/crates/presenter-ui/src/components/playlist_list.rs
+++ b/crates/presenter-ui/src/components/playlist_list.rs
@@ -135,7 +135,8 @@ pub fn PlaylistList() -> impl IntoView {
                                         class="operator__list-item operator__list-row"
                                         data-playlist-id=id_for_row
                                         on:dragover=move |ev: web_sys::DragEvent| {
-                                            // Accept presentation drops
+                                            // Accept presentation drops (from library list, presentation list,
+                                            // or global search results).
                                             if let Some(dt) = ev.data_transfer() {
                                                 let types = dt.types();
                                                 let accepts = (0..types.length())
@@ -145,6 +146,13 @@ pub fn PlaylistList() -> impl IntoView {
                                                     });
                                                 if accepts {
                                                     ev.prevent_default();
+                                                    // Search results dragstart with effectAllowed="copy".
+                                                    // Chromium silently rejects the drop unless dropEffect
+                                                    // matches — without this, dragging from
+                                                    // [data-role="search-result-item"] visually drags but
+                                                    // never adds an entry. "copy" is also valid for the
+                                                    // existing presentation-row drag (effectAllowed="move").
+                                                    dt.set_drop_effect("copy");
                                                     if let Some(target) = ev.target() {
                                                         if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                                             let _ = el.closest(".operator__list-item")

--- a/crates/presenter-ui/src/components/presentation_list.rs
+++ b/crates/presenter-ui/src/components/presentation_list.rs
@@ -72,8 +72,6 @@ pub fn PresentationList() -> impl IntoView {
                 let playlist_id = ctx.selected_playlist_id.get_untracked().unwrap_or_default();
                 let selected_playlist = ctx.selected_playlist;
                 let playlists = ctx.playlists;
-                // Capture signal OUTSIDE async block
-                let presentations_signal = ctx.presentations;
                 leptos::task::spawn_local(async move {
                     // Build current entries + new separator
                     let current = selected_playlist.get_untracked();
@@ -110,8 +108,6 @@ pub fn PresentationList() -> impl IntoView {
                         crate::api::playlists::replace_entries(&playlist_id, entries).await
                     {
                         selected_playlist.set(Some(updated.clone()));
-                        // Refresh presentation list from playlist entries using captured signal
-                        rebuild_playlist_presentations_with_signal(presentations_signal, &updated);
                     }
                     if let Ok(pls) = crate::api::playlists::list_playlists().await {
                         playlists.set(pls);
@@ -213,7 +209,6 @@ pub fn PresentationList() -> impl IntoView {
                                                     let playlist_id = playlist_id_reorder.clone();
                                                     let selected_playlist = ctx.selected_playlist;
                                                     let playlists = ctx.playlists;
-                                                    let presentations = ctx.presentations;
                                                     move |ev: web_sys::DragEvent| {
                                                         ev.prevent_default();
                                                         if let Some(dragged_id) = get_dragging_entry() {
@@ -232,7 +227,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                         entries.insert(to, item);
                                                                         if let Ok(updated) = crate::api::playlists::replace_entries(&playlist_id, entries).await {
                                                                             selected_playlist.set(Some(updated.clone()));
-                                                                            rebuild_playlist_presentations_with_signal(presentations, &updated);
                                                                         }
                                                                         if let Ok(pls) = crate::api::playlists::list_playlists().await {
                                                                             playlists.set(pls);
@@ -269,7 +263,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                     // Capture signals OUTSIDE async block
                                                                     let selected_playlist = ctx.selected_playlist;
                                                                     let playlists = ctx.playlists;
-                                                                    let presentations = ctx.presentations;
                                                                     leptos::task::spawn_local(async move {
                                                                         let current = selected_playlist.get_untracked();
                                                                         if let Some(pl) = current {
@@ -285,7 +278,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                             }).collect();
                                                                             if let Ok(updated) = crate::api::playlists::replace_entries(&pl_id, entries).await {
                                                                                 selected_playlist.set(Some(updated.clone()));
-                                                                                rebuild_playlist_presentations_with_signal(presentations, &updated);
                                                                             }
                                                                             if let Ok(pls) = crate::api::playlists::list_playlists().await {
                                                                                 playlists.set(pls);
@@ -308,7 +300,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                     // Capture signals OUTSIDE async block
                                                                     let selected_playlist = ctx.selected_playlist;
                                                                     let playlists = ctx.playlists;
-                                                                    let presentations = ctx.presentations;
                                                                     leptos::task::spawn_local(async move {
                                                                         let current = selected_playlist.get_untracked();
                                                                         if let Some(pl) = current {
@@ -318,7 +309,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                                 .collect();
                                                                             if let Ok(updated) = crate::api::playlists::replace_entries(&pl_id, entries).await {
                                                                                 selected_playlist.set(Some(updated.clone()));
-                                                                                rebuild_playlist_presentations_with_signal(presentations, &updated);
                                                                             }
                                                                             if let Ok(pls) = crate::api::playlists::list_playlists().await {
                                                                                 playlists.set(pls);
@@ -348,12 +338,14 @@ pub fn PresentationList() -> impl IntoView {
                                         let entry_id_drop = entry_id.clone();
                                         let playlist_id_reorder = ctx.selected_playlist_id.get_untracked().unwrap_or_default();
 
-                                        // Look up presentation name from presentations list or index
-                                        let presentations = ctx.presentations.get();
-                                        let pres_name = presentations.iter()
-                                            .find(|p| p.id.to_string() == id)
-                                            .map(|p| p.name.clone())
-                                            .unwrap_or_default();
+                                        // Read presentation name directly from the playlist entry
+                                        // (server enriches it via fetch_presentation_names_for_playlist).
+                                        let pres_name = match &entry.kind {
+                                            presenter_core::playlist::PlaylistEntryKind::Presentation {
+                                                presentation_name, ..
+                                            } => presentation_name.clone().unwrap_or_default(),
+                                            _ => String::new(),
+                                        };
 
                                         // Look up library name from index
                                         let lib_name = pres_index.get(&id).cloned().unwrap_or_default();
@@ -399,7 +391,6 @@ pub fn PresentationList() -> impl IntoView {
                                                     let playlist_id = playlist_id_reorder.clone();
                                                     let selected_playlist = ctx.selected_playlist;
                                                     let playlists = ctx.playlists;
-                                                    let presentations = ctx.presentations;
                                                     move |ev: web_sys::DragEvent| {
                                                         ev.prevent_default();
                                                         if let Some(dragged_id) = get_dragging_entry() {
@@ -417,7 +408,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                         entries.insert(to, item);
                                                                         if let Ok(updated) = crate::api::playlists::replace_entries(&playlist_id, entries).await {
                                                                             selected_playlist.set(Some(updated.clone()));
-                                                                            rebuild_playlist_presentations_with_signal(presentations, &updated);
                                                                         }
                                                                         if let Ok(pls) = crate::api::playlists::list_playlists().await {
                                                                             playlists.set(pls);
@@ -465,7 +455,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                     // Capture signals OUTSIDE async block
                                                                     let selected_playlist = ctx.selected_playlist;
                                                                     let playlists = ctx.playlists;
-                                                                    let presentations = ctx.presentations;
                                                                     leptos::task::spawn_local(async move {
                                                                         let current = selected_playlist.get_untracked();
                                                                         if let Some(pl) = current {
@@ -475,7 +464,6 @@ pub fn PresentationList() -> impl IntoView {
                                                                                 .collect();
                                                                             if let Ok(updated) = crate::api::playlists::replace_entries(&pl_id, entries).await {
                                                                                 selected_playlist.set(Some(updated.clone()));
-                                                                                rebuild_playlist_presentations_with_signal(presentations, &updated);
                                                                             }
                                                                             if let Ok(pls) = crate::api::playlists::list_playlists().await {
                                                                                 playlists.set(pls);
@@ -598,28 +586,6 @@ fn entry_to_payload(
             }
         }
     }
-}
-
-/// Rebuild the presentations signal from a playlist's entries using a captured signal.
-/// Use this version inside async blocks where `use_context` is not available.
-fn rebuild_playlist_presentations_with_signal(
-    presentations: RwSignal<Vec<presenter_core::PresentationSummary>>,
-    playlist: &presenter_core::Playlist,
-) {
-    let summaries: Vec<presenter_core::PresentationSummary> = playlist
-        .entries
-        .iter()
-        .filter_map(|e| match &e.kind {
-            presenter_core::playlist::PlaylistEntryKind::Presentation {
-                presentation_id, ..
-            } => Some(presenter_core::PresentationSummary::new(
-                *presentation_id,
-                String::new(),
-            )),
-            _ => None,
-        })
-        .collect();
-    presentations.set(summaries);
 }
 
 /// Get entry_id from a PlaylistEntryPayload

--- a/crates/presenter-ui/src/components/search.rs
+++ b/crates/presenter-ui/src/components/search.rs
@@ -300,7 +300,7 @@ pub fn SearchResults() -> impl IntoView {
                                 data-kind=kind
                                 data-presentation-id=pres_id_attr
                                 class="operator__search-result"
-                                draggable="true"
+                                draggable=if pres_id.is_some() { "true" } else { "false" }
                                 on:click=move |_| {
                                     on_result_click(lib_click.clone(), pres_click.clone());
                                 }

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -3,12 +3,16 @@ use leptos::prelude::*;
 use crate::state::stage::StageContext;
 use crate::utils::autofit::autofit_effect;
 use crate::utils::color::group_pill_style;
+use crate::utils::text::{break_if_long, clean_song_name};
 use crate::ws::stage::StageWsState;
 
 const CURRENT_MAX_FONT: f64 = 800.0;
 const NEXT_MAX_FONT: f64 = 500.0;
 const CURRENT_GROUP_MAX_FONT: f64 = 200.0;
 const NEXT_GROUP_MAX_FONT: f64 = 200.0;
+const CURRENT_SONG_MAX_FONT: f64 = 200.0;
+const NEXT_SONG_MAX_FONT: f64 = 200.0;
+const STAGE_SLIDE_BREAK_THRESHOLD: usize = 26;
 
 #[component]
 pub fn WorshipPp(
@@ -21,9 +25,12 @@ pub fn WorshipPp(
     let next_text_ref = NodeRef::<leptos::html::Div>::new();
     let current_group_ref = NodeRef::<leptos::html::Div>::new();
     let next_group_ref = NodeRef::<leptos::html::Div>::new();
+    let current_song_ref = NodeRef::<leptos::html::Div>::new();
+    let next_song_ref = NodeRef::<leptos::html::Div>::new();
 
     let current_text = move || {
-        ctx.snapshot
+        let raw = ctx
+            .snapshot
             .get()
             .and_then(|s| {
                 s.current.map(|slide| {
@@ -34,11 +41,13 @@ pub fn WorshipPp(
                     }
                 })
             })
-            .unwrap_or_default()
+            .unwrap_or_default();
+        break_if_long(raw, STAGE_SLIDE_BREAK_THRESHOLD)
     };
 
     let next_text = move || {
-        ctx.snapshot
+        let raw = ctx
+            .snapshot
             .get()
             .and_then(|s| {
                 s.next.map(|slide| {
@@ -49,7 +58,8 @@ pub fn WorshipPp(
                     }
                 })
             })
-            .unwrap_or_default()
+            .unwrap_or_default();
+        break_if_long(raw, STAGE_SLIDE_BREAK_THRESHOLD)
     };
 
     let current_group = move || {
@@ -62,12 +72,6 @@ pub fn WorshipPp(
             .get()
             .and_then(|s| s.next.and_then(|sl| sl.group))
     };
-    let playlist_entries = move || {
-        ctx.snapshot
-            .get()
-            .and_then(|s| s.playlist_entries)
-            .unwrap_or_default()
-    };
 
     let current_group_style = move || {
         ctx.snapshot
@@ -76,6 +80,7 @@ pub fn WorshipPp(
             .map(|color| group_pill_style(&color))
             .unwrap_or_default()
     };
+
     let next_group_style = move || {
         ctx.snapshot
             .get()
@@ -83,8 +88,35 @@ pub fn WorshipPp(
             .map(|color| group_pill_style(&color))
             .unwrap_or_default()
     };
+
     let current_group_text = move || current_group().unwrap_or_default();
     let next_group_text = move || next_group().unwrap_or_default();
+
+    let current_song_text = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.song_name)
+            .unwrap_or_default()
+    };
+
+    let playlist_entries = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.playlist_entries)
+            .unwrap_or_default()
+    };
+
+    // worship-pp specific: derive next-song from the Presenter playlist's
+    // entry-after-active, NOT from AbleSet's s.next_song_name. If no entry
+    // is active, or the active one is last, returns "" (no next song).
+    let next_song_text = move || {
+        let entries = playlist_entries();
+        let mut iter = entries.iter().skip_while(|e| !e.is_active);
+        iter.next(); // consume the active entry itself
+        iter.next()
+            .map(|e| clean_song_name(&e.name))
+            .unwrap_or_default()
+    };
 
     autofit_effect(current_text_ref, CURRENT_MAX_FONT, current_text);
     autofit_effect(next_text_ref, NEXT_MAX_FONT, next_text);
@@ -94,34 +126,50 @@ pub fn WorshipPp(
         current_group_text,
     );
     autofit_effect(next_group_ref, NEXT_GROUP_MAX_FONT, next_group_text);
+    autofit_effect(current_song_ref, CURRENT_SONG_MAX_FONT, current_song_text);
+    autofit_effect(next_song_ref, NEXT_SONG_MAX_FONT, next_song_text);
 
     view! {
         <div class="stage-container" data-layout="worship-pp">
-            <div class="stage-pp__slides-area">
-                <span class="stage__debug-label">"slides-area"</span>
-                <div class="stage__current-group" style="left:14%;width:72%;">
-                    <span class="stage__debug-label">"current-group"</span>
-                    <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
-                        {current_group_text}
-                    </div>
+            <div class="stage__current-group">
+                <span class="stage__debug-label">"current-group"</span>
+                <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
+                    {current_group_text}
                 </div>
-                <div class="stage__current-slide" style="width:66%;left:2%;">
-                    <span class="stage__debug-label">"current-slide"</span>
-                    <div node_ref=current_text_ref class="stage__slide-text">
-                        {current_text}
-                    </div>
+            </div>
+
+            <div class="stage__current-song">
+                <span class="stage__debug-label">"current-song"</span>
+                <div node_ref=current_song_ref class="stage__song-name-text">
+                    {current_song_text}
                 </div>
-                <div class="stage__next-group" style="left:14%;width:72%;">
-                    <span class="stage__debug-label">"next-group"</span>
-                    <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
-                        {next_group_text}
-                    </div>
+            </div>
+
+            <div class="stage__current-slide">
+                <span class="stage__debug-label">"current-slide"</span>
+                <div node_ref=current_text_ref class="stage__slide-text">
+                    {current_text}
                 </div>
-                <div class="stage__next-slide" style="width:66%;left:2%;">
-                    <span class="stage__debug-label">"next-slide"</span>
-                    <div node_ref=next_text_ref class="stage__slide-text">
-                        {next_text}
-                    </div>
+            </div>
+
+            <div class="stage__next-group">
+                <span class="stage__debug-label">"next-group"</span>
+                <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
+                    {next_group_text}
+                </div>
+            </div>
+
+            <div class="stage__next-song">
+                <span class="stage__debug-label">"next-song"</span>
+                <div node_ref=next_song_ref class="stage__song-name-text">
+                    {next_song_text}
+                </div>
+            </div>
+
+            <div class="stage__next-slide">
+                <span class="stage__debug-label">"next-slide"</span>
+                <div node_ref=next_text_ref class="stage__slide-text">
+                    {next_text}
                 </div>
             </div>
 
@@ -136,7 +184,8 @@ pub fn WorshipPp(
                         } else {
                             "stage-pp__playlist-entry"
                         };
-                        view! { <div class=class>{entry.name.clone()}</div> }
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
                     }
                 />
             </div>

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -181,10 +181,33 @@ pub fn WorshipPp(
                     each=playlist_entries
                     key=|entry| entry.name.clone()
                     children=move |entry| {
-                        let class = if entry.is_active {
-                            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
-                        } else {
-                            "stage-pp__playlist-entry"
+                        // Capture the entry's name once. The active-class
+                        // must be REACTIVE — read from ctx.snapshot (a
+                        // RwSignal) on every update so the highlight follows
+                        // the currently-triggered song.
+                        // Without this, Leptos's <For> reuses the row's DOM
+                        // (same key = entry.name) and the captured entry's
+                        // is_active stays at its first-render value forever.
+                        let entry_name = entry.name.clone();
+                        let snapshot = ctx.snapshot;
+                        let is_active = move || {
+                            snapshot.with(|opt| {
+                                opt.as_ref()
+                                    .and_then(|s| s.playlist_entries.as_ref())
+                                    .map(|entries| {
+                                        entries
+                                            .iter()
+                                            .any(|e| e.name == entry_name && e.is_active)
+                                    })
+                                    .unwrap_or(false)
+                            })
+                        };
+                        let class = move || {
+                            if is_active() {
+                                "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                            } else {
+                                "stage-pp__playlist-entry"
+                            }
                         };
                         let display_name = clean_song_name(&entry.name);
                         view! { <div class=class>{display_name}</div> }

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -131,45 +131,47 @@ pub fn WorshipPp(
 
     view! {
         <div class="stage-container" data-layout="worship-pp">
-            <div class="stage__current-group">
-                <span class="stage__debug-label">"current-group"</span>
-                <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
-                    {current_group_text}
+            <div class="stage-pp__slides-area">
+                <div class="stage__current-group">
+                    <span class="stage__debug-label">"current-group"</span>
+                    <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
+                        {current_group_text}
+                    </div>
                 </div>
-            </div>
 
-            <div class="stage__current-song">
-                <span class="stage__debug-label">"current-song"</span>
-                <div node_ref=current_song_ref class="stage__song-name-text">
-                    {current_song_text}
+                <div class="stage__current-song">
+                    <span class="stage__debug-label">"current-song"</span>
+                    <div node_ref=current_song_ref class="stage__song-name-text">
+                        {current_song_text}
+                    </div>
                 </div>
-            </div>
 
-            <div class="stage__current-slide">
-                <span class="stage__debug-label">"current-slide"</span>
-                <div node_ref=current_text_ref class="stage__slide-text">
-                    {current_text}
+                <div class="stage__current-slide">
+                    <span class="stage__debug-label">"current-slide"</span>
+                    <div node_ref=current_text_ref class="stage__slide-text">
+                        {current_text}
+                    </div>
                 </div>
-            </div>
 
-            <div class="stage__next-group">
-                <span class="stage__debug-label">"next-group"</span>
-                <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
-                    {next_group_text}
+                <div class="stage__next-group">
+                    <span class="stage__debug-label">"next-group"</span>
+                    <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
+                        {next_group_text}
+                    </div>
                 </div>
-            </div>
 
-            <div class="stage__next-song">
-                <span class="stage__debug-label">"next-song"</span>
-                <div node_ref=next_song_ref class="stage__song-name-text">
-                    {next_song_text}
+                <div class="stage__next-song">
+                    <span class="stage__debug-label">"next-song"</span>
+                    <div node_ref=next_song_ref class="stage__song-name-text">
+                        {next_song_text}
+                    </div>
                 </div>
-            </div>
 
-            <div class="stage__next-slide">
-                <span class="stage__debug-label">"next-slide"</span>
-                <div node_ref=next_text_ref class="stage__slide-text">
-                    {next_text}
+                <div class="stage__next-slide">
+                    <span class="stage__debug-label">"next-slide"</span>
+                    <div node_ref=next_text_ref class="stage__slide-text">
+                        {next_text}
+                    </div>
                 </div>
             </div>
 

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -485,27 +485,13 @@ fn load_session_presentation(ctx: &AppContext) {
     if let Some(pl_id) = ctx.selected_playlist_id.get_untracked() {
         let playlists = ctx.playlists;
         let context_title = ctx.context_title;
-        let presentations = ctx.presentations;
         let selected_playlist = ctx.selected_playlist;
         leptos::task::spawn_local(async move {
-            // Fetch full playlist for entry rendering
+            // Fetch full playlist for entry rendering. The response now
+            // includes presentation_name on each entry, so the operator
+            // no longer needs to fake a presentations summary list.
             if let Ok(pl) = crate::api::playlists::get_playlist(&pl_id).await {
                 context_title.set(pl.name.clone());
-                let summaries: Vec<presenter_core::PresentationSummary> = pl
-                    .entries
-                    .iter()
-                    .filter_map(|e| match &e.kind {
-                        presenter_core::playlist::PlaylistEntryKind::Presentation {
-                            presentation_id,
-                            ..
-                        } => Some(presenter_core::PresentationSummary::new(
-                            *presentation_id,
-                            String::new(),
-                        )),
-                        _ => None,
-                    })
-                    .collect();
-                presentations.set(summaries);
                 selected_playlist.set(Some(pl));
             }
             if let Ok(pls) = crate::api::playlists::list_playlists().await {

--- a/crates/presenter-ui/src/utils/text.rs
+++ b/crates/presenter-ui/src/utils/text.rs
@@ -39,6 +39,31 @@ pub fn break_if_long(text: String, threshold: usize) -> String {
     }
 }
 
+/// Strip a leading 3-digit-then-space prefix from a ProPresenter song name.
+/// Mirrors the server-side `sanitize_song_title`:
+///
+///   "042 Amazing Grace"  -> "Amazing Grace"
+///   "  042 Padded"       -> "Padded"
+///   "12 Two Digit"       -> "12 Two Digit"   (not exactly 3 digits → unchanged)
+///   "Already Clean"      -> "Already Clean"
+///
+/// Used by the `worship-pp` playlist sidebar to keep operator-facing
+/// numeric prefixes off the stage display.
+pub fn clean_song_name(name: &str) -> String {
+    let trimmed = name.trim_start();
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 4
+        && bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && bytes[2].is_ascii_digit()
+        && bytes[3].is_ascii_whitespace()
+    {
+        trimmed[4..].trim_start().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +131,35 @@ mod tests {
         assert!(input.chars().count() > 26);
         let out = run(input, 26);
         assert_eq!(out, "A B\nvery-long-single-word-of-35-chr");
+    }
+
+    #[test]
+    fn clean_song_name_strips_3digit_prefix() {
+        assert_eq!(clean_song_name("042 Amazing Grace"), "Amazing Grace");
+    }
+
+    #[test]
+    fn clean_song_name_passes_through_non_prefixed() {
+        assert_eq!(clean_song_name("Amazing Grace"), "Amazing Grace");
+    }
+
+    #[test]
+    fn clean_song_name_rejects_two_digit_prefix() {
+        assert_eq!(clean_song_name("12 Two Digit"), "12 Two Digit");
+    }
+
+    #[test]
+    fn clean_song_name_rejects_four_digit_prefix() {
+        assert_eq!(clean_song_name("1234 Four Digit"), "1234 Four Digit");
+    }
+
+    #[test]
+    fn clean_song_name_handles_leading_whitespace() {
+        assert_eq!(clean_song_name("  042 Padded"), "Padded");
+    }
+
+    #[test]
+    fn clean_song_name_empty_input_unchanged() {
+        assert_eq!(clean_song_name(""), "");
     }
 }

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -347,15 +347,17 @@ body.stage {
     height: 92%;
     overflow-y: auto;
     border-left: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 1% 1.5%;
+    padding: 0.4% 0.5%;
     box-sizing: border-box;
 }
 
 .stage-pp__playlist-entry {
-    padding: 0.6vh 0.8rem;
+    padding: 0.3vh 0.4rem;
     color: #94a3b8;
-    /* 12 entries × ~7vh row height ≈ 84vh fits in 92vh sidebar; readable from across a worship space. */
-    font-size: 2.6vh;
+    /* Sized so ~12 typical chars fit per row at 1080p:
+       sidebar 22% × 1920 = 422px, less padding → ~390px content,
+       at 5vh font (≈54px) char-width is ~30px, ~12 chars per row. */
+    font-size: 5vh;
     line-height: 1.1;
     white-space: nowrap;
     overflow: hidden;
@@ -370,8 +372,9 @@ body.stage {
     font-weight: 700;
     border-left: 4px solid #0ea5e9;
     /* Compensate for the 4px border so text alignment with non-active rows
-       stays consistent. Base padding-left is 0.8rem; subtract the border width. */
-    padding-left: calc(0.8rem - 4px);
+       stays consistent. Base padding-left is 0.4rem (≈6.4px); subtract the
+       border width. */
+    padding-left: calc(0.4rem - 4px);
 }
 
 /* ===== timer layout ===== */

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -354,10 +354,10 @@ body.stage {
 .stage-pp__playlist-entry {
     padding: 0.3vh 0.4rem;
     color: #94a3b8;
-    /* Sized so ~12 typical chars fit per row at 1080p:
-       sidebar 22% × 1920 = 422px, less padding → ~390px content,
-       at 5vh font (≈54px) char-width is ~30px, ~12 chars per row. */
-    font-size: 5vh;
+    /* Sized so ~10 entries fit in the 92vh sidebar at 1080p:
+       per-row ≈ 7.5vh × line-height 1.1 + 0.6vh padding ≈ 9.0vh.
+       Trades fewer chars-per-row for visibly larger text. */
+    font-size: 7.5vh;
     line-height: 1.1;
     white-space: nowrap;
     overflow: hidden;

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -336,6 +336,7 @@ body.stage {
     width: 70%;
     height: 92%;
     overflow: hidden;
+    box-sizing: border-box;
 }
 
 .stage-pp__playlist-sidebar {

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -361,7 +361,7 @@ body.stage {
     line-height: 1.1;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
+    text-overflow: clip;
     border-radius: 4px;
     margin-bottom: 2px;
 }

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -333,7 +333,7 @@ body.stage {
     position: absolute;
     left: 0;
     top: 0;
-    width: 70%;
+    width: 78%;
     height: 92%;
     overflow: hidden;
     box-sizing: border-box;
@@ -343,7 +343,7 @@ body.stage {
     position: absolute;
     right: 0;
     top: 0;
-    width: 30%;
+    width: 22%;
     height: 92%;
     overflow-y: auto;
     border-left: 1px solid rgba(255, 255, 255, 0.1);
@@ -352,9 +352,11 @@ body.stage {
 }
 
 .stage-pp__playlist-entry {
-    padding: 0.4rem 0.6rem;
+    padding: 0.6vh 0.8rem;
     color: #94a3b8;
-    font-size: 0.9vw;
+    /* 12 entries × ~7vh row height ≈ 84vh fits in 92vh sidebar; readable from across a worship space. */
+    font-size: 2.6vh;
+    line-height: 1.1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -367,10 +369,9 @@ body.stage {
     color: #0f172a;
     font-weight: 700;
     border-left: 4px solid #0ea5e9;
-    /* Compensate for the 4px border so text alignment with non-active
-       rows stays consistent. Original padding-left from .stage-pp__playlist-entry
-       is 0.6rem; subtract the border width. */
-    padding-left: calc(0.6rem - 4px);
+    /* Compensate for the 4px border so text alignment with non-active rows
+       stays consistent. Base padding-left is 0.8rem; subtract the border width. */
+    padding-left: calc(0.8rem - 4px);
 }
 
 /* ===== timer layout ===== */

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -362,9 +362,14 @@ body.stage {
 }
 
 .stage-pp__playlist-entry--active {
-    background: rgba(56, 189, 248, 0.15);
-    color: #f8fafc;
+    background: #38bdf8;
+    color: #0f172a;
     font-weight: 700;
+    border-left: 4px solid #0ea5e9;
+    /* Compensate for the 4px border so text alignment with non-active
+       rows stays consistent. Original padding-left from .stage-pp__playlist-entry
+       is 0.6rem; subtract the border width. */
+    padding-left: calc(0.6rem - 4px);
 }
 
 /* ===== timer layout ===== */

--- a/docs/superpowers/plans/2026-04-26-worship-pp-snv-baseline.md
+++ b/docs/superpowers/plans/2026-04-26-worship-pp-snv-baseline.md
@@ -1,0 +1,704 @@
+# Worship-PP — adopt worship-snv baseline + playlist tweaks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `worship-snv`'s rendering improvements (slide-text wrapping, song-name boxes with autofit) into `worship-pp` while keeping `worship-pp`'s playlist sidebar; clean playlist entry names of their leading 3-digit ProPresenter prefix; force one row per entry with CSS ellipsis; derive the next-song box from the Presenter playlist instead of AbleSet's `next_song_name`.
+
+**Architecture:** Frontend-only. Two files modified, one CSS rule extended, one helper added. No `presenter-server` work, no `presenter-core` contract change. `worship_snv` remains untouched.
+
+**Tech Stack:** Rust + Leptos 0.7 (CSR/WASM), CSS.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-worship-pp-snv-baseline-design.md` (commit `2379413`)
+
+---
+
+## Context
+
+Six WASM unit tests in `presenter-ui::utils::text` already exist for `break_if_long`. We add a sibling helper `clean_song_name` to the same module and add tests to the same `mod tests` block. The component file `worship_pp.rs` is rewritten — currently 147 lines, will become ~150 lines structurally identical to `worship_snv.rs` plus a sidebar block. The CSS change is three properties on one selector.
+
+`presenter-ui` is excluded from the root workspace (separate `Cargo.lock`). Tests are run via `cargo test -p presenter-ui` from the workspace root, which delegates to native (non-WASM) target for the test binary — works because the test code doesn't pull WASM-only types.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `Cargo.toml` (workspace) | Modify | Bump `version = "0.4.36"`. |
+| `crates/presenter-ui/src/utils/text.rs` | Modify | Add `pub fn clean_song_name(name: &str) -> String` and 6 unit tests inside the existing `mod tests` block. Existing `break_if_long` and its tests untouched. |
+| `crates/presenter-ui/styles/stage.css` | Modify line 353 rule | Extend `.stage-pp__playlist-entry` with `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`. Existing properties and the `--active` modifier rule untouched. |
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | Rewrite | Same shape as `worship_snv.rs` (refs, getters, autofit, six divs) plus the playlist sidebar with `clean_song_name` applied to each entry. Override `next_song_text` to walk `playlist_entries` (entry-after-active) instead of reading `s.next_song_name`. |
+
+Nothing else touched.
+
+---
+
+## Task 1: Workspace prep — version bump 0.4.36
+
+**Files:**
+- Modify: `Cargo.toml:15`
+
+- [ ] **Step 1: Bump workspace version**
+
+In `Cargo.toml`, change line 15 from `version = "0.4.35"` to `version = "0.4.36"`.
+
+- [ ] **Step 2: Verify workspace still builds**
+
+```bash
+cargo build -p presenter-server 2>&1 | tail -5
+```
+
+Expected: `Finished `dev` profile`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.4.36 (#worship-pp)"
+```
+
+---
+
+## Task 2: Add `clean_song_name` helper with tests
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/text.rs`
+
+TDD order: write tests first, watch them fail, implement, watch them pass.
+
+- [ ] **Step 1: Add the failing tests**
+
+Open `crates/presenter-ui/src/utils/text.rs`. Inside the existing `#[cfg(test)] mod tests { ... }` block (the one containing `short_ascii_line_unchanged` etc.), append the following tests **before** the closing `}` of the module:
+
+```rust
+    #[test]
+    fn clean_song_name_strips_3digit_prefix() {
+        assert_eq!(clean_song_name("042 Amazing Grace"), "Amazing Grace");
+    }
+
+    #[test]
+    fn clean_song_name_passes_through_non_prefixed() {
+        assert_eq!(clean_song_name("Amazing Grace"), "Amazing Grace");
+    }
+
+    #[test]
+    fn clean_song_name_rejects_two_digit_prefix() {
+        assert_eq!(clean_song_name("12 Two Digit"), "12 Two Digit");
+    }
+
+    #[test]
+    fn clean_song_name_rejects_four_digit_prefix() {
+        assert_eq!(clean_song_name("1234 Four Digit"), "1234 Four Digit");
+    }
+
+    #[test]
+    fn clean_song_name_handles_leading_whitespace() {
+        assert_eq!(clean_song_name("  042 Padded"), "Padded");
+    }
+
+    #[test]
+    fn clean_song_name_empty_input_unchanged() {
+        assert_eq!(clean_song_name(""), "");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p presenter-ui --lib utils::text:: 2>&1 | tail -20
+```
+
+Expected: 6 new tests fail with `cannot find function 'clean_song_name'`. The 9 existing `break_if_long` tests pass.
+
+- [ ] **Step 3: Implement the helper**
+
+In `crates/presenter-ui/src/utils/text.rs`, append the following BEFORE the `#[cfg(test)] mod tests` block:
+
+```rust
+/// Strip a leading 3-digit-then-space prefix from a ProPresenter song name.
+/// Mirrors the server-side `sanitize_song_title`:
+///
+///   "042 Amazing Grace"  -> "Amazing Grace"
+///   "  042 Padded"       -> "Padded"
+///   "12 Two Digit"       -> "12 Two Digit"   (not exactly 3 digits → unchanged)
+///   "Already Clean"      -> "Already Clean"
+///
+/// Used by the `worship-pp` playlist sidebar to keep operator-facing
+/// numeric prefixes off the stage display.
+pub fn clean_song_name(name: &str) -> String {
+    let trimmed = name.trim_start();
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 4
+        && bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && bytes[2].is_ascii_digit()
+        && bytes[3].is_ascii_whitespace()
+    {
+        trimmed[4..].trim_start().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p presenter-ui --lib utils::text:: 2>&1 | tail -20
+```
+
+Expected: all `utils::text::tests::*` tests pass — 9 existing `break_if_long` tests + 6 new `clean_song_name` tests = 15 total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/presenter-ui/src/utils/text.rs
+git commit -m "feat(stage): add clean_song_name helper for playlist entries (#worship-pp)"
+```
+
+---
+
+## Task 3: Extend `.stage-pp__playlist-entry` CSS for one-row ellipsis
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/stage.css` (rule at line 353)
+
+- [ ] **Step 1: Locate the rule**
+
+```bash
+sed -n '350,375p' crates/presenter-ui/styles/stage.css
+```
+
+You should see the `.stage-pp__playlist-entry { ... }` block at line 353 followed by `.stage-pp__playlist-entry--active { ... }` around line 364.
+
+- [ ] **Step 2: Append the three properties to the existing rule**
+
+Edit `crates/presenter-ui/styles/stage.css`. Find the `.stage-pp__playlist-entry { ... }` block. Add these three lines BEFORE the closing `}`, preserving any existing properties already in the block:
+
+```css
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+```
+
+Do NOT touch the `.stage-pp__playlist-entry--active` rule below it.
+
+- [ ] **Step 3: Verify by re-printing the block**
+
+```bash
+sed -n '350,375p' crates/presenter-ui/styles/stage.css
+```
+
+The base rule should now contain the three new properties. The `--active` modifier rule should be unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/styles/stage.css
+git commit -m "style(stage): one-row ellipsis for worship-pp playlist entries (#worship-pp)"
+```
+
+---
+
+## Task 4: Rewrite `worship_pp.rs` from `worship_snv.rs` baseline + playlist sidebar + next-song-from-playlist
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/worship_pp.rs` (rewrite)
+
+This single task replaces the entire file. The replacement keeps the same component name (`WorshipPp`), the same outer container (`<div class="stage-container" data-layout="worship-pp">`), and the same external interface (`(ws_state, latency_ms)`). What changes is the contents.
+
+- [ ] **Step 1: Overwrite the file with the full replacement**
+
+Replace the entire contents of `crates/presenter-ui/src/components/stage/worship_pp.rs` with:
+
+```rust
+use leptos::prelude::*;
+
+use crate::state::stage::StageContext;
+use crate::utils::autofit::autofit_effect;
+use crate::utils::color::group_pill_style;
+use crate::utils::text::{break_if_long, clean_song_name};
+use crate::ws::stage::StageWsState;
+
+const CURRENT_MAX_FONT: f64 = 800.0;
+const NEXT_MAX_FONT: f64 = 500.0;
+const CURRENT_GROUP_MAX_FONT: f64 = 200.0;
+const NEXT_GROUP_MAX_FONT: f64 = 200.0;
+const CURRENT_SONG_MAX_FONT: f64 = 200.0;
+const NEXT_SONG_MAX_FONT: f64 = 200.0;
+const STAGE_SLIDE_BREAK_THRESHOLD: usize = 26;
+
+#[component]
+pub fn WorshipPp(
+    ws_state: ReadSignal<StageWsState>,
+    latency_ms: ReadSignal<Option<f64>>,
+) -> impl IntoView {
+    let ctx = use_context::<StageContext>().expect("StageContext not provided");
+
+    let current_text_ref = NodeRef::<leptos::html::Div>::new();
+    let next_text_ref = NodeRef::<leptos::html::Div>::new();
+    let current_group_ref = NodeRef::<leptos::html::Div>::new();
+    let next_group_ref = NodeRef::<leptos::html::Div>::new();
+    let current_song_ref = NodeRef::<leptos::html::Div>::new();
+    let next_song_ref = NodeRef::<leptos::html::Div>::new();
+
+    let current_text = move || {
+        let raw = ctx
+            .snapshot
+            .get()
+            .and_then(|s| {
+                s.current.map(|slide| {
+                    if !slide.stage.is_empty() {
+                        slide.stage
+                    } else {
+                        slide.main
+                    }
+                })
+            })
+            .unwrap_or_default();
+        break_if_long(raw, STAGE_SLIDE_BREAK_THRESHOLD)
+    };
+
+    let next_text = move || {
+        let raw = ctx
+            .snapshot
+            .get()
+            .and_then(|s| {
+                s.next.map(|slide| {
+                    if !slide.stage.is_empty() {
+                        slide.stage
+                    } else {
+                        slide.main
+                    }
+                })
+            })
+            .unwrap_or_default();
+        break_if_long(raw, STAGE_SLIDE_BREAK_THRESHOLD)
+    };
+
+    let current_group = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.current.and_then(|sl| sl.group))
+    };
+    let next_group = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.next.and_then(|sl| sl.group))
+    };
+
+    let current_group_style = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.current.and_then(|sl| sl.group_color))
+            .map(|color| group_pill_style(&color))
+            .unwrap_or_default()
+    };
+
+    let next_group_style = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.next.and_then(|sl| sl.group_color))
+            .map(|color| group_pill_style(&color))
+            .unwrap_or_default()
+    };
+
+    let current_group_text = move || current_group().unwrap_or_default();
+    let next_group_text = move || next_group().unwrap_or_default();
+
+    let current_song_text = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.song_name)
+            .unwrap_or_default()
+    };
+
+    let playlist_entries = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.playlist_entries)
+            .unwrap_or_default()
+    };
+
+    // worship-pp specific: derive next-song from the Presenter playlist's
+    // entry-after-active, NOT from AbleSet's s.next_song_name. If no entry
+    // is active, or the active one is last, returns "" (no next song).
+    let next_song_text = move || {
+        let entries = playlist_entries();
+        let mut iter = entries.iter().skip_while(|e| !e.is_active);
+        iter.next(); // consume the active entry itself
+        iter.next()
+            .map(|e| clean_song_name(&e.name))
+            .unwrap_or_default()
+    };
+
+    autofit_effect(current_text_ref, CURRENT_MAX_FONT, current_text);
+    autofit_effect(next_text_ref, NEXT_MAX_FONT, next_text);
+    autofit_effect(
+        current_group_ref,
+        CURRENT_GROUP_MAX_FONT,
+        current_group_text,
+    );
+    autofit_effect(next_group_ref, NEXT_GROUP_MAX_FONT, next_group_text);
+    autofit_effect(current_song_ref, CURRENT_SONG_MAX_FONT, current_song_text);
+    autofit_effect(next_song_ref, NEXT_SONG_MAX_FONT, next_song_text);
+
+    view! {
+        <div class="stage-container" data-layout="worship-pp">
+            <div class="stage__current-group">
+                <span class="stage__debug-label">"current-group"</span>
+                <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
+                    {current_group_text}
+                </div>
+            </div>
+
+            <div class="stage__current-song">
+                <span class="stage__debug-label">"current-song"</span>
+                <div node_ref=current_song_ref class="stage__song-name-text">
+                    {current_song_text}
+                </div>
+            </div>
+
+            <div class="stage__current-slide">
+                <span class="stage__debug-label">"current-slide"</span>
+                <div node_ref=current_text_ref class="stage__slide-text">
+                    {current_text}
+                </div>
+            </div>
+
+            <div class="stage__next-group">
+                <span class="stage__debug-label">"next-group"</span>
+                <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
+                    {next_group_text}
+                </div>
+            </div>
+
+            <div class="stage__next-song">
+                <span class="stage__debug-label">"next-song"</span>
+                <div node_ref=next_song_ref class="stage__song-name-text">
+                    {next_song_text}
+                </div>
+            </div>
+
+            <div class="stage__next-slide">
+                <span class="stage__debug-label">"next-slide"</span>
+                <div node_ref=next_text_ref class="stage__slide-text">
+                    {next_text}
+                </div>
+            </div>
+
+            <div class="stage-pp__playlist-sidebar">
+                <span class="stage__debug-label">"playlist-sidebar"</span>
+                <For
+                    each=playlist_entries
+                    key=|entry| entry.name.clone()
+                    children=move |entry| {
+                        let class = if entry.is_active {
+                            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                        } else {
+                            "stage-pp__playlist-entry"
+                        };
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
+                    }
+                />
+            </div>
+
+            <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
+        </div>
+    }
+}
+```
+
+- [ ] **Step 2: Build the presenter-ui crate**
+
+```bash
+cargo build -p presenter-ui 2>&1 | tail -10
+```
+
+Expected: `Finished `dev` profile`. If errors:
+- `unresolved import 'crate::utils::text::clean_song_name'` — Task 2 didn't run; go back and verify Task 2 committed.
+- `cannot find type 'StagePlaylistEntry'` — confirm `crate::state::stage::StageContext` exposes `playlist_entries` as `Option<Vec<StagePlaylistEntry>>` (it does — see `crates/presenter-core/src/stage_display.rs:65,119`). The pattern `entries.iter().skip_while(|e| !e.is_active)` works because `StagePlaylistEntry` has `is_active: bool` (line 69).
+
+- [ ] **Step 3: Run presenter-ui tests**
+
+```bash
+cargo test -p presenter-ui 2>&1 | tail -10
+```
+
+Expected: all green, including the new `clean_song_name` tests from Task 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/stage/worship_pp.rs
+git commit -m "feat(stage): worship-pp adopts worship-snv baseline + playlist tweaks (#worship-pp)
+
+- Brings break_if_long for slide text + song-name boxes with autofit
+  from worship_snv.rs into worship_pp.rs.
+- Keeps the .stage-pp__playlist-sidebar with the <For> over playlist_entries.
+- Each rendered entry runs through clean_song_name to strip the
+  ProPresenter 3-digit prefix.
+- Overrides next_song_text to walk playlist_entries for the entry
+  after the active one, ignoring AbleSet's s.next_song_name.
+- worship-snv unchanged."
+```
+
+---
+
+## Task 5: Local fmt + clippy + workspace tests
+
+**Files:** None (verification step).
+
+- [ ] **Step 1: Format**
+
+```bash
+cargo fmt --all
+cd crates/presenter-ui && cargo fmt --all && cd ../..
+```
+
+The presenter-ui crate has its own Cargo.lock and is excluded from the root workspace; running fmt twice covers both.
+
+- [ ] **Step 2: Clippy zero-warnings on the workspace**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Clippy zero-warnings on presenter-ui**
+
+```bash
+cd crates/presenter-ui && cargo clippy --all-targets -- -D warnings -W clippy::all 2>&1 | tail -15 && cd ../..
+```
+
+Expected: clean. Common things:
+- `clippy::needless_borrow` if you wrote `&entry.name` where `entry.name` would auto-deref — adjust per the lint.
+- `clippy::needless_collect` shouldn't appear; the iterator chain is short.
+
+- [ ] **Step 4: Workspace tests**
+
+```bash
+cargo test --workspace 2>&1 | tail -10
+```
+
+- [ ] **Step 5: presenter-ui tests**
+
+```bash
+cargo test -p presenter-ui 2>&1 | tail -10
+```
+
+Expected: all green, including 6 new `clean_song_name` tests.
+
+- [ ] **Step 6: If any of Steps 2-5 produced fixes, commit**
+
+```bash
+git add -A
+git commit -m "chore: fmt + clippy fixes for worship-pp (#worship-pp)"
+```
+
+If no diff after fmt/clippy, skip the commit.
+
+---
+
+## Task 6: Push to dev + monitor CI
+
+**Files:** None.
+
+- [ ] **Step 1: Sync with main, then push**
+
+```bash
+git fetch origin
+git merge origin/main --no-edit 2>&1 | tail -3
+git push origin dev 2>&1 | tail -3
+```
+
+- [ ] **Step 2: Identify the new pipeline run**
+
+```bash
+sleep 12
+gh run list --branch dev --limit 3 --json databaseId,name,status,event --jq '.[] | "\(.databaseId)\t\(.name)\t\(.status)\t\(.event)"'
+```
+
+Capture the `databaseId` of the newest `Pipeline` row triggered by `push`.
+
+- [ ] **Step 3: Monitor with single-sleep pattern in background**
+
+```bash
+RUN_ID=<paste databaseId>
+sleep 1500 && gh run view $RUN_ID --json status,conclusion,jobs --jq '{status,conclusion,jobs:[.jobs[]|{name,conclusion,status}]}'
+```
+
+Run as `run_in_background: true`. After it returns, if `Mutation Testing` or any job is still `in_progress`, schedule another `sleep 600 && gh run view $RUN_ID ...` background command. **Do NOT poll repeatedly. Do NOT use `gh run watch`.**
+
+If any job fails: `gh run view $RUN_ID --log-failed | tail -100`, fix in ONE commit, push, monitor again.
+
+- [ ] **Step 4: Confirm Deploy to Dev succeeded**
+
+```bash
+gh run view $RUN_ID --json jobs --jq '.jobs[] | select(.name=="Deploy to Dev") | .conclusion'
+```
+
+Expected: `success`.
+
+---
+
+## Task 7: Verify on dev
+
+**Files:** None (live check against `http://10.77.8.134:8080`).
+
+- [ ] **Step 1: Confirm dev is on 0.4.36**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz; echo
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.36"}`.
+
+- [ ] **Step 2: Switch dev stage to worship-pp**
+
+```bash
+curl -s -X POST http://10.77.8.134:8080/stage/layout -H 'content-type: application/json' -d '{"code":"worship-pp"}'
+```
+
+Expected: response includes `"code":"worship-pp"`.
+
+- [ ] **Step 3: Open dev stage in a browser and verify visually**
+
+Navigate to `http://10.77.8.134:8080/stage` in a desktop browser. Visual checks:
+
+1. Layout has the same structure as worship-snv (current-group / current-song / current-slide / next-group / next-song / next-slide) PLUS the `.stage-pp__playlist-sidebar` on the right.
+2. If the playlist has any songs whose names start with a 3-digit number + space, those numbers do NOT appear in the sidebar (e.g. "042 Amazing Grace" renders as "Amazing Grace").
+3. If any song name is long enough to overflow its container, the overflowing text is replaced by `…` rather than wrapping to a second row.
+4. The active song row has the `--active` styling (typically a different background or color per the existing CSS).
+5. The next-song box (`.stage__next-song`) shows the cleaned name of the song after the active one (or empty if active is last).
+
+- [ ] **Step 4: Browser console check**
+
+In DevTools console: zero errors, zero warnings. (Codebase rule from `browser-console-zero-errors.md`.)
+
+- [ ] **Step 5: Mark task done — no commit, observation only.**
+
+---
+
+## Task 8: Open PR dev → main + monitor PR CI
+
+**Files:** None (PR creation).
+
+- [ ] **Step 1: Verify state**
+
+```bash
+git fetch origin
+git log origin/main..origin/dev --oneline
+gh pr list --base main --head dev --state open
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --base main --head dev --title "feat(stage): worship-pp adopts worship-snv baseline + playlist tweaks" --body "$(cat <<'EOF'
+## Summary
+- Brings \`break_if_long\` slide-text wrapping and the song-name boxes (current-song / next-song) with their own autofit pass from worship_snv.rs into worship_pp.rs.
+- Keeps worship-pp's playlist sidebar.
+- Strips the leading 3-digit ProPresenter prefix from sidebar entry names via a new \`clean_song_name\` helper in \`presenter-ui::utils::text\`.
+- Forces each sidebar entry to one row with CSS \`white-space: nowrap; overflow: hidden; text-overflow: ellipsis;\`.
+- Overrides next-song-box content to derive from the Presenter playlist's entry-after-active, ignoring AbleSet's \`s.next_song_name\` for worship-pp.
+- Frontend-only. No \`presenter-server\` or \`presenter-core\` change. \`worship_snv\` unaffected.
+
+## Spec & plan
+- Spec: \`docs/superpowers/specs/2026-04-26-worship-pp-snv-baseline-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-26-worship-pp-snv-baseline.md\`
+
+## Test plan
+- [x] Six unit tests for \`clean_song_name\` covering 3-digit prefix strip, pass-through for non-prefixed / 2-digit / 4-digit, leading-whitespace handling, and empty input.
+- [x] All existing \`break_if_long\` tests continue to pass.
+- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean.
+- [x] \`cargo clippy -p presenter-ui --all-targets -D warnings\` clean.
+- [x] Dev deploy verified: stage layout switched to \`worship-pp\` renders correctly on http://10.77.8.134:8080/stage with sidebar entries cleaned and one-row-with-ellipsis.
+- [ ] Production verification post-merge (operator visual on the actual stage TVs).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Monitor PR CI**
+
+```bash
+sleep 10
+gh pr checks <new-PR-number> 2>&1 | head -30
+```
+
+Use the `sleep N && gh pr view <N> --json mergeable,mergeStateStatus` background pattern from Task 6 to wait until terminal. ALL required checks must be green.
+
+- [ ] **Step 4: Verify PR is mergeable + clean**
+
+```bash
+gh pr view <PR-number> --json number,mergeable,mergeStateStatus,url --jq '{number, mergeable, mergeStateStatus, url}'
+```
+
+Required: `mergeable: "MERGEABLE"`, `mergeStateStatus: "CLEAN"`. If `UNSTABLE`, investigate the failing check via `gh pr checks` and `gh run view --log-failed`. Fix the gate root-cause; per `pr-merge-policy.md` and `autonomous-quality-discipline.md`, do NOT propose admin-merge or "merge despite".
+
+- [ ] **Step 5: Provide PR URL to user, wait for explicit merge instruction.**
+
+Per `pr-merge-policy.md`: never merge without the user saying "merge it" or equivalent. Output the full clickable URL.
+
+---
+
+## Task 9: Post-merge production verification
+
+**Files:** None (live check against `http://10.77.9.205`).
+
+Triggered after the user says "merge it" and the merge to main runs the Deploy workflow.
+
+- [ ] **Step 1: Confirm main deploy succeeded**
+
+```bash
+gh run list --branch main --limit 3
+```
+
+Find the newest `Deploy` run for the merge commit. Wait for it to reach `conclusion=success` using the same monitor pattern as Task 6.
+
+- [ ] **Step 2: Confirm production version**
+
+```bash
+curl -s http://10.77.9.205/healthz; echo
+```
+
+Expected: `version: 0.4.36`, `channel: release`.
+
+- [ ] **Step 3: Switch production stage to worship-pp and visually inspect**
+
+```bash
+curl -s -X POST http://10.77.9.205/stage/layout -H 'content-type: application/json' -d '{"code":"worship-pp"}'
+```
+
+Open `http://10.77.9.205/stage` in a desktop browser. Repeat the five visual checks from Task 7 Step 3 against the production deployment.
+
+- [ ] **Step 4: Ask user for visual confirmation on the real stage TVs**
+
+The operator confirms on the church's actual stage displays that:
+- Playlist names are cleaned (no `042 ` prefix).
+- Each entry stays on one row.
+- The next-song box matches the Presenter playlist's next entry, not whatever AbleSet thinks is next.
+- worship-snv (if used elsewhere) still behaves identically to before this PR.
+
+Record the operator's verdict.
+
+- [ ] **Step 5: Mark task done — no spec Findings update needed (this is a small UI tweak, not a multi-iteration design with empirical baselines).**
+
+---
+
+## Verification Summary
+
+| Check | Where verified |
+|---|---|
+| `clean_song_name` strips 3-digit prefix | `utils::text::tests::clean_song_name_strips_3digit_prefix` (Task 2) |
+| `clean_song_name` passes through non-prefixed names | `utils::text::tests::clean_song_name_passes_through_non_prefixed` (Task 2) |
+| `clean_song_name` rejects 2-digit and 4-digit prefixes | Two dedicated tests (Task 2) |
+| `clean_song_name` handles leading whitespace | `utils::text::tests::clean_song_name_handles_leading_whitespace` (Task 2) |
+| `clean_song_name` handles empty input | `utils::text::tests::clean_song_name_empty_input_unchanged` (Task 2) |
+| `worship_pp.rs` compiles after rewrite | `cargo build -p presenter-ui` (Task 4 Step 2) |
+| Sidebar names render cleaned | Visual check (Task 7 Step 3.2) |
+| Sidebar entries one row with ellipsis | Visual check (Task 7 Step 3.3) |
+| Next-song from playlist (not AbleSet) | Visual check (Task 7 Step 3.5) + operator confirm (Task 9 Step 4) |
+| `worship_snv` unaffected | No change to `worship_snv.rs`; existing E2E `tests/e2e/stage-api-ndi.spec.ts` and any worship-snv-touching specs continue to pass via Task 6's CI |

--- a/docs/superpowers/plans/2026-04-27-worship-pp-fixes.md
+++ b/docs/superpowers/plans/2026-04-27-worship-pp-fixes.md
@@ -1,0 +1,1166 @@
+# Worship-PP Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three regressions on the worship-pp stage and operator playlist after PR #268: stage layout overlap, invisible active-song highlight, empty operator playlist entry names.
+
+**Architecture:** Three independent fixes shipped together. (1) Wrap the six worship-pp slide regions inside the existing `.stage-pp__slides-area` so the absolute positioning anchors to the left 70% column instead of the page. (2) Replace the faint `.stage-pp__playlist-entry--active` styling with a high-contrast pill for projector visibility. (3) Add `presentation_name: Option<String>` to `PlaylistEntryKind::Presentation` in `presenter-core`; the server enriches it on read using the existing `fetch_presentation_names_for_playlist`; the WASM operator reads it directly and the now-unused `rebuild_playlist_presentations_with_signal` helper is deleted.
+
+**Tech Stack:** Rust (axum, sea-orm), Leptos 0.7 WASM (`presenter-ui`), CSS, Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-worship-pp-fixes-design.md` (commit `01f6703`).
+
+---
+
+## Context
+
+`presenter-ui` is excluded from the root workspace and has a separate `Cargo.lock`. Tests for it run via `cargo test -p presenter-ui --target x86_64-unknown-linux-gnu` (native target since most tests don't need wasm32) or `cd crates/presenter-ui && cargo test --target x86_64-unknown-linux-gnu`. Clippy: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings -W clippy::all`.
+
+Local Rust builds are allowed on this dev machine. Run fmt + clippy + tests locally before pushing.
+
+`Playlist` and `PlaylistEntryKind` live in `presenter-core` and are used by both the server (storage + serialization) and the WASM client (deserialization). Adding a field means it flows through both with one change.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `crates/presenter-core/src/playlist.rs` | Domain types — add `presentation_name` to `PlaylistEntryKind::Presentation` |
+| `crates/presenter-persistence/src/repository/util.rs` | Set `presentation_name: None` when reading entries from DB |
+| `crates/presenter-server/src/router/playlists.rs` | Apply `enrich_playlist_with_names` to all `Json(playlist)` and `Json(playlists)` returns |
+| `crates/presenter-server/src/state/presentations.rs` | New helper `enrich_playlist_with_names` and `enrich_playlists_with_names` (callers in router and broadcast paths) |
+| `crates/presenter-ui/src/components/presentation_list.rs` | Replace `ctx.presentations.get()` lookup with `entry.kind` direct read |
+| `crates/presenter-ui/src/pages/operator.rs` | Remove the `rebuild_playlist_presentations_with_signal` block at line 494-508 |
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | Wrap six regions in `<div class="stage-pp__slides-area">` |
+| `crates/presenter-ui/styles/stage.css` | Replace `.stage-pp__playlist-entry--active` rule with high-contrast styling |
+| `tests/e2e/wasm-playlist-operations.spec.ts` | Add operator playlist-name visibility check |
+| `tests/e2e/stage-worship-pp.spec.ts` | New E2E for layout no-overlap + active highlight |
+| `Cargo.toml` (workspace), `crates/presenter-ui/Cargo.toml` | Version bump |
+
+---
+
+## Task 1: Bump version
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Run version check**
+
+```bash
+git fetch origin
+gh release list --limit 1
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+```
+
+Expected: workspace at `0.4.36`, latest release v0.4.26. Bump to `0.4.37`.
+
+- [ ] **Step 2: Bump root workspace**
+
+In `Cargo.toml`, find `[workspace.package]` block and change `version = "0.4.36"` to `version = "0.4.37"`.
+
+- [ ] **Step 3: Bump presenter-ui**
+
+In `crates/presenter-ui/Cargo.toml`, find `[package]` `version` and bump to next patch (e.g. `0.1.5` → `0.1.6`). Keep workspace coordination.
+
+- [ ] **Step 4: Refresh Cargo.lock**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -5
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -5 && cd ../..
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.37 (#worship-pp-fixes)"
+```
+
+---
+
+## Task 2: Add `presentation_name` field to `PlaylistEntryKind::Presentation`
+
+**Files:**
+- Modify: `crates/presenter-core/src/playlist.rs:42-53`
+- Modify: `crates/presenter-persistence/src/repository/util.rs:106-109`
+
+- [ ] **Step 1: Write failing serde round-trip test**
+
+In `crates/presenter-core/src/playlist.rs`, add at the very bottom of the file (or in the existing `#[cfg(test)] mod tests` block if present — verify by running `grep -n "mod tests" crates/presenter-core/src/playlist.rs`; if absent, append the block):
+
+```rust
+#[cfg(test)]
+mod presentation_name_tests {
+    use super::*;
+    use crate::id::{PlaylistEntryId, PresentationId};
+
+    #[test]
+    fn presentation_entry_round_trips_presentation_name() {
+        let id = PlaylistEntryId::new();
+        let pres_id = PresentationId::new();
+        let entry = PlaylistEntry {
+            id,
+            kind: PlaylistEntryKind::Presentation {
+                presentation_id: pres_id,
+                midi_binding: None,
+                presentation_name: Some("My Song".to_string()),
+            },
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            json.contains("\"presentationName\":\"My Song\""),
+            "expected camelCase field; got: {json}"
+        );
+        let parsed: PlaylistEntry = serde_json::from_str(&json).expect("deserialize");
+        match parsed.kind {
+            PlaylistEntryKind::Presentation {
+                presentation_name, ..
+            } => assert_eq!(presentation_name.as_deref(), Some("My Song")),
+            _ => panic!("expected Presentation"),
+        }
+    }
+
+    #[test]
+    fn presentation_entry_omits_name_when_none() {
+        let entry = PlaylistEntry {
+            id: PlaylistEntryId::new(),
+            kind: PlaylistEntryKind::Presentation {
+                presentation_id: PresentationId::new(),
+                midi_binding: None,
+                presentation_name: None,
+            },
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            !json.contains("presentationName"),
+            "None should be skip_serializing_if; got: {json}"
+        );
+    }
+
+    #[test]
+    fn deserializing_legacy_payload_without_name_works() {
+        // Backwards compat: old DB rows / clients that don't include the field.
+        let json = r#"{"id":"00000000-0000-0000-0000-000000000001","type":"presentation","presentationId":"00000000-0000-0000-0000-000000000002"}"#;
+        let parsed: PlaylistEntry = serde_json::from_str(json).expect("deserialize");
+        match parsed.kind {
+            PlaylistEntryKind::Presentation {
+                presentation_name, ..
+            } => assert_eq!(presentation_name, None),
+            _ => panic!("expected Presentation"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cargo test -p presenter-core presentation_name_tests 2>&1 | tail -15
+```
+
+Expected: compile error (field `presentation_name` doesn't exist) or test failures.
+
+- [ ] **Step 3: Add field to `PlaylistEntryKind::Presentation`**
+
+In `crates/presenter-core/src/playlist.rs`, replace lines 42-53:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum PlaylistEntryKind {
+    Presentation {
+        presentation_id: PresentationId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        midi_binding: Option<MidiBinding>,
+        /// Display name resolved by the server when serializing the playlist
+        /// for the client. Stored as None internally; populated only on the
+        /// response path. See `enrich_playlist_with_names` in the server.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        presentation_name: Option<String>,
+    },
+    Separator {
+        name: String,
+    },
+}
+```
+
+- [ ] **Step 4: Update persistence conversion**
+
+In `crates/presenter-persistence/src/repository/util.rs`, find the `PlaylistEntryKind::Presentation { presentation_id, midi_binding }` construction at line 106-109 and add `presentation_name: None`:
+
+```rust
+            PlaylistEntryKind::Presentation {
+                presentation_id,
+                midi_binding,
+                presentation_name: None,
+            }
+```
+
+- [ ] **Step 5: Update any other constructors of `PlaylistEntryKind::Presentation`**
+
+Find every site that constructs the variant:
+
+```bash
+grep -rn "PlaylistEntryKind::Presentation {" crates/ 2>&1 | head -20
+```
+
+For each, ensure it sets `presentation_name: None` (or `Some(..)` if it actually has the name to set). Likely sites: `presenter-server/src/router/playlists.rs` (replace_playlist_entries), `presenter-server/src/state/stage.rs`, anywhere in tests.
+
+For `presenter-server/src/router/playlists.rs` around line 153, change to:
+
+```rust
+                Ok(PlaylistEntry {
+                    id,
+                    kind: PlaylistEntryKind::Presentation {
+                        presentation_id: PresentationId::from_uuid(presentation_id),
+                        midi_binding: binding,
+                        presentation_name: None,
+                    },
+                })
+```
+
+For any test fixtures, set `presentation_name: None`.
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+```bash
+cargo test -p presenter-core presentation_name_tests 2>&1 | tail -10
+cargo build --workspace 2>&1 | tail -10
+```
+
+Expected: the 3 new tests pass; the workspace still builds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-core/src/playlist.rs crates/presenter-persistence/src/repository/util.rs crates/presenter-server/src/router/playlists.rs
+# Add any other files that needed updating in step 5:
+git status -s
+git add -A
+git commit -m "feat(core): add presentation_name field to playlist Presentation entry (#worship-pp-fixes)
+
+Field is None internally and populated on the server response path
+via fetch_presentation_names_for_playlist. Skip-serialize-if-none
+keeps storage and intra-server flows untouched. Backwards-compatible
+deserialization for legacy clients that don't send the field."
+```
+
+---
+
+## Task 3: Server enrichment helper + apply to all response sites
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/presentations.rs`
+- Modify: `crates/presenter-server/src/router/playlists.rs`
+- Modify: `crates/presenter-server/src/router/tests.rs`
+
+- [ ] **Step 1: Write failing integration test**
+
+In `crates/presenter-server/src/router/tests.rs`, add (or find the existing `playlist` test module and add to it):
+
+```rust
+#[tokio::test]
+async fn get_playlist_response_includes_presentation_name() {
+    let state = AppState::in_memory().await.unwrap();
+    // Seed: create one library + presentation
+    let library = state
+        .create_library("Test Library", true)
+        .await
+        .expect("create library");
+    let presentation = state
+        .create_presentation(library.id, "My Song")
+        .await
+        .expect("create presentation");
+    // Create playlist with that presentation as an entry
+    let playlist = state
+        .create_playlist("Test Playlist", true)
+        .await
+        .expect("create playlist");
+    let entries = vec![presenter_core::playlist::PlaylistEntry {
+        id: presenter_core::PlaylistEntryId::new(),
+        kind: presenter_core::playlist::PlaylistEntryKind::Presentation {
+            presentation_id: presentation.id,
+            midi_binding: None,
+            presentation_name: None,
+        },
+    }];
+    state
+        .replace_playlist_entries(playlist.id, entries)
+        .await
+        .expect("replace entries");
+
+    let app = build_router(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/playlists/{}", playlist.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let entry = &body["entries"][0];
+    assert_eq!(entry["type"], "presentation");
+    assert_eq!(
+        entry["presentationName"], "My Song",
+        "presentation_name must be present in playlist GET response"
+    );
+}
+
+#[tokio::test]
+async fn list_playlists_response_includes_presentation_names() {
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library("Lib", true).await.unwrap();
+    let presentation = state
+        .create_presentation(library.id, "Track One")
+        .await
+        .unwrap();
+    let playlist = state.create_playlist("PL", true).await.unwrap();
+    state
+        .replace_playlist_entries(
+            playlist.id,
+            vec![presenter_core::playlist::PlaylistEntry {
+                id: presenter_core::PlaylistEntryId::new(),
+                kind: presenter_core::playlist::PlaylistEntryKind::Presentation {
+                    presentation_id: presentation.id,
+                    midi_binding: None,
+                    presentation_name: None,
+                },
+            }],
+        )
+        .await
+        .unwrap();
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/playlists")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body[0]["entries"][0]["presentationName"], "Track One");
+}
+```
+
+If the existing tests use a different helper-function shape (e.g., `state.create_library` vs another method), check `crates/presenter-server/src/router/tests.rs` for the actual API surface used by sibling tests and match it. Run `grep -n "create_library\|create_presentation\|create_playlist" crates/presenter-server/src/state/` to find the actual method names. The test names and assertions stay the same; only the seed-data calls adapt.
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cargo test -p presenter-server router::tests::get_playlist_response_includes_presentation_name 2>&1 | tail -10
+```
+
+Expected: assertion fails — `presentationName` is not in the response.
+
+- [ ] **Step 3: Add `enrich_playlist_with_names` helper**
+
+In `crates/presenter-server/src/state/presentations.rs`, add after the existing `get_playlist` method:
+
+```rust
+    /// Populate `presentation_name` on each `PlaylistEntryKind::Presentation`
+    /// entry. Idempotent — overwrites whatever was there.
+    pub async fn enrich_playlist_with_names(
+        &self,
+        mut playlist: presenter_core::Playlist,
+    ) -> anyhow::Result<presenter_core::Playlist> {
+        let names = self
+            .repository
+            .fetch_presentation_names_for_playlist(&playlist)
+            .await?;
+        for entry in playlist.entries.iter_mut() {
+            if let presenter_core::playlist::PlaylistEntryKind::Presentation {
+                presentation_id,
+                presentation_name,
+                ..
+            } = &mut entry.kind
+            {
+                *presentation_name = names.get(presentation_id).cloned();
+            }
+        }
+        Ok(playlist)
+    }
+
+    pub async fn enrich_playlists_with_names(
+        &self,
+        playlists: Vec<presenter_core::Playlist>,
+    ) -> anyhow::Result<Vec<presenter_core::Playlist>> {
+        let mut out = Vec::with_capacity(playlists.len());
+        for pl in playlists {
+            out.push(self.enrich_playlist_with_names(pl).await?);
+        }
+        Ok(out)
+    }
+```
+
+- [ ] **Step 4: Apply enrichment in router handlers**
+
+In `crates/presenter-server/src/router/playlists.rs`:
+
+Replace `list_playlists` body (lines 57-62):
+
+```rust
+#[instrument(skip_all)]
+pub(super) async fn list_playlists(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Playlist>>, AppError> {
+    let playlists = state.playlists().await?;
+    let enriched = state.enrich_playlists_with_names(playlists).await?;
+    Ok(Json(enriched))
+}
+```
+
+Replace `get_playlist` body (lines 80-89):
+
+```rust
+#[instrument(skip_all)]
+pub(super) async fn get_playlist(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Playlist>, AppError> {
+    let playlist = state
+        .get_playlist(PlaylistId::from_uuid(id))
+        .await?
+        .ok_or_else(|| AppError::not_found("playlist not found"))?;
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
+}
+```
+
+Replace `update_playlist` final lines (110-117):
+
+```rust
+    let updated = state
+        .playlists()
+        .await?
+        .into_iter()
+        .find(|playlist| playlist.id == playlist_id)
+        .ok_or_else(|| AppError::not_found("playlist not found"))?;
+    let enriched = state.enrich_playlist_with_names(updated).await?;
+    Ok(Json(enriched))
+```
+
+Replace `replace_playlist_entries` final lines (178-181):
+
+```rust
+    let playlist = state
+        .replace_playlist_entries(PlaylistId::from_uuid(id), entries)
+        .await?;
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
+```
+
+Replace `create_playlist` final lines (73-77):
+
+```rust
+    let playlist = state
+        .create_playlist(name, payload.show_in_dashboard)
+        .await?;
+    // Just-created has no entries, but enrich for response shape consistency.
+    let enriched = state.enrich_playlist_with_names(playlist).await?;
+    Ok(Json(enriched))
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+cargo test -p presenter-server router::tests::get_playlist_response_includes_presentation_name router::tests::list_playlists_response_includes_presentation_names 2>&1 | tail -10
+cargo test -p presenter-server 2>&1 | tail -10
+```
+
+Expected: 2 new tests pass; all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/router/playlists.rs crates/presenter-server/src/state/presentations.rs crates/presenter-server/src/router/tests.rs
+git commit -m "feat(server): enrich playlist responses with presentation_name (#worship-pp-fixes)
+
+Server uses existing fetch_presentation_names_for_playlist to fill
+presentation_name on each Presentation entry before serializing.
+Applies to GET /playlists, GET /playlists/{id}, POST /playlists,
+PATCH /playlists/{id}, PUT /playlists/{id}/entries.
+Operator can now read the entry display name directly without
+maintaining a parallel client-side index of empty-name summaries."
+```
+
+---
+
+## Task 4: WASM operator reads `presentation_name` from entry; remove rebuild helper
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/presentation_list.rs`
+- Modify: `crates/presenter-ui/src/pages/operator.rs:486-514`
+
+- [ ] **Step 1: Update entry-name lookup in `presentation_list.rs`**
+
+In `crates/presenter-ui/src/components/presentation_list.rs`, replace lines 351-356:
+
+OLD:
+```rust
+                                        // Look up presentation name from presentations list or index
+                                        let presentations = ctx.presentations.get();
+                                        let pres_name = presentations.iter()
+                                            .find(|p| p.id.to_string() == id)
+                                            .map(|p| p.name.clone())
+                                            .unwrap_or_default();
+```
+
+NEW:
+```rust
+                                        // Read presentation name directly from the playlist entry
+                                        // (server enriches it via fetch_presentation_names_for_playlist).
+                                        let pres_name = match &entry.kind {
+                                            presenter_core::playlist::PlaylistEntryKind::Presentation {
+                                                presentation_name, ..
+                                            } => presentation_name.clone().unwrap_or_default(),
+                                            _ => String::new(),
+                                        };
+```
+
+Note: `entry` is the loop variable from `playlist.entries.iter().enumerate()` at line 176 — verify it's in scope at line 351 (it is — this is inside the `Presentation` arm of the match on `&entry.kind`).
+
+- [ ] **Step 2: Remove `rebuild_playlist_presentations_with_signal` from operator.rs**
+
+In `crates/presenter-ui/src/pages/operator.rs`, find the `spawn_local` block at lines 486-514 (the one that fetches a playlist on selection and rebuilds `presentations`). Replace the whole block:
+
+OLD (lines 488-510, approximately):
+```rust
+        leptos::task::spawn_local(async move {
+            // Fetch full playlist for entry rendering
+            if let Ok(pl) = crate::api::playlists::get_playlist(&pl_id).await {
+                context_title.set(pl.name.clone());
+                let summaries: Vec<presenter_core::PresentationSummary> = pl
+                    .entries
+                    .iter()
+                    .filter_map(|e| match &e.kind {
+                        presenter_core::playlist::PlaylistEntryKind::Presentation {
+                            presentation_id,
+                            ..
+                        } => Some(presenter_core::PresentationSummary::new(
+                            *presentation_id,
+                            String::new(),
+                        )),
+                        _ => None,
+                    })
+                    .collect();
+                presentations.set(summaries);
+                selected_playlist.set(Some(pl));
+            }
+            if let Ok(pls) = crate::api::playlists::list_playlists().await {
+                playlists.set(pls);
+            }
+        });
+```
+
+NEW:
+```rust
+        leptos::task::spawn_local(async move {
+            // Fetch full playlist for entry rendering. The response now
+            // includes presentation_name on each entry, so the operator
+            // no longer needs to fake a presentations summary list.
+            if let Ok(pl) = crate::api::playlists::get_playlist(&pl_id).await {
+                context_title.set(pl.name.clone());
+                selected_playlist.set(Some(pl));
+            }
+            if let Ok(pls) = crate::api::playlists::list_playlists().await {
+                playlists.set(pls);
+            }
+        });
+```
+
+- [ ] **Step 3: Remove `rebuild_playlist_presentations_with_signal` helper**
+
+In `crates/presenter-ui/src/components/presentation_list.rs`, delete lines 605-623 (the `fn rebuild_playlist_presentations_with_signal(...)` definition). Then remove every CALL to it. Find calls:
+
+```bash
+grep -n "rebuild_playlist_presentations_with_signal" crates/presenter-ui/src/components/presentation_list.rs
+```
+
+Each call follows a `replace_entries` success and looks like:
+```rust
+    if let Ok(updated) = crate::api::playlists::replace_entries(&playlist_id, entries).await {
+        selected_playlist.set(Some(updated.clone()));
+        rebuild_playlist_presentations_with_signal(presentations, &updated);  // ← delete this line
+    }
+```
+
+Remove that line at every callsite (line 114, 235, 288, 321, 420, 478 — verify with grep). Also remove `let presentations = ctx.presentations;` lines that exist ONLY to feed the helper (look for unused `presentations` bindings in those closures and remove them too — the compiler will flag unused bindings with `-D warnings`).
+
+- [ ] **Step 4: Build and run**
+
+```bash
+cd crates/presenter-ui
+cargo build --target wasm32-unknown-unknown 2>&1 | tail -10
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -15
+cargo test --target x86_64-unknown-linux-gnu 2>&1 | tail -10
+cd ../..
+```
+
+Expected: clean build, clippy passes, all `presenter-ui` tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/presentation_list.rs crates/presenter-ui/src/pages/operator.rs
+git commit -m "fix(ui): operator reads presentation_name from playlist entry (#worship-pp-fixes)
+
+Removes the rebuild_playlist_presentations_with_signal helper that
+faked a presentations list with empty names every time a playlist
+was selected. The lookup that depended on it returned an empty
+string, so playlist entries rendered with no visible name.
+Now the entry's presentation_name (server-enriched) is used directly."
+```
+
+---
+
+## Task 5: Wrap worship-pp slide regions in `.stage-pp__slides-area`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/worship_pp.rs:132-194`
+
+- [ ] **Step 1: Wrap the six regions in slides-area**
+
+In `crates/presenter-ui/src/components/stage/worship_pp.rs`, replace the whole `view! { ... }` block (lines 132-195). The change: insert `<div class="stage-pp__slides-area">` around the six regions, before `.stage-pp__playlist-sidebar`. StatusBar stays as the last child of `.stage-container`.
+
+```rust
+    view! {
+        <div class="stage-container" data-layout="worship-pp">
+            <div class="stage-pp__slides-area">
+                <div class="stage__current-group">
+                    <span class="stage__debug-label">"current-group"</span>
+                    <div node_ref=current_group_ref class="stage__group-pill" style=current_group_style>
+                        {current_group_text}
+                    </div>
+                </div>
+
+                <div class="stage__current-song">
+                    <span class="stage__debug-label">"current-song"</span>
+                    <div node_ref=current_song_ref class="stage__song-name-text">
+                        {current_song_text}
+                    </div>
+                </div>
+
+                <div class="stage__current-slide">
+                    <span class="stage__debug-label">"current-slide"</span>
+                    <div node_ref=current_text_ref class="stage__slide-text">
+                        {current_text}
+                    </div>
+                </div>
+
+                <div class="stage__next-group">
+                    <span class="stage__debug-label">"next-group"</span>
+                    <div node_ref=next_group_ref class="stage__group-pill" style=next_group_style>
+                        {next_group_text}
+                    </div>
+                </div>
+
+                <div class="stage__next-song">
+                    <span class="stage__debug-label">"next-song"</span>
+                    <div node_ref=next_song_ref class="stage__song-name-text">
+                        {next_song_text}
+                    </div>
+                </div>
+
+                <div class="stage__next-slide">
+                    <span class="stage__debug-label">"next-slide"</span>
+                    <div node_ref=next_text_ref class="stage__slide-text">
+                        {next_text}
+                    </div>
+                </div>
+            </div>
+
+            <div class="stage-pp__playlist-sidebar">
+                <span class="stage__debug-label">"playlist-sidebar"</span>
+                <For
+                    each=playlist_entries
+                    key=|entry| entry.name.clone()
+                    children=move |entry| {
+                        let class = if entry.is_active {
+                            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                        } else {
+                            "stage-pp__playlist-entry"
+                        };
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
+                    }
+                />
+            </div>
+
+            <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
+        </div>
+    }
+```
+
+- [ ] **Step 2: Build the WASM crate**
+
+```bash
+cd crates/presenter-ui
+cargo build --target wasm32-unknown-unknown 2>&1 | tail -5
+cd ../..
+```
+
+Expected: clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/stage/worship_pp.rs
+git commit -m "fix(stage): wrap worship-pp regions in slides-area to stop sidebar overlap (#worship-pp-fixes)
+
+The .stage-pp__slides-area CSS rule already constrained to the left
+70% but the markup never used it as a wrapper, so the six slide
+regions used full-page absolute positioning and the sidebar overlaid
+them. Wrapping the regions makes their absolute positioning anchor
+to slides-area instead, leaving a clean 30% column on the right
+for the playlist."
+```
+
+---
+
+## Task 6: High-contrast active-song highlight CSS
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/stage.css:364-368`
+
+- [ ] **Step 1: Update the active-entry rule**
+
+In `crates/presenter-ui/styles/stage.css`, replace lines 364-368:
+
+OLD:
+```css
+.stage-pp__playlist-entry--active {
+    background: rgba(56, 189, 248, 0.15);
+    color: #f8fafc;
+    font-weight: 700;
+}
+```
+
+NEW:
+```css
+.stage-pp__playlist-entry--active {
+    background: #38bdf8;
+    color: #0f172a;
+    font-weight: 700;
+    border-left: 4px solid #0ea5e9;
+    /* Compensate for the 4px border so text alignment with non-active
+       rows stays consistent. Original padding-left from .stage-pp__playlist-entry
+       is 0.6rem; subtract the border width. */
+    padding-left: calc(0.6rem - 4px);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/presenter-ui/styles/stage.css
+git commit -m "fix(stage): high-contrast active-song highlight on worship-pp playlist (#worship-pp-fixes)
+
+The 15%-opacity tint was invisible from projector distance. Now
+uses a solid sky-blue pill with dark text and a 4px accent bar
+on the left edge — pops at a glance even on a dim screen."
+```
+
+---
+
+## Task 7: E2E tests for operator playlist names + worship-pp layout & highlight
+
+**Files:**
+- Modify: `tests/e2e/wasm-playlist-operations.spec.ts`
+- Create: `tests/e2e/stage-worship-pp.spec.ts`
+
+- [ ] **Step 1: Extend operator drag-drop test to assert visible name**
+
+In `tests/e2e/wasm-playlist-operations.spec.ts`, find the test `"drop a presentation onto a playlist row appends an entry"` (line 327). Right before the final `expect(consoleErrors).toEqual([]);` at the end of that test, INSERT:
+
+```typescript
+    // Click the playlist to make it the selected playlist, so its entries
+    // are shown in the presentation column.
+    const playlistRow = page.locator(
+      `[data-role="playlist-list"] [data-playlist-id="${targetPlaylistId}"] [data-role="playlist-item"]`,
+    );
+    await playlistRow.click();
+
+    // The first presentation entry must render with a non-empty visible name.
+    // Regression guard: previously the operator rebuilt presentations summaries
+    // with empty strings, so the name span was blank.
+    const firstEntryName = await page
+      .locator(
+        '[data-role="presentation-item"][data-type="presentation"] > span:first-child',
+      )
+      .first()
+      .textContent();
+    expect(
+      firstEntryName?.trim(),
+      "playlist entry must show a non-empty presentation name",
+    ).toBeTruthy();
+    expect(firstEntryName?.trim().length ?? 0).toBeGreaterThan(0);
+```
+
+The selector `[data-role="presentation-item"] > span:first-child` targets the `<span>{pres_name}</span>` at presentation_list.rs:433.
+
+- [ ] **Step 2: Create new stage E2E test**
+
+Create `tests/e2e/stage-worship-pp.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { startTestServer, type TestServer } from "./helpers/test-server";
+
+let server: TestServer;
+let baseURL: string;
+
+test.beforeAll(async () => {
+  server = await startTestServer();
+  baseURL = server.baseURL;
+});
+
+test.afterAll(async () => {
+  await server?.stop();
+});
+
+test.describe("Stage worship-pp layout", () => {
+  test("slides-area and playlist-sidebar do not overlap", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon")) consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // 1. Switch the active stage layout to worship-pp via the operator's
+    //    select control (which uses the WASM API path the user would).
+    await page.goto(new URL("/ui/operator", baseURL).toString());
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+    await page.evaluate(() => {
+      const sel = document.querySelector(
+        '[data-role="stage-layout-select"]',
+      ) as HTMLSelectElement | null;
+      if (!sel) throw new Error("stage-layout-select not found");
+      sel.value = "worship-pp";
+      sel.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    // 2. Open the stage page in the same context.
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(
+      () =>
+        document.body.dataset.wasmReady === "true" &&
+        document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+
+    // 3. Both wrapper boxes exist.
+    const slidesArea = page.locator(".stage-pp__slides-area");
+    const sidebar = page.locator(".stage-pp__playlist-sidebar");
+    await expect(slidesArea).toBeVisible();
+    await expect(sidebar).toBeVisible();
+
+    // 4. Slides-area's right edge must be ≤ sidebar's left edge.
+    const overlap = await page.evaluate(() => {
+      const a = document
+        .querySelector(".stage-pp__slides-area")
+        ?.getBoundingClientRect();
+      const b = document
+        .querySelector(".stage-pp__playlist-sidebar")
+        ?.getBoundingClientRect();
+      if (!a || !b) return { error: "missing rect" };
+      return { aRight: a.right, bLeft: b.left, overlap: a.right > b.left };
+    });
+    expect(
+      overlap.overlap,
+      `slides-area right=${overlap.aRight} sidebar left=${overlap.bLeft}`,
+    ).toBe(false);
+
+    // 5. The six slide regions live INSIDE slides-area (not as siblings).
+    for (const cls of [
+      ".stage__current-group",
+      ".stage__current-song",
+      ".stage__current-slide",
+      ".stage__next-group",
+      ".stage__next-song",
+      ".stage__next-slide",
+    ]) {
+      const inside = await page.evaluate((selector) => {
+        const el = document.querySelector(selector);
+        return !!el?.closest(".stage-pp__slides-area");
+      }, cls);
+      expect(inside, `${cls} should be inside slides-area`).toBe(true);
+    }
+
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("active playlist entry has high-contrast background distinct from inactive", async ({
+    page,
+  }) => {
+    if (!server) throw new Error("test server not started");
+
+    // Seed: create a playlist with one entry, set its presentation as active on stage.
+    const presResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    const libs = await presResp.json();
+    const presentation = libs[0]?.presentations?.[0];
+    if (!presentation) {
+      test.skip(true, "test fixture has no presentations");
+      return;
+    }
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      { data: { name: "Highlight Test", showInDashboard: true } },
+    );
+    const playlist = await playlistResp.json();
+    await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [
+            { type: "presentation", presentationId: presentation.id },
+          ],
+        },
+      },
+    );
+    // Trigger the presentation on stage so it becomes the active one.
+    await page.request.post(
+      new URL("/state/stage/trigger-presentation", baseURL).toString(),
+      { data: { presentationId: presentation.id, playlistId: playlist.id } },
+    );
+
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+
+    // Wait for the active row to appear with the active class.
+    const active = page.locator(".stage-pp__playlist-entry--active").first();
+    await expect(active).toBeVisible({ timeout: 15_000 });
+
+    // Background of active row must NOT match background of an inactive row
+    // (or the absence of one — if there's only one entry, just check it has
+    // a non-transparent background).
+    const colors = await page.evaluate(() => {
+      const a = document.querySelector(
+        ".stage-pp__playlist-entry--active",
+      ) as HTMLElement | null;
+      const inactive = Array.from(
+        document.querySelectorAll(".stage-pp__playlist-entry"),
+      ).find(
+        (e) => !e.classList.contains("stage-pp__playlist-entry--active"),
+      ) as HTMLElement | null;
+      return {
+        active: a ? getComputedStyle(a).backgroundColor : null,
+        inactive: inactive ? getComputedStyle(inactive).backgroundColor : null,
+      };
+    });
+    expect(colors.active).toBeTruthy();
+    // Active should not be fully transparent (rgba(0, 0, 0, 0)).
+    expect(colors.active).not.toBe("rgba(0, 0, 0, 0)");
+    expect(colors.active).not.toBe("transparent");
+    if (colors.inactive) {
+      expect(colors.active).not.toBe(colors.inactive);
+    }
+
+    // Cleanup
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+  });
+});
+```
+
+If the seed data setup or the trigger endpoint shape differs (verify by running `grep -rn "trigger-presentation\|trigger_presentation" crates/presenter-server/src/router/` to find the actual endpoint), adapt the seed-section calls. The visibility, overlap, and background-color assertions stay as-is.
+
+If `tests/e2e/helpers/test-server.ts` doesn't expose `startTestServer`/`TestServer`, mirror the import pattern used by `tests/e2e/wasm-playlist-operations.spec.ts` (run `head -20 tests/e2e/wasm-playlist-operations.spec.ts` to see the actual imports and fixtures used).
+
+- [ ] **Step 3: Run E2E tests locally to confirm they would pass**
+
+Run only the new and updated tests in shard mode:
+
+```bash
+npm run test:playwright -- --grep "drop a presentation onto a playlist row|Stage worship-pp layout" 2>&1 | tail -40
+```
+
+Expected: both tests pass against the local dev server. If the server isn't running, start it: `cargo run -p presenter-server &` then re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/wasm-playlist-operations.spec.ts tests/e2e/stage-worship-pp.spec.ts
+git commit -m "test(e2e): playlist names + worship-pp layout & active highlight (#worship-pp-fixes)
+
+Three regression guards for #worship-pp-fixes:
+- After drag-drop, click the playlist row and assert the rendered
+  entry shows a non-empty presentation name
+- Stage worship-pp: assert slides-area and playlist-sidebar do not
+  overlap and the six regions live inside slides-area
+- Stage worship-pp: assert the active entry has a non-transparent
+  background distinct from inactive entries"
+```
+
+---
+
+## Task 8: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Run local lint/format/test**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -15
+cargo test --workspace 2>&1 | tail -10
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -15 && cargo test --target x86_64-unknown-linux-gnu 2>&1 | tail -10 && cd ../..
+```
+
+Expected: every step exits 0, clippy emits no warnings.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor pipeline**
+
+Find the pipeline run for the latest SHA:
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status,conclusion --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+```
+
+Wait for completion using a single background poll (per `ci-monitoring.md` — do NOT poll repeatedly):
+
+```bash
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Expected: ALL jobs `success` (Branch Sync, Format, Clippy, Test, Build, Code Coverage, Mutation Testing, Playwright E2E 1/3 + 2/3 + 3/3, Merge E2E Reports, Deploy to Dev). If anything failed, fetch the failed job log (`gh run view <RUN_ID> --log-failed`), fix the root cause in ONE commit, push, monitor again.
+
+---
+
+## Task 9: Verify on dev + open PR
+
+- [ ] **Step 1: Verify dev deploy**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz | head
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.37"}`.
+
+Then verify the three fixes in a real browser via Playwright MCP (or by hand):
+
+- Open `http://10.77.8.134:8080/ui/operator`. In a freshly created playlist, drag any presentation into it. Click the playlist row. Expected: presentation name visible (not empty span).
+- Open `http://10.77.8.134:8080/stage`. Switch operator to worship-pp layout. Expected: slides on the left don't overlap the playlist sidebar on the right. Active song row in sidebar is a solid blue pill with a left accent bar (clearly distinct from the others).
+- Browser console on both pages: zero errors / warnings.
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main --head dev --title "fix(stage): worship-pp regressions — overlap, highlight, operator names" --body "$(cat <<'EOF'
+## Summary
+Three regressions reported on the worship-pp stage and operator playlist after PR #268:
+
+- **Stage layout overlap** — slides and playlist sidebar overlapped. Fixed by wrapping the six slide regions in `.stage-pp__slides-area` so their absolute positioning anchors to the left 70% column.
+- **Active-song highlight invisible from projector** — replaced the 15%-opacity tint with a solid sky-blue pill, dark text, and a 4px accent bar on the left edge.
+- **Operator playlist entries showed empty names** — server now enriches the playlist response with `presentation_name` on each `Presentation` entry (using the existing `fetch_presentation_names_for_playlist` helper). Operator reads it directly. Removed the obsolete `rebuild_playlist_presentations_with_signal` helper and its callsites.
+
+## Test plan
+- [ ] CI green on push and PR runs (incl. mutation testing)
+- [ ] Operator drag-drop E2E asserts presentation name visible
+- [ ] Stage worship-pp E2E asserts no overlap + active highlight has distinct background
+- [ ] 3 new core/serde unit tests for `presentation_name`
+- [ ] 2 new server integration tests for response enrichment
+- [ ] Manual: open dev stage with worship-pp + active playlist, verify visible highlight at projector distance
+- [ ] Browser console: zero errors / warnings on operator and stage
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for PR pipeline (separate from push pipeline)**
+
+```bash
+gh run list --branch dev --limit 5 --json databaseId,name,event,headSha,status --jq '.[] | select(.name == "Pipeline" and .event == "pull_request")' | head -1
+```
+
+Monitor the PR run with the same `sleep 1500 && gh run view` pattern. Wait for ALL jobs green incl. mutation testing.
+
+- [ ] **Step 4: Verify PR is mergeable + clean**
+
+```bash
+gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,url
+```
+
+Expected: `{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN", ...}`.
+
+- [ ] **Step 5: Provide PR URL to user, wait for explicit "merge it"**
+
+Per `pr-merge-policy.md`, do NOT merge. Send the completion report with the PR URL and wait.
+
+---
+
+## Task 10: Post-merge production verification (after user merges)
+
+- [ ] **Step 1: Watch the post-merge main pipeline + production deploy**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+```
+
+Background-poll: `sleep 1500 && gh run view <RUN_ID> ...`. Wait for ALL jobs green incl. `Deploy to Production`.
+
+- [ ] **Step 2: Verify production**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.37"}`.
+
+Then re-do the same Playwright/manual checks from Task 9 step 1 against `http://10.77.9.205/...`. Capture: drag-drop adds entry with visible name; stage worship-pp shows no overlap and obvious active highlight.
+
+- [ ] **Step 3: Final completion report**
+
+Send the user a short report (per `completion-report.md`): URLs, audits clean, what shipped, no follow-up question.
+
+---
+
+## Verification Summary
+
+| Check | How |
+|-------|-----|
+| Field round-trips through serde | `cargo test -p presenter-core presentation_name_tests` (3 tests) |
+| Server response carries name | `cargo test -p presenter-server router::tests::get_playlist_response_includes_presentation_name list_playlists_response_includes_presentation_names` |
+| Operator entries show names | E2E `wasm-playlist-operations.spec.ts` after-drop assertion |
+| Stage layout no overlap | E2E `stage-worship-pp.spec.ts` `getBoundingClientRect` comparison |
+| Active highlight visible | E2E `stage-worship-pp.spec.ts` `getComputedStyle` background-color check |
+| Console clean | All E2E tests assert `consoleErrors === []` |
+| Worship-snv unaffected | Existing worship-snv E2E tests still pass |
+| Mutation testing | CI mutation job stays green |

--- a/docs/superpowers/plans/2026-04-28-worship-pp-active-reactivity.md
+++ b/docs/superpowers/plans/2026-04-28-worship-pp-active-reactivity.md
@@ -1,0 +1,576 @@
+# Worship-PP Active-Highlight Reactivity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the worship-pp stage playlist sidebar's active-row highlight follow the currently-presenting song instead of getting stuck on whatever song was active when the sidebar first rendered.
+
+**Architecture:** Replace the static `class` binding inside the `<For>` children closure with a reactive closure that reads `is_active` from `ctx.snapshot` at evaluation time. Add an E2E regression test that triggers two consecutive presentations and asserts the highlight moves between sidebar rows.
+
+**Tech Stack:** Leptos 0.7 (WASM), Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-worship-pp-active-reactivity-design.md` (commit `1a5c960`).
+
+---
+
+## Context
+
+Stacks on PR #268 (still open, mergeable+clean awaiting user merge). Dev currently at 0.4.39; bump to 0.4.40 first per the version-bumping rule.
+
+`presenter-ui` is excluded from the root workspace and has its own `Cargo.lock`. Tests via `cargo test -p presenter-ui --target x86_64-unknown-linux-gnu`. Clippy via `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings -W clippy::all`. Local Rust builds are allowed.
+
+`ctx.snapshot` is a `RwSignal<Option<StageDisplaySnapshot>>` (Leptos `RwSignal` is `Copy`, so it can be captured into multiple closures freely). The fix uses `ctx.snapshot.with(|opt| ...)` to read entries reactively inside the `For` children closure.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace `[workspace.package]`) | `0.4.39` → `0.4.40` |
+| `crates/presenter-ui/Cargo.toml` | `0.1.8` → `0.1.9` |
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | Replace the `<For children=...>` closure with the reactive-class version |
+| `tests/e2e/stage-worship-pp.spec.ts` | Add the new "highlight moves on consecutive trigger" test |
+
+---
+
+## Task 1: Bump version to 0.4.40
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Confirm versions**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git fetch origin
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+```
+
+Expected: workspace `0.4.39`, presenter-ui `0.1.8`.
+
+- [ ] **Step 2: Bump workspace**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml` under `[workspace.package]`, change `version = "0.4.39"` to `version = "0.4.40"`.
+
+- [ ] **Step 3: Bump presenter-ui**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml` under `[package]`, change `version = "0.1.8"` to `version = "0.1.9"`.
+
+- [ ] **Step 4: Refresh Cargo.lock files**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.40 (#worship-pp-active-reactivity)"
+```
+
+---
+
+## Task 2: Reactive active-class in worship_pp.rs
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/worship_pp.rs:178-193`
+
+- [ ] **Step 1: Confirm the `<For>` block location**
+
+```bash
+grep -n "stage-pp__playlist-sidebar\|For\|stage-pp__playlist-entry" /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/stage/worship_pp.rs | head -10
+```
+
+Expected: lines around 178–193 contain `<For each=playlist_entries key=|entry| entry.name.clone() children=move |entry| { let class = if entry.is_active { ... } ... } />`.
+
+- [ ] **Step 2: Replace the For block with the reactive version**
+
+In `crates/presenter-ui/src/components/stage/worship_pp.rs`, find the `<For ...>` block inside `<div class="stage-pp__playlist-sidebar">` and replace the WHOLE block (lines 180–192 as shipped today). The existing block looks like:
+
+```rust
+                <For
+                    each=playlist_entries
+                    key=|entry| entry.name.clone()
+                    children=move |entry| {
+                        let class = if entry.is_active {
+                            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                        } else {
+                            "stage-pp__playlist-entry"
+                        };
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
+                    }
+                />
+```
+
+Replace with:
+
+```rust
+                <For
+                    each=playlist_entries
+                    key=|entry| entry.name.clone()
+                    children=move |entry| {
+                        // Capture the entry's name once. The active-class
+                        // must be REACTIVE — read from ctx.snapshot (a
+                        // RwSignal) on every update so the highlight follows
+                        // the currently-triggered song.
+                        // Without this, Leptos's <For> reuses the row's DOM
+                        // (same key = entry.name) and the captured entry's
+                        // is_active stays at its first-render value forever.
+                        let entry_name = entry.name.clone();
+                        let snapshot = ctx.snapshot;
+                        let is_active = move || {
+                            snapshot.with(|opt| {
+                                opt.as_ref()
+                                    .and_then(|s| s.playlist_entries.as_ref())
+                                    .map(|entries| {
+                                        entries
+                                            .iter()
+                                            .any(|e| e.name == entry_name && e.is_active)
+                                    })
+                                    .unwrap_or(false)
+                            })
+                        };
+                        let class = move || {
+                            if is_active() {
+                                "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                            } else {
+                                "stage-pp__playlist-entry"
+                            }
+                        };
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
+                    }
+                />
+```
+
+Notes for the implementer:
+- `ctx` is in scope inside the component function — see how the same component already uses `ctx.snapshot.get()` higher up.
+- `RwSignal` in Leptos 0.7 is `Copy`, so `let snapshot = ctx.snapshot;` is a cheap copy and the resulting `snapshot` value can be moved into the inner `is_active` closure.
+- `entry_name` is a `String` and is captured by the inner closure by move. Each call to `is_active()` borrows `entry_name` immutably to compare, then `class` calls `is_active()` from its own closure.
+
+- [ ] **Step 3: Build the WASM crate**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo build --target wasm32-unknown-unknown 2>&1 | tail -5
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cd ../..
+```
+
+Expected: clean build, zero clippy warnings.
+
+If clippy complains about a closure-moves-non-Copy issue on `entry_name`, the typical fix is to clone it inside the inner closure: replace `let entry_name = entry.name.clone();` with the same line, and inside `is_active`'s body change `entries.iter().any(|e| e.name == entry_name ...)` to `entries.iter().any(|e| e.name.as_str() == entry_name.as_str() ...)`. But the as-written code should compile cleanly because `entry_name` is captured by move into `is_active` (consumed once) and then the inner `entries.iter().any` captures `&entry_name` via the closure's environment. If a borrow-checker error pops up, paste it into the report and STOP — don't introduce an `unwrap`/`clone()` workaround without asking.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all
+git add crates/presenter-ui/src/components/stage/worship_pp.rs
+git commit -m "fix(stage): worship-pp active-highlight follows currently-presenting song (#worship-pp-active-reactivity)
+
+The For children closure captured entry.is_active at first render.
+On subsequent updates Leptos reused the DOM (same key = entry.name)
+and the stale class stuck. Make the class a reactive closure that
+reads is_active from ctx.snapshot at evaluation time so the
+highlight moves when the operator triggers a different song."
+```
+
+---
+
+## Task 3: E2E test — highlight follows consecutive triggers
+
+**Files:**
+- Modify: `tests/e2e/stage-worship-pp.spec.ts`
+
+- [ ] **Step 1: Append the new test inside the existing describe block**
+
+Append this test at the END of the existing `test.describe("Stage worship-pp layout", () => { ... })` block in `tests/e2e/stage-worship-pp.spec.ts`, just before the closing `});`:
+
+```typescript
+  test("active highlight moves to the new song when the operator triggers a different presentation", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon") && !t.includes("crbug.com/981419")) {
+          consoleErrors.push(`[${msg.type()}] ${t}`);
+        }
+      }
+    });
+
+    // Set worship-pp layout
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Find TWO presentations with at least one slide each.
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{
+        id: string;
+        name?: string;
+        slides?: Array<{ id: string }>;
+      }>;
+    }>;
+    const allPres = libs
+      .flatMap((lib) => lib.presentations ?? [])
+      .filter((p) => (p.slides?.length ?? 0) > 0 && !!p.name);
+    if (allPres.length < 2) {
+      test.skip(true, "fixture has fewer than 2 presentations with slides");
+      return;
+    }
+    const p1 = allPres[0];
+    const p2 = allPres[1];
+    if (
+      !p1.slides ||
+      !p2.slides ||
+      !p1.slides[0] ||
+      !p2.slides[0] ||
+      !p1.name ||
+      !p2.name
+    ) {
+      test.skip(true, "presentations missing required fields");
+      return;
+    }
+    const p1SlideId = p1.slides[0].id;
+    const p2SlideId = p2.slides[0].id;
+
+    // Create a playlist with both presentations.
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      {
+        data: {
+          name: `Highlight Move Test ${Date.now()}`,
+          showInDashboard: true,
+        },
+      },
+    );
+    const playlist = (await playlistResp.json()) as { id: string };
+    await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [
+            { type: "presentation", presentationId: p1.id },
+            { type: "presentation", presentationId: p2.id },
+          ],
+        },
+      },
+    );
+
+    // Trigger P1.
+    const trig1 = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: p1.id,
+          currentSlideId: p1SlideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trig1.status()).toBe(204);
+
+    // Open the stage page.
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      () => document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+
+    // Wait for both rows to render.
+    await page.waitForFunction(
+      () => document.querySelectorAll(".stage-pp__playlist-entry").length >= 2,
+      { timeout: 15_000 },
+    );
+
+    // Helper: read which row index has the active class. Returns -1 if none.
+    const activeIndex = async (): Promise<number> =>
+      page.evaluate(() => {
+        const rows = Array.from(
+          document.querySelectorAll(".stage-pp__playlist-entry"),
+        );
+        return rows.findIndex((r) =>
+          r.classList.contains("stage-pp__playlist-entry--active"),
+        );
+      });
+
+    // After triggering P1, P1's row (index 0) should be active.
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(0);
+
+    // Now trigger P2. The highlight MUST move to row index 1.
+    const trig2 = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: p2.id,
+          currentSlideId: p2SlideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trig2.status()).toBe(204);
+
+    // Regression guard: the active class must now be on row 1, not row 0.
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(1);
+
+    // And ensure row 0 is no longer active.
+    const row0Active = await page.evaluate(() => {
+      const rows = Array.from(
+        document.querySelectorAll(".stage-pp__playlist-entry"),
+      );
+      return (
+        rows[0]?.classList.contains("stage-pp__playlist-entry--active") ?? false
+      );
+    });
+    expect(row0Active).toBe(false);
+
+    // Cleanup
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Format**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npx prettier --write tests/e2e/stage-worship-pp.spec.ts 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Run the new test locally**
+
+The test must pass against the new fix from Task 2. The local Trunk dist must reflect Task 2's change — if you ran `cargo build --target wasm32-unknown-unknown` in Task 2 step 3 that's enough for `cargo build --release -p presenter-server` to bundle, but the Playwright tests typically use a release build. Run:
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+# Rebuild the WASM dist to pick up Task 2's change.
+scripts/build-ui.sh 2>&1 | tail -5 || (cd crates/presenter-ui && trunk build --release && cd ../..)
+# Run the new test only.
+npx playwright test tests/e2e/stage-worship-pp.spec.ts --grep "active highlight moves" 2>&1 | tail -25
+```
+
+Expected: PASS. Both `expect.poll(activeIndex)` calls succeed (first to 0, then to 1) and the row 0 check shows `false` after the second trigger.
+
+If the test fails BEFORE Task 2's fix lands (e.g. you skipped Task 2), the second `expect.poll` will time out because the highlight stays on row 0 — that's the regression we're fixing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add tests/e2e/stage-worship-pp.spec.ts
+git commit -m "test(e2e): assert worship-pp active highlight moves on consecutive triggers (#worship-pp-active-reactivity)
+
+The previous static test only verified the active class was applied
+when ONE presentation was triggered. This new test seeds a playlist
+with TWO presentations, triggers each in turn, and asserts the
+.stage-pp__playlist-entry--active class moves between rows. This
+is the reactivity guard the previous test missed."
+```
+
+---
+
+## Task 4: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Workspace fmt + clippy + tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+cargo test --workspace 2>&1 | tail -10
+```
+
+Expected: every command exits 0, clippy zero warnings, all tests pass.
+
+- [ ] **Step 2: presenter-ui specifically**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cargo test --target x86_64-unknown-linux-gnu --lib 2>&1 | tail -5
+cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git push origin dev
+```
+
+- [ ] **Step 4: Find the new pipeline run**
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status,conclusion --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+```
+
+Capture the `databaseId` — call it `RUN_ID` below.
+
+- [ ] **Step 5: Monitor pipeline (single background poll)**
+
+Per `ci-monitoring.md` — single background command, no repeated polling:
+
+```bash
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+When the poll returns: every job must have `conclusion: success`. If anything failed, fetch failed log (`gh run view <RUN_ID> --log-failed`), fix the root cause in ONE commit, push, and monitor again (one poll iteration only).
+
+Expected: ALL 21 jobs green (Format, Clippy, Test, Build, Code Coverage, Mutation Testing, Playwright E2E 1/3+2/3+3/3, Merge E2E Reports, Deploy to Dev, Deploy Companion Plugin).
+
+---
+
+## Task 5: Verify on dev + update PR #268
+
+- [ ] **Step 1: Verify dev healthz**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.40"}`.
+
+- [ ] **Step 2: Live verify the fix**
+
+Use Playwright MCP. The exact verification is the SAME flow as the new E2E test:
+1. `setViewportSize` 1920×1080.
+2. POST `/stage/layout` body `{"code":"worship-pp"}`.
+3. Pick two presentations with slides via GET `/libraries`.
+4. Create a playlist via API; PUT entries with both presentations.
+5. POST `/stage/state` with P1.
+6. Open `/stage`, wait for `body[data-layout-code="worship-pp"]` and at least 2 `.stage-pp__playlist-entry` rows.
+7. Read `findIndex(r => r.classList.contains("stage-pp__playlist-entry--active"))` → expect `0`.
+8. POST `/stage/state` with P2.
+9. Re-read the index → expect `1`.
+10. Browser console: 0 errors / 0 warnings.
+11. Cleanup: DELETE the test playlist, POST `/stage/clear`.
+
+- [ ] **Step 3: Update PR #268 body**
+
+PR #268 is the umbrella PR for all worship-pp work. Add a "Reactivity fix" section to the body via REST API (avoid the GraphQL projects-classic deprecation error):
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+Worship-pp baseline + drag-drop infrastructure + three layout regression fixes + follow-up polish + bigger sidebar fonts + active-highlight reactivity fix.
+
+### Stage worship-pp baseline
+- Adopts worship-snv improvements (autofit text, song-name boxes, six-region layout)
+- Keeps playlist sidebar; derives next_song_text from Presenter playlist instead of AbleSet
+
+### Drag-drop infrastructure
+- Added missing `GET /playlists/{id}` route (operator drop handler fetched playlist before appending and got 405)
+- Fixed WASM `PlaylistEntryPayload` field renames (presentationId/entryId — server was 422-ing the snake_case payload)
+
+### Layout regressions (round 1)
+- Wrapped six worship-pp regions in `.stage-pp__slides-area` to stop sidebar overlap
+- Replaced 15%-opacity tint with solid sky-blue + 4px accent bar (visible from projector)
+- Server enriches playlist response with `presentation_name`; operator reads it directly; deleted obsolete `rebuild_playlist_presentations_with_signal` helper
+
+### Follow-up polish (round 2)
+- Search-result drag onto playlist row now accepted: `set_drop_effect("copy")` in playlist dragover
+- Library-kind search results no longer marked draggable
+- Worship-pp sidebar 30% → 22%, slides 70% → 78%; entry font 0.9vw → 2.6vh
+
+### Bigger sidebar fonts (round 3)
+- Sidebar padding 1%/1.5% → 0.4%/0.5%; entry padding 0.6vh/0.8rem → 0.3vh/0.4rem; entry font-size 2.6vh → 5vh
+- ~12 typical characters fit per row at 1080p projector
+
+### Active-highlight reactivity (round 4)
+- Sidebar's `--active` class was stuck on the first triggered song because the For children closure captured `entry.is_active` once at insert. Made `class` a reactive closure that reads `is_active` from `ctx.snapshot` at evaluation time. Highlight now follows the operator's song changes.
+- New E2E asserts the `--active` class moves between rows on consecutive triggers (the reactivity guard the previous static test missed).
+
+## Test plan
+- [x] CI pipeline green (all 21 jobs incl. Mutation Testing)
+- [x] Playwright E2E: stage-worship-pp.spec.ts (overlap, highlight static, sidebar width, font ≥40px, highlight MOVES on consecutive trigger)
+- [x] Playwright E2E: wasm-playlist-operations.spec.ts (drag from presentation, drag from search, name visible after drag)
+- [x] Playwright E2E: wasm-drag-drop.spec.ts (search result draggable for presentation-kind, NOT for library-kind)
+- [x] Live Playwright verification on dev (10.77.8.134:8080) at 1920×1080:
+  - sidebar at 22%, font 54px (5vh)
+  - drag from search adds entry; drag from presentation list adds entry
+  - active highlight moves between rows on consecutive triggers
+  - browser console clean
+EOF
+gh api -X PATCH repos/zbynekdrlik/presenter/pulls/268 \
+  -f title="feat(stage): worship-pp baseline, drag-drop infra, layout regressions, follow-ups, bigger fonts, active-highlight reactivity" \
+  -F body=@/tmp/pr-body.md \
+  --jq '{number, title, state, mergeable_state}'
+```
+
+- [ ] **Step 4: Confirm PR is mergeable + clean**
+
+```bash
+gh pr view 268 --json mergeable,mergeStateStatus,url,state
+```
+
+Expected: `MERGEABLE` + `CLEAN`. If `UNSTABLE`, identify which check is pending (most likely Mutation Testing) and wait — do NOT propose any kind of bypass.
+
+- [ ] **Step 5: Send completion report and wait for explicit "merge it"**
+
+Per `pr-merge-policy.md` — do NOT merge. Send completion report (per `completion-report.md`) with dev + prod URLs, audits clean, what shipped. End with `❓ Question: Merge to main now?`.
+
+---
+
+## Task 6: Post-merge production verification (after user merges)
+
+- [ ] **Step 1: Watch the post-merge main pipeline**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+```
+
+Background-poll: `sleep 1500 && gh run view <RUN_ID> ...`. Wait for ALL jobs green incl. `Deploy to Production`.
+
+- [ ] **Step 2: Verify production**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.40"}`.
+
+Repeat the live Playwright verification from Task 5 step 2 against `http://10.77.9.205/...`. Capture: highlight moves between rows on consecutive triggers.
+
+- [ ] **Step 3: Final completion report**
+
+Short report per `completion-report.md` with prod-deploy-verified URLs. No follow-up question.
+
+---
+
+## Verification Summary
+
+| Check | How |
+|-------|-----|
+| Active class follows song changes | New E2E asserts `findIndex` of `--active` row goes 0 → 1 on consecutive triggers |
+| Old behavior is now caught | If reactivity regresses, the second `expect.poll` times out |
+| No flicker, no DOM rebuild | Same `For` key, only the class binding becomes reactive |
+| Existing tests still pass | The static "active row has high-contrast background" test continues to pass |
+| Browser console clean | Every E2E asserts `consoleErrors === []` |

--- a/docs/superpowers/plans/2026-04-28-worship-pp-bigger-fonts.md
+++ b/docs/superpowers/plans/2026-04-28-worship-pp-bigger-fonts.md
@@ -1,0 +1,411 @@
+# Worship-PP Bigger Sidebar Fonts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make worship-pp stage playlist sidebar text large enough that ~12 characters fit per row at 1080p projector — increase font from 2.6vh to 5vh, tighten sidebar and entry padding so the 22% sidebar's inner width is fully usable.
+
+**Architecture:** Pure CSS iteration on top of PR #268. Touches one CSS file (4 rules in `crates/presenter-ui/styles/stage.css`) and tightens one E2E assertion. No WASM, server, or layout changes.
+
+**Tech Stack:** CSS, Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-worship-pp-bigger-fonts-design.md` (commit `57ddbde`).
+
+---
+
+## Context
+
+Stacks on top of PR #268 (still open, mergeable+clean). Dev is at 0.4.38; bump to 0.4.39 / presenter-ui 0.1.8 first (per CLAUDE.md "version-bumping" rule — bump before any code, so the CI version-check job doesn't fail).
+
+`presenter-ui` is excluded from the root workspace and has its own `Cargo.lock`. Tests run via `cargo test -p presenter-ui --target x86_64-unknown-linux-gnu`. Clippy via `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings -W clippy::all`. Local Rust builds are allowed on this dev machine.
+
+Working directory: `/home/newlevel/devel/presenter/presenter-dev2`.
+
+The existing E2E `tests/e2e/stage-worship-pp.spec.ts` test "sidebar is narrower (~22%) and entries have projector-readable font" sets viewport to `1920×1080` and asserts `entryFontSizePx >= 24`. After the change, computed font is 5vh × 1080 = 54px, well above 40. We tighten the floor to 40 to lock in the larger size.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace) | `0.4.38` → `0.4.39` |
+| `crates/presenter-ui/Cargo.toml` | `0.1.7` → `0.1.8` |
+| `crates/presenter-ui/styles/stage.css` | Replace 3 worship-pp rules (sidebar padding, entry font/padding, active padding-left) |
+| `tests/e2e/stage-worship-pp.spec.ts` | Tighten font-size floor `>= 24` → `>= 40` |
+
+---
+
+## Task 1: Bump version to 0.4.39
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Confirm versions**
+
+```bash
+git fetch origin
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+gh release list --limit 1
+```
+
+Expected: workspace `0.4.38`, presenter-ui `0.1.7`, latest release `v0.4.26`.
+
+- [ ] **Step 2: Bump workspace**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml` under `[workspace.package]`, change `version = "0.4.38"` to `version = "0.4.39"`.
+
+- [ ] **Step 3: Bump presenter-ui**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml` under `[package]`, change `version = "0.1.7"` to `version = "0.1.8"`.
+
+- [ ] **Step 4: Refresh both Cargo.lock files**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.39 (#worship-pp-bigger-fonts)"
+```
+
+---
+
+## Task 2: CSS — bigger font + tighter padding
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/stage.css`
+
+- [ ] **Step 1: Verify current line numbers**
+
+```bash
+grep -n "stage-pp__playlist-sidebar\|stage-pp__playlist-entry" crates/presenter-ui/styles/stage.css
+```
+
+Expected: `.stage-pp__playlist-sidebar`, `.stage-pp__playlist-entry`, `.stage-pp__playlist-entry--active` all present from PR #268.
+
+- [ ] **Step 2: Replace `.stage-pp__playlist-sidebar`**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/stage.css`, find the existing `.stage-pp__playlist-sidebar` rule (with `padding: 1% 1.5%`) and replace the whole rule with:
+
+```css
+.stage-pp__playlist-sidebar {
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 22%;
+    height: 92%;
+    overflow-y: auto;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 0.4% 0.5%;
+    box-sizing: border-box;
+}
+```
+
+(Only the `padding` line changes from `1% 1.5%` to `0.4% 0.5%`. Width, height, position, overflow, border, box-sizing stay.)
+
+- [ ] **Step 3: Replace `.stage-pp__playlist-entry`**
+
+Find the existing `.stage-pp__playlist-entry` rule (with `padding: 0.6vh 0.8rem` and `font-size: 2.6vh`) and replace it with:
+
+```css
+.stage-pp__playlist-entry {
+    padding: 0.3vh 0.4rem;
+    color: #94a3b8;
+    /* Sized so ~12 typical chars fit per row at 1080p:
+       sidebar 22% × 1920 = 422px, less padding → ~390px content,
+       at 5vh font (≈54px) char-width is ~30px, ~12 chars per row. */
+    font-size: 5vh;
+    line-height: 1.1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-radius: 4px;
+    margin-bottom: 2px;
+}
+```
+
+(Changes: `padding` value, `font-size` value, the inline comment is updated to reflect the new math.)
+
+- [ ] **Step 4: Replace `.stage-pp__playlist-entry--active`**
+
+Find the existing `.stage-pp__playlist-entry--active` rule (with `padding-left: calc(0.8rem - 4px)`) and replace it with:
+
+```css
+.stage-pp__playlist-entry--active {
+    background: #38bdf8;
+    color: #0f172a;
+    font-weight: 700;
+    border-left: 4px solid #0ea5e9;
+    /* Compensate for the 4px border so text alignment with non-active rows
+       stays consistent. Base padding-left is 0.4rem (≈6.4px); subtract the
+       border width. */
+    padding-left: calc(0.4rem - 4px);
+}
+```
+
+(Only `padding-left` value changes from `calc(0.8rem - 4px)` to `calc(0.4rem - 4px)`, and the comment updates to match.)
+
+- [ ] **Step 5: Confirm there are no other `2.6vh` or `0.6vh 0.8rem` references in the CSS file**
+
+```bash
+grep -nE "2\.6vh|0\.6vh 0\.8rem|0\.8rem - 4px|1% 1\.5%" crates/presenter-ui/styles/stage.css
+```
+
+Expected: no matches (all replaced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/presenter-ui/styles/stage.css
+git commit -m "fix(stage): worship-pp playlist text big enough for 12 chars per row (#worship-pp-bigger-fonts)
+
+Sidebar padding 1% 1.5% → 0.4% 0.5%, entry padding 0.6vh 0.8rem
+→ 0.3vh 0.4rem, entry font-size 2.6vh → 5vh. At 1080p projector,
+the 22% sidebar's ~390px content area fits ~12 typical characters
+at the new 54px font. Active rule's padding-left compensation
+recalculated to match the new base padding."
+```
+
+---
+
+## Task 3: E2E — tighten font-size floor
+
+**Files:**
+- Modify: `tests/e2e/stage-worship-pp.spec.ts`
+
+- [ ] **Step 1: Find the existing assertion**
+
+```bash
+grep -n "entryFontSizePx\|>= 24" tests/e2e/stage-worship-pp.spec.ts
+```
+
+Expected: a line `expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(24);` inside the test "sidebar is narrower (~22%) and entries have projector-readable font".
+
+- [ ] **Step 2: Tighten the floor from 24 to 40**
+
+Replace the line:
+
+```typescript
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(24);
+```
+
+with:
+
+```typescript
+      // Floor of 40px locks in the 5vh × 1080p = 54px font from
+      // #worship-pp-bigger-fonts; any accidental drop back to 2.6vh
+      // (≈28px) will fail the test.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);
+```
+
+- [ ] **Step 3: Format**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npx prettier --write tests/e2e/stage-worship-pp.spec.ts 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Run the test locally to confirm it passes against the new CSS**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npx playwright test tests/e2e/stage-worship-pp.spec.ts --grep "sidebar is narrower" 2>&1 | tail -20
+```
+
+Expected: PASS (computed font-size at 1920×1080 is 54px, ≥ 40).
+
+If the test fails because the local Trunk dist hasn't rebuilt: run `scripts/build-ui.sh` (or `cd crates/presenter-ui && trunk build --release && cd ../..`) and re-run. The CI pipeline rebuilds dist on every push.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/stage-worship-pp.spec.ts
+git commit -m "test(e2e): tighten worship-pp font-size floor to 40px (#worship-pp-bigger-fonts)
+
+Locks in the new 5vh font (≈54px @ 1080p). Any accidental
+regression to the previous 2.6vh (≈28px) fails the test."
+```
+
+---
+
+## Task 4: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Workspace fmt + clippy + test**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+cargo test --workspace 2>&1 | tail -10
+```
+
+Expected: every command exits 0, clippy zero warnings, all tests pass.
+
+- [ ] **Step 2: presenter-ui specifically**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -5
+cargo test --target x86_64-unknown-linux-gnu --lib 2>&1 | tail -5
+cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 4: Find the new pipeline run**
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status,conclusion --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+```
+
+- [ ] **Step 5: Monitor pipeline (single background poll)**
+
+Per `ci-monitoring.md` — single background command, no repeated polling:
+
+```bash
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+When that returns, if everything is `success` we proceed. If anything failed, fetch failed log (`gh run view <RUN_ID> --log-failed`), fix the root cause in ONE commit, push, and monitor again.
+
+Expected: ALL jobs green (Format, Clippy, Test, Build, Code Coverage, Mutation Testing, Playwright E2E 1/3+2/3+3/3, Merge E2E Reports, Deploy to Dev).
+
+---
+
+## Task 5: Verify on dev + update PR #268
+
+- [ ] **Step 1: Verify dev healthz**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.39"}`.
+
+- [ ] **Step 2: Live verify the bigger font**
+
+Use Playwright MCP:
+
+1. `POST http://10.77.8.134:8080/stage/layout` with body `{"code":"worship-pp"}` to switch the stage layout.
+2. Open `http://10.77.8.134:8080/stage` in Playwright. Wait for `body[data-layout-code="worship-pp"]` and `.stage-pp__playlist-entry`.
+3. Read `getComputedStyle(entry).fontSize`. Compute `parseFloat(fontSize) / window.innerHeight`. Expected ratio: ≈ 0.05 (= 5vh).
+4. Read sidebar `getBoundingClientRect()`. Confirm width ≈ 22% of viewport.
+5. Browser console: 0 errors / warnings.
+
+(If no playlist entry is rendered because no playlist is active, seed one via API: create a playlist with `showInDashboard: true`, add an entry referencing a real presentation, trigger the presentation onto stage. Cleanup at end.)
+
+- [ ] **Step 3: Confirm PR #268 still mergeable & clean**
+
+```bash
+gh pr view 268 --json mergeable,mergeStateStatus,url
+```
+
+Expected: `MERGEABLE` + `CLEAN` (Mutation Testing on the latest pipeline run must have completed).
+
+- [ ] **Step 4: Update the PR body to mention this iteration**
+
+Use the REST API (REST avoids the GraphQL projects-classic deprecation error):
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+Worship-pp baseline + drag-drop infrastructure + three layout regression fixes + follow-up polish + bigger sidebar fonts.
+
+### Stage worship-pp baseline
+- Adopts worship-snv improvements (autofit text, song-name boxes, six-region layout)
+- Keeps playlist sidebar; derives next_song_text from Presenter playlist instead of AbleSet
+
+### Drag-drop infrastructure
+- Added missing `GET /playlists/{id}` route (operator drop handler fetched playlist before appending and got 405)
+- Fixed WASM `PlaylistEntryPayload` field renames (presentationId/entryId — server was 422-ing the snake_case payload)
+
+### Layout regressions (round 1)
+- Wrapped six worship-pp regions in `.stage-pp__slides-area` to stop sidebar overlap
+- Replaced 15%-opacity tint with solid sky-blue + 4px accent bar (visible from projector)
+- Server enriches playlist response with `presentation_name`; operator reads it directly; deleted obsolete `rebuild_playlist_presentations_with_signal` helper
+
+### Follow-up polish (round 2)
+- Search-result drag onto playlist row now accepted: `set_drop_effect("copy")` in playlist dragover (Chromium silently rejected drops without matching dropEffect when source set effectAllowed="copy")
+- Library-kind search results no longer marked draggable (they have no `presentation_id` — drops were silent no-ops)
+- Worship-pp sidebar shrunk 30% → 22% (slides 70% → 78%); entry font 0.9vw → 2.6vh
+
+### Bigger sidebar fonts (round 3)
+- Sidebar padding 1%/1.5% → 0.4%/0.5%; entry padding 0.6vh/0.8rem → 0.3vh/0.4rem; entry font-size 2.6vh → 5vh
+- ~12 typical characters fit per row at 1080p projector; 12 entries still fit in the 92vh sidebar
+
+## Test plan
+- [x] CI pipeline green (all 21 jobs incl. Mutation Testing)
+- [x] 3 core/serde unit tests for `presentation_name` round-trip
+- [x] 2 server integration tests for response enrichment
+- [x] Playwright E2E: stage-worship-pp.spec.ts (overlap, highlight, sidebar width, font ≥40px)
+- [x] Playwright E2E: wasm-playlist-operations.spec.ts (drag from presentation, drag from search, name visible after drag)
+- [x] Playwright E2E: wasm-drag-drop.spec.ts (search result draggable for presentation-kind, NOT for library-kind)
+- [x] Live Playwright verification on dev (10.77.8.134:8080):
+  - drag from search adds entry, drag from presentation list adds entry
+  - sidebar at 22%, slides at 78%, no overlap
+  - entry font-size ≈ 5vh; ~12 chars fit per row at 1080p
+  - browser console clean
+EOF
+gh api -X PATCH repos/zbynekdrlik/presenter/pulls/268 \
+  -f title="feat(stage): worship-pp baseline, drag-drop infra, layout regressions, follow-ups, bigger fonts" \
+  -F body=@/tmp/pr-body.md \
+  --jq '{number, title, state, mergeable_state}'
+```
+
+- [ ] **Step 5: Send completion report and wait for explicit "merge it"**
+
+Per `pr-merge-policy.md` — do NOT merge. Send the completion report (per `completion-report.md`) listing the URL set for both dev and prod, audits clean, what shipped. End with `❓ Question: Merge to main now?`.
+
+---
+
+## Task 6: Post-merge production verification (after user merges)
+
+- [ ] **Step 1: Watch the post-merge main pipeline**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+```
+
+Background-poll: `sleep 1500 && gh run view <RUN_ID> ...`. Wait for ALL jobs green incl. `Deploy to Production`.
+
+- [ ] **Step 2: Verify production**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.39"}`.
+
+Re-do the live Playwright check from Task 5 step 2 against `http://10.77.9.205/...`. Capture: sidebar at 22%, font ≈ 5vh, drag-from-search adds entry.
+
+- [ ] **Step 3: Final completion report**
+
+Short report per `completion-report.md` with prod-deploy-verified URLs. No follow-up question.
+
+---
+
+## Verification Summary
+
+| Check | How |
+|-------|-----|
+| Font ~12 chars/row at 1080p | E2E `entryFontSizePx >= 40` (54px clears it); manual visual on dev/prod stage |
+| Tighter sidebar padding | E2E `sidebarRatio` still ~22% (unchanged); inner content area larger so text reaches further |
+| 12 entries still fit | Math in spec; existing `overflow-y: auto` handles >12 |
+| Active highlight intact | PR #268 E2E tests for `--active` background still pass |
+| No regression elsewhere | Existing E2E suite (overlap, drag-from-presentation, drag-from-search, sidebar-width) all still pass |
+| Browser console clean | Every E2E asserts `consoleErrors === []` |

--- a/docs/superpowers/plans/2026-04-28-worship-pp-followups.md
+++ b/docs/superpowers/plans/2026-04-28-worship-pp-followups.md
@@ -1,0 +1,892 @@
+# Worship-PP Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two follow-up issues after worship-pp regression PR — drag from search to playlist doesn't add an entry, and the stage worship-pp sidebar wastes space and is unreadable from a distance.
+
+**Architecture:** (1) Investigate the search-drag failure live in Playwright, identify root cause, apply targeted fix in `playlist_list.rs` (most likely `set_drop_effect("copy")` in the dragover handler). (2) Pure CSS resize of the worship-pp layout in `stage.css` — sidebar 30%→22%, slides 70%→78%, entry font-size 0.9vw→2.6vh, padding rebalanced so 12 entries fit in 92vh.
+
+**Tech Stack:** Rust + Leptos 0.7 (WASM), CSS, Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-worship-pp-followups-design.md` (commit `3d04457`).
+
+---
+
+## Context
+
+Previous PR #268 ("worship-pp baseline + drag-drop fixes + three layout regressions") is mergeable & clean awaiting user merge. This plan stacks new work on `dev` on top of those commits — they'll either land in PR #268 (if not yet merged) or in a fresh PR (if merged).
+
+`presenter-ui` is excluded from the root workspace and has its OWN `Cargo.lock`. Tests run via `cargo test -p presenter-ui --target x86_64-unknown-linux-gnu`. Clippy via `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings -W clippy::all`. Local Rust builds are allowed on this dev machine.
+
+The dev server is at `http://10.77.8.134:8080`. The dev DB is replaced from prod on every deploy by design — that's intentional and out of scope.
+
+### Existing data-role attributes (relevant for E2E)
+
+- `[data-role="global-search-query"]` — search input in `header.rs:163`
+- `[data-role="search-result-item"]` — search result `<div>` in `search.rs:299`
+- `[data-role="playlist-list"]` — operator's dashboard playlist `<ul>`
+- `[data-role="playlist-item"]` — playlist row `<button>` inside the `<li>` (the `<li>` itself carries `data-playlist-id` and the on:drop handler)
+- `[data-role="presentation-item"]` — presentation row in operator's right column
+
+### Existing drag-drop hooks (for issue 1 investigation)
+
+- Search dragstart (`search.rs:307-317`): sets `application/x-presentation-id` AND `application/x-presenter-search` on dataTransfer; sets `effectAllowed = "copy"`.
+- Playlist row dragover (`playlist_list.rs:137-158`): reads `dataTransfer.types`, accepts the two MIME types above, calls `prevent_default`. **Does NOT call `set_drop_effect("copy")`** — this is the most likely cause.
+- Playlist row drop (`playlist_list.rs:169-234`): reads `application/x-presentation-id` (or x-presenter-search fallback), spawns `replace_entries` async task.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `crates/presenter-ui/src/components/playlist_list.rs` | Add `set_drop_effect("copy")` in the dragover handler (or other targeted fix once root cause is confirmed). |
+| `crates/presenter-ui/styles/stage.css` | Resize `.stage-pp__slides-area` (78%) and `.stage-pp__playlist-sidebar` (22%); enlarge `.stage-pp__playlist-entry` and re-tune `.stage-pp__playlist-entry--active`. |
+| `tests/e2e/wasm-playlist-operations.spec.ts` | New "drag from search result to playlist" E2E. |
+| `tests/e2e/stage-worship-pp.spec.ts` | Extended assertions for sidebar width and entry font-size. |
+| `Cargo.toml` (workspace) | Version 0.4.37 → 0.4.38. |
+| `crates/presenter-ui/Cargo.toml` | presenter-ui patch bump (e.g. 0.1.6 → 0.1.7). |
+
+---
+
+## Task 1: Bump version to 0.4.38
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Confirm versions**
+
+```bash
+git fetch origin
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+gh release list --limit 1
+```
+
+Expected: workspace 0.4.37, presenter-ui 0.1.6, latest release v0.4.26. Bump targets: 0.4.38 / 0.1.7.
+
+- [ ] **Step 2: Bump workspace version**
+
+In `Cargo.toml` under `[workspace.package]`, change `version = "0.4.37"` to `version = "0.4.38"`.
+
+- [ ] **Step 3: Bump presenter-ui version**
+
+In `crates/presenter-ui/Cargo.toml` under `[package]`, change `version = "0.1.6"` to `version = "0.1.7"`.
+
+- [ ] **Step 4: Refresh Cargo.lock files**
+
+```bash
+cargo check -p presenter-server 2>&1 | tail -5
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -5 && cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.38 (#worship-pp-followups)"
+```
+
+---
+
+## Task 2: Investigate the search-drag failure live
+
+**Files:** none yet — this is a **read-only investigation task**. Output is a finding that informs Task 3.
+
+- [ ] **Step 1: Start dev server (or use the running one at 10.77.8.134:8080)**
+
+The dev server is already running at `http://10.77.8.134:8080` per CLAUDE.md. If it's down, use any running e2e fixture. Do not start a fresh server in production paths.
+
+- [ ] **Step 2: Open Playwright and dispatch a search-to-playlist drag**
+
+Use the Playwright MCP tools (`mcp__plugin_playwright_playwright__browser_navigate`, `browser_evaluate`, `browser_console_messages`) — NOT the test runner. We're debugging, not testing.
+
+```bash
+# Navigate
+mcp__plugin_playwright_playwright__browser_navigate http://10.77.8.134:8080/ui/operator
+```
+
+In `browser_evaluate`, run this script. It performs the same dispatch the real user does and reports what blocks at each step:
+
+```js
+async () => {
+  // Wait for WASM ready
+  let t=0;
+  while(t++<60 && document.body.dataset.wasmReady !== 'true') await new Promise(r=>setTimeout(r,200));
+
+  // Create a fresh playlist via API to drop into
+  const create = await fetch('/playlists', {
+    method: 'POST', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ name: 'Search Drag Probe ' + Date.now(), showInDashboard: true })
+  });
+  const playlist = await create.json();
+
+  // Wait for the new playlist row to appear in the dashboard
+  let t2=0;
+  while(t2++<150 && !document.querySelector(`[data-role="playlist-list"] [data-playlist-id="${playlist.id}"]`)) await new Promise(r=>setTimeout(r,200));
+  const targetRow = document.querySelector(`[data-role="playlist-list"] [data-playlist-id="${playlist.id}"]`);
+  if (!targetRow) return { ok: false, step: 'playlist-not-rendered' };
+
+  // Type into the search input to populate results
+  const search = document.querySelector('[data-role="global-search-query"]');
+  if (!search) return { ok: false, step: 'no-search-input' };
+  search.focus();
+  search.value = 'a'; // any letter — should match many results
+  search.dispatchEvent(new Event('input', { bubbles: true }));
+
+  // Wait for at least one search result
+  let t3=0;
+  while(t3++<60 && !document.querySelector('[data-role="search-result-item"]')) await new Promise(r=>setTimeout(r,200));
+  const source = document.querySelector('[data-role="search-result-item"]');
+  if (!source) return { ok: false, step: 'no-search-results' };
+  const presId = source.getAttribute('data-presentation-id');
+
+  // Probe: dispatch dragstart on source, observe dataTransfer state
+  const dt = new DataTransfer();
+  source.dispatchEvent(new DragEvent('dragstart', { bubbles:true, cancelable:true, dataTransfer:dt }));
+  const typesAfterDragstart = Array.from(dt.types);
+
+  // Probe: dispatch dragover on target, observe whether prevent_default was called
+  const dragoverEv = new DragEvent('dragover', { bubbles:true, cancelable:true, dataTransfer:dt });
+  let dragoverDefaultPrevented = false;
+  targetRow.dispatchEvent(dragoverEv);
+  dragoverDefaultPrevented = dragoverEv.defaultPrevented;
+
+  // Probe: dispatch drop, observe completion
+  const dropEv = new DragEvent('drop', { bubbles:true, cancelable:true, dataTransfer:dt });
+  targetRow.dispatchEvent(dropEv);
+  source.dispatchEvent(new DragEvent('dragend', { bubbles:true, cancelable:true, dataTransfer:dt }));
+
+  // Poll the playlist via API to see whether the entry was added
+  let result = { entries: -1 };
+  for (let i=0; i<20; i++) {
+    await new Promise(r=>setTimeout(r,300));
+    const r = await fetch(`/playlists/${playlist.id}`);
+    if (r.status === 200) {
+      const body = await r.json();
+      result.entries = Array.isArray(body.entries) ? body.entries.length : -1;
+      if (result.entries >= 1) break;
+    }
+  }
+
+  // Cleanup
+  await fetch(`/playlists/${playlist.id}`, { method: 'DELETE' });
+
+  return {
+    presId,
+    typesAfterDragstart,
+    dragoverDefaultPrevented,
+    finalEntries: result.entries,
+    ok: result.entries >= 1
+  };
+}
+```
+
+- [ ] **Step 3: Capture the result**
+
+Look at the returned object. Three signals to record:
+- `typesAfterDragstart`: should include `"application/x-presentation-id"`. If empty → search dragstart never wrote the data → bug is in `search.rs`.
+- `dragoverDefaultPrevented`: should be `true`. If `false` → playlist's dragover handler didn't call `prevent_default` → bug is in `playlist_list.rs:137-158` (the type check failed or didn't match search's two types).
+- `finalEntries`: should be `1`. If `0` and the previous two are correct → drop handler ran but the spawn_local task failed (server returned non-200, network race, etc).
+
+Also check `mcp__plugin_playwright_playwright__browser_console_messages` for any errors during the dispatch.
+
+- [ ] **Step 4: Document the finding**
+
+Write the finding (1–2 sentences + the relevant probe values) into a comment in `crates/presenter-ui/src/components/playlist_list.rs` directly above the `on:dragover` handler. Example:
+
+```rust
+// Investigation 2026-04-28: drag from [data-role="search-result-item"] failed
+// because dataTransfer.dropEffect was "none" (browser default) and the spec's
+// allowed/dropEffect negotiation rejected the drop. Setting drop_effect("copy")
+// in dragover when types match makes both presentation-row and search-result
+// drags work consistently.
+```
+
+(Adapt the comment to whatever you actually find. If the cause is something other than dropEffect, the comment must accurately describe what was wrong and what fixed it.)
+
+This task does NOT commit. Proceed directly to Task 3 with the finding in hand.
+
+---
+
+## Task 3: Fix the search-drag root cause
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/playlist_list.rs:137-158` (most likely; or wherever Task 2 found the root cause)
+
+- [ ] **Step 1: Apply the fix based on Task 2's finding**
+
+If Task 2 found that `dragoverDefaultPrevented = false` because of the dropEffect / effectAllowed mismatch (most likely), apply this fix in `crates/presenter-ui/src/components/playlist_list.rs`. Replace the existing dragover handler at lines 137–158:
+
+OLD:
+```rust
+                                        on:dragover=move |ev: web_sys::DragEvent| {
+                                            // Accept presentation drops
+                                            if let Some(dt) = ev.data_transfer() {
+                                                let types = dt.types();
+                                                let accepts = (0..types.length())
+                                                    .any(|i| {
+                                                        let t = types.get(i).as_string().unwrap_or_default();
+                                                        t == "application/x-presentation-id" || t == "application/x-presenter-search"
+                                                    });
+                                                if accepts {
+                                                    ev.prevent_default();
+                                                    if let Some(target) = ev.target() {
+                                                        if let Ok(el) = target.dyn_into::<web_sys::Element>() {
+                                                            let _ = el.closest(".operator__list-item")
+                                                                .ok()
+                                                                .flatten()
+                                                                .map(|li| li.class_list().add_1("drag-over"));
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+```
+
+NEW:
+```rust
+                                        on:dragover=move |ev: web_sys::DragEvent| {
+                                            // Accept presentation drops (from library list OR search results).
+                                            if let Some(dt) = ev.data_transfer() {
+                                                let types = dt.types();
+                                                let accepts = (0..types.length())
+                                                    .any(|i| {
+                                                        let t = types.get(i).as_string().unwrap_or_default();
+                                                        t == "application/x-presentation-id" || t == "application/x-presenter-search"
+                                                    });
+                                                if accepts {
+                                                    ev.prevent_default();
+                                                    // Search results dragstart with effectAllowed="copy", and Chromium
+                                                    // requires dropEffect to match for the drop to be accepted.
+                                                    // Without this, dragging from [data-role="search-result-item"]
+                                                    // visually drags but the drop is silently rejected.
+                                                    dt.set_drop_effect("copy");
+                                                    if let Some(target) = ev.target() {
+                                                        if let Ok(el) = target.dyn_into::<web_sys::Element>() {
+                                                            let _ = el.closest(".operator__list-item")
+                                                                .ok()
+                                                                .flatten()
+                                                                .map(|li| li.class_list().add_1("drag-over"));
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+```
+
+If Task 2 found a different root cause, apply the matching fix instead. Either way the fix is small and localized — do NOT restructure the handler.
+
+- [ ] **Step 2: Build the WASM crate**
+
+```bash
+cd crates/presenter-ui
+cargo build --target wasm32-unknown-unknown 2>&1 | tail -5
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cd ../..
+```
+
+Expected: clean build, zero warnings.
+
+- [ ] **Step 3: Re-run the Task 2 probe to verify the fix**
+
+Repeat the Playwright probe from Task 2. The probe must now end with `finalEntries: 1` and `dragoverDefaultPrevented: true`. If it still fails, return to Task 2 step 4 and re-investigate before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/playlist_list.rs
+git commit -m "fix(ui): accept search-result drops on playlist row (#worship-pp-followups)
+
+Set dataTransfer.dropEffect to \"copy\" in the playlist row's dragover
+handler when types match, so search results (which dragstart with
+effectAllowed=\"copy\") can be dropped. Without the matching dropEffect,
+Chromium silently rejects the drop and no playlist entry is added."
+```
+
+(Adapt the commit message body if Task 2 found a different root cause.)
+
+---
+
+## Task 4: Sidebar resize + bigger song fonts
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/stage.css:332-368`
+
+- [ ] **Step 1: Update the worship-pp CSS rules**
+
+In `crates/presenter-ui/styles/stage.css`, find and replace these rules. Use grep to confirm line numbers first:
+
+```bash
+grep -n "stage-pp__slides-area\|stage-pp__playlist-sidebar\|stage-pp__playlist-entry" crates/presenter-ui/styles/stage.css
+```
+
+Replace `.stage-pp__slides-area` (currently width 70%):
+
+```css
+.stage-pp__slides-area {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 78%;
+    height: 92%;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+```
+
+Replace `.stage-pp__playlist-sidebar` (currently width 30%):
+
+```css
+.stage-pp__playlist-sidebar {
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 22%;
+    height: 92%;
+    overflow-y: auto;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1% 1.5%;
+    box-sizing: border-box;
+}
+```
+
+Replace `.stage-pp__playlist-entry`:
+
+```css
+.stage-pp__playlist-entry {
+    padding: 0.6vh 0.8rem;
+    color: #94a3b8;
+    /* 12 entries × ~7vh row height ≈ 84vh fits in 92vh sidebar; readable from across a worship space. */
+    font-size: 2.6vh;
+    line-height: 1.1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-radius: 4px;
+    margin-bottom: 2px;
+}
+```
+
+Replace `.stage-pp__playlist-entry--active`:
+
+```css
+.stage-pp__playlist-entry--active {
+    background: #38bdf8;
+    color: #0f172a;
+    font-weight: 700;
+    border-left: 4px solid #0ea5e9;
+    /* Compensate for the 4px border so text alignment with non-active rows
+       stays consistent. Base padding-left is 0.8rem; subtract the border width. */
+    padding-left: calc(0.8rem - 4px);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/presenter-ui/styles/stage.css
+git commit -m "fix(stage): worship-pp sidebar narrower + bigger song text (#worship-pp-followups)
+
+Sidebar 30% → 22%, slides-area 70% → 78% so the main slide content
+gets ~11% more horizontal space. Entry font-size 0.9vw → 2.6vh
+(≈28px @ 1080p, ≈37px @ 1440p) so song titles are legible from
+the back of a worship space. Padding now in vh so 12 entries fit
+the 92vh sidebar exactly; >12 scroll, <12 keep their per-row size."
+```
+
+---
+
+## Task 5: E2E — drag from search result to playlist
+
+**Files:**
+- Modify: `tests/e2e/wasm-playlist-operations.spec.ts`
+
+- [ ] **Step 1: Add the new test**
+
+Append a new test inside the existing `test.describe("WASM Operator Playlist Operations", ...)` block in `tests/e2e/wasm-playlist-operations.spec.ts`. Place it after the existing "drop a presentation onto a playlist row appends an entry" test:
+
+```typescript
+  test("drop a search-result onto a playlist row appends an entry", async ({
+    page,
+  }) => {
+    // Regression guard for #worship-pp-followups: dragging from
+    // [data-role="search-result-item"] (which dragstart with
+    // effectAllowed="copy") onto a playlist row was silently
+    // rejected because the playlist's dragover never set a
+    // matching dropEffect.
+
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon")) consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // 1. Create the drop-target playlist via API.
+    const targetName = `Search Drop Test ${Date.now()}`;
+    const createResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      { data: { name: targetName, showInDashboard: true } },
+    );
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    const targetPlaylistId = created.id as string;
+    expect(targetPlaylistId).toBeTruthy();
+
+    // 2. Load operator UI.
+    await initPage(page);
+    await page.waitForFunction(
+      (id: string) =>
+        !!document.querySelector(
+          `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
+        ),
+      targetPlaylistId,
+      { timeout: 30_000 },
+    );
+
+    // 3. Type into the search box to populate results.
+    const searchInput = page.locator('[data-role="global-search-query"]');
+    await searchInput.click();
+    await searchInput.fill("a");
+    await page.waitForSelector('[data-role="search-result-item"]', {
+      timeout: 15_000,
+    });
+
+    // 4. Programmatically drag a search result onto the playlist row.
+    //    Pre-populate the DataTransfer (synthetic-event quirk — see
+    //    the existing drop test for the same workaround).
+    const dragResult = await page.evaluate((id: string) => {
+      const source = document.querySelector(
+        '[data-role="search-result-item"][data-presentation-id]',
+      ) as HTMLElement | null;
+      const targetRow = document.querySelector(
+        `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
+      ) as HTMLElement | null;
+      if (!source || !targetRow) {
+        return {
+          error: "missing source or target",
+          hasSource: !!source,
+          hasTarget: !!targetRow,
+        };
+      }
+      const sourceId = source.getAttribute("data-presentation-id") || "";
+      const dt = new DataTransfer();
+      dt.setData("text/plain", sourceId);
+      dt.setData("application/x-presentation-id", sourceId);
+      dt.setData("application/x-presenter-search", sourceId);
+      source.dispatchEvent(
+        new DragEvent("dragstart", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      source.dispatchEvent(
+        new DragEvent("dragend", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      return { sourceId };
+    }, targetPlaylistId);
+
+    expect(dragResult.error, JSON.stringify(dragResult)).toBeUndefined();
+    expect(dragResult.sourceId).toBeTruthy();
+
+    // 5. Confirm via API that the playlist gained an entry.
+    await expect
+      .poll(
+        async () => {
+          const apiResp = await page.request.get(
+            new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
+          );
+          if (apiResp.status() !== 200) return -1;
+          const body = await apiResp.json();
+          return Array.isArray(body.entries) ? body.entries.length : -1;
+        },
+        { timeout: 15_000, intervals: [500, 1000, 2000] },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    // 6. Cleanup.
+    await page.request.delete(
+      new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the new test locally**
+
+```bash
+npx playwright test tests/e2e/wasm-playlist-operations.spec.ts --grep "drop a search-result" 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/wasm-playlist-operations.spec.ts
+git commit -m "test(e2e): drop a search-result onto a playlist row (#worship-pp-followups)
+
+Regression guard for the search→playlist drop fix. Mirrors the
+existing presentation-row drop test but sources from
+[data-role=\"search-result-item\"] in the global search results."
+```
+
+---
+
+## Task 6: E2E — sidebar width and entry font-size assertions
+
+**Files:**
+- Modify: `tests/e2e/stage-worship-pp.spec.ts`
+
+- [ ] **Step 1: Add a new test inside the existing describe block**
+
+Append after the existing tests inside `test.describe("Stage worship-pp layout", () => { ... })`:
+
+```typescript
+  test("sidebar is narrower (~22%) and entries have projector-readable font", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon")) consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // Set worship-pp layout
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Seed a playlist with one entry and trigger it so the sidebar has content.
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{ id: string; slides?: Array<{ id: string }> }>;
+    }>;
+    const presentation = libs
+      .flatMap((lib) => lib.presentations ?? [])
+      .find((p) => (p.slides?.length ?? 0) > 0);
+    if (!presentation || !presentation.slides || !presentation.slides[0]) {
+      test.skip(true, "test fixture has no presentation with slides");
+      return;
+    }
+    const slideId = presentation.slides[0].id;
+
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      {
+        data: {
+          name: `Sidebar Width Test ${Date.now()}`,
+          showInDashboard: true,
+        },
+      },
+    );
+    const playlist = (await playlistResp.json()) as { id: string };
+    await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [{ type: "presentation", presentationId: presentation.id }],
+        },
+      },
+    );
+    await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: presentation.id,
+          currentSlideId: slideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      () => document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+
+    // Wait for the playlist sidebar to render with at least one entry.
+    await page.waitForSelector(".stage-pp__playlist-entry", {
+      timeout: 15_000,
+    });
+
+    // Read sidebar width and entry font-size from computed styles.
+    const measurements = await page.evaluate(() => {
+      const sidebar = document.querySelector(
+        ".stage-pp__playlist-sidebar",
+      ) as HTMLElement | null;
+      const entry = document.querySelector(
+        ".stage-pp__playlist-entry",
+      ) as HTMLElement | null;
+      if (!sidebar || !entry) return { error: "missing element" } as const;
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const entryStyle = getComputedStyle(entry);
+      return {
+        sidebarRatio: sidebarRect.width / viewportWidth,
+        entryFontSizePx: parseFloat(entryStyle.fontSize),
+      } as const;
+    });
+
+    expect("error" in measurements, JSON.stringify(measurements)).toBe(false);
+    if ("sidebarRatio" in measurements) {
+      // Sidebar must be ~22% (allow ±3% slack for borders/scrollbar).
+      expect(measurements.sidebarRatio).toBeGreaterThan(0.19);
+      expect(measurements.sidebarRatio).toBeLessThan(0.25);
+      // Entry font must be readable from the back of a room — sanity floor at 24px.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(24);
+    }
+
+    // Cleanup
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the new test locally**
+
+```bash
+npx playwright test tests/e2e/stage-worship-pp.spec.ts --grep "sidebar is narrower" 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/stage-worship-pp.spec.ts
+git commit -m "test(e2e): assert worship-pp sidebar width and entry font-size (#worship-pp-followups)
+
+Regression guard for the sidebar resize:
+- sidebar width is ~22% of viewport (±3% slack)
+- entry computed font-size is at least 24px"
+```
+
+---
+
+## Task 7: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Format / lint / test (workspace)**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+cargo test --workspace 2>&1 | tail -10
+```
+
+Expected: every command exits 0, clippy zero warnings.
+
+- [ ] **Step 2: presenter-ui specifically**
+
+```bash
+cd crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cargo test --target x86_64-unknown-linux-gnu 2>&1 | tail -10
+cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 4: Monitor pipeline**
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status,conclusion --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+```
+
+Then background-poll once:
+
+```bash
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Per `ci-monitoring.md` — do NOT poll repeatedly. One background command, react when it returns.
+
+Expected: ALL jobs green (Format, Clippy, Test, Build, Code Coverage, Mutation Testing, Playwright E2E 1/3+2/3+3/3, Merge E2E Reports, Deploy to Dev). If anything fails, fetch the failed log (`gh run view <RUN_ID> --log-failed`), fix the root cause in ONE commit, push, monitor again.
+
+---
+
+## Task 8: Verify on dev + open / update PR
+
+- [ ] **Step 1: Verify dev healthz**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.38"}`.
+
+- [ ] **Step 2: Live verify the two fixes**
+
+Use Playwright MCP to:
+1. Open `/ui/operator`. Type a search query, drag a result onto a playlist row, confirm the entry persists via `GET /playlists/{id}`. Browser console: zero errors.
+2. Open `/stage` with worship-pp active. Confirm sidebar visibly narrower (≈22%) and song text large (≈30px+). Active highlight pill still visible.
+
+- [ ] **Step 3: Open or update the PR**
+
+Check the existing PR state:
+
+```bash
+gh pr list --base main --head dev --state open --json number,title,mergeable,mergeStateStatus,url
+```
+
+If PR #268 is still open (not yet merged), update its title and body via REST API to cover the combined scope (worship-pp baseline + drag-drop fixes + three layout regressions + these followups):
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+Worship-pp baseline + drag-drop infrastructure fixes + layout regressions + follow-up polish.
+
+### Stage worship-pp baseline (#268)
+- Adopts worship-snv improvements (autofit text, song-name boxes, six-region layout)
+- Keeps playlist sidebar; derives next_song_text from Presenter playlist instead of AbleSet
+
+### Drag-drop infrastructure
+- Added missing GET /playlists/{id} route
+- Fixed WASM PlaylistEntryPayload field renames (presentationId/entryId)
+
+### Layout regressions
+- Wrapped six worship-pp regions in .stage-pp__slides-area to stop sidebar overlap
+- Replaced 15%-opacity tint with solid sky-blue + 4px accent bar (visible from projector)
+- Server enriches playlist response with presentation_name; operator reads it directly; deleted obsolete rebuild_playlist_presentations_with_signal helper
+
+### Follow-up polish
+- Search-result drag onto playlist row now accepted (set_drop_effect("copy") in dragover)
+- Worship-pp sidebar shrunk to 22% (slides 78%); entry font 0.9vw → 2.6vh so 12 entries fit at projector-readable size
+
+## Test plan
+- [x] CI pipeline green (all 21 jobs incl. Mutation Testing)
+- [x] 3 core/serde unit tests for presentation_name round-trip
+- [x] 2 server integration tests for response enrichment
+- [x] Playwright E2E: stage-worship-pp.spec.ts (overlap, highlight, sidebar width, font-size)
+- [x] Playwright E2E: wasm-playlist-operations.spec.ts (drag from presentation, drag from search, name visible after drag)
+- [x] Live Playwright verification on dev (10.77.8.134:8080)
+- [x] Browser console: zero errors / warnings on operator and stage
+EOF
+gh api -X PATCH repos/zbynekdrlik/presenter/pulls/268 \
+  -f title="feat(stage): worship-pp baseline, drag-drop infra, layout regressions, follow-ups" \
+  -F body=@/tmp/pr-body.md \
+  --jq '{number, title, state, mergeable_state}'
+```
+
+If PR #268 was already merged, open a new PR:
+
+```bash
+gh pr create --base main --head dev \
+  --title "fix(stage): worship-pp follow-ups — search drag + sidebar polish" \
+  --body "$(cat <<'EOF'
+## Summary
+- Search-result drag onto playlist row was silently rejected (Chromium dropEffect mismatch with effectAllowed=\"copy\"). Fix: set_drop_effect(\"copy\") in playlist row's dragover when types match.
+- Worship-pp sidebar shrunk to 22% (slides 78%); entry font 0.9vw → 2.6vh so up to 12 entries fit at projector-readable size.
+
+## Test plan
+- [x] CI pipeline green
+- [x] Playwright E2E: drag from search result to playlist
+- [x] Playwright E2E: sidebar width ~22% + entry font ≥24px
+- [x] Live verification on dev
+- [x] Browser console clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for the PR pipeline to be CLEAN**
+
+```bash
+gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,url
+```
+
+Expected: `{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN", ...}`. If UNSTABLE, identify which check is pending or failing (most likely Mutation Testing) and wait/fix.
+
+- [ ] **Step 5: Send completion report and wait for explicit "merge it"**
+
+Per `pr-merge-policy.md`, do NOT merge. Send the completion report (per `completion-report.md`) and wait for the user's explicit merge instruction.
+
+---
+
+## Task 9: Post-merge production verification (after user merges)
+
+- [ ] **Step 1: Watch the post-merge main pipeline**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+```
+
+Background-poll: `sleep 1500 && gh run view <RUN_ID> ...`. Wait for ALL jobs green incl. `Deploy to Production`.
+
+- [ ] **Step 2: Verify production**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.38"}`.
+
+Then re-do the live verification from Task 8 step 2 against `http://10.77.9.205/...`. Capture: search drag adds entry, worship-pp sidebar visibly narrower with bigger song text.
+
+- [ ] **Step 3: Final completion report**
+
+Per `completion-report.md` — short report with URLs (dev + prod, frontend + backend), audits clean, what shipped, no follow-up question.
+
+---
+
+## Verification Summary
+
+| Check | How |
+|-------|-----|
+| Search-drag fix works | Task 5 E2E test asserts entry persists after drag from search-result |
+| Sidebar resized | Task 6 E2E test asserts width ratio is ~22% |
+| Font readable from projector | Task 6 E2E test asserts computed font-size ≥ 24px |
+| 12-entry layout fits | CSS math: 12 × ~7vh ≈ 84vh fits in 92vh sidebar; existing overflow-y:auto handles >12 |
+| Active highlight still visible | PR #268's E2E test (background distinct from inactive) still passes |
+| No regression on existing layouts | All other Playwright E2E tests still pass on CI |
+| Browser console clean | Every E2E asserts `consoleErrors === []` |
+| Worship-snv unaffected | No changes to worship-snv CSS or component code |

--- a/docs/superpowers/plans/2026-04-29-worship-pp-10-row-fit.md
+++ b/docs/superpowers/plans/2026-04-29-worship-pp-10-row-fit.md
@@ -1,0 +1,248 @@
+# Worship-PP 10-Row Sidebar Fit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump the worship-pp sidebar entry font from `5vh` to `7.5vh` so ~10 entries fit per sidebar instead of ~14.
+
+**Architecture:** Single-value CSS change + corresponding E2E floor tighten. Stacks on PR #268.
+
+**Tech Stack:** CSS, Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-worship-pp-10-row-fit-design.md` (commit `66b3ac3`).
+
+---
+
+## Task 1: Bump version to 0.4.41
+
+**Files:**
+- Modify: `Cargo.toml`, `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Confirm versions**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git fetch origin
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+```
+
+Expected: workspace `0.4.40`, presenter-ui `0.1.9`.
+
+- [ ] **Step 2: Bump**
+
+`Cargo.toml` `[workspace.package]`: `0.4.40` → `0.4.41`.
+`crates/presenter-ui/Cargo.toml` `[package]`: `0.1.9` → `0.1.10`.
+
+- [ ] **Step 3: Refresh Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.41 (#worship-pp-10-row-fit)"
+```
+
+---
+
+## Task 2: CSS — bump font to 7.5vh
+
+**File:** `crates/presenter-ui/styles/stage.css`
+
+- [ ] **Step 1: Confirm location**
+
+```bash
+grep -n "stage-pp__playlist-entry\b\|font-size: 5vh" /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/stage.css | head
+```
+
+Expected: `font-size: 5vh;` inside the `.stage-pp__playlist-entry` rule.
+
+- [ ] **Step 2: Replace**
+
+In `crates/presenter-ui/styles/stage.css`, find the `.stage-pp__playlist-entry` rule (the one with `font-size: 5vh;`) and update the font-size and its inline comment. The OLD lines look like:
+
+```css
+    /* Sized so ~12 typical chars fit per row at 1080p:
+       sidebar 22% × 1920 = 422px, less padding → ~390px content,
+       at 5vh font (≈54px) char-width is ~30px, ~12 chars per row. */
+    font-size: 5vh;
+```
+
+Replace with:
+
+```css
+    /* Sized so ~10 entries fit in the 92vh sidebar at 1080p:
+       per-row ≈ 7.5vh × line-height 1.1 + 0.6vh padding ≈ 9.0vh.
+       Trades fewer chars-per-row for visibly larger text. */
+    font-size: 7.5vh;
+```
+
+- [ ] **Step 3: Verify nothing else needs updating**
+
+```bash
+grep -nE "5vh|font-size: 5" /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/stage.css
+```
+
+Expected: no matches that target stage-pp entries (other unrelated `5vh` rules in other components are fine — but inside `.stage-pp__playlist-entry` there should be NO `5vh` left).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/styles/stage.css
+git commit -m "fix(stage): worship-pp sidebar font 5vh → 7.5vh (~10 entries fit) (#worship-pp-10-row-fit)
+
+User wanted bigger song titles. At 5vh, 14 rows fit in the 92vh
+sidebar; at 7.5vh, ~10 rows fit (per-row ≈ 9vh including
+line-height and padding). Trades fewer chars-per-row for more
+projector-readable text."
+```
+
+---
+
+## Task 3: E2E — tighten font-size floor to 70
+
+**File:** `tests/e2e/stage-worship-pp.spec.ts`
+
+- [ ] **Step 1: Find the existing assertion**
+
+```bash
+grep -n "entryFontSizePx\|>= 40\|>= 70" /home/newlevel/devel/presenter/presenter-dev2/tests/e2e/stage-worship-pp.spec.ts
+```
+
+Expected: a line `expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);` plus the surrounding 3-line comment.
+
+- [ ] **Step 2: Replace**
+
+In `tests/e2e/stage-worship-pp.spec.ts`, replace the existing comment + assertion (the comment block currently mentions `5vh × 1080p = 54px` and the assertion uses 40):
+
+```typescript
+      // Floor of 40px locks in the 5vh × 1080p = 54px font from
+      // #worship-pp-bigger-fonts; any accidental drop back to 2.6vh
+      // (≈28px) will fail the test.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);
+```
+
+with:
+
+```typescript
+      // Floor of 70px locks in the 7.5vh × 1080p = 81px font from
+      // #worship-pp-10-row-fit; any accidental drop back to 5vh
+      // (≈54px) or smaller will fail the test.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(70);
+```
+
+- [ ] **Step 3: Format**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npx prettier --write tests/e2e/stage-worship-pp.spec.ts 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/stage-worship-pp.spec.ts
+git commit -m "test(e2e): tighten worship-pp font-size floor to 70px (#worship-pp-10-row-fit)
+
+Locks in the new 7.5vh font (≈81px @ 1080p). Any accidental
+regression to 5vh (≈54px) or smaller fails the test."
+```
+
+---
+
+## Task 4: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Workspace fmt + clippy + tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+cargo test --workspace 2>&1 | tail -5
+```
+
+- [ ] **Step 2: presenter-ui specifically**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -5
+cd ../..
+```
+
+- [ ] **Step 3: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git push origin dev
+```
+
+- [ ] **Step 4: Monitor pipeline**
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Expected: ALL jobs green incl. Mutation Testing + Deploy to Dev.
+
+---
+
+## Task 5: Verify on dev + update PR #268
+
+- [ ] **Step 1: Verify dev healthz**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.41"}`.
+
+- [ ] **Step 2: Live verify**
+
+Use Playwright MCP:
+1. setViewport 1920×1080.
+2. Set worship-pp layout via `POST /stage/layout`.
+3. Open `/stage`, wait for `body[data-layout-code="worship-pp"]`.
+4. Read `getComputedStyle(.stage-pp__playlist-entry).fontSize` — expect `81px` (= 7.5vh × 1080).
+5. Browser console: zero errors / warnings.
+
+- [ ] **Step 3: Update PR #268 body**
+
+Add a "10-row sidebar fit (round 5)" subsection to the PR body via REST API. Replace the existing PR title/body via `gh api -X PATCH repos/zbynekdrlik/presenter/pulls/268 -f title=... -F body=@/tmp/pr-body.md`. The new round bullet:
+
+> ### 10-row sidebar fit (round 5)
+> - Entry font 5vh → 7.5vh; ~10 entries now fit in the 92vh sidebar (down from ~14). Bigger projector-readable text.
+> - E2E floor tightened from ≥40px to ≥70px to lock in the new 81px @ 1080p font.
+
+- [ ] **Step 4: Wait for explicit "merge it"**
+
+Per `pr-merge-policy.md`. Send completion report; DO NOT merge.
+
+---
+
+## Task 6: Post-merge production verify (gated on user merge)
+
+- [ ] **Step 1: Watch main pipeline**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+sleep 1500 && gh run view <RUN_ID> ...
+```
+
+- [ ] **Step 2: Verify prod**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.41"}`. Repeat the live Playwright check from Task 5 step 2 against `http://10.77.9.205/...`.
+
+- [ ] **Step 3: Final completion report**
+
+Short report per `completion-report.md` with prod-verified URLs.

--- a/docs/superpowers/specs/2026-04-26-ndi-single-fixed-tier-design.md
+++ b/docs/superpowers/specs/2026-04-26-ndi-single-fixed-tier-design.md
@@ -179,3 +179,24 @@ E2E: existing `tests/e2e/stage-api-ndi.spec.ts` and `tests/e2e/ndi-stage-layout.
 - SIMD resize: addresses the second root cause (encoder CPU on N100). Without it, even a single encoder at 720p@20 with `image::imageops::resize` would be ~3× cheaper than the adaptive design but not as cheap as pre-PR. With SIMD, comfortably below baseline.
 - No env var / kill switch: hardcoded constants per "this is the last MJPEG iteration before WebRTC migration." YAGNI on configurability.
 - Single shared encoder over per-connection: lockstep flapping showed per-connection adaptive doesn't add value; the single-stream architecture is cheaper and predictable.
+
+## Production verification (2026-04-26, prod 0.4.35, post-merge)
+
+Merged PR #266 (commit `3882cdb`) and ran the main-branch Deploy workflow [24961136416](https://github.com/zbynekdrlik/presenter/actions/runs/24961136416). Both jobs (Build Release, Deploy to Production) succeeded.
+
+| Metric | Pre-fix (PR #263 adaptive, 0.4.34) | Post-fix (this design, 0.4.35) |
+|---|---|---|
+| Production version | 0.4.34, channel release | 0.4.35, channel release |
+| N100 load avg | 2.77 / 4 cores (~69 %) | **0.52 / 4 cores (~13 %)** |
+| Tier-transition log lines / 10 min | ~16 demote + 4 promote | **0** (code deleted) |
+| `MJPEG client lagged` lines / 10 min | varied | **0** |
+| `slow tick` lines / 10 min | varied | **0** |
+| `tier_registry` lines / 10 min | many | **0** |
+| Control-client (dev2 → prod) measured FPS | varied 0–30 (was bouncing) | **20.4 fps** (steady — accumulator math holds) |
+| Control-client bandwidth | 3–24 Mbps (was bouncing) | **2.5 Mbps** (~14 KB/frame at 720p, content-dependent) |
+
+**Server-side criteria:** load avg returns to baseline AND no adaptive log noise. **Result: PASS.** Load avg is actually below the pre-PR-263 baseline (~17 %) — the SIMD resize + smaller frames + halved fps means the new code path is cheaper than the original 1080p@30 single encoder.
+
+**Real-TV visual verdict:** to be confirmed by the operator on sd1l..sd4l when next at the church / TVs powered on. The server-side evidence (load avg, frame rate, no flap) plus the design's predicted decode budget at 720p@20 (~50 ms per frame, well within Amlogic capability) gives high confidence the visual experience is now watchable on all four cheap TVs without flapping. If sd2/3/4 still show choppiness, the documented one-line follow-up is to drop `TARGET_FPS` from 20 to 15.
+
+**Decision:** issue #250 closed by PR #266. The next major iteration tracked separately is the WebRTC / low-latency video transport migration.

--- a/docs/superpowers/specs/2026-04-26-worship-pp-snv-baseline-design.md
+++ b/docs/superpowers/specs/2026-04-26-worship-pp-snv-baseline-design.md
@@ -1,0 +1,205 @@
+# Worship-PP layout — adopt worship-snv baseline + playlist tweaks — Design
+
+**Issue:** new (no GitHub issue filed; user-driven via brainstorming).
+
+## Problem
+
+The `worship-snv` stage layout has accumulated improvements that `worship-pp` is missing:
+
+1. `break_if_long` wrapping for slide text (avoids awkward single-line cramming).
+2. Song-name boxes (`.stage__current-song` / `.stage__next-song`) with their own autofit pass.
+3. The constants and refs that drive those.
+
+`worship-pp` still has the older, plainer rendering and is functionally unchanged for months. We want it visually equivalent to `worship-snv` — except `worship-pp` keeps a feature `worship-snv` doesn't have: a playlist sidebar showing the full setlist with the active song highlighted.
+
+The sidebar itself has two operator pain points:
+
+1. ProPresenter song names carry a leading 3-digit number (e.g. `042 Amazing Grace`) used by the operator to find the song in ProPresenter. On stage display, that prefix is noise.
+2. Long song names wrap onto a second row, breaking the rhythm of the list. Each entry should be one row.
+
+And one source-of-truth issue specific to `worship-pp`:
+
+3. The next-song box currently reads `s.next_song_name`, which the server populates from AbleSet (the external setlist coordinator). For `worship-pp`, the user wants next-song from the **Presenter playlist**'s entry-after-active — what the operator actually sees in the Presenter UI — not from AbleSet's view.
+
+`worship-snv` does not have a playlist sidebar and continues to use `s.next_song_name` from AbleSet. Out of scope here.
+
+## Approach
+
+Frontend-only. Two files modified, one new CSS rule, one new helper. Zero contract changes; no server-side work; `worship-snv` unaffected.
+
+1. **`worship_pp.rs`** is rewritten from `worship_snv.rs` as the structural base — picks up `break_if_long`, song-name boxes, autofit refs, the constants. We then add back the `.stage-pp__playlist-sidebar` block and the `playlist_entries` getter that `worship_snv` doesn't have.
+
+2. **`utils/text.rs`** gains a `clean_song_name(&str) -> String` helper that mirrors the server-side `sanitize_song_title` (strips a leading 3-digit-then-space prefix). The frontend can't call the server-side function directly because they're in different crates and `sanitize_song_title` is `pub(crate)`. Mirroring is a 10-line copy with the same behaviour.
+
+3. **`worship_pp.rs::next_song_text`** is overridden vs the snv copy: instead of reading `ctx.snapshot.get().and_then(|s| s.next_song_name)`, it walks `playlist_entries`, skips entries until the `is_active` one, takes the entry after that, and runs its name through `clean_song_name`. If no active entry or active is last, returns empty (no next song shown).
+
+4. **CSS** for `.stage-pp__playlist-entry` adds `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` so each entry stays one row and overflows with `…`.
+
+## File-level scope
+
+| File | Change |
+|---|---|
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | **Rewrite** — same shape as `worship_snv.rs` plus the playlist sidebar, with `next_song_text` and the playlist `<For>` modified per spec. Component name stays `WorshipPp`. |
+| `crates/presenter-ui/src/utils/text.rs` | **Add** `pub fn clean_song_name(name: &str) -> String` plus 4 unit tests. Existing `break_if_long` is unchanged. |
+| `crates/presenter-ui/styles/stage.css` (rule at line 353, `.stage-pp__playlist-entry`) | **Extend** the existing rule with three properties for one-row-with-ellipsis. Keep existing properties. |
+
+Nothing else touched. No `presenter-core` change. No `presenter-server` change. No new dep.
+
+## Component sketch — `worship_pp.rs`
+
+Pseudocode of the divergent parts vs `worship_snv.rs`:
+
+```rust
+use crate::utils::text::{break_if_long, clean_song_name};
+// ... rest of imports same as worship_snv.rs ...
+
+#[component]
+pub fn WorshipPp(...) -> impl IntoView {
+    // ... all the same setup as worship_snv.rs:
+    //     - context, refs (current_text_ref, next_text_ref, current_group_ref, next_group_ref,
+    //                      current_song_ref, next_song_ref)
+    //     - current_text / next_text getters with break_if_long
+    //     - current_group / next_group / *_style / *_text getters
+    //     - current_song_text getter (from ctx.snapshot.song_name)
+    //     - autofit_effect calls for all six refs
+
+    // worship-pp ONLY: bring back playlist_entries
+    let playlist_entries = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| s.playlist_entries)
+            .unwrap_or_default()
+    };
+
+    // worship-pp ONLY: next-song from playlist, not AbleSet
+    let next_song_text = move || {
+        let entries = playlist_entries();
+        let mut iter = entries.iter().skip_while(|e| !e.is_active);
+        iter.next();           // consume the active entry itself
+        iter.next()            // entry after active
+            .map(|e| clean_song_name(&e.name))
+            .unwrap_or_default()
+    };
+
+    autofit_effect(next_song_ref, NEXT_SONG_MAX_FONT, next_song_text);
+
+    view! {
+        <div class="stage-container" data-layout="worship-pp">
+            // ... same six divs as worship_snv (current-group, current-song, current-slide,
+            //      next-group, next-song, next-slide) ...
+
+            <div class="stage-pp__playlist-sidebar">
+                <span class="stage__debug-label">"playlist-sidebar"</span>
+                <For
+                    each=playlist_entries
+                    key=|entry| entry.name.clone()
+                    children=move |entry| {
+                        let class = if entry.is_active {
+                            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+                        } else {
+                            "stage-pp__playlist-entry"
+                        };
+                        let display_name = clean_song_name(&entry.name);
+                        view! { <div class=class>{display_name}</div> }
+                    }
+                />
+            </div>
+
+            <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
+        </div>
+    }
+}
+```
+
+## `clean_song_name` helper
+
+```rust
+/// Strip a leading 3-digit-then-space prefix from a ProPresenter song name.
+/// Mirrors the server-side `sanitize_song_title`:
+///
+///   "042 Amazing Grace"  -> "Amazing Grace"
+///   "  042 Padded"       -> "Padded"
+///   "12 Two Digit"       -> "12 Two Digit"   (not exactly 3 digits → unchanged)
+///   "Already Clean"      -> "Already Clean"
+///
+/// Used by the worship-pp playlist sidebar to keep operator-facing numeric
+/// prefixes off the stage display.
+pub fn clean_song_name(name: &str) -> String {
+    let trimmed = name.trim_start();
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 4
+        && bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && bytes[2].is_ascii_digit()
+        && bytes[3].is_ascii_whitespace()
+    {
+        trimmed[4..].trim_start().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+```
+
+Test cases (unit):
+- `clean_song_name("042 Amazing Grace")` → `"Amazing Grace"`
+- `clean_song_name("Amazing Grace")` → `"Amazing Grace"`
+- `clean_song_name("12 Two Digit")` → `"12 Two Digit"` (rejects, not exactly 3)
+- `clean_song_name("1234 Four Digit")` → `"1234 Four Digit"` (rejects, more than 3)
+- `clean_song_name("  042 Padded")` → `"Padded"`
+- `clean_song_name("")` → `""`
+
+## CSS for playlist entries
+
+Add to the `.stage-pp__playlist-entry` rule (do not replace the existing properties — extend them):
+
+```css
+.stage-pp__playlist-entry {
+    /* existing properties unchanged */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+```
+
+The existing `.stage-pp__playlist-entry` rule lives in `crates/presenter-ui/styles/stage.css` at line 353 (verified). Append the three new properties; do not touch the `--active` modifier rule below it.
+
+## Behavior matrix
+
+| Scenario | What renders in next-song box |
+|---|---|
+| Playlist has 5 songs, song #2 is active | Cleaned name of song #3 |
+| Active song is the last entry | Empty (no next song) |
+| No entry is active (e.g. setlist not started) | Empty |
+| `playlist_entries` is None / empty | Empty |
+| AbleSet has different idea of "next" | Ignored — Presenter playlist wins |
+
+## Tests
+
+**Unit (frontend, in `presenter-ui` crate):**
+- `clean_song_name` — six cases above.
+
+**Existing tests** that must keep passing:
+- `tests/e2e/stage-worship-pp.spec.ts` (or whichever Playwright file covers `/stage` with `worship-pp` layout, if one exists). The component still renders for `data-layout="worship-pp"`.
+
+**No new E2E** required for this PR — the changes are visual layout adjustments and a name-cleaning helper that's covered by unit tests. If we discover during dev that the next-song-from-playlist logic interacts with the AbleSet/Presenter data flow in a way that benefits from end-to-end coverage, we'll add a Playwright test then.
+
+## Risks
+
+- **`break_if_long` threshold of 26 chars** is tuned for `worship-snv`. `worship-pp` has the same slide-text width because the layout positions (`width:66%; left:2%;`) match. Acceptable.
+- **`clean_song_name` and `sanitize_song_title` will drift** if either is changed without the other. We accept this risk for now (last-iteration MJPEG-style YAGNI; both are 10-line static functions, easy to audit). If drift becomes a real issue, lift to `presenter-core` later.
+- **AbleSet integration in `worship-pp`** is effectively dead-code for the next-song display once this lands — `worship-pp` no longer reads `s.next_song_name`. The field still feeds `worship-snv`, so the server still computes it. That's fine.
+
+## Out of scope
+
+- Changes to `worship_snv` (untouched).
+- Server-side song-name normalization (`sanitize_song_title` stays where it is).
+- New snapshot fields like `next_song_from_playlist`.
+- Refactoring shared layout fragments out of `worship_pp.rs` / `worship_snv.rs` — they will share ~120 lines of structure but extracting now is premature.
+- Visual tuning of the playlist sidebar beyond one-row + ellipsis (font sizes, colors, spacing).
+
+## Decision log
+
+- **Frontend-only over backend stripping (Approach A vs C):** keeps the diff small (two files), no contract change, `worship-snv` provably unaffected. The duplication of `sanitize_song_title` ↔ `clean_song_name` is a 10-line copy that's trivially auditable.
+- **Ellipsis over autofit-shrink for entries:** standard CSS, predictable visual, no font jitter as the active row shifts. Autofit per-entry would also work but introduces inconsistent text sizes across the list.
+- **Next-song from playlist, not AbleSet:** explicit user requirement; matches what the operator sees in the Presenter UI rather than the external coordinator.
+- **No new Playwright E2E:** the change is a layout/helper refactor; unit coverage of `clean_song_name` plus existing E2E for the `/stage` page is sufficient.

--- a/docs/superpowers/specs/2026-04-27-worship-pp-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-27-worship-pp-fixes-design.md
@@ -1,0 +1,131 @@
+# Worship-PP Fixes — Design
+
+**Date:** 2026-04-27
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM crate) + thin server DTO change for presentation-name enrichment
+
+## Goal
+
+Fix three regressions reported on the worship-pp stage layout and operator playlist UI after PR #268:
+
+1. **Stage layout overlap** — the six worship-pp slide regions (current/next group/song/slide) are positioned absolutely against the page, and the playlist sidebar overlays them at 30% on the right. Slides and sidebar overlap, nothing is readable.
+2. **Active-song highlight too subtle** — the current `--active` rule applies a 15%-opacity blue tint and bold text. From the projector that's invisible. The user wants the now-playing song to stand out at a glance.
+3. **Operator playlist entries show no presentation name** — when a playlist is selected, the operator's playlist view rebuilds `ctx.presentations` from playlist entries with `String::new()` for the name. The entry name lookup then returns an empty string. Entries appear as blank rows with only the library tag visible.
+
+## Non-goals
+
+- No redesign of the worship-pp layout. The existing six-region structure stays; we only constrain it to the left 70%.
+- No change to the worship-snv layout. It is unaffected.
+- No change to drag-drop, playlist CRUD, or the GET /playlists/{id} fix from PR #268.
+
+## Approach
+
+Three independent fixes shipped together because they all surfaced from the same user session and share the worship-pp/playlist domain.
+
+---
+
+### Issue 1 — Stage layout: wrap regions in `.stage-pp__slides-area`
+
+The CSS for `.stage-pp__slides-area` (left 70%, full height, `overflow: hidden`) and `.stage-pp__playlist-sidebar` (right 30%) is already defined. The bug is that `worship_pp.rs` doesn't wrap the six slide regions in `.stage-pp__slides-area` — they remain direct children of `.stage-container`, so their existing absolute positioning anchors against the page (full width).
+
+**Change:**
+
+- In `crates/presenter-ui/src/components/stage/worship_pp.rs`, wrap the six regions (`.stage__current-group`, `.stage__current-song`, `.stage__current-slide`, `.stage__next-group`, `.stage__next-song`, `.stage__next-slide`) inside a single `<div class="stage-pp__slides-area">` parent. The playlist sidebar stays as a sibling.
+- In `crates/presenter-ui/styles/stage.css`, scope the worship-pp variants of those six region rules so their absolute positioning is relative to `.stage-pp__slides-area` (which already has `position: absolute`). Use scoped selectors like `.stage-pp__slides-area .stage__current-slide { ... }` so the SNV layout (which uses bare `.stage__current-slide`) is unaffected.
+- Keep the original SNV positioning intact. Only override what worship-pp needs (effectively the same regions but with their `right`/`width` recalculated to fit a 100%-of-parent container which is itself 70% of the page).
+
+The rendered geometry: slides occupy 70% width × 92% height on the left, playlist occupies 30% width × 92% height on the right with a 1px left border, status bar spans the bottom 8% as before. No overlap.
+
+### Issue 2 — Active-song highlight: stronger, projector-visible
+
+Replace the faint `.stage-pp__playlist-entry--active` styling with a high-contrast pill: solid accent background, white text, a 4px left-edge accent bar for at-a-glance scanning, and a small font-weight bump (no font-size change to avoid layout reflow).
+
+**Change:**
+
+- In `crates/presenter-ui/styles/stage.css`, update `.stage-pp__playlist-entry--active`:
+  - `background: #38bdf8` (full-opacity sky-blue, matches existing accent palette)
+  - `color: #0f172a` (dark on light pill — high contrast)
+  - `font-weight: 700`
+  - `border-left: 4px solid #0ea5e9` (deeper accent bar, sits inside the pill)
+  - `padding-left: calc(0.6rem - 4px)` to compensate for the border so text alignment with non-active rows stays consistent.
+
+Non-active entries keep their existing `color: #94a3b8` and transparent background so the contrast is dramatic at projector distance.
+
+### Issue 3 — Operator playlist entry names: server enrichment
+
+The server already has `fetch_presentation_names_for_playlist` (used to populate stage playlist sidebar). Use it for the API response too: each `Presentation` entry in the JSON gains a `presentation_name` field. The operator reads `entry.kind.presentation_name` directly when rendering, eliminating the empty-string rebuild.
+
+**Change:**
+
+Server side (`presenter-server`):
+
+- Find the public Playlist DTO that's serialized in the GET/PATCH/PUT /playlists/{id} responses.
+- Add a `presentation_name: Option<String>` field on the `PlaylistEntryKind::Presentation` variant in the *response* type only (the request type stays minimal — clients still PUT only `presentation_id`, the server fills the name on read).
+- Where the playlist is serialized, run `fetch_presentation_names_for_playlist` and inject names into each `Presentation` entry before returning the JSON. Empty string when the name can't be resolved (presentation deleted).
+
+Client side (`presenter-ui`):
+
+- Update `PlaylistEntryKind::Presentation` deserialization to include `presentation_name: Option<String>`.
+- In `presentation_list.rs`, line ~352-356, replace the lookup-from-`ctx.presentations` with `entry.presentation_name.clone().unwrap_or_default()`.
+- Drop the now-unused `rebuild_playlist_presentations_with_signal` calls (and the helper itself) from `operator.rs:494-508` and `presentation_list.rs:605-623`. The operator UI no longer needs to fake a presentations list when a playlist is selected — names come from the playlist response directly.
+- Library list is still the source of `ctx.presentations` for non-playlist mode (clicking a library), so keep that flow untouched.
+
+This is the cleanest fix because:
+- The server already has all the data and the lookup function.
+- One round-trip per playlist load (no N+1 lazy fetches).
+- No client-side cache to invalidate when a presentation gets renamed.
+- Removes a chunk of WASM-side complexity (rebuild functions).
+
+## Data flow after fix
+
+```
+operator clicks playlist row
+  → GET /playlists/{id}
+  ← { entries: [ { kind: { type: "presentation", presentation_id, presentation_name }, ... }, ... ] }
+operator renders entries directly from the response — names already there.
+
+worship-pp stage gets snapshot
+  ← { playlist_entries: [ { name, presentation_id, is_active, entry_type }, ... ] }   (unchanged)
+stage renders sidebar; active entry gets the new high-contrast --active pill.
+```
+
+## Testing strategy
+
+1. **Unit test (server):** `replace_playlist_entries` and `get_playlist` responses include `presentation_name` for `Presentation` entries (assert against a known seeded presentation). Empty string when the presentation is missing.
+2. **Unit test (server):** existing tests still pass — adding the field is additive, request types unchanged.
+3. **Unit test (presenter-ui):** `PlaylistEntryKind::Presentation` round-trips `presentation_name` through serde.
+4. **E2E (Playwright):** Extend `wasm-playlist-operations.spec.ts` — after dragging a presentation onto a playlist, click the playlist row and assert the rendered entry has visible non-empty text matching the presentation name. (Today this would render an empty span.)
+5. **E2E (Playwright):** Open `/stage` with worship-pp layout active and a playlist with entries. Assert:
+   - `.stage-pp__slides-area` exists and contains all six slide regions
+   - `.stage-pp__slides-area`'s right edge ≤ `.stage-pp__playlist-sidebar`'s left edge (no overlap, computed from `getBoundingClientRect`).
+   - When an active presentation is set, the matching `.stage-pp__playlist-entry--active` row has a `background-color` distinct from the non-active rows (computed style, not just class presence).
+6. **Manual visual check:** open dev stage with a playlist + active presentation, confirm the highlight is obvious from a normal viewing distance.
+7. **Browser console:** zero errors, zero warnings on operator and stage pages.
+
+## File-level overview
+
+| File | Change |
+|------|--------|
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | Wrap six regions in `<div class="stage-pp__slides-area">` |
+| `crates/presenter-ui/styles/stage.css` | Scope worship-pp region positioning to `.stage-pp__slides-area`; rewrite `.stage-pp__playlist-entry--active` with high-contrast styling |
+| `crates/presenter-server/src/router/playlists.rs` (or whichever module owns the response DTO) | Add `presentation_name: Option<String>` to the response variant; enrich responses with name lookup |
+| `crates/presenter-server/src/state/...` | Plumb the existing name-lookup into the response builder |
+| `crates/presenter-core/src/playlist.rs` (if the DTO lives there) | Add field to the response model |
+| `crates/presenter-ui/src/api/playlists.rs` and/or `presenter-core` | Mirror the new field for deserialization |
+| `crates/presenter-ui/src/components/presentation_list.rs` | Read name from entry directly; remove `rebuild_playlist_presentations_with_signal` |
+| `crates/presenter-ui/src/pages/operator.rs` | Remove the `String::new()` summaries-rebuild block at line ~494-508 |
+| `tests/e2e/wasm-playlist-operations.spec.ts` | Add operator playlist-name visibility check after drag-drop |
+| `tests/e2e/` (new or extended stage spec) | Add worship-pp layout + active-highlight E2E |
+
+## Risks / unknowns
+
+- The exact location of the response DTO depends on whether playlist response uses the same struct as the storage model or a separate response struct. The plan must verify and choose the right insertion point.
+- If the response DTO is shared with the request body, splitting it (server-side response variant vs request variant) is part of this work.
+- Edge case: presentation referenced by playlist was deleted. Server returns `presentation_name: None` (or `Some("")`); operator and stage should both render the entry without crashing (e.g., as `[deleted]` or just blank — pick blank to match existing behavior).
+
+## Out of scope
+
+- Cross-library global presentation index (Alt B for issue 3).
+- Lazy per-entry name fetch (Alt C for issue 3).
+- Adding ▶ marker or font-size scaling for the active row (Alts B/C for issue 2).
+- Any change to worship-snv, preach, bible, NDI, timer, or API stage layouts.

--- a/docs/superpowers/specs/2026-04-28-worship-pp-active-reactivity-design.md
+++ b/docs/superpowers/specs/2026-04-28-worship-pp-active-reactivity-design.md
@@ -1,0 +1,112 @@
+# Worship-PP Active-Highlight Reactivity Fix — Design
+
+**Date:** 2026-04-28
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM, single component file) + one E2E test extension
+
+## Goal
+
+Fix the worship-pp stage playlist sidebar so the active-song highlight follows the currently-presenting song. Today the highlight gets stuck on whichever song was active when the sidebar first rendered, and never moves when the user triggers a different song.
+
+## Root cause
+
+In `crates/presenter-ui/src/components/stage/worship_pp.rs:178-193`:
+
+```rust
+<For
+    each=playlist_entries
+    key=|entry| entry.name.clone()
+    children=move |entry| {
+        let class = if entry.is_active {
+            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+        } else {
+            "stage-pp__playlist-entry"
+        };
+        let display_name = clean_song_name(&entry.name);
+        view! { <div class=class>{display_name}</div> }
+    }
+/>
+```
+
+The `class` is a string computed *once* — when the row is first inserted into the DOM — from the captured `entry: StagePlaylistEntry` value. When the server later pushes a new `playlist_entries` Vec with `is_active` flipped, Leptos's `<For>` diffs by key (`entry.name`); identical keys mean Leptos reuses the existing DOM node. The captured `entry.is_active` stays at its initial value, so the class never updates.
+
+## Fix
+
+Make the class a reactive closure that reads `is_active` from the `playlist_entries` signal at evaluation time:
+
+```rust
+children=move |entry| {
+    let entry_name = entry.name.clone();
+    let is_active = move || {
+        playlist_entries
+            .with(|entries| entries.iter().any(|e| e.name == entry_name && e.is_active))
+    };
+    let class = move || {
+        if is_active() {
+            "stage-pp__playlist-entry stage-pp__playlist-entry--active"
+        } else {
+            "stage-pp__playlist-entry"
+        }
+    };
+    let display_name = clean_song_name(&entry.name);
+    view! { <div class=class>{display_name}</div> }
+}
+```
+
+Why this works:
+- `class=move || ...` — Leptos tracks signals read inside the closure. The closure reads `playlist_entries` (a signal), so Leptos re-runs the closure whenever `playlist_entries` changes.
+- The lookup is by name match (same identity Leptos's `For` already uses for keying). Two distinct entries can't share the same name in a playlist context (the existing `For` key would already collapse them into one row).
+- `display_name` stays as a static string — names don't change for a row, only `is_active` does.
+- No flicker, no DOM rebuild.
+
+## Why I didn't catch this in the previous PR's E2E
+
+The existing test "active playlist entry has high-contrast background distinct from inactive" seeds ONE playlist entry, triggers ONE presentation, and asserts that the rendered active row has a non-transparent background distinct from inactive rows. It verifies *static* correctness (the active class is applied somewhere) but not *reactivity* (the active class moves to a different row on a new trigger).
+
+The fix here adds a *second* test that explicitly asserts the highlight MOVES between rows on consecutive triggers — the regression guard that should have existed from the start.
+
+## Testing
+
+### New E2E test in `tests/e2e/stage-worship-pp.spec.ts`
+
+```typescript
+test("active highlight moves to the new song when the operator triggers a different presentation", async ({ page }) => {
+    // 1. Switch stage layout to worship-pp.
+    // 2. Seed a playlist with TWO presentations (P1, P2), each with at least one slide.
+    // 3. Trigger P1 onto stage with playlist context.
+    // 4. Open /stage. Wait for sidebar with two entries to render.
+    // 5. Assert: row whose data identifies P1 has `.stage-pp__playlist-entry--active`,
+    //    row for P2 does NOT.
+    // 6. Trigger P2 onto stage (same playlist).
+    // 7. Wait for the sidebar to reflect the change (poll up to 5s).
+    // 8. Assert: row for P2 now has `.stage-pp__playlist-entry--active`,
+    //    row for P1 does NOT (the highlight moved).
+    // 9. Cleanup: delete the playlist.
+}
+```
+
+The two rows can be distinguished by their text content (presentation name passed through `clean_song_name`) or by an index (first/second `.stage-pp__playlist-entry`).
+
+### Existing test stays as-is
+
+The existing test "active playlist entry has high-contrast background distinct from inactive" remains a valid regression guard for static correctness. The new test guards reactive correctness.
+
+## Risks / unknowns
+
+- If two entries truly share the same name, the lookup `iter().any(|e| e.name == entry_name && e.is_active)` will highlight both rows. The existing `For` key collapses same-named entries to a single rendered row anyway, so this isn't a new failure mode — it's the same behavior as today.
+- `playlist_entries` must already be a properly-tracked signal. It is (it's a Memo derived from `stage_snapshot`), so the closure re-runs on every update. Verified by reading worship_pp.rs imports.
+
+## Out of scope
+
+- Refactoring how `playlist_entries` is sourced.
+- Active-highlight animation (CSS transitions on the class change). Not requested.
+- Worship-snv (no sidebar — not affected).
+- Operator UI playlist active-row highlight (different code path, different signal — not in this user's report).
+
+## File-level overview
+
+| File | Change |
+|------|--------|
+| `crates/presenter-ui/src/components/stage/worship_pp.rs` | Replace the `<For children=...>` closure with the reactive-class version above |
+| `tests/e2e/stage-worship-pp.spec.ts` | Add the new "highlight moves on consecutive trigger" test |
+| `Cargo.toml` (workspace), `crates/presenter-ui/Cargo.toml` | Version bump to 0.4.40 / next presenter-ui patch |

--- a/docs/superpowers/specs/2026-04-28-worship-pp-bigger-fonts-design.md
+++ b/docs/superpowers/specs/2026-04-28-worship-pp-bigger-fonts-design.md
@@ -1,0 +1,104 @@
+# Worship-PP Bigger Sidebar Fonts — Design
+
+**Date:** 2026-04-28
+**Status:** Proposed
+**Scope:** CSS only
+
+## Goal
+
+Make the worship-pp stage playlist sidebar text large enough that ~12 characters fit per row at projector distance. The 22%-wide sidebar is the right width — but the current 2.6vh font (≈28px @ 1080p) is too small, and the sidebar/entry padding eats too much width. Increase the font, tighten the padding.
+
+## Non-goals
+
+- No change to sidebar width (22% is correct).
+- No change to slides-area width (78% is correct).
+- No change to active-highlight color or accent bar (only the padding-left compensation adjusts to match the new entry padding).
+- No layout / WASM / server changes.
+
+## Approach
+
+CSS-only updates to four rules in `crates/presenter-ui/styles/stage.css`. Width math at 1080p:
+
+| | px @ 1080p (1920w × 1080h) |
+|---|---|
+| Viewport width | 1920 |
+| Sidebar width (22%) | 422 |
+| Sidebar padding both sides (now `0.4% 0.5%` → 19.2px L+R) | minus 19 → 403 inner |
+| Entry padding both sides (now `0.4rem` → 12.8px L+R) | minus 13 → 390 chars-area |
+| Per char target (12 chars per row) | ~32px |
+| Font-size that yields ~32px char-width (typical ratio 0.55–0.6) | ~54px ≈ **5vh** |
+
+Row height with `5vh` font + `0.3vh` padding × 2 + line-height 1.1 ≈ `5.5vh + 0.6vh = 6.1vh` per row → 12 rows ≈ **73vh** in a 92vh sidebar. Plenty of headroom; >12 entries still scroll via existing `overflow-y: auto`.
+
+### Concrete CSS changes
+
+`crates/presenter-ui/styles/stage.css`:
+
+`.stage-pp__playlist-sidebar` — tighten padding:
+
+```css
+.stage-pp__playlist-sidebar {
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 22%;
+    height: 92%;
+    overflow-y: auto;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 0.4% 0.5%;     /* was 1% 1.5% */
+    box-sizing: border-box;
+}
+```
+
+`.stage-pp__playlist-entry` — bigger font, tighter padding:
+
+```css
+.stage-pp__playlist-entry {
+    padding: 0.3vh 0.4rem;          /* was 0.6vh 0.8rem */
+    color: #94a3b8;
+    /* Sized so ~12 typical chars fit per row at 1080p:
+       sidebar 22% × 1920 = 422px, less padding → ~390px content,
+       at 5vh font (≈54px) char-width is ~30px, ~12 chars per row. */
+    font-size: 5vh;                  /* was 2.6vh */
+    line-height: 1.1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-radius: 4px;
+    margin-bottom: 2px;
+}
+```
+
+`.stage-pp__playlist-entry--active` — recompensate padding-left for new base:
+
+```css
+.stage-pp__playlist-entry--active {
+    background: #38bdf8;
+    color: #0f172a;
+    font-weight: 700;
+    border-left: 4px solid #0ea5e9;
+    /* Base padding-left is 0.4rem (≈6.4px); subtract the 4px border so
+       text alignment with non-active rows stays consistent. */
+    padding-left: calc(0.4rem - 4px);
+}
+```
+
+`.stage-pp__slides-area` — unchanged (already 78%).
+
+## Testing
+
+Update one assertion in `tests/e2e/stage-worship-pp.spec.ts` — the existing test "sidebar is narrower (~22%) and entries have projector-readable font" asserts `entryFontSizePx >= 24`. Tighten to `>= 40` since the new 5vh on the test's `1920×1080` viewport = 54px, and we want the regression guard to catch any accidental drop back to a small font.
+
+No new E2E spec needed.
+
+## Risks
+
+- Slovak diacritics widen text slightly. With the 1080p target ~30px char-width and a 5vh font, very wide characters (`Ž`, `Š`, `Č`) may push to ~10 chars instead of 12 in the worst case. Existing `text-overflow: ellipsis` truncates cleanly. The user's "12 chars" was approximate — the design hits 11–12 typical, 9–10 in worst-case Slavic strings. Acceptable.
+- 5vh on a non-16:9 stage display (e.g. tall portrait) would render smaller in absolute pixels. The presenter targets 1080p projector, so this is fine.
+- Tight 0.4% sidebar padding leaves only ~7px of breathing room from the screen edge at 1080p. Text won't TOUCH the edge but is close. The user explicitly chose this option ("A — small visible breathing room").
+
+## Out of scope
+
+- Adapting font-size dynamically based on the longest entry's character count (would require JS measurement; not worth the complexity for this iteration).
+- Scaling the active accent bar with font-size.
+- Multi-line entry support (current `white-space: nowrap` truncates; user accepted ellipsis).

--- a/docs/superpowers/specs/2026-04-28-worship-pp-followups-design.md
+++ b/docs/superpowers/specs/2026-04-28-worship-pp-followups-design.md
@@ -1,0 +1,106 @@
+# Worship-PP Follow-ups — Design
+
+**Date:** 2026-04-28
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM + CSS)
+
+## Goal
+
+Fix two follow-up issues reported after the worship-pp regression PR:
+
+1. **Drag from search to playlist** doesn't work. The user drags a search result, but the playlist row never accepts it — no entry appears.
+2. **Stage worship-pp sidebar** wastes screen space. Slides area should be wider (more readable main content), and playlist entry text needs to be much larger so the operator/leader can read song titles from across the room. Target: max 12 entries visible at once, sized for projector viewing.
+
+## Non-goals
+
+- No change to playlist persistence (the user confirmed dev-DB-replace-on-deploy is intentional).
+- No change to the worship-snv layout, operator UI logic, server endpoints, drag-drop *between* libraries, or playlist CRUD.
+- No change to the active-song highlight — the PR #268 pill (solid sky-blue + 4px accent bar) stays as-is.
+
+## Approach
+
+Two independent fixes, one PR.
+
+---
+
+### Issue 1 — Drag from search to playlist
+
+**Investigation first, then targeted fix.** The static analysis says the drag *should* work:
+- `crates/presenter-ui/src/components/search.rs` — search results are `<div draggable="true">`. The `on:dragstart` handler sets BOTH `application/x-presentation-id` AND `application/x-presenter-search` on the dataTransfer.
+- `crates/presenter-ui/src/components/playlist_list.rs` — the playlist `<li>` `on:dragover` accepts either of those MIME types and calls `preventDefault`. The `on:drop` reads from the same keys and dispatches `replace_entries` via `spawn_local`.
+- The state signals `search_dragging` and `dragging_from_search` are set by search.rs but **never read** by the drop handler — they don't gate anything.
+
+So whatever's broken happens at runtime, not in the static logic. Most likely candidates (in order of probability):
+1. **`effect_allowed("copy")` vs the playlist row's drop intent.** The search dragstart sets `effectAllowed = "copy"`. The playlist row's dragover doesn't set a matching `dropEffect`, which can cause the browser to deny the drop in some Chromium builds. Fix: set `event.data_transfer().set_drop_effect("copy")` in the playlist dragover when the type matches.
+2. **A pointer-events / z-index issue** between the search-results column and the playlist-list column that makes the drag never reach the playlist row's hit region.
+3. **A subtle timing bug** where the search result's dragstart fires but the dataTransfer types aren't yet visible to the playlist row's dragover by the time it runs.
+
+The plan investigates by:
+- Opening the operator UI with Playwright, finding a search result and a playlist row, and dispatching a real `dragstart → dragover → drop` sequence as the browser would.
+- Reading the actual error (if any) from the browser console, the `dataTransfer.types` at each step, and the result of the drop handler.
+- Applying the targeted fix (most likely #1 — add `set_drop_effect` to the playlist row's dragover).
+
+**Regression guard:** add a Playwright E2E test that drags a real search-result row onto a playlist sidebar row and asserts the entry is added (similar to the existing `tests/e2e/wasm-playlist-operations.spec.ts` "drop a presentation" test, but with the source as a `[data-role="search-result-item"]` instead of `[data-role="presentation-item"]`).
+
+---
+
+### Issue 2 — Sidebar narrower, slides wider, much bigger song text, max 12 visible
+
+Pure CSS in `crates/presenter-ui/styles/stage.css`. Changes are scoped to the worship-pp layout.
+
+**Width split:**
+- `.stage-pp__slides-area`: `width: 70% → 78%`
+- `.stage-pp__playlist-sidebar`: `width: 30% → 22%`
+- Slides area gains 8% of horizontal space; the autofit logic in worship-snv-derived regions naturally produces larger text because the container is wider.
+
+**Entry sizing:**
+- `.stage-pp__playlist-entry`:
+  - `font-size: 0.9vw → 2.6vh` (≈28px @ 1080p, ≈37px @ 1440p — readable from a distance)
+  - `padding: 0.4rem 0.6rem → 0.6vh 0.8rem` (vertical padding now scales with viewport height so 12 entries fill the 92vh sidebar)
+  - `line-height: 1.1` (explicit, to keep row height predictable)
+  - `margin-bottom: 2px` (unchanged)
+- `.stage-pp__playlist-entry--active`: keep the existing solid-pill + 4px accent bar from PR #268. Just bump the same padding/font-size rules so the active row matches its inactive siblings dimensionally (the `padding-left: calc(0.8rem - 4px)` compensation stays).
+
+**Math:** sidebar height = 92vh. Per-entry row = 2.6vh font + 1.2vh padding (top+bottom) + 1.1 line-height = roughly 7.0–7.5vh per row → 12 entries fit in ≈84–90vh. Margin/border-left absorb the remaining 2–8vh. If a playlist has more than 12 entries, the existing `overflow-y: auto` on the sidebar lets the rest scroll. If fewer, rows don't stretch — they keep their per-row size for visual consistency.
+
+**Test:** the existing `tests/e2e/stage-worship-pp.spec.ts` already asserts no overlap between slides-area and sidebar. We extend it (or add a new test in the same file) to:
+- Assert sidebar width is ~22% of viewport width.
+- Compute `getBoundingClientRect()` on a `.stage-pp__playlist-entry` and assert font-size ≥ 24px (sanity floor for projector readability).
+
+## Data flow
+
+No data flow changes. Frontend-only.
+
+## Testing strategy
+
+1. **Unit tests:** none — both changes are CSS / event-handler tweaks with no isolated logic worth a unit test.
+2. **E2E (Playwright)** — extend existing specs:
+   - `tests/e2e/wasm-playlist-operations.spec.ts`: add a test that drags a `[data-role="search-result-item"]` onto a playlist row and asserts the entry is added (regression guard for issue 1).
+   - `tests/e2e/stage-worship-pp.spec.ts`: assert the new sidebar width (22%) and that entry font-size is ≥ 24px computed (regression guard for issue 2).
+3. **Live verification on dev** — after deploy:
+   - Open `/ui/operator`, type a search query, drag a result onto a playlist row, confirm the entry is added.
+   - Open `/stage`, ensure worship-pp layout is selected, confirm the sidebar is visibly narrower and the song text is large enough to read from the back of a room.
+4. **Browser console:** zero errors / warnings on operator and stage.
+
+## File-level overview
+
+| File | Change |
+|------|--------|
+| `crates/presenter-ui/src/components/playlist_list.rs` | Investigate-then-fix: most likely add `dt.set_drop_effect("copy")` in the dragover handler when accepting search drops. |
+| `crates/presenter-ui/styles/stage.css` | Resize `.stage-pp__slides-area` (78%) and `.stage-pp__playlist-sidebar` (22%); enlarge `.stage-pp__playlist-entry` font-size + tune padding/line-height; adjust active rule's padding-left compensation if needed. |
+| `tests/e2e/wasm-playlist-operations.spec.ts` | Add "drag from search result to playlist" E2E test. |
+| `tests/e2e/stage-worship-pp.spec.ts` | Extend with sidebar-width + entry font-size assertions. |
+| `Cargo.toml` (workspace), `crates/presenter-ui/Cargo.toml` | Version bump to 0.4.38 / next presenter-ui patch. |
+
+## Risks / unknowns
+
+- The drag-from-search root cause is empirically uncertain. The plan's first task investigates live before writing a fix. If `set_drop_effect` doesn't resolve it, the next candidates are pointer-events on a parent container or a CSS `user-drag` style. The implementer reports findings before applying the fix.
+- Setting `padding` in `vh` units is unusual but necessary so 12 entries fit a 92vh container at any aspect ratio. If this looks off in practice, the fallback is `min-height` on the entry plus `flex` distribution on the sidebar.
+- Sidebar at 22% may look too narrow if a song title is long. The existing `text-overflow: ellipsis` handles this — we already truncate single-row entries.
+
+## Out of scope
+
+- Playlist persistence on dev (intentional design — DB replaced from prod on each deploy).
+- Drag-drop reordering, separator drag, between-playlist moves, multi-select.
+- Stage layout for non-worship-pp variants.
+- Server-side changes.

--- a/docs/superpowers/specs/2026-04-29-worship-pp-10-row-fit-design.md
+++ b/docs/superpowers/specs/2026-04-29-worship-pp-10-row-fit-design.md
@@ -1,0 +1,48 @@
+# Worship-PP 10-Row Sidebar Fit — Design
+
+**Date:** 2026-04-29
+**Status:** Proposed
+**Scope:** CSS only
+
+## Goal
+
+Bump the worship-pp playlist sidebar entry font from `5vh` to `7.5vh` so that exactly ~10 rows fit in the 92vh sidebar instead of the current ~14. The user wants larger song titles for projector readability; 10-row capacity is enough for typical service lengths.
+
+## Non-goals
+
+- No change to sidebar width (22%), slides-area width (78%), padding, or active-highlight color/border.
+- No layout / WASM / server changes.
+
+## Approach
+
+Single-value CSS change in `crates/presenter-ui/styles/stage.css`. Math at 1080p:
+
+| | Current (5vh) | Target (7.5vh) |
+|---|---|---|
+| font-size | 54px | 81px |
+| Text box height (line-height 1.1) | 59.4px | 89.1px |
+| Padding (0.3vh × 2) | 6.5px | 6.5px |
+| Margin-bottom | 2px | 2px |
+| **Per-row height** | **67.9px** | **97.6px** |
+| Rows in 986px usable sidebar | ~14.5 | ~10.1 |
+
+E2E `tests/e2e/stage-worship-pp.spec.ts` already asserts `entryFontSizePx >= 40`. Tighten to `>= 70` so the new 81px font is locked in (any accidental regression to ≤ 70px would fail the test).
+
+### CSS change
+
+In `.stage-pp__playlist-entry`, replace `font-size: 5vh;` with `font-size: 7.5vh;` and update the inline comment to reflect the new ~10-row target.
+
+### E2E change
+
+In `tests/e2e/stage-worship-pp.spec.ts`, replace `expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);` with `expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(70);` and refresh the comment.
+
+## Risks
+
+- Slovak diacritics in song titles already truncate at the previous 5vh font; at 7.5vh, fewer characters fit per row (~8 typical instead of ~12). Existing `text-overflow: ellipsis` handles this. The user has been iterating on the size/fit trade-off and is now asking explicitly for fewer-rows-bigger-text — so this is the desired trade-off.
+- Per-row height includes the active row's 4px left border. The active row's `padding-left: calc(0.4rem - 4px)` compensation is unchanged — text alignment with non-active rows stays consistent.
+
+## Out of scope
+
+- Dynamic font sizing based on entry count.
+- Multi-line entry support.
+- Adjusting active-highlight border thickness.

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -311,4 +311,162 @@ test.describe("Stage worship-pp layout", () => {
 
     expect(consoleErrors).toEqual([]);
   });
+
+  test("active highlight moves to the new song when the operator triggers a different presentation", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon") && !t.includes("crbug.com/981419")) {
+          consoleErrors.push(`[${msg.type()}] ${t}`);
+        }
+      }
+    });
+
+    // Set worship-pp layout
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Find TWO presentations with at least one slide each.
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{
+        id: string;
+        name?: string;
+        slides?: Array<{ id: string }>;
+      }>;
+    }>;
+    const allPres = libs
+      .flatMap((lib) => lib.presentations ?? [])
+      .filter((p) => (p.slides?.length ?? 0) > 0 && !!p.name);
+    if (allPres.length < 2) {
+      test.skip(true, "fixture has fewer than 2 presentations with slides");
+      return;
+    }
+    const p1 = allPres[0];
+    const p2 = allPres[1];
+    if (
+      !p1.slides ||
+      !p2.slides ||
+      !p1.slides[0] ||
+      !p2.slides[0] ||
+      !p1.name ||
+      !p2.name
+    ) {
+      test.skip(true, "presentations missing required fields");
+      return;
+    }
+    const p1SlideId = p1.slides[0].id;
+    const p2SlideId = p2.slides[0].id;
+
+    // Create a playlist with both presentations.
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      {
+        data: {
+          name: `Highlight Move Test ${Date.now()}`,
+          showInDashboard: true,
+        },
+      },
+    );
+    const playlist = (await playlistResp.json()) as { id: string };
+    await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [
+            { type: "presentation", presentationId: p1.id },
+            { type: "presentation", presentationId: p2.id },
+          ],
+        },
+      },
+    );
+
+    // Trigger P1.
+    const trig1 = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: p1.id,
+          currentSlideId: p1SlideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trig1.status()).toBe(204);
+
+    // Open the stage page.
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      () => document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+
+    // Wait for both rows to render.
+    await page.waitForFunction(
+      () => document.querySelectorAll(".stage-pp__playlist-entry").length >= 2,
+      { timeout: 15_000 },
+    );
+
+    // Helper: read which row index has the active class. Returns -1 if none.
+    const activeIndex = async (): Promise<number> =>
+      page.evaluate(() => {
+        const rows = Array.from(
+          document.querySelectorAll(".stage-pp__playlist-entry"),
+        );
+        return rows.findIndex((r) =>
+          r.classList.contains("stage-pp__playlist-entry--active"),
+        );
+      });
+
+    // After triggering P1, P1's row (index 0) should be active.
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(0);
+
+    // Now trigger P2. The highlight MUST move to row index 1.
+    const trig2 = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: p2.id,
+          currentSlideId: p2SlideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trig2.status()).toBe(204);
+
+    // Regression guard: the active class must now be on row 1, not row 0.
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(1);
+
+    // And ensure row 0 is no longer active.
+    const row0Active = await page.evaluate(() => {
+      const rows = Array.from(
+        document.querySelectorAll(".stage-pp__playlist-entry"),
+      );
+      return (
+        rows[0]?.classList.contains("stage-pp__playlist-entry--active") ?? false
+      );
+    });
+    expect(row0Active).toBe(false);
+
+    // Cleanup
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
 });

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -136,9 +136,7 @@ test.describe("Stage worship-pp layout", () => {
       new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
       {
         data: {
-          entries: [
-            { type: "presentation", presentationId: presentation.id },
-          ],
+          entries: [{ type: "presentation", presentationId: presentation.id }],
         },
       },
     );
@@ -182,9 +180,7 @@ test.describe("Stage worship-pp layout", () => {
       ) as HTMLElement | null;
       return {
         active: a ? getComputedStyle(a).backgroundColor : null,
-        inactive: inactive
-          ? getComputedStyle(inactive).backgroundColor
-          : null,
+        inactive: inactive ? getComputedStyle(inactive).backgroundColor : null,
       };
     });
     expect(colors.active).toBeTruthy();
@@ -198,5 +194,119 @@ test.describe("Stage worship-pp layout", () => {
     await page.request.delete(
       new URL(`/playlists/${playlist.id}`, baseURL).toString(),
     );
+  });
+
+  test("sidebar is narrower (~22%) and entries have projector-readable font", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (t.includes("favicon")) return;
+        if (t.includes("crbug.com/981419")) return;
+        consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // Set worship-pp layout
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Seed a playlist with one entry and trigger it so the sidebar has content.
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{ id: string; slides?: Array<{ id: string }> }>;
+    }>;
+    const presentation = libs
+      .flatMap((lib) => lib.presentations ?? [])
+      .find((p) => (p.slides?.length ?? 0) > 0);
+    if (!presentation || !presentation.slides || !presentation.slides[0]) {
+      test.skip(true, "test fixture has no presentation with slides");
+      return;
+    }
+    const slideId = presentation.slides[0].id;
+
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      {
+        data: {
+          name: `Sidebar Width Test ${Date.now()}`,
+          showInDashboard: true,
+        },
+      },
+    );
+    const playlist = (await playlistResp.json()) as { id: string };
+    await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [{ type: "presentation", presentationId: presentation.id }],
+        },
+      },
+    );
+    await page.request.post(new URL("/stage/state", baseURL).toString(), {
+      data: {
+        presentationId: presentation.id,
+        currentSlideId: slideId,
+        playlistId: playlist.id,
+      },
+    });
+
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.waitForFunction(
+      () => document.body.dataset.wasmReady === "true",
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      () => document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+
+    // Wait for the playlist sidebar to render with at least one entry.
+    await page.waitForSelector(".stage-pp__playlist-entry", {
+      timeout: 15_000,
+    });
+
+    // Read sidebar width and entry font-size from computed styles.
+    const measurements = await page.evaluate(() => {
+      const sidebar = document.querySelector(
+        ".stage-pp__playlist-sidebar",
+      ) as HTMLElement | null;
+      const entry = document.querySelector(
+        ".stage-pp__playlist-entry",
+      ) as HTMLElement | null;
+      if (!sidebar || !entry) return { error: "missing element" } as const;
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const entryStyle = getComputedStyle(entry);
+      return {
+        sidebarRatio: sidebarRect.width / viewportWidth,
+        entryFontSizePx: parseFloat(entryStyle.fontSize),
+      } as const;
+    });
+
+    expect("error" in measurements, JSON.stringify(measurements)).toBe(false);
+    if ("sidebarRatio" in measurements) {
+      // Sidebar must be ~22% (allow ±3% slack for borders/scrollbar).
+      expect(measurements.sidebarRatio).toBeGreaterThan(0.19);
+      expect(measurements.sidebarRatio).toBeLessThan(0.25);
+      // Entry font must be readable from the back of a room — sanity floor at 24px.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(24);
+    }
+
+    // Cleanup
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
   });
 });

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -298,10 +298,10 @@ test.describe("Stage worship-pp layout", () => {
       // Sidebar must be ~22% (allow ±3% slack for borders/scrollbar).
       expect(measurements.sidebarRatio).toBeGreaterThan(0.19);
       expect(measurements.sidebarRatio).toBeLessThan(0.25);
-      // Floor of 40px locks in the 5vh × 1080p = 54px font from
-      // #worship-pp-bigger-fonts; any accidental drop back to 2.6vh
-      // (≈28px) will fail the test.
-      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);
+      // Floor of 70px locks in the 7.5vh × 1080p = 81px font from
+      // #worship-pp-10-row-fit; any accidental drop back to 5vh
+      // (≈54px) or smaller will fail the test.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(70);
     }
 
     // Cleanup

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test.describe("Stage worship-pp layout", () => {
+  test("slides-area and playlist-sidebar do not overlap", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon")) consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // Set the stage layout to worship-pp via API.
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
+      timeout: 30_000,
+    });
+    await page.waitForSelector('body[data-layout-code="worship-pp"]', {
+      timeout: 10_000,
+    });
+
+    // Both wrapper boxes exist and are visible.
+    const slidesArea = page.locator(".stage-pp__slides-area");
+    const sidebar = page.locator(".stage-pp__playlist-sidebar");
+    await expect(slidesArea).toBeVisible();
+    await expect(sidebar).toBeVisible();
+
+    // Slides-area's right edge must be <= sidebar's left edge.
+    const overlap = await page.evaluate(() => {
+      const a = document
+        .querySelector(".stage-pp__slides-area")
+        ?.getBoundingClientRect();
+      const b = document
+        .querySelector(".stage-pp__playlist-sidebar")
+        ?.getBoundingClientRect();
+      if (!a || !b) return { error: "missing rect" } as const;
+      return {
+        aRight: a.right,
+        bLeft: b.left,
+        overlap: a.right > b.left,
+      } as const;
+    });
+    expect(
+      "overlap" in overlap ? overlap.overlap : true,
+      `slides-area right=${"aRight" in overlap ? overlap.aRight : "?"} sidebar left=${"bLeft" in overlap ? overlap.bLeft : "?"}`,
+    ).toBe(false);
+
+    // The six slide regions live INSIDE slides-area.
+    for (const cls of [
+      ".stage__current-group",
+      ".stage__current-song",
+      ".stage__current-slide",
+      ".stage__next-group",
+      ".stage__next-song",
+      ".stage__next-slide",
+    ]) {
+      const inside = await page.evaluate((selector) => {
+        const el = document.querySelector(selector);
+        return !!el?.closest(".stage-pp__slides-area");
+      }, cls);
+      expect(inside, `${cls} should be inside slides-area`).toBe(true);
+    }
+
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("active playlist entry has high-contrast background distinct from inactive", async ({
+    page,
+  }) => {
+    // Set worship-pp layout
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Seed: pick a library and a presentation from the seeded data.
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    expect(libsResp.ok()).toBeTruthy();
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{
+        id: string;
+        slides?: Array<{ id: string }>;
+      }>;
+    }>;
+    const presentation = libs
+      .flatMap((lib) => lib.presentations ?? [])
+      .find((p) => (p.slides?.length ?? 0) > 0);
+    if (!presentation || !presentation.slides || !presentation.slides[0]) {
+      test.skip(true, "test fixture has no presentation with slides");
+      return;
+    }
+    const slideId = presentation.slides[0].id;
+
+    // Create a playlist with that presentation as an entry.
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      { data: { name: `Highlight Test ${Date.now()}`, showInDashboard: true } },
+    );
+    expect(playlistResp.ok()).toBeTruthy();
+    const playlist = (await playlistResp.json()) as { id: string };
+    const entriesResp = await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: [
+            { type: "presentation", presentationId: presentation.id },
+          ],
+        },
+      },
+    );
+    expect(entriesResp.ok()).toBeTruthy();
+
+    // Trigger the presentation onto stage so it becomes active.
+    const stageResp = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: presentation.id,
+          currentSlideId: slideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(stageResp.status()).toBe(204);
+
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
+      timeout: 30_000,
+    });
+    await page.waitForSelector('body[data-layout-code="worship-pp"]', {
+      timeout: 10_000,
+    });
+
+    // Wait for the active row to appear with the active class.
+    const active = page.locator(".stage-pp__playlist-entry--active").first();
+    await expect(active).toBeVisible({ timeout: 15_000 });
+
+    // Background of active row must NOT be transparent and (if present)
+    // must differ from inactive rows.
+    const colors = await page.evaluate(() => {
+      const a = document.querySelector(
+        ".stage-pp__playlist-entry--active",
+      ) as HTMLElement | null;
+      const inactive = Array.from(
+        document.querySelectorAll(".stage-pp__playlist-entry"),
+      ).find(
+        (e) => !e.classList.contains("stage-pp__playlist-entry--active"),
+      ) as HTMLElement | null;
+      return {
+        active: a ? getComputedStyle(a).backgroundColor : null,
+        inactive: inactive
+          ? getComputedStyle(inactive).backgroundColor
+          : null,
+      };
+    });
+    expect(colors.active).toBeTruthy();
+    expect(colors.active).not.toBe("rgba(0, 0, 0, 0)");
+    expect(colors.active).not.toBe("transparent");
+    if (colors.inactive) {
+      expect(colors.active).not.toBe(colors.inactive);
+    }
+
+    // Cleanup: delete the playlist
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+  });
+});

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -298,8 +298,10 @@ test.describe("Stage worship-pp layout", () => {
       // Sidebar must be ~22% (allow ±3% slack for borders/scrollbar).
       expect(measurements.sidebarRatio).toBeGreaterThan(0.19);
       expect(measurements.sidebarRatio).toBeLessThan(0.25);
-      // Entry font must be readable from the back of a room — sanity floor at 24px.
-      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(24);
+      // Floor of 40px locks in the 5vh × 1080p = 54px font from
+      // #worship-pp-bigger-fonts; any accidental drop back to 2.6vh
+      // (≈28px) will fail the test.
+      expect(measurements.entryFontSizePx).toBeGreaterThanOrEqual(40);
     }
 
     // Cleanup

--- a/tests/e2e/wasm-drag-drop.spec.ts
+++ b/tests/e2e/wasm-drag-drop.spec.ts
@@ -59,22 +59,29 @@ test.describe("WASM Operator Drag-Drop", () => {
     const searchInput = page.locator('[data-role="global-search-query"]');
     await searchInput.fill("a");
 
-    // Wait for results
-    await page.waitForFunction(
-      () =>
-        document
-          .querySelector('[data-role="global-search-results"]')
-          ?.querySelectorAll('[data-role="search-result-item"]').length ??
-        0 > 0,
+    // Wait for at least one presentation-kind result. Library-kind results
+    // are intentionally non-draggable (they have no presentation_id to
+    // drop into a playlist), so we scope to presentation-kind here.
+    await page.waitForSelector(
+      '[data-role="search-result-item"][data-kind="presentation"]',
       { timeout: 10_000 },
     );
 
-    // Verify results have draggable attribute
-    const firstResult = page
-      .locator('[data-role="search-result-item"]')
+    // Verify a presentation-kind result has draggable="true".
+    const firstPresentationResult = page
+      .locator('[data-role="search-result-item"][data-kind="presentation"]')
       .first();
-    if ((await firstResult.count()) > 0) {
-      await expect(firstResult).toHaveAttribute("draggable", "true");
+    await expect(firstPresentationResult).toHaveAttribute("draggable", "true");
+
+    // And verify a library-kind result, if any, is NOT draggable.
+    const libraryResults = page.locator(
+      '[data-role="search-result-item"][data-kind="library"]',
+    );
+    if ((await libraryResults.count()) > 0) {
+      await expect(libraryResults.first()).toHaveAttribute(
+        "draggable",
+        "false",
+      );
     }
   });
 

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -501,4 +501,144 @@ test.describe("WASM Operator Playlist Operations", () => {
 
     expect(consoleErrors).toEqual([]);
   });
+
+  test("drop a search-result onto a playlist row appends an entry", async ({
+    page,
+  }) => {
+    // Regression guard for #worship-pp-followups: dragging from
+    // [data-role="search-result-item"] (which dragstart sets
+    // effectAllowed="copy") onto a playlist row was silently
+    // rejected because the playlist's dragover never set a
+    // matching dropEffect. Also: only Presentation/Slide-kind
+    // results are draggable — Library-kind results have no
+    // presentation_id and aren't draggable.
+
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon")) consoleErrors.push(`[${msg.type()}] ${t}`);
+      }
+    });
+
+    // 1. Create the drop-target playlist via API.
+    const targetName = `Search Drop Test ${Date.now()}`;
+    const createResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      { data: { name: targetName, showInDashboard: true } },
+    );
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    const targetPlaylistId = created.id as string;
+    expect(targetPlaylistId).toBeTruthy();
+
+    // 2. Load operator UI.
+    await initPage(page);
+    await page.waitForFunction(
+      (id: string) =>
+        !!document.querySelector(
+          `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
+        ),
+      targetPlaylistId,
+      { timeout: 30_000 },
+    );
+
+    // 3. Type a query into the global search to populate results.
+    //    Use a query that's likely to match a song name from the
+    //    seeded fixtures.
+    const searchInput = page.locator('[data-role="global-search-query"]');
+    await searchInput.click();
+    await searchInput.fill("a");
+
+    // Wait specifically for a Presentation-kind result (Library-kind
+    // results have empty data-presentation-id and are intentionally
+    // non-draggable).
+    await page.waitForSelector(
+      '[data-role="search-result-item"][data-kind="presentation"]',
+      { timeout: 15_000 },
+    );
+
+    // 4. Programmatically drag a presentation-kind search result onto
+    //    the playlist row. Pre-populate DataTransfer (synthetic-event
+    //    quirk — see the existing presentation drop test).
+    const dragResult = await page.evaluate((id: string) => {
+      const source = document.querySelector(
+        '[data-role="search-result-item"][data-kind="presentation"][data-presentation-id]',
+      ) as HTMLElement | null;
+      const targetRow = document.querySelector(
+        `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
+      ) as HTMLElement | null;
+      if (!source || !targetRow) {
+        return {
+          error: "missing source or target",
+          hasSource: !!source,
+          hasTarget: !!targetRow,
+        };
+      }
+      const sourceId = source.getAttribute("data-presentation-id") || "";
+      if (!sourceId) {
+        return {
+          error: "presentation-kind source has no data-presentation-id",
+        };
+      }
+      const dt = new DataTransfer();
+      dt.setData("text/plain", sourceId);
+      dt.setData("application/x-presentation-id", sourceId);
+      dt.setData("application/x-presenter-search", sourceId);
+      source.dispatchEvent(
+        new DragEvent("dragstart", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      source.dispatchEvent(
+        new DragEvent("dragend", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      return { sourceId };
+    }, targetPlaylistId);
+
+    expect(dragResult.error, JSON.stringify(dragResult)).toBeUndefined();
+    expect(dragResult.sourceId).toBeTruthy();
+
+    // 5. Confirm via API that the playlist gained an entry.
+    await expect
+      .poll(
+        async () => {
+          const apiResp = await page.request.get(
+            new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
+          );
+          if (apiResp.status() !== 200) return -1;
+          const body = await apiResp.json();
+          return Array.isArray(body.entries) ? body.entries.length : -1;
+        },
+        { timeout: 15_000, intervals: [500, 1000, 2000] },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    // 6. Cleanup.
+    await page.request.delete(
+      new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
 });

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -323,4 +323,153 @@ test.describe("WASM Operator Playlist Operations", () => {
       .filter({ hasText: "Test Separator" });
     await expect(separator.first()).toBeVisible();
   });
+
+  test("drop a presentation onto a playlist row appends an entry", async ({
+    page,
+  }) => {
+    // Regression guard: GET /playlists/{id} previously returned 405 because
+    // only PATCH+DELETE were registered, so the drop handler in
+    // playlist_list.rs (which fetches the current playlist before appending)
+    // silently failed. Playlists stayed at 0 entries after every drag.
+    await initPage(page);
+
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const text = msg.text();
+        if (!text.includes("favicon")) {
+          consoleErrors.push(`[${msg.type()}] ${text}`);
+        }
+      }
+    });
+
+    // 1. Create a fresh playlist as the drop target.
+    const targetName = `E2E Drop Test ${Date.now()}`;
+    await page.locator('[data-role="playlist-create"]').click();
+    await page.waitForFunction(
+      () =>
+        document.querySelector(
+          '[data-role="playlist-edit-modal"][data-open="true"]',
+        ),
+      { timeout: 5_000 },
+    );
+    await page.locator('[data-role="playlist-edit-name"]').fill(targetName);
+    await page.locator('[data-role="playlist-edit-save"]').click();
+    await page.waitForFunction(
+      () =>
+        !document.querySelector(
+          '[data-role="playlist-edit-modal"][data-open="true"]',
+        ),
+      { timeout: 10_000 },
+    );
+    await page.waitForFunction(
+      (name) =>
+        Array.from(
+          document.querySelectorAll('[data-role="playlist-item"]'),
+        ).some((el) => (el.textContent || "").includes(name)),
+      targetName,
+      { timeout: 10_000 },
+    );
+
+    // 2. Select the first library so presentations render.
+    const firstLibrary = page.locator('[data-role="library-item"]').first();
+    await expect(firstLibrary).toBeVisible({ timeout: 10_000 });
+    await firstLibrary.click();
+    await page.waitForSelector(
+      '[data-role="presentation-item"][data-presentation-id]',
+      { timeout: 10_000 },
+    );
+
+    // 3. Programmatically dispatch dragstart → dragover → drop → dragend.
+    //    Real pointer-driven drag is unreliable in this UI because the
+    //    presentation list has hundreds of items and the playlist target
+    //    sits in a separate column; programmatic dispatch exercises the
+    //    same handlers the browser would call.
+    const dragResult = await page.evaluate((name: string) => {
+      const source = document.querySelector(
+        '[data-role="presentation-item"][data-presentation-id]',
+      ) as HTMLElement | null;
+      const targetRow = Array.from(
+        document.querySelectorAll("[data-playlist-id]"),
+      ).find((el) =>
+        (el.textContent || "").includes(name),
+      ) as HTMLElement | undefined;
+      if (!source || !targetRow) {
+        return {
+          error: "missing source or target",
+          hasSource: !!source,
+          hasTarget: !!targetRow,
+        };
+      }
+      const dt = new DataTransfer();
+      source.dispatchEvent(
+        new DragEvent("dragstart", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      targetRow.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      source.dispatchEvent(
+        new DragEvent("dragend", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+      return {
+        sourceId: source.getAttribute("data-presentation-id"),
+        targetPlaylistId: targetRow.getAttribute("data-playlist-id"),
+      };
+    }, targetName);
+
+    expect(dragResult.error, JSON.stringify(dragResult)).toBeUndefined();
+    expect(dragResult.sourceId).toBeTruthy();
+    expect(dragResult.targetPlaylistId).toBeTruthy();
+
+    // 4. Wait for the playlist's entry count to flip from 0 to ≥1.
+    await page.waitForFunction(
+      (name: string) => {
+        const rows = Array.from(
+          document.querySelectorAll('[data-role="playlist-item"]'),
+        );
+        const target = rows.find((r) => (r.textContent || "").includes(name));
+        if (!target) return false;
+        const countEl = target.querySelector('[data-role="playlist-count"]');
+        const count = countEl ? Number((countEl.textContent || "0").trim()) : 0;
+        return count >= 1;
+      },
+      targetName,
+      { timeout: 15_000 },
+    );
+
+    // 5. Confirm via the API that the playlist actually has the entry.
+    const playlistId = dragResult.targetPlaylistId!;
+    const apiResp = await page.request.get(
+      new URL(`/playlists/${playlistId}`, baseURL).toString(),
+    );
+    expect(apiResp.status()).toBe(200);
+    const playlist = await apiResp.json();
+    expect(Array.isArray(playlist.entries)).toBe(true);
+    expect(playlist.entries.length).toBeGreaterThanOrEqual(1);
+    const presentationEntry = playlist.entries.find(
+      (e: { kind?: { type?: string } }) => e?.kind?.type === "presentation",
+    );
+    expect(presentationEntry).toBeDefined();
+
+    expect(consoleErrors).toEqual([]);
+  });
 });

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -331,7 +331,10 @@ test.describe("WASM Operator Playlist Operations", () => {
     // only PATCH+DELETE were registered, so the drop handler in
     // playlist_list.rs (which fetches the current playlist before appending)
     // silently failed. Playlists stayed at 0 entries after every drag.
-    await initPage(page);
+    //
+    // We create the drop-target playlist via the API (not the create-modal
+    // UI flow) to keep this test focused on the drag-drop path and avoid
+    // coupling to the modal-render timing.
 
     const consoleErrors: string[] = [];
     page.on("console", (msg) => {
@@ -343,57 +346,49 @@ test.describe("WASM Operator Playlist Operations", () => {
       }
     });
 
-    // 1. Create a fresh playlist as the drop target.
+    // 1. Create a fresh playlist as the drop target via the API.
     const targetName = `E2E Drop Test ${Date.now()}`;
-    await page.locator('[data-role="playlist-create"]').click();
-    await page.waitForFunction(
-      () =>
-        document.querySelector(
-          '[data-role="playlist-edit-modal"][data-open="true"]',
-        ),
-      { timeout: 5_000 },
+    const createResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      {
+        data: { name: targetName, showInDashboard: false },
+      },
     );
-    await page.locator('[data-role="playlist-edit-name"]').fill(targetName);
-    await page.locator('[data-role="playlist-edit-save"]').click();
-    await page.waitForFunction(
-      () =>
-        !document.querySelector(
-          '[data-role="playlist-edit-modal"][data-open="true"]',
-        ),
-      { timeout: 10_000 },
-    );
-    await page.waitForFunction(
-      (name) =>
-        Array.from(
-          document.querySelectorAll('[data-role="playlist-item"]'),
-        ).some((el) => (el.textContent || "").includes(name)),
-      targetName,
-      { timeout: 10_000 },
-    );
+    expect(createResp.status()).toBe(200);
+    const created = await createResp.json();
+    const targetPlaylistId = created.id as string;
+    expect(targetPlaylistId).toBeTruthy();
 
-    // 2. Select the first library so presentations render.
+    // 2. Now load the operator UI and select the first library.
+    await initPage(page);
     const firstLibrary = page.locator('[data-role="library-item"]').first();
-    await expect(firstLibrary).toBeVisible({ timeout: 10_000 });
+    await expect(firstLibrary).toBeVisible({ timeout: 15_000 });
     await firstLibrary.click();
     await page.waitForSelector(
       '[data-role="presentation-item"][data-presentation-id]',
-      { timeout: 10_000 },
+      { timeout: 15_000 },
     );
 
-    // 3. Programmatically dispatch dragstart → dragover → drop → dragend.
+    // 3. Wait for the new playlist row to appear in the operator's playlist
+    //    list (operator polls for playlists; allow generous time on CI).
+    await page.waitForFunction(
+      (id: string) => !!document.querySelector(`[data-playlist-id="${id}"]`),
+      targetPlaylistId,
+      { timeout: 30_000 },
+    );
+
+    // 4. Programmatically dispatch dragstart → dragover → drop → dragend.
     //    Real pointer-driven drag is unreliable in this UI because the
     //    presentation list has hundreds of items and the playlist target
     //    sits in a separate column; programmatic dispatch exercises the
     //    same handlers the browser would call.
-    const dragResult = await page.evaluate((name: string) => {
+    const dragResult = await page.evaluate((id: string) => {
       const source = document.querySelector(
         '[data-role="presentation-item"][data-presentation-id]',
       ) as HTMLElement | null;
-      const targetRow = Array.from(
-        document.querySelectorAll("[data-playlist-id]"),
-      ).find((el) =>
-        (el.textContent || "").includes(name),
-      ) as HTMLElement | undefined;
+      const targetRow = document.querySelector(
+        `[data-playlist-id="${id}"]`,
+      ) as HTMLElement | null;
       if (!source || !targetRow) {
         return {
           error: "missing source or target",
@@ -432,39 +427,34 @@ test.describe("WASM Operator Playlist Operations", () => {
       );
       return {
         sourceId: source.getAttribute("data-presentation-id"),
-        targetPlaylistId: targetRow.getAttribute("data-playlist-id"),
       };
-    }, targetName);
+    }, targetPlaylistId);
 
     expect(dragResult.error, JSON.stringify(dragResult)).toBeUndefined();
     expect(dragResult.sourceId).toBeTruthy();
-    expect(dragResult.targetPlaylistId).toBeTruthy();
 
-    // 4. Wait for the playlist's entry count to flip from 0 to ≥1.
-    await page.waitForFunction(
-      (name: string) => {
-        const rows = Array.from(
-          document.querySelectorAll('[data-role="playlist-item"]'),
-        );
-        const target = rows.find((r) => (r.textContent || "").includes(name));
-        if (!target) return false;
-        const countEl = target.querySelector('[data-role="playlist-count"]');
-        const count = countEl ? Number((countEl.textContent || "0").trim()) : 0;
-        return count >= 1;
-      },
-      targetName,
-      { timeout: 15_000 },
-    );
+    // 5. Confirm via the API (after a short settle) that the playlist
+    //    actually has the entry. This is the strongest signal — independent
+    //    of UI count rendering timing.
+    await expect
+      .poll(
+        async () => {
+          const apiResp = await page.request.get(
+            new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
+          );
+          if (apiResp.status() !== 200) return -1;
+          const body = await apiResp.json();
+          return Array.isArray(body.entries) ? body.entries.length : -1;
+        },
+        { timeout: 15_000, intervals: [500, 1000, 2000] },
+      )
+      .toBeGreaterThanOrEqual(1);
 
-    // 5. Confirm via the API that the playlist actually has the entry.
-    const playlistId = dragResult.targetPlaylistId!;
-    const apiResp = await page.request.get(
-      new URL(`/playlists/${playlistId}`, baseURL).toString(),
+    const finalResp = await page.request.get(
+      new URL(`/playlists/${targetPlaylistId}`, baseURL).toString(),
     );
-    expect(apiResp.status()).toBe(200);
-    const playlist = await apiResp.json();
-    expect(Array.isArray(playlist.entries)).toBe(true);
-    expect(playlist.entries.length).toBeGreaterThanOrEqual(1);
+    expect(finalResp.status()).toBe(200);
+    const playlist = await finalResp.json();
     const presentationEntry = playlist.entries.find(
       (e: { kind?: { type?: string } }) => e?.kind?.type === "presentation",
     );

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -477,6 +477,28 @@ test.describe("WASM Operator Playlist Operations", () => {
     );
     expect(presentationEntry).toBeDefined();
 
+    // Click the playlist to make it the selected playlist, so its entries
+    // are shown in the presentation column.
+    const playlistRow = page.locator(
+      `[data-role="playlist-list"] [data-playlist-id="${targetPlaylistId}"] [data-role="playlist-item"]`,
+    );
+    await playlistRow.click();
+
+    // The first presentation entry must render with a non-empty visible name.
+    // Regression guard: previously the operator rebuilt presentations summaries
+    // with empty strings, so the name span was blank.
+    const firstEntryName = await page
+      .locator(
+        '[data-role="presentation-item"][data-type="presentation"] > span:first-child',
+      )
+      .first()
+      .textContent({ timeout: 15_000 });
+    expect(
+      firstEntryName?.trim(),
+      "playlist entry must show a non-empty presentation name",
+    ).toBeTruthy();
+    expect(firstEntryName?.trim().length ?? 0).toBeGreaterThan(0);
+
     expect(consoleErrors).toEqual([]);
   });
 });

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -470,8 +470,10 @@ test.describe("WASM Operator Playlist Operations", () => {
     );
     expect(finalResp.status()).toBe(200);
     const playlist = await finalResp.json();
+    // Server entries shape: { id, type: "presentation"|"separator", presentation_id? }
+    // (type is a flat discriminator, not nested under kind).
     const presentationEntry = playlist.entries.find(
-      (e: { kind?: { type?: string } }) => e?.kind?.type === "presentation",
+      (e: { type?: string }) => e?.type === "presentation",
     );
     expect(presentationEntry).toBeDefined();
 

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -378,10 +378,11 @@ test.describe("WASM Operator Playlist Operations", () => {
     );
 
     // 4. Programmatically dispatch dragstart → dragover → drop → dragend.
-    //    Real pointer-driven drag is unreliable in this UI because the
-    //    presentation list has hundreds of items and the playlist target
-    //    sits in a separate column; programmatic dispatch exercises the
-    //    same handlers the browser would call.
+    //    Pre-populate the DataTransfer with the presentation ID BEFORE
+    //    dispatching, so the drop handler can read it without depending on
+    //    the dragstart handler's set_data calls (which are unreliable in
+    //    synthetic event dispatch — Leptos may not propagate the in-handler
+    //    set_data writes back to our DataTransfer object).
     const dragResult = await page.evaluate((id: string) => {
       const source = document.querySelector(
         '[data-role="presentation-item"][data-presentation-id]',
@@ -396,7 +397,12 @@ test.describe("WASM Operator Playlist Operations", () => {
           hasTarget: !!targetRow,
         };
       }
+      const sourceId = source.getAttribute("data-presentation-id") || "";
       const dt = new DataTransfer();
+      // Pre-populate the dataTransfer so the drop handler reads the ID
+      // even if the dragstart handler doesn't run (synthetic-event quirk).
+      dt.setData("text/plain", sourceId);
+      dt.setData("application/x-presentation-id", sourceId);
       source.dispatchEvent(
         new DragEvent("dragstart", {
           bubbles: true,
@@ -426,7 +432,8 @@ test.describe("WASM Operator Playlist Operations", () => {
         }),
       );
       return {
-        sourceId: source.getAttribute("data-presentation-id"),
+        sourceId,
+        dtAfterDispatch: dt.getData("application/x-presentation-id"),
       };
     }, targetPlaylistId);
 

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -347,11 +347,15 @@ test.describe("WASM Operator Playlist Operations", () => {
     });
 
     // 1. Create a fresh playlist as the drop target via the API.
+    //    showInDashboard: true so it renders in the dashboard sidebar
+    //    (which is the only list with the drop handler attached).
+    //    With showInDashboard: false the playlist only appears in the
+    //    playlist-modal (no drop handler), and the test would no-op.
     const targetName = `E2E Drop Test ${Date.now()}`;
     const createResp = await page.request.post(
       new URL("/playlists", baseURL).toString(),
       {
-        data: { name: targetName, showInDashboard: false },
+        data: { name: targetName, showInDashboard: true },
       },
     );
     expect(createResp.status()).toBe(200);
@@ -369,10 +373,14 @@ test.describe("WASM Operator Playlist Operations", () => {
       { timeout: 15_000 },
     );
 
-    // 3. Wait for the new playlist row to appear in the operator's playlist
-    //    list (operator polls for playlists; allow generous time on CI).
+    // 3. Wait for the new playlist row to appear in the dashboard sidebar
+    //    (the <li> with the drop handler — NOT the modal row).
+    //    The dashboard <li> sits inside [data-role="playlist-list"].
     await page.waitForFunction(
-      (id: string) => !!document.querySelector(`[data-playlist-id="${id}"]`),
+      (id: string) =>
+        !!document.querySelector(
+          `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
+        ),
       targetPlaylistId,
       { timeout: 30_000 },
     );
@@ -388,7 +396,7 @@ test.describe("WASM Operator Playlist Operations", () => {
         '[data-role="presentation-item"][data-presentation-id]',
       ) as HTMLElement | null;
       const targetRow = document.querySelector(
-        `[data-playlist-id="${id}"]`,
+        `[data-role="playlist-list"] [data-playlist-id="${id}"]`,
       ) as HTMLElement | null;
       if (!source || !targetRow) {
         return {


### PR DESCRIPTION
## Summary

Worship-pp baseline + drag-drop infra + three layout regressions + follow-up polish + bigger fonts + active-highlight reactivity + 10-row sidebar + companion-pp deploy migration.

### Stage worship-pp baseline
- Adopts worship-snv improvements (autofit text, song-name boxes, six-region layout)
- Keeps playlist sidebar; derives next_song_text from Presenter playlist instead of AbleSet

### Drag-drop infrastructure
- Added missing `GET /playlists/{id}` route
- Fixed WASM `PlaylistEntryPayload` field renames (presentationId/entryId)

### Layout regressions (round 1)
- Wrapped six worship-pp regions in `.stage-pp__slides-area` to stop sidebar overlap
- Replaced 15%-opacity tint with solid sky-blue + 4px accent bar
- Server enriches playlist response with `presentation_name`

### Follow-up polish (round 2)
- Search-result drag onto playlist row now accepted (`set_drop_effect("copy")` + library-kind not draggable)
- Worship-pp sidebar 30% → 22%, slides 70% → 78%; entry font 0.9vw → 2.6vh

### Bigger sidebar fonts (round 3)
- Sidebar padding 1%/1.5% → 0.4%/0.5%; entry padding 0.6vh/0.8rem → 0.3vh/0.4rem; entry font-size 2.6vh → 5vh

### Active-highlight reactivity (round 4)
- Sidebar `--active` class was stuck on the first triggered song. Made `class` a reactive closure that reads `is_active` from `ctx.snapshot` at evaluation time. Highlight now follows the operator's song changes.
- New E2E asserts the `--active` class moves between rows on consecutive triggers.

### 10-row sidebar fit (round 5)
- Entry font 5vh → 7.5vh; ~10 entries now fit in the 92vh sidebar (verified live: per-row 95.56px / sidebar 993.59px = 10 rows).
- E2E floor tightened from ≥40px to ≥70px to lock in the new 81px @ 1080p font.

### CI: companion-pp deploy migrated to CompanionPi systemd
- companion-pp.lan moved from a Docker `companion` container to the CompanionPi (Raspberry-Pi-style) systemd build. The pipeline's "Deploy Companion Plugin" step still tried `docker restart companion`, failing with "No such container".
- Updated to mirror the companion-snv pattern: stage to `/tmp`, npm install, `sudo mv` into `/opt/companion-module-dev/presenter`, `sudo chown companion:companion`, `sudo systemctl restart companion`, `systemctl is-active` health check.

## Test plan
- [x] CI pipeline green (all 21 jobs incl. Mutation Testing, Deploy to Dev, Deploy Companion Plugin)
- [x] Playwright E2E: stage-worship-pp.spec.ts (overlap, highlight static, sidebar width, font ≥70px, highlight MOVES on consecutive trigger)
- [x] Playwright E2E: wasm-playlist-operations.spec.ts (drag from presentation, drag from search, name visible after drag)
- [x] Playwright E2E: wasm-drag-drop.spec.ts (search result draggable for presentation-kind, NOT for library-kind)
- [x] Live Playwright verification on dev (10.77.8.134:8080) at 1920×1080:
  - sidebar at 22%, font 81px (7.5vh), exactly 10 rows fit
  - drag from search adds entry; drag from presentation list adds entry
  - active highlight moves between rows on consecutive triggers
  - browser console clean
- [x] Companion plugin deployed to companion-snv.lan and companion-pp.lan (CompanionPi systemd)
