### PR TITLE
fix(ui): split clipboard-import slides on section headers, filter ProPresenter metadata (#275)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.44"
+version = "0.4.45"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.46"
+version = "0.4.47"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.45"
+version = "0.4.46"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/api/presentations.rs
+++ b/crates/presenter-ui/src/api/presentations.rs
@@ -24,7 +24,7 @@ struct CreatePresentationRequest {
     slides: Option<Vec<SlideInput>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SlideInput {
     pub main: String,

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -453,7 +453,7 @@ pub fn PresentationModals() -> impl IntoView {
                         <h3>"Create Presentation"</h3>
                     </header>
                     <div class="operator__library-edit-body">
-                        <label>
+                        <label style:display=move || if create_step.get() == "paste" { "none" } else { "block" }>
                             <span>"Presentation name"</span>
                             <input
                                 type="text"

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -234,14 +234,22 @@ pub fn PresentationModals() -> impl IntoView {
                 Some(id) => id,
                 None => return,
             };
-            let name = create_name.get_untracked().trim().to_string();
-            let name = if name.is_empty() {
-                "New Presentation".to_string()
-            } else {
-                name
-            };
             let text = op.paste_text.get_untracked();
+            let line_limit = op.line_limit.get_untracked() as usize;
+
+            // Title from the paste always wins; fallback to "Untitled" if
+            // the paste has no Title: line (operator can rename via the
+            // existing rename flow after creation).
+            let name = crate::utils::song_parser::extract_title(&text)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Untitled".to_string());
+
+            // Run the full pipeline.
             let slides = crate::utils::song_parser::parse_song_text(&text);
+            let slides = crate::utils::song_parser::wrap_long_lines(slides, line_limit);
+            let slides = crate::utils::song_parser::chunk_to_two_lines(slides);
+            let slides = crate::utils::song_parser::wrap_with_empty_bookends(slides);
+
             if slides.is_empty() {
                 return;
             }

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -241,7 +241,7 @@ pub fn PresentationModals() -> impl IntoView {
                 name
             };
             let text = op.paste_text.get_untracked();
-            let slides = crate::utils::test_helpers::parse_song_text(&text);
+            let slides = crate::utils::song_parser::parse_song_text(&text);
             if slides.is_empty() {
                 return;
             }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -361,8 +361,17 @@ pub fn SlideList() -> impl IntoView {
                         let group_inherited =
                             effective_group_name.is_some() && !group_is_new;
 
-                        // Header badge: always render the effective group. Dim if inherited.
-                        let group_badge_text = effective_group_name.clone();
+                        // Header badge: render the effective group; dim if inherited.
+                        // Suppress entirely for "true blank" slides — empty main AND no
+                        // explicit group — so empty bookend slides created by the paste
+                        // pipeline (#275) render as truly empty rather than picking up
+                        // an inherited badge from the previous section.
+                        let group_badge_text =
+                            if main_text.is_empty() && explicit_group_name.is_none() {
+                                None
+                            } else {
+                                effective_group_name.clone()
+                            };
                         let group_badge_inherited = group_inherited;
 
                         // Edit-mode group input:

--- a/crates/presenter-ui/src/utils/mod.rs
+++ b/crates/presenter-ui/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod autofit;
 pub mod color;
 pub mod keyboard;
+pub mod song_parser;
 pub mod test_helpers;
 pub mod text;
 pub mod window;

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -1,0 +1,283 @@
+//! Song-text parser for the clipboard-paste "create presentation" flow.
+//!
+//! Splits a pasted song into one [`SlideInput`] per section. Triggers:
+//! - Metadata lines (`Title:`, `Misc N`, `^[A-Z]`) → filter out.
+//! - Group lines (`Verse N`, `Chorus`, `Bridge`, …) → flush current slide,
+//!   start a new one with this line as the group name.
+//! - Blank lines → flush current slide if non-empty.
+//! - Anything else → append to the current slide's main text.
+//!
+//! See `docs/superpowers/specs/2026-04-29-clipboard-import-section-split-design.md`.
+
+use crate::api::presentations::SlideInput;
+
+/// Parse a pasted song into one [`SlideInput`] per section.
+pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
+    let mut slides: Vec<SlideInput> = Vec::new();
+    let mut current_group: Option<String> = None;
+    let mut current_main: Vec<String> = Vec::new();
+
+    for raw_line in text.lines() {
+        let trimmed = raw_line.trim();
+
+        if is_metadata_line(trimmed) {
+            continue;
+        }
+
+        if is_group_line(trimmed) {
+            flush_slide(&mut slides, &mut current_group, &mut current_main);
+            current_group = Some(trimmed.to_string());
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            // Only flush if we've accumulated content; otherwise ignore.
+            if current_group.is_some() || !current_main.is_empty() {
+                flush_slide(&mut slides, &mut current_group, &mut current_main);
+            }
+            continue;
+        }
+
+        current_main.push(raw_line.to_string());
+    }
+
+    flush_slide(&mut slides, &mut current_group, &mut current_main);
+    slides
+}
+
+fn flush_slide(
+    slides: &mut Vec<SlideInput>,
+    group: &mut Option<String>,
+    main_lines: &mut Vec<String>,
+) {
+    let main = main_lines.join("\n").trim_end().to_string();
+    let took_group = group.take();
+    main_lines.clear();
+    if main.is_empty() && took_group.is_none() {
+        return;
+    }
+    slides.push(SlideInput {
+        main,
+        translation: None,
+        stage: None,
+        group: took_group,
+    });
+}
+
+/// Recognised section/group headings (the ProPresenter-style group names).
+/// Mirrors the original list from `test_helpers.rs::is_group_line` and accepts
+/// optional trailing digits / whitespace (e.g. `Verse 2`, `Chorus`).
+fn is_group_line(line: &str) -> bool {
+    let line_lower = line.trim().to_lowercase();
+    let patterns = [
+        "verse",
+        "chorus",
+        "bridge",
+        "intro",
+        "outro",
+        "pre-chorus",
+        "prechorus",
+        "tag",
+        "interlude",
+        "refrain",
+        "hook",
+        "coda",
+        "ending",
+        "instrumental",
+    ];
+    for pattern in patterns {
+        if let Some(rest) = line_lower.strip_prefix(pattern) {
+            let rest = rest.trim();
+            if rest.is_empty()
+                || rest
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || c.is_whitespace())
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// ProPresenter-style metadata / control markers we want to silently drop:
+/// - `Title:` prefix (case-insensitive)
+/// - `Misc <digits>` (case-insensitive)
+/// - `^X` where X is a single ASCII uppercase letter (control marker)
+fn is_metadata_line(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    let lower = line.to_lowercase();
+    if lower.starts_with("title:") {
+        return true;
+    }
+    // ^B / ^A / ^C etc. — exactly two chars: caret + uppercase ASCII letter.
+    let bytes = line.as_bytes();
+    if bytes.len() == 2 && bytes[0] == b'^' && bytes[1].is_ascii_uppercase() {
+        return true;
+    }
+    // "Misc 1", "MISC 12", etc.
+    if let Some(rest) = lower.strip_prefix("misc ") {
+        if !rest.is_empty()
+            && rest
+                .chars()
+                .all(|c| c.is_ascii_digit() || c.is_whitespace())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_no_slides() {
+        assert!(parse_song_text("").is_empty());
+        assert!(parse_song_text("   \n\n  ").is_empty());
+    }
+
+    #[test]
+    fn user_pasted_song_splits_into_one_slide_per_section() {
+        // Regression guard for issue #275.
+        let input = "Title: 326 Všetko, čo v sebe držím \n\
+            Misc 1\n\
+            ^B\n\
+            Verse 1\n\
+            Všetko, čo v sebe držím: s túžbami, nádejami aj\n\
+            s vysnívaným!\n\
+            Ty ma chceš Pane... aj s tým všetkým, čo mám ja.\n\
+            \n\
+            Chorus\n\
+            Mám Spasiteľa, žije vo mne, ó, ó,\n\
+            chcem viac, chcem Teba spoznávať viac.\n\
+            \n\
+            Verse 2\n\
+            Všetko, čo v sebe držím: s túžbami, nádejami aj\n\
+            s vysnívaným!\n\
+            \n\
+            Interlude\n\
+            \n\
+            Outro\n\
+            Nikto mi Ťa už nemôže vziať!\n\
+            Misc 1\n\
+            ^B\n";
+        let slides = parse_song_text(input);
+        let groups: Vec<Option<&str>> =
+            slides.iter().map(|s| s.group.as_deref()).collect();
+        assert_eq!(
+            groups,
+            vec![
+                Some("Verse 1"),
+                Some("Chorus"),
+                Some("Verse 2"),
+                Some("Interlude"),
+                Some("Outro"),
+            ],
+            "expected one slide per section, no Title/Misc/^B leakage"
+        );
+        // No slide's main contains Title:, Misc, or ^B.
+        for s in &slides {
+            assert!(
+                !s.main.to_lowercase().contains("title:")
+                    && !s.main.to_lowercase().contains("misc ")
+                    && !s.main.contains("^B"),
+                "slide leaked metadata: {:?}",
+                s
+            );
+        }
+        // Outro slide should contain only the Nikto... lyric (Misc/^B trailing
+        // metadata filtered).
+        let outro = slides.iter().find(|s| s.group.as_deref() == Some("Outro")).unwrap();
+        assert_eq!(outro.main, "Nikto mi Ťa už nemôže vziať!");
+    }
+
+    #[test]
+    fn group_line_in_middle_of_paragraph_starts_new_slide() {
+        // No blank line between Verse and Chorus.
+        let input = "Verse 1\nlyric a\nlyric b\nChorus\nlyric c";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric a\nlyric b");
+        assert_eq!(slides[1].group.as_deref(), Some("Chorus"));
+        assert_eq!(slides[1].main, "lyric c");
+    }
+
+    #[test]
+    fn metadata_lines_are_filtered() {
+        let input = "Title: My Song\n\nVerse 1\nlyric";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric");
+    }
+
+    #[test]
+    fn caret_uppercase_filtered_but_caret_alone_is_text() {
+        let s1 = parse_song_text("Verse 1\n^B\nlyric");
+        // ^B filtered, slide has just "lyric"
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s1[0].main, "lyric");
+
+        let s2 = parse_song_text("Verse 1\n^\nlyric");
+        // Bare ^ is NOT filtered — treated as text.
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2[0].main, "^\nlyric");
+    }
+
+    #[test]
+    fn misc_n_filtered_but_miscellaneous_is_text() {
+        let s1 = parse_song_text("Verse 1\nMisc 1\nlyric");
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s1[0].main, "lyric");
+
+        let s2 = parse_song_text("Verse 1\nMiscellaneous things\nlyric");
+        // "Miscellaneous" is NOT filtered — treated as text.
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2[0].main, "Miscellaneous things\nlyric");
+    }
+
+    #[test]
+    fn empty_interlude_emits_slide_with_empty_main() {
+        let input = "Interlude\n\nChorus\nlyric";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert_eq!(slides[0].group.as_deref(), Some("Interlude"));
+        assert_eq!(slides[0].main, "");
+        assert_eq!(slides[1].group.as_deref(), Some("Chorus"));
+        assert_eq!(slides[1].main, "lyric");
+    }
+
+    #[test]
+    fn loose_paragraphs_without_groups_split_on_blank_lines() {
+        let input = "Stanza 1\nline 2\n\nStanza 3\nline 4";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert!(slides[0].group.is_none());
+        assert_eq!(slides[0].main, "Stanza 1\nline 2");
+        assert!(slides[1].group.is_none());
+        assert_eq!(slides[1].main, "Stanza 3\nline 4");
+    }
+
+    #[test]
+    fn group_line_is_case_insensitive() {
+        let input = "chorus\nlower\n\nCHORUS\nupper\n\nVerse 2\nnumbered";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 3);
+        assert_eq!(slides[0].group.as_deref(), Some("chorus"));
+        assert_eq!(slides[1].group.as_deref(), Some("CHORUS"));
+        assert_eq!(slides[2].group.as_deref(), Some("Verse 2"));
+    }
+
+    #[test]
+    fn lyric_indentation_preserved() {
+        let input = "Verse 1\n  indented\n    more indent\nflush";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].main, "  indented\n    more indent\nflush");
+    }
+}

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -128,6 +128,48 @@ fn is_metadata_line(line: &str) -> bool {
     false
 }
 
+/// Extract the song title from the first `Title:` line in the input.
+///
+/// Returns the trimmed content after the colon, with a leading 1-3 digit
+/// numeric prefix padded to 3 digits via [`pad_title_number`]. Returns
+/// [`None`] if no `Title:` line is found.
+pub fn extract_title(text: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if !lower.starts_with("title:") {
+            return None;
+        }
+        // 6 = len("title:") — the prefix is ASCII so byte index works on
+        // the original (preserves casing of the title content).
+        let raw = trimmed[6..].trim();
+        Some(pad_title_number(raw))
+    })
+}
+
+/// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
+/// digits with leading zeros so songs sort correctly.
+///
+/// - `"76 Arriba"`        → `"076 Arriba"`
+/// - `"6 Foo"`            → `"006 Foo"`
+/// - `"102 10000 Armád"`  → `"102 10000 Armád"`  (already 3 digits)
+/// - `"1234 Bar"`         → `"1234 Bar"`          (4+ digits, untouched)
+/// - `"Arriba"`           → `"Arriba"`            (no leading number)
+/// - `"76Arriba"`         → `"76Arriba"`          (no whitespace separator)
+fn pad_title_number(title: &str) -> String {
+    let trimmed = title.trim();
+    if let Some(space_idx) = trimmed.find(char::is_whitespace) {
+        let (prefix, rest) = trimmed.split_at(space_idx);
+        if !prefix.is_empty()
+            && prefix.len() <= 3
+            && prefix.chars().all(|c| c.is_ascii_digit())
+        {
+            return format!("{prefix:0>3}{rest}");
+        }
+    }
+    trimmed.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,5 +322,73 @@ mod tests {
         let slides = parse_song_text(input);
         assert_eq!(slides.len(), 1);
         assert_eq!(slides[0].main, "  indented\n    more indent\nflush");
+    }
+
+    #[test]
+    fn extract_title_pads_two_digit_prefix() {
+        assert_eq!(
+            extract_title("Title: 76 Arriba\nMisc 1\n\nVerse 1\nlyric"),
+            Some("076 Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_pads_one_digit_prefix() {
+        assert_eq!(
+            extract_title("Title: 6 Foo"),
+            Some("006 Foo".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_leaves_three_digit_prefix_unchanged() {
+        assert_eq!(
+            extract_title("Title: 102 10000 Armád"),
+            Some("102 10000 Armád".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_leaves_four_digit_prefix_unchanged() {
+        assert_eq!(
+            extract_title("Title: 1234 Bar"),
+            Some("1234 Bar".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_no_leading_number_unchanged() {
+        assert_eq!(
+            extract_title("Title: Arriba"),
+            Some("Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_no_space_after_digits_unchanged() {
+        // No whitespace separator → not a song-number prefix; leave alone.
+        assert_eq!(
+            extract_title("Title: 76Arriba"),
+            Some("76Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_returns_none_when_absent() {
+        assert_eq!(extract_title("Verse 1\nlyric"), None);
+    }
+
+    #[test]
+    fn extract_title_is_case_insensitive() {
+        assert_eq!(extract_title("TITLE: foo"), Some("foo".to_string()));
+        assert_eq!(extract_title("title: foo"), Some("foo".to_string()));
+    }
+
+    #[test]
+    fn extract_title_strips_surrounding_whitespace() {
+        assert_eq!(
+            extract_title("Title:   foo bar  "),
+            Some("foo bar".to_string())
+        );
     }
 }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -65,45 +65,42 @@ fn flush_slide(
 }
 
 /// Recognised section/group headings (the ProPresenter-style group names).
-/// Mirrors the original list from `test_helpers.rs::is_group_line` and accepts
-/// optional trailing digits / whitespace (e.g. `Verse 2`, `Chorus`).
+/// Accepts optional trailing digits / whitespace (e.g. `Verse 2`, `Chorus`).
+/// Input must already be trimmed (the only call site trims before calling).
+const GROUP_PATTERNS: &[&str] = &[
+    "verse",
+    "chorus",
+    "bridge",
+    "intro",
+    "outro",
+    "pre-chorus",
+    "prechorus",
+    "tag",
+    "interlude",
+    "refrain",
+    "hook",
+    "coda",
+    "ending",
+    "instrumental",
+];
+
 fn is_group_line(line: &str) -> bool {
-    let line_lower = line.trim().to_lowercase();
-    let patterns = [
-        "verse",
-        "chorus",
-        "bridge",
-        "intro",
-        "outro",
-        "pre-chorus",
-        "prechorus",
-        "tag",
-        "interlude",
-        "refrain",
-        "hook",
-        "coda",
-        "ending",
-        "instrumental",
-    ];
-    for pattern in patterns {
-        if let Some(rest) = line_lower.strip_prefix(pattern) {
+    let line_lower = line.to_lowercase();
+    GROUP_PATTERNS.iter().any(|pattern| {
+        line_lower.strip_prefix(pattern).is_some_and(|rest| {
             let rest = rest.trim();
-            if rest.is_empty()
+            rest.is_empty()
                 || rest
                     .chars()
                     .all(|c| c.is_ascii_digit() || c.is_whitespace())
-            {
-                return true;
-            }
-        }
-    }
-    false
+        })
+    })
 }
 
 /// ProPresenter-style metadata / control markers we want to silently drop:
 /// - `Title:` prefix (case-insensitive)
 /// - `Misc <digits>` (case-insensitive)
-/// - `^X` where X is a single ASCII uppercase letter (control marker)
+/// - ProPresenter control marker `^X` (exactly two bytes: caret + one ASCII uppercase letter; `^BB` is NOT filtered)
 fn is_metadata_line(line: &str) -> bool {
     if line.is_empty() {
         return false;
@@ -166,8 +163,7 @@ mod tests {
             Misc 1\n\
             ^B\n";
         let slides = parse_song_text(input);
-        let groups: Vec<Option<&str>> =
-            slides.iter().map(|s| s.group.as_deref()).collect();
+        let groups: Vec<Option<&str>> = slides.iter().map(|s| s.group.as_deref()).collect();
         assert_eq!(
             groups,
             vec![
@@ -191,7 +187,10 @@ mod tests {
         }
         // Outro slide should contain only the Nikto... lyric (Misc/^B trailing
         // metadata filtered).
-        let outro = slides.iter().find(|s| s.group.as_deref() == Some("Outro")).unwrap();
+        let outro = slides
+            .iter()
+            .find(|s| s.group.as_deref() == Some("Outro"))
+            .expect("outro slide present");
         assert_eq!(outro.main, "Nikto mi Ťa už nemôže vziať!");
     }
 

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -49,6 +49,8 @@ pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
             continue;
         }
 
+        // Push the sanitized line (NOT trimmed) so leading indentation
+        // on indented lyric lines is preserved.
         current_main.push(sanitized);
     }
 

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -254,6 +254,38 @@ fn hard_break_into(out: &mut Vec<String>, current: &mut String, word: &str, limi
     }
 }
 
+/// Split each section's `main` into successive 2-line chunks, emitting
+/// one slide per chunk. The first chunk inherits the original slide's
+/// `group`; subsequent chunks have `group = None` (the operator UI
+/// renders these as `--inherited` from the preceding effective group).
+/// Slides with empty `main` (e.g. an `Interlude` heading with no body)
+/// pass through unchanged.
+pub fn chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    let mut out = Vec::new();
+    for slide in slides {
+        if slide.main.is_empty() {
+            out.push(slide);
+            continue;
+        }
+        let lines: Vec<&str> = slide.main.split('\n').collect();
+        if lines.len() <= 2 {
+            out.push(slide);
+            continue;
+        }
+        let mut first = true;
+        for chunk in lines.chunks(2) {
+            out.push(SlideInput {
+                main: chunk.join("\n"),
+                translation: None,
+                stage: None,
+                group: if first { slide.group.clone() } else { None },
+            });
+            first = false;
+        }
+    }
+    out
+}
+
 /// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
 /// digits with leading zeros so songs sort correctly.
 ///
@@ -581,5 +613,77 @@ mod tests {
         let out = wrap_long_lines(vec![slide], 32);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].main, line, "30 Slovak codepoints fit at limit 32");
+    }
+
+    #[test]
+    fn chunk_to_two_lines_splits_six_line_section() {
+        let slide = SlideInput {
+            main: "l1\nl2\nl3\nl4\nl5\nl6".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[0].main, "l1\nl2");
+        assert_eq!(out[1].group, None, "second chunk inherits");
+        assert_eq!(out[1].main, "l3\nl4");
+        assert_eq!(out[2].group, None);
+        assert_eq!(out[2].main, "l5\nl6");
+    }
+
+    #[test]
+    fn chunk_to_two_lines_handles_odd_line_count() {
+        let slide = SlideInput {
+            main: "l1\nl2\nl3\nl4\nl5".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Chorus".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].group.as_deref(), Some("Chorus"));
+        assert_eq!(out[0].main, "l1\nl2");
+        assert_eq!(out[1].group, None);
+        assert_eq!(out[1].main, "l3\nl4");
+        assert_eq!(out[2].group, None);
+        assert_eq!(out[2].main, "l5");
+    }
+
+    #[test]
+    fn chunk_to_two_lines_passes_through_short_sections() {
+        let two_line = SlideInput {
+            main: "a\nb".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let one_line = SlideInput {
+            main: "single".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Tag".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![two_line.clone(), one_line.clone()]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].main, "a\nb");
+        assert_eq!(out[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[1].main, "single");
+        assert_eq!(out[1].group.as_deref(), Some("Tag"));
+    }
+
+    #[test]
+    fn chunk_to_two_lines_preserves_empty_interlude() {
+        let slide = SlideInput {
+            main: String::new(),
+            translation: None,
+            stage: None,
+            group: Some("Interlude".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, "");
+        assert_eq!(out[0].group.as_deref(), Some("Interlude"));
     }
 }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -136,14 +136,11 @@ fn is_metadata_line(line: &str) -> bool {
 pub fn extract_title(text: &str) -> Option<String> {
     text.lines().find_map(|line| {
         let trimmed = line.trim();
-        let lower = trimmed.to_ascii_lowercase();
-        if !lower.starts_with("title:") {
+        let prefix = trimmed.get(..6)?;
+        if !prefix.eq_ignore_ascii_case("title:") {
             return None;
         }
-        // 6 = len("title:") — the prefix is ASCII so byte index works on
-        // the original (preserves casing of the title content).
-        let raw = trimmed[6..].trim();
-        Some(pad_title_number(raw))
+        Some(pad_title_number(trimmed[6..].trim()))
     })
 }
 
@@ -160,10 +157,7 @@ fn pad_title_number(title: &str) -> String {
     let trimmed = title.trim();
     if let Some(space_idx) = trimmed.find(char::is_whitespace) {
         let (prefix, rest) = trimmed.split_at(space_idx);
-        if !prefix.is_empty()
-            && prefix.len() <= 3
-            && prefix.chars().all(|c| c.is_ascii_digit())
-        {
+        if !prefix.is_empty() && prefix.len() <= 3 && prefix.chars().all(|c| c.is_ascii_digit()) {
             return format!("{prefix:0>3}{rest}");
         }
     }
@@ -334,10 +328,7 @@ mod tests {
 
     #[test]
     fn extract_title_pads_one_digit_prefix() {
-        assert_eq!(
-            extract_title("Title: 6 Foo"),
-            Some("006 Foo".to_string())
-        );
+        assert_eq!(extract_title("Title: 6 Foo"), Some("006 Foo".to_string()));
     }
 
     #[test]
@@ -358,10 +349,7 @@ mod tests {
 
     #[test]
     fn extract_title_no_leading_number_unchanged() {
-        assert_eq!(
-            extract_title("Title: Arriba"),
-            Some("Arriba".to_string())
-        );
+        assert_eq!(extract_title("Title: Arriba"), Some("Arriba".to_string()));
     }
 
     #[test]

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -272,15 +272,13 @@ pub fn chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput> {
             out.push(slide);
             continue;
         }
-        let mut first = true;
-        for chunk in lines.chunks(2) {
+        for (i, chunk) in lines.chunks(2).enumerate() {
             out.push(SlideInput {
                 main: chunk.join("\n"),
                 translation: None,
                 stage: None,
-                group: if first { slide.group.clone() } else { None },
+                group: if i == 0 { slide.group.clone() } else { None },
             });
-            first = false;
         }
     }
     out

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -18,7 +18,26 @@ pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
     let mut current_main: Vec<String> = Vec::new();
 
     for raw_line in text.lines() {
-        let trimmed = raw_line.trim();
+        // Originally-blank lines (whitespace only) flush the current slide
+        // — even if sanitization would later collapse a non-blank line to
+        // empty, that's a different signal.
+        if raw_line.trim().is_empty() {
+            if current_group.is_some() || !current_main.is_empty() {
+                flush_slide(&mut slides, &mut current_group, &mut current_main);
+            }
+            continue;
+        }
+
+        // Strip Unicode control + zero-width chars so stray bytes from any
+        // pasted source don't pollute slides.
+        let sanitized = sanitize_line(raw_line);
+        let trimmed = sanitized.trim();
+
+        // If sanitization left only whitespace, the line was entirely a
+        // stray control byte — skip silently without flushing.
+        if trimmed.is_empty() {
+            continue;
+        }
 
         if is_metadata_line(trimmed) {
             continue;
@@ -30,15 +49,7 @@ pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
             continue;
         }
 
-        if trimmed.is_empty() {
-            // Only flush if we've accumulated content; otherwise ignore.
-            if current_group.is_some() || !current_main.is_empty() {
-                flush_slide(&mut slides, &mut current_group, &mut current_main);
-            }
-            continue;
-        }
-
-        current_main.push(raw_line.to_string());
+        current_main.push(sanitized);
     }
 
     flush_slide(&mut slides, &mut current_group, &mut current_main);
@@ -126,6 +137,20 @@ fn is_metadata_line(line: &str) -> bool {
         }
     }
     false
+}
+
+/// Strip Unicode control chars (Cc category) and zero-width chars (BOM,
+/// U+200B–200D) from a line. Used to clean lyric lines before pushing
+/// them onto a slide so stray bytes from any pasted source (web pages,
+/// Word, ProPresenter) don't render as a tofu/square character on stage.
+fn sanitize_line(line: &str) -> String {
+    line.chars()
+        .filter(|c| !c.is_control() && !is_zero_width(*c))
+        .collect()
+}
+
+fn is_zero_width(c: char) -> bool {
+    matches!(c, '\u{FEFF}' | '\u{200B}' | '\u{200C}' | '\u{200D}')
 }
 
 /// Extract the song title from the first `Title:` line in the input.
@@ -378,5 +403,27 @@ mod tests {
             extract_title("Title:   foo bar  "),
             Some("foo bar".to_string())
         );
+    }
+
+    #[test]
+    fn parse_song_text_strips_control_chars_from_lyric_lines() {
+        // STX (\x02), BOM (\u{FEFF}), and ZWSP (\u{200B}) all stripped;
+        // visible content survives.
+        let input = "Verse 1\n\u{FEFF}lyric\u{200B} one\x02";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric one");
+    }
+
+    #[test]
+    fn parse_song_text_skips_lines_that_become_empty_after_strip() {
+        // A line that is ONLY a control byte should not produce a slide
+        // and should not flush an in-progress section.
+        let input = "Verse 1\nlyric a\n\x02\nlyric b";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1, "stray \\x02 line should not flush");
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric a\nlyric b");
     }
 }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -284,6 +284,27 @@ pub fn chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput> {
     out
 }
 
+/// Prepend and append an empty `SlideInput` to the list, matching the
+/// worship-service convention of starting and ending on a blank slide.
+/// An empty input passes through unchanged so we don't emit two empty
+/// slides for an empty paste.
+pub fn wrap_with_empty_bookends(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    if slides.is_empty() {
+        return slides;
+    }
+    let empty = || SlideInput {
+        main: String::new(),
+        translation: None,
+        stage: None,
+        group: None,
+    };
+    let mut out = Vec::with_capacity(slides.len() + 2);
+    out.push(empty());
+    out.extend(slides);
+    out.push(empty());
+    out
+}
+
 /// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
 /// digits with leading zeros so songs sort correctly.
 ///
@@ -683,5 +704,40 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].main, "");
         assert_eq!(out[0].group.as_deref(), Some("Interlude"));
+    }
+
+    #[test]
+    fn wrap_with_empty_bookends_adds_front_and_back() {
+        let slides = vec![
+            SlideInput {
+                main: "a".to_string(),
+                translation: None,
+                stage: None,
+                group: Some("Verse 1".to_string()),
+            },
+            SlideInput {
+                main: "b".to_string(),
+                translation: None,
+                stage: None,
+                group: None,
+            },
+        ];
+        let out = wrap_with_empty_bookends(slides);
+        assert_eq!(out.len(), 4);
+        // First and last are empty.
+        assert_eq!(out[0].main, "");
+        assert!(out[0].group.is_none());
+        assert_eq!(out[3].main, "");
+        assert!(out[3].group.is_none());
+        // Middle slides preserved.
+        assert_eq!(out[1].main, "a");
+        assert_eq!(out[1].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[2].main, "b");
+    }
+
+    #[test]
+    fn wrap_with_empty_bookends_skips_empty_input() {
+        let out = wrap_with_empty_bookends(vec![]);
+        assert!(out.is_empty(), "no bookends on empty input");
     }
 }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -105,13 +105,14 @@ fn is_metadata_line(line: &str) -> bool {
     if line.is_empty() {
         return false;
     }
-    let lower = line.to_ascii_lowercase();
-    if lower.starts_with("title:") {
-        return true;
-    }
-    // ^B / ^A / ^C etc. — exactly two chars: caret + uppercase ASCII letter.
+    // Cheapest check first: ^B / ^A / ^C etc. — exactly two chars,
+    // caret + uppercase ASCII letter. No allocation needed.
     let bytes = line.as_bytes();
     if bytes.len() == 2 && bytes[0] == b'^' && bytes[1].is_ascii_uppercase() {
+        return true;
+    }
+    let lower = line.to_ascii_lowercase();
+    if lower.starts_with("title:") {
         return true;
     }
     // "Misc 1", "MISC 12", etc.
@@ -177,9 +178,10 @@ mod tests {
         );
         // No slide's main contains Title:, Misc, or ^B.
         for s in &slides {
+            let main_lower = s.main.to_ascii_lowercase();
             assert!(
-                !s.main.to_lowercase().contains("title:")
-                    && !s.main.to_lowercase().contains("misc ")
+                !main_lower.contains("title:")
+                    && !main_lower.contains("misc ")
                     && !s.main.contains("^B"),
                 "slide leaked metadata: {:?}",
                 s

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -177,6 +177,7 @@ pub fn extract_title(text: &str) -> Option<String> {
 /// `line_limit` are hard-broken at the limit boundary. `line_limit == 0`
 /// is treated as "no wrapping" (defensive — keeps signature stable if
 /// the operator clears the setting).
+/// Runs of whitespace within a line are collapsed to single spaces.
 pub fn wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideInput> {
     if line_limit == 0 {
         return slides;
@@ -197,6 +198,18 @@ pub fn wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideI
         .collect()
 }
 
+/// Start a fresh wrapped line with `word`. If the word fits within
+/// `limit`, push it onto `current`. Otherwise hard-break it: push
+/// complete `limit`-sized pieces to `out` and leave the trailing
+/// remainder in `current` so subsequent words can keep accumulating.
+fn start_new_line(out: &mut Vec<String>, current: &mut String, word: &str, limit: usize) {
+    if word.chars().count() > limit {
+        hard_break_into(out, current, word, limit);
+    } else {
+        current.push_str(word);
+    }
+}
+
 fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
     if line.chars().count() <= limit {
         return vec![line.to_string()];
@@ -206,21 +219,13 @@ fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
     for word in line.split_whitespace() {
         let word_len = word.chars().count();
         if current.is_empty() {
-            if word_len > limit {
-                hard_break_into(&mut out, &mut current, word, limit);
-            } else {
-                current.push_str(word);
-            }
+            start_new_line(&mut out, &mut current, word, limit);
         } else if current.chars().count() + 1 + word_len <= limit {
             current.push(' ');
             current.push_str(word);
         } else {
             out.push(std::mem::take(&mut current));
-            if word_len > limit {
-                hard_break_into(&mut out, &mut current, word, limit);
-            } else {
-                current.push_str(word);
-            }
+            start_new_line(&mut out, &mut current, word, limit);
         }
     }
     if !current.is_empty() {
@@ -230,18 +235,23 @@ fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
 }
 
 /// Hard-break an oversize word at codepoint boundaries. Pushes complete
-/// `limit`-sized pieces to `out` and leaves the trailing remainder in
-/// `current` so subsequent words can still accumulate onto the same line.
+/// `limit`-codepoint pieces to `out` and leaves the trailing remainder
+/// in `current` so subsequent words can still accumulate onto the same
+/// line.
 fn hard_break_into(out: &mut Vec<String>, current: &mut String, word: &str, limit: usize) {
-    let chars: Vec<char> = word.chars().collect();
-    let mut idx = 0;
-    while chars.len() - idx > limit {
-        let piece: String = chars[idx..idx + limit].iter().collect();
-        out.push(piece);
-        idx += limit;
+    let mut piece_start = 0;
+    let mut chars_in_piece = 0;
+    for (byte_idx, _) in word.char_indices() {
+        if chars_in_piece == limit {
+            out.push(word[piece_start..byte_idx].to_string());
+            piece_start = byte_idx;
+            chars_in_piece = 0;
+        }
+        chars_in_piece += 1;
     }
-    let remainder: String = chars[idx..].iter().collect();
-    *current = remainder;
+    if piece_start < word.len() {
+        *current = word[piece_start..].to_string();
+    }
 }
 
 /// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -85,7 +85,7 @@ const GROUP_PATTERNS: &[&str] = &[
 ];
 
 fn is_group_line(line: &str) -> bool {
-    let line_lower = line.to_lowercase();
+    let line_lower = line.to_ascii_lowercase();
     GROUP_PATTERNS.iter().any(|pattern| {
         line_lower.strip_prefix(pattern).is_some_and(|rest| {
             let rest = rest.trim();
@@ -105,7 +105,7 @@ fn is_metadata_line(line: &str) -> bool {
     if line.is_empty() {
         return false;
     }
-    let lower = line.to_lowercase();
+    let lower = line.to_ascii_lowercase();
     if lower.starts_with("title:") {
         return true;
     }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -171,6 +171,79 @@ pub fn extract_title(text: &str) -> Option<String> {
     })
 }
 
+/// Word-aware greedy wrapping per `\n`-separated line, so every line in
+/// every slide's `main` fits within `line_limit` codepoints. Lines that
+/// already fit pass through unchanged. Single words longer than
+/// `line_limit` are hard-broken at the limit boundary. `line_limit == 0`
+/// is treated as "no wrapping" (defensive — keeps signature stable if
+/// the operator clears the setting).
+pub fn wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideInput> {
+    if line_limit == 0 {
+        return slides;
+    }
+    slides
+        .into_iter()
+        .map(|slide| {
+            let wrapped: Vec<String> = slide
+                .main
+                .split('\n')
+                .flat_map(|line| wrap_one_line(line, line_limit))
+                .collect();
+            SlideInput {
+                main: wrapped.join("\n"),
+                ..slide
+            }
+        })
+        .collect()
+}
+
+fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
+    if line.chars().count() <= limit {
+        return vec![line.to_string()];
+    }
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in line.split_whitespace() {
+        let word_len = word.chars().count();
+        if current.is_empty() {
+            if word_len > limit {
+                hard_break_into(&mut out, &mut current, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        } else if current.chars().count() + 1 + word_len <= limit {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            out.push(std::mem::take(&mut current));
+            if word_len > limit {
+                hard_break_into(&mut out, &mut current, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Hard-break an oversize word at codepoint boundaries. Pushes complete
+/// `limit`-sized pieces to `out` and leaves the trailing remainder in
+/// `current` so subsequent words can still accumulate onto the same line.
+fn hard_break_into(out: &mut Vec<String>, current: &mut String, word: &str, limit: usize) {
+    let chars: Vec<char> = word.chars().collect();
+    let mut idx = 0;
+    while chars.len() - idx > limit {
+        let piece: String = chars[idx..idx + limit].iter().collect();
+        out.push(piece);
+        idx += limit;
+    }
+    let remainder: String = chars[idx..].iter().collect();
+    *current = remainder;
+}
+
 /// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
 /// digits with leading zeros so songs sort correctly.
 ///
@@ -427,5 +500,76 @@ mod tests {
         assert_eq!(slides.len(), 1, "stray \\x02 line should not flush");
         assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
         assert_eq!(slides[0].main, "lyric a\nlyric b");
+    }
+
+    #[test]
+    fn wrap_long_lines_word_wraps_at_limit() {
+        let slide = SlideInput {
+            main: "Ak Boh je za mňa,  kto je proti mne".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Bridge".to_string()),
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        assert_eq!(out.len(), 1);
+        // Should wrap to >=2 lines, each ≤ 32 chars.
+        let lines: Vec<&str> = out[0].main.split('\n').collect();
+        assert!(lines.len() >= 2, "expected wrapping, got: {:?}", lines);
+        for line in &lines {
+            assert!(
+                line.chars().count() <= 32,
+                "wrapped line '{line}' exceeds 32 chars: {}",
+                line.chars().count()
+            );
+        }
+        // The original group should be preserved.
+        assert_eq!(out[0].group.as_deref(), Some("Bridge"));
+    }
+
+    #[test]
+    fn wrap_long_lines_passes_through_short_lines() {
+        let slide = SlideInput {
+            main: "short line\nanother short".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let out = wrap_long_lines(vec![slide.clone()], 32);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, slide.main);
+    }
+
+    #[test]
+    fn wrap_long_lines_hard_breaks_oversize_word() {
+        // Single 50-char word at limit 32 → 2 pieces (32 + 18).
+        let big_word: String = "a".repeat(50);
+        let slide = SlideInput {
+            main: big_word,
+            translation: None,
+            stage: None,
+            group: None,
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        let lines: Vec<&str> = out[0].main.split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].chars().count(), 32);
+        assert_eq!(lines[1].chars().count(), 18);
+    }
+
+    #[test]
+    fn wrap_long_lines_counts_unicode_codepoints_not_bytes() {
+        // Slovak diacritics — each char is one codepoint (multi-byte UTF-8).
+        // 30 'á' chars = 30 codepoints = 60 bytes. At limit 32, this should
+        // pass through (≤ limit by codepoint), not wrap.
+        let line: String = "á".repeat(30);
+        let slide = SlideInput {
+            main: line.clone(),
+            translation: None,
+            stage: None,
+            group: None,
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, line, "30 Slovak codepoints fit at limit 32");
     }
 }

--- a/crates/presenter-ui/src/utils/song_parser.rs
+++ b/crates/presenter-ui/src/utils/song_parser.rs
@@ -740,4 +740,122 @@ mod tests {
         let out = wrap_with_empty_bookends(vec![]);
         assert!(out.is_empty(), "no bookends on empty input");
     }
+
+    #[test]
+    fn pipeline_user_76_arriba_paste_produces_correct_output() {
+        // Regression guard for issue #275 follow-up. Exercises the full
+        // pipeline (extract_title + parse_song_text +
+        // wrap_long_lines + chunk_to_two_lines + wrap_with_empty_bookends)
+        // on the user's canonical spevnik export.
+        let input = "Title: 76 Arriba\n\
+                     Misc 1\n\
+                     \n\
+                     Verse 1\n\
+                     Môj Boh je nekonečný\n\
+                     Má všetku moc a je večný\n\
+                     Jeho Duch vo mne je živý\n\
+                     A všetko pre mňa učiní\n\
+                     \n\
+                     Pre-Chorus\n\
+                     Žehná ma žehná\n\
+                     Priazeñ nad priazeň\n\
+                     A padá to na mňa, padá na mňa\n\
+                     Žehná ma žehná\n\
+                     Priazeň nad priazeň\n\
+                     A tá ku mne prúdi, ku mne prúdi\n\
+                     \n\
+                     Chorus\n\
+                     Jeden dva tri\n\
+                     Zakrič On je najlepší\n\
+                     Jeden dva tri\n\
+                     Ja som v ňom požehnaný\n\
+                     Jeden dva tri\n\
+                     Všetka sláva Jemu, v Ňom\n\
+                     Ja som tým, kým hovorí že som\n\
+                     Jeden dva tri\n\
+                     \n\
+                     Verse 2\n\
+                     Ja vidím veci na nebi\n\
+                     Tie zmeny sú aj na zemi\n\
+                     Jeho Duch vo mne je živý\n\
+                     Nie je nič čo neučiní\n\
+                     \n\
+                     Bridge\n\
+                     Ak Boh je za mňa,  kto je proti mne\n\
+                     Ja chválim Ho, ja chválim Ho\n\
+                     Misc 1\n";
+
+        // Title extraction with 2-digit padding.
+        let name = extract_title(input);
+        assert_eq!(name.as_deref(), Some("076 Arriba"));
+
+        // Run the full pipeline at line_limit 32.
+        let slides = parse_song_text(input);
+        let slides = wrap_long_lines(slides, 32);
+        let slides = chunk_to_two_lines(slides);
+        let slides = wrap_with_empty_bookends(slides);
+
+        // Total: empty + 13 lyric chunks + empty = 15.
+        assert_eq!(
+            slides.len(),
+            15,
+            "expected 15 slides, got {}: {:#?}",
+            slides.len(),
+            slides
+        );
+
+        // Bookends.
+        assert_eq!(slides[0].main, "");
+        assert!(slides[0].group.is_none(), "first bookend has no group");
+        assert_eq!(slides[14].main, "");
+        assert!(slides[14].group.is_none(), "last bookend has no group");
+
+        // First content slide is Verse 1, chunk 1.
+        assert_eq!(slides[1].group.as_deref(), Some("Verse 1"));
+
+        // Inherited groups: chunks 2+ of any section have group=None.
+        assert_eq!(slides[2].group, None, "Verse 1 chunk 2 inherits");
+
+        // Pre-Chorus first chunk is at index 3.
+        assert_eq!(slides[3].group.as_deref(), Some("Pre-Chorus"));
+
+        // Chorus first chunk is at index 6 (after Pre-Chorus's 3 chunks).
+        assert_eq!(slides[6].group.as_deref(), Some("Chorus"));
+
+        // Verse 2 first chunk is at index 10 (after Chorus's 4 chunks).
+        assert_eq!(slides[10].group.as_deref(), Some("Verse 2"));
+
+        // Bridge first chunk is at index 12 (after Verse 2's 2 chunks).
+        // Bridge's first input line was 35 chars at limit 32, so it
+        // wrapped — the chunked first slide may have either parts of
+        // the wrapped first line OR the wrapped line + the second line.
+        // Asserting its group + that all lines fit is enough.
+        assert_eq!(slides[12].group.as_deref(), Some("Bridge"));
+
+        // No content slide should contain Title:, Misc, ^B, or any line
+        // longer than line_limit (32). Bookends excluded.
+        for (idx, slide) in slides.iter().enumerate() {
+            assert!(
+                !slide.main.contains("Title:"),
+                "slide {idx} leaked 'Title:': {:?}",
+                slide.main
+            );
+            assert!(
+                !slide.main.to_ascii_lowercase().contains("misc "),
+                "slide {idx} leaked 'Misc': {:?}",
+                slide.main
+            );
+            assert!(
+                !slide.main.contains("^B"),
+                "slide {idx} leaked '^B': {:?}",
+                slide.main
+            );
+            for line in slide.main.split('\n') {
+                assert!(
+                    line.chars().count() <= 32,
+                    "slide {idx} line '{line}' exceeds 32 chars (line_limit)"
+                );
+            }
+        }
+    }
 }

--- a/crates/presenter-ui/src/utils/test_helpers.rs
+++ b/crates/presenter-ui/src/utils/test_helpers.rs
@@ -1,4 +1,3 @@
-use crate::api::presentations::SlideInput;
 use crate::state::operator::OperatorState;
 use crate::state::AppContext;
 use leptos::prelude::*;
@@ -328,7 +327,7 @@ fn create_test_helpers(ctx: &AppContext, op: &OperatorState) {
     // parseSongText(text)
     {
         let func = Closure::wrap(Box::new(move |text: String| -> JsValue {
-            let slides = parse_song_text(&text);
+            let slides = super::song_parser::parse_song_text(&text);
             serde_wasm_bindgen::to_value(&slides).unwrap_or(JsValue::NULL)
         }) as Box<dyn Fn(String) -> JsValue>);
         let _ = js_sys::Reflect::set(&helpers, &"parseSongText".into(), func.as_ref());
@@ -340,75 +339,4 @@ fn create_test_helpers(ctx: &AppContext, op: &OperatorState) {
         &JsValue::from_str("__presenterOperatorTestHelpers"),
         &helpers,
     );
-}
-
-/// Regex-like pattern matching for group names (Verse, Chorus, etc.)
-fn is_group_line(line: &str) -> bool {
-    let line_lower = line.trim().to_lowercase();
-    let patterns = [
-        "verse",
-        "chorus",
-        "bridge",
-        "intro",
-        "outro",
-        "pre-chorus",
-        "prechorus",
-        "tag",
-        "interlude",
-        "refrain",
-        "hook",
-        "coda",
-        "ending",
-        "instrumental",
-    ];
-    for pattern in patterns {
-        if let Some(rest) = line_lower.strip_prefix(pattern) {
-            // Check if rest is empty or just a number/whitespace
-            let rest = rest.trim();
-            if rest.is_empty()
-                || rest
-                    .chars()
-                    .all(|c| c.is_ascii_digit() || c.is_whitespace())
-            {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return Vec::new();
-    }
-    trimmed
-        .split("\n\n")
-        .filter(|section| !section.trim().is_empty())
-        .map(|section| {
-            let section = section.trim();
-            let lines: Vec<&str> = section.lines().collect();
-
-            // Check if first line is a group name
-            if let Some(first_line) = lines.first() {
-                if is_group_line(first_line) {
-                    let group_name = first_line.trim().to_string();
-                    let main_content = lines[1..].join("\n");
-                    return SlideInput {
-                        main: main_content,
-                        translation: None,
-                        stage: None,
-                        group: Some(group_name),
-                    };
-                }
-            }
-
-            SlideInput {
-                main: section.to_string(),
-                translation: None,
-                stage: None,
-                group: None,
-            }
-        })
-        .collect()
 }

--- a/docs/superpowers/plans/2026-04-29-clipboard-import-section-split.md
+++ b/docs/superpowers/plans/2026-04-29-clipboard-import-section-split.md
@@ -1,0 +1,707 @@
+# Clipboard Import: Split Slides on Section Markers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the operator's clipboard-paste presentation creator split a song into one slide per section (Verse N, Chorus, Bridge, …), filtering ProPresenter-style metadata markers (`Title:`, `Misc N`, `^B`).
+
+**Architecture:** Replace the blank-line-only splitter `parse_song_text` with a line-walk parser that flushes on section markers AND blank lines, and filters metadata. Move it out of `test_helpers.rs` (where it inappropriately lived as production code) into a new `song_parser.rs` utility module.
+
+**Tech Stack:** Rust + Leptos (WASM), Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-clipboard-import-section-split-design.md` (commit `c93d133`).
+
+---
+
+## Context
+
+`parse_song_text` is used by:
+1. The operator's "create presentation from paste" modal (`crates/presenter-ui/src/components/presentation_modal.rs:244`).
+2. The JS test bridge `window.__presenterOperatorTestHelpers.parseSongText` (`crates/presenter-ui/src/utils/test_helpers.rs:328-335`), exercised by E2E test `tests/e2e/wasm-edge-cases.spec.ts:259` (`"parseSongText handles verse markers"`).
+
+After this work the implementation moves but the JS-bridge name `parseSongText` stays the same, so the existing E2E test keeps working — it's actually a regression guard for the move.
+
+`presenter-ui` is excluded from the root workspace and has its own `Cargo.lock`. Tests via `cargo test -p presenter-ui --target x86_64-unknown-linux-gnu`. Clippy via `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown -- -D warnings -W clippy::all`. Local Rust builds are allowed on this dev machine.
+
+`SlideInput` is defined in `crates/presenter-ui/src/api/presentations.rs` (already imported in `test_helpers.rs`).
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace `[workspace.package]`) | `0.4.45` → `0.4.46` |
+| `crates/presenter-ui/Cargo.toml` | `0.1.14` → `0.1.15` |
+| `crates/presenter-ui/src/utils/song_parser.rs` | **NEW.** Public `parse_song_text(text: &str) -> Vec<SlideInput>` with private helpers `is_group_line` and `is_metadata_line`. ~10 unit tests. |
+| `crates/presenter-ui/src/utils/mod.rs` | Add `pub mod song_parser;` |
+| `crates/presenter-ui/src/utils/test_helpers.rs` | Remove the local `parse_song_text` and `is_group_line` functions (lines 345-414). Update the `parseSongText` JS bridge to call `crate::utils::song_parser::parse_song_text` instead. |
+| `crates/presenter-ui/src/components/presentation_modal.rs:244` | Change call from `crate::utils::test_helpers::parse_song_text` → `crate::utils::song_parser::parse_song_text` |
+
+---
+
+## Task 1: Bump version to 0.4.46
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Confirm versions**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git fetch origin
+grep '^version' Cargo.toml | head -1
+grep '^version' crates/presenter-ui/Cargo.toml | head -1
+```
+
+Expected: workspace `0.4.45`, presenter-ui `0.1.14`.
+
+- [ ] **Step 2: Bump workspace**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml` under `[workspace.package]`, change `version = "0.4.45"` to `version = "0.4.46"`.
+
+- [ ] **Step 3: Bump presenter-ui**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml` under `[package]`, change `version = "0.1.14"` to `version = "0.1.15"`.
+
+- [ ] **Step 4: Refresh Cargo.lock files**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.46 (#275)"
+```
+
+---
+
+## Task 2: Create song_parser.rs with TDD
+
+**Files:**
+- Create: `crates/presenter-ui/src/utils/song_parser.rs`
+- Modify: `crates/presenter-ui/src/utils/mod.rs`
+
+- [ ] **Step 1: Add the module declaration**
+
+Edit `crates/presenter-ui/src/utils/mod.rs`. Find the existing `pub mod` lines (use `cat /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/utils/mod.rs` to see them) and add:
+
+```rust
+pub mod song_parser;
+```
+
+- [ ] **Step 2: Create the new file with failing tests + skeleton**
+
+Create `crates/presenter-ui/src/utils/song_parser.rs` with the following content:
+
+```rust
+//! Song-text parser for the clipboard-paste "create presentation" flow.
+//!
+//! Splits a pasted song into one [`SlideInput`] per section. Triggers:
+//! - Metadata lines (`Title:`, `Misc N`, `^[A-Z]`) → filter out.
+//! - Group lines (`Verse N`, `Chorus`, `Bridge`, …) → flush current slide,
+//!   start a new one with this line as the group name.
+//! - Blank lines → flush current slide if non-empty.
+//! - Anything else → append to the current slide's main text.
+//!
+//! See `docs/superpowers/specs/2026-04-29-clipboard-import-section-split-design.md`.
+
+use crate::api::presentations::SlideInput;
+
+/// Parse a pasted song into one [`SlideInput`] per section.
+pub fn parse_song_text(text: &str) -> Vec<SlideInput> {
+    let mut slides: Vec<SlideInput> = Vec::new();
+    let mut current_group: Option<String> = None;
+    let mut current_main: Vec<String> = Vec::new();
+
+    for raw_line in text.lines() {
+        let trimmed = raw_line.trim();
+
+        if is_metadata_line(trimmed) {
+            continue;
+        }
+
+        if is_group_line(trimmed) {
+            flush_slide(&mut slides, &mut current_group, &mut current_main);
+            current_group = Some(trimmed.to_string());
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            // Only flush if we've accumulated content; otherwise ignore.
+            if current_group.is_some() || !current_main.is_empty() {
+                flush_slide(&mut slides, &mut current_group, &mut current_main);
+            }
+            continue;
+        }
+
+        current_main.push(raw_line.to_string());
+    }
+
+    flush_slide(&mut slides, &mut current_group, &mut current_main);
+    slides
+}
+
+fn flush_slide(
+    slides: &mut Vec<SlideInput>,
+    group: &mut Option<String>,
+    main_lines: &mut Vec<String>,
+) {
+    let main = main_lines.join("\n").trim_end().to_string();
+    let took_group = group.take();
+    main_lines.clear();
+    if main.is_empty() && took_group.is_none() {
+        return;
+    }
+    slides.push(SlideInput {
+        main,
+        translation: None,
+        stage: None,
+        group: took_group,
+    });
+}
+
+/// Recognised section/group headings (the ProPresenter-style group names).
+/// Mirrors the original list from `test_helpers.rs::is_group_line` and accepts
+/// optional trailing digits / whitespace (e.g. `Verse 2`, `Chorus`).
+fn is_group_line(line: &str) -> bool {
+    let line_lower = line.trim().to_lowercase();
+    let patterns = [
+        "verse",
+        "chorus",
+        "bridge",
+        "intro",
+        "outro",
+        "pre-chorus",
+        "prechorus",
+        "tag",
+        "interlude",
+        "refrain",
+        "hook",
+        "coda",
+        "ending",
+        "instrumental",
+    ];
+    for pattern in patterns {
+        if let Some(rest) = line_lower.strip_prefix(pattern) {
+            let rest = rest.trim();
+            if rest.is_empty()
+                || rest
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || c.is_whitespace())
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// ProPresenter-style metadata / control markers we want to silently drop:
+/// - `Title:` prefix (case-insensitive)
+/// - `Misc <digits>` (case-insensitive)
+/// - `^X` where X is a single ASCII uppercase letter (control marker)
+fn is_metadata_line(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    let lower = line.to_lowercase();
+    if lower.starts_with("title:") {
+        return true;
+    }
+    // ^B / ^A / ^C etc. — exactly two chars: caret + uppercase ASCII letter.
+    let bytes = line.as_bytes();
+    if bytes.len() == 2 && bytes[0] == b'^' && bytes[1].is_ascii_uppercase() {
+        return true;
+    }
+    // "Misc 1", "MISC 12", etc.
+    if let Some(rest) = lower.strip_prefix("misc ") {
+        if !rest.is_empty()
+            && rest
+                .chars()
+                .all(|c| c.is_ascii_digit() || c.is_whitespace())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_no_slides() {
+        assert!(parse_song_text("").is_empty());
+        assert!(parse_song_text("   \n\n  ").is_empty());
+    }
+
+    #[test]
+    fn user_pasted_song_splits_into_one_slide_per_section() {
+        // Regression guard for issue #275.
+        let input = "Title: 326 Všetko, čo v sebe držím \n\
+            Misc 1\n\
+            ^B\n\
+            Verse 1\n\
+            Všetko, čo v sebe držím: s túžbami, nádejami aj\n\
+            s vysnívaným!\n\
+            Ty ma chceš Pane... aj s tým všetkým, čo mám ja.\n\
+            \n\
+            Chorus\n\
+            Mám Spasiteľa, žije vo mne, ó, ó,\n\
+            chcem viac, chcem Teba spoznávať viac.\n\
+            \n\
+            Verse 2\n\
+            Všetko, čo v sebe držím: s túžbami, nádejami aj\n\
+            s vysnívaným!\n\
+            \n\
+            Interlude\n\
+            \n\
+            Outro\n\
+            Nikto mi Ťa už nemôže vziať!\n\
+            Misc 1\n\
+            ^B\n";
+        let slides = parse_song_text(input);
+        let groups: Vec<Option<&str>> =
+            slides.iter().map(|s| s.group.as_deref()).collect();
+        assert_eq!(
+            groups,
+            vec![
+                Some("Verse 1"),
+                Some("Chorus"),
+                Some("Verse 2"),
+                Some("Interlude"),
+                Some("Outro"),
+            ],
+            "expected one slide per section, no Title/Misc/^B leakage"
+        );
+        // No slide's main contains Title:, Misc, or ^B.
+        for s in &slides {
+            assert!(
+                !s.main.to_lowercase().contains("title:")
+                    && !s.main.to_lowercase().contains("misc ")
+                    && !s.main.contains("^B"),
+                "slide leaked metadata: {:?}",
+                s
+            );
+        }
+        // Outro slide should contain only the Nikto... lyric (Misc/^B trailing
+        // metadata filtered).
+        let outro = slides.iter().find(|s| s.group.as_deref() == Some("Outro")).unwrap();
+        assert_eq!(outro.main, "Nikto mi Ťa už nemôže vziať!");
+    }
+
+    #[test]
+    fn group_line_in_middle_of_paragraph_starts_new_slide() {
+        // No blank line between Verse and Chorus.
+        let input = "Verse 1\nlyric a\nlyric b\nChorus\nlyric c";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric a\nlyric b");
+        assert_eq!(slides[1].group.as_deref(), Some("Chorus"));
+        assert_eq!(slides[1].main, "lyric c");
+    }
+
+    #[test]
+    fn metadata_lines_are_filtered() {
+        let input = "Title: My Song\n\nVerse 1\nlyric";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric");
+    }
+
+    #[test]
+    fn caret_uppercase_filtered_but_caret_alone_is_text() {
+        let s1 = parse_song_text("Verse 1\n^B\nlyric");
+        // ^B filtered, slide has just "lyric"
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s1[0].main, "lyric");
+
+        let s2 = parse_song_text("Verse 1\n^\nlyric");
+        // Bare ^ is NOT filtered — treated as text.
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2[0].main, "^\nlyric");
+    }
+
+    #[test]
+    fn misc_n_filtered_but_miscellaneous_is_text() {
+        let s1 = parse_song_text("Verse 1\nMisc 1\nlyric");
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s1[0].main, "lyric");
+
+        let s2 = parse_song_text("Verse 1\nMiscellaneous things\nlyric");
+        // "Miscellaneous" is NOT filtered — treated as text.
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s2[0].main, "Miscellaneous things\nlyric");
+    }
+
+    #[test]
+    fn empty_interlude_emits_slide_with_empty_main() {
+        let input = "Interlude\n\nChorus\nlyric";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert_eq!(slides[0].group.as_deref(), Some("Interlude"));
+        assert_eq!(slides[0].main, "");
+        assert_eq!(slides[1].group.as_deref(), Some("Chorus"));
+        assert_eq!(slides[1].main, "lyric");
+    }
+
+    #[test]
+    fn loose_paragraphs_without_groups_split_on_blank_lines() {
+        let input = "Stanza 1\nline 2\n\nStanza 3\nline 4";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 2);
+        assert!(slides[0].group.is_none());
+        assert_eq!(slides[0].main, "Stanza 1\nline 2");
+        assert!(slides[1].group.is_none());
+        assert_eq!(slides[1].main, "Stanza 3\nline 4");
+    }
+
+    #[test]
+    fn group_line_is_case_insensitive() {
+        let input = "chorus\nlower\n\nCHORUS\nupper\n\nVerse 2\nnumbered";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 3);
+        assert_eq!(slides[0].group.as_deref(), Some("chorus"));
+        assert_eq!(slides[1].group.as_deref(), Some("CHORUS"));
+        assert_eq!(slides[2].group.as_deref(), Some("Verse 2"));
+    }
+
+    #[test]
+    fn lyric_indentation_preserved() {
+        let input = "Verse 1\n  indented\n    more indent\nflush";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].main, "  indented\n    more indent\nflush");
+    }
+}
+```
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo test -p presenter-ui --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -20
+```
+
+Expected: all 10 tests pass.
+
+If any test fails, fix the implementation. **Do NOT lower test expectations** — every assertion is a real requirement from the spec.
+
+- [ ] **Step 4: Run clippy on the new module**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cd ../..
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all
+git add crates/presenter-ui/src/utils/mod.rs crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "feat(ui): add song_parser module with section-aware splitting (#275)
+
+Line-walk parser with three triggers:
+- Metadata lines (Title:/Misc N/^[A-Z]) -> filter
+- Group lines (Verse/Chorus/Bridge/...) -> flush + start new slide
+- Blank lines -> flush if non-empty
+
+10 unit tests covering: user's exact pasted input from the issue
+(regression guard), mid-paragraph group split, metadata filtering,
+empty Interlude -> empty slide with group, loose paragraphs without
+groups (preserves old behavior), case-insensitive group lines,
+lyric indentation preservation."
+```
+
+---
+
+## Task 3: Wire the new module into call sites
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/test_helpers.rs`
+- Modify: `crates/presenter-ui/src/components/presentation_modal.rs`
+
+- [ ] **Step 1: Update presentation_modal.rs to use the new module**
+
+In `crates/presenter-ui/src/components/presentation_modal.rs`, line 244, replace:
+
+```rust
+            let slides = crate::utils::test_helpers::parse_song_text(&text);
+```
+
+with:
+
+```rust
+            let slides = crate::utils::song_parser::parse_song_text(&text);
+```
+
+- [ ] **Step 2: Update test_helpers.rs to use the new module**
+
+In `crates/presenter-ui/src/utils/test_helpers.rs`, the JS bridge at line 331 currently calls the local `parse_song_text` (defined later in the same file). Update it to call the new module:
+
+Old (line 331):
+```rust
+            let slides = parse_song_text(&text);
+```
+
+New:
+```rust
+            let slides = crate::utils::song_parser::parse_song_text(&text);
+```
+
+- [ ] **Step 3: Remove the now-unused functions from test_helpers.rs**
+
+Delete the entire `is_group_line` function (lines 345-378) and the entire `parse_song_text` function (lines 380-414) from `crates/presenter-ui/src/utils/test_helpers.rs`. Also remove any `use` of `SlideInput` if it's no longer referenced in this file (verify with `grep -n SlideInput crates/presenter-ui/src/utils/test_helpers.rs` after the deletion — if no matches remain except in the import, remove the import too).
+
+- [ ] **Step 4: Build and clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo build --target wasm32-unknown-unknown 2>&1 | tail -5
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -10
+cd ../..
+```
+
+Expected: clean build, zero warnings. If clippy complains about unused imports in `test_helpers.rs`, remove them.
+
+- [ ] **Step 5: Run all presenter-ui tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo test -p presenter-ui --target x86_64-unknown-linux-gnu 2>&1 | tail -10
+```
+
+Expected: all tests pass (the existing presenter-ui suite plus the 10 new song_parser tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all
+git add crates/presenter-ui/src/utils/test_helpers.rs crates/presenter-ui/src/components/presentation_modal.rs
+git commit -m "refactor(ui): wire song_parser into modal + test-helpers bridge (#275)
+
+Move the parse_song_text + is_group_line implementations out of
+test_helpers.rs (where they lived inappropriately as production
+code) into the new song_parser module. The JS bridge
+window.__presenterOperatorTestHelpers.parseSongText keeps the
+same name and signature, so the existing
+tests/e2e/wasm-edge-cases.spec.ts:259 'parseSongText handles
+verse markers' E2E test continues to work unchanged."
+```
+
+---
+
+## Task 4: Local checks + push + monitor pipeline CI
+
+- [ ] **Step 1: Workspace fmt + clippy + tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+cargo test --workspace 2>&1 | tail -5
+```
+
+Expected: every command exits 0, clippy zero warnings, all tests pass.
+
+- [ ] **Step 2: presenter-ui specifically**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown -- -D warnings 2>&1 | tail -5
+cargo test --target x86_64-unknown-linux-gnu 2>&1 | tail -5
+cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git push origin dev
+```
+
+- [ ] **Step 4: Find new pipeline run**
+
+```bash
+gh run list --branch dev --limit 3 --json databaseId,name,event,headSha,status,conclusion --jq '.[] | select(.name == "Pipeline" and .event == "push")' | head -1
+```
+
+- [ ] **Step 5: Monitor (single background poll)**
+
+Per `ci-monitoring.md` — single background command, no repeated polling:
+
+```bash
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+When the poll returns: every job must have `conclusion: success`. If anything failed, fetch failed log (`gh run view <RUN_ID> --log-failed`), fix the root cause in ONE commit, push, and monitor again (one poll iteration only).
+
+Expected: ALL jobs green incl. Mutation Testing, Playwright E2E 1/3+2/3+3/3, Deploy to Dev. The `wasm-edge-cases.spec.ts` E2E test "parseSongText handles verse markers" (which calls the `parseSongText` JS bridge) is the regression guard for the move — if it fails, the bridge isn't wired correctly.
+
+---
+
+## Task 5: Verify on dev + open PR + merge
+
+- [ ] **Step 1: Verify dev healthz**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.46"}`.
+
+- [ ] **Step 2: Live verify the fix**
+
+Use Playwright MCP to verify the user's exact reproduction:
+
+1. Navigate to `http://10.77.8.134:8080/ui/operator`, wait for `body[data-wasm-ready="true"]`.
+2. Run via `browser_evaluate`:
+
+```js
+const text = `Title: 326 Všetko, čo v sebe držím
+Misc 1
+^B
+Verse 1
+Všetko, čo v sebe držím: s túžbami, nádejami aj
+s vysnívaným!
+Ty ma chceš Pane... aj s tým všetkým, čo mám ja.
+
+Chorus
+Mám Spasiteľa, žije vo mne, ó, ó,
+chcem viac, chcem Teba spoznávať viac.
+
+Verse 2
+Všetko, čo v sebe držím: s túžbami, nádejami aj
+s vysnívaným!
+
+Interlude
+
+Outro
+Nikto mi Ťa už nemôže vziať!
+Misc 1
+^B`;
+const result = window.__presenterOperatorTestHelpers.parseSongText(text);
+return {
+  count: result.length,
+  groups: result.map(s => s.group),
+  hasMetadataLeak: result.some(s =>
+    /title:|misc |\^[A-Z]/i.test(s.main)
+  ),
+};
+```
+
+Expected:
+- `count`: 5
+- `groups`: `["Verse 1", "Chorus", "Verse 2", "Interlude", "Outro"]`
+- `hasMetadataLeak`: `false`
+
+3. Browser console: zero errors / warnings.
+
+- [ ] **Step 3: Open PR dev → main**
+
+```bash
+gh pr create --base main --head dev --title "fix(ui): clipboard import splits song into one slide per section (#275)" --body "$(cat <<'EOF'
+## Summary
+Fixes #275. The clipboard-paste presentation creator now splits a pasted song into one slide per section (Verse, Chorus, Bridge, Outro, Interlude, …) and filters ProPresenter metadata markers (`Title:`, `Misc N`, `^B`).
+
+## Changes
+- New `crates/presenter-ui/src/utils/song_parser.rs` line-walk parser
+- Move `parse_song_text` + `is_group_line` out of `test_helpers.rs` (they were production code mis-located)
+- Update the one production call site (`presentation_modal.rs:244`) and the JS test bridge to import from the new module
+- 10 new unit tests including the user's exact pasted input as a regression guard
+
+## Test plan
+- [x] CI green (all 21 jobs incl. Mutation Testing, Playwright E2E 1/3+2/3+3/3, Deploy to Dev, Deploy Companion Plugin)
+- [x] Existing `tests/e2e/wasm-edge-cases.spec.ts` "parseSongText handles verse markers" passes — proves the JS bridge move is correct
+- [x] Live verification on dev: pasted user's example into `parseSongText` JS helper, got 5 slides with the expected group names, no metadata leakage
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for PR pipeline + verify CLEAN**
+
+```bash
+gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,url
+```
+
+Expected: `MERGEABLE` + `CLEAN`. If `UNSTABLE`, identify which check is pending (most likely Mutation Testing) and wait — do NOT propose a bypass.
+
+- [ ] **Step 5: Send completion report and wait for explicit "merge it"**
+
+Per `pr-merge-policy.md`, do NOT merge. Send the completion report (per `completion-report.md`) with the PR URL and wait.
+
+---
+
+## Task 6: Post-merge production verify (gated on user merge instruction)
+
+- [ ] **Step 1: Watch the post-merge main pipeline**
+
+```bash
+gh run list --branch main --limit 3 --json databaseId,name,event,status,conclusion --jq '.[] | select(.event == "push")' | head -1
+sleep 1500 && gh run view <RUN_ID> --json status,conclusion,jobs ...
+```
+
+Wait for ALL jobs green incl. `Deploy to Production`.
+
+- [ ] **Step 2: Verify production**
+
+```bash
+curl -s http://10.77.9.205/healthz
+```
+
+Expected: `{"channel":"release","status":"ok","version":"0.4.46"}`.
+
+Repeat the live `parseSongText` Playwright check from Task 5 step 2 against `http://10.77.9.205/ui/operator`. Same pasted text, same expected output.
+
+- [ ] **Step 3: Bump dev version (post-release lifecycle)**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git fetch origin
+git checkout dev
+git pull origin main 2>&1 | tail -3
+sed -i 's/^version = "0.4.46"$/version = "0.4.47"/' Cargo.toml
+sed -i 's/^version = "0.1.15"$/version = "0.1.16"/' crates/presenter-ui/Cargo.toml
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.47 (post-release)"
+git push origin dev
+```
+
+- [ ] **Step 4: Final completion report**
+
+Short report per `completion-report.md` with prod-verified URLs. No follow-up question.
+
+---
+
+## Verification Summary
+
+| Check | How |
+|-------|-----|
+| User's exact pasted input parses correctly | `song_parser::tests::user_pasted_song_splits_into_one_slide_per_section` |
+| Metadata lines filtered | `song_parser::tests::metadata_lines_are_filtered`, `caret_uppercase_filtered_but_caret_alone_is_text`, `misc_n_filtered_but_miscellaneous_is_text` |
+| Section markers split mid-paragraph | `song_parser::tests::group_line_in_middle_of_paragraph_starts_new_slide` |
+| Loose paragraphs still split on blank lines | `song_parser::tests::loose_paragraphs_without_groups_split_on_blank_lines` |
+| Empty Interlude emits empty-main slide with group | `song_parser::tests::empty_interlude_emits_slide_with_empty_main` |
+| JS bridge `parseSongText` still works | `tests/e2e/wasm-edge-cases.spec.ts:259` (existing test, unchanged) |
+| Live dev verification | Playwright MCP probe with user's exact input |
+| Browser console clean | Live dev verification asserts 0 errors / 0 warnings |

--- a/docs/superpowers/plans/2026-04-30-clipboard-import-followup.md
+++ b/docs/superpowers/plans/2026-04-30-clipboard-import-followup.md
@@ -1,0 +1,1641 @@
+# Clipboard Import Follow-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the operator's "create from paste" flow extract a Title-as-presentation-name (zero-padded), word-wrap long lyric lines, chunk each section into ≤ 2-line slides, strip Unicode control chars, and add empty bookend slides — so a spevnik song export imports cleanly.
+
+**Architecture:** Pipeline of small composable functions in `crates/presenter-ui/src/utils/song_parser.rs` (extract_title → parse_song_text with sanitize → wrap_long_lines → chunk_to_two_lines → wrap_with_empty_bookends). Modal's `on_paste_confirm` reads `op.line_limit`, runs the pipeline, ignores any typed name, hides the name input on the paste sub-screen.
+
+**Tech Stack:** Rust + Leptos 0.7 (WASM), Playwright/TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-clipboard-import-followup-design.md` (commit `248a66c`).
+
+---
+
+## Context
+
+Builds on PR #277 (currently open from `dev` to `main`, mergeable, clean). `dev` is at commit `248a66c` (1 spec commit ahead of #277's last fix). New work piles onto `dev` — PR #277 auto-updates.
+
+The existing `parse_song_text(text) -> Vec<SlideInput>` from PR #277 stays — only its lyric-line append is modified to call a new `sanitize_line` helper. The JS bridge `__presenterOperatorTestHelpers.parseSongText` keeps the same signature (it calls `parse_song_text`); the existing E2E `tests/e2e/wasm-edge-cases.spec.ts:259` regression test still passes.
+
+`presenter-ui` has its own `Cargo.lock` (excluded from workspace).
+- Tests: `cd crates/presenter-ui && cargo test --target x86_64-unknown-linux-gnu --lib song_parser`
+- Clippy: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`
+- Format: `cd crates/presenter-ui && cargo fmt`
+- Workspace fmt check (root): `cargo fmt --all --check`
+
+`OperatorState.line_limit` is a `RwSignal<u32>` (default 32, persisted to localStorage as `lineLimit`) defined in `crates/presenter-ui/src/state/operator.rs:75`. The modal already has `op` in scope, so `op.line_limit.get_untracked() as usize` is the source of truth for line wrapping.
+
+The modal sub-flow signal is `create_step: RwSignal<String>` taking values `"options"` / `"paste"` / `"import"` (declared at the top of `presentation_modal.rs`). Hiding the name input on paste = `style:display=move || if create_step.get() == "paste" { "none" } else { "block" }` on the `<label>` wrapping the input.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace `[workspace.package]`) | `0.4.46` → `0.4.47` |
+| `crates/presenter-ui/Cargo.toml` | `0.1.15` → `0.1.16` |
+| `crates/presenter-ui/src/utils/song_parser.rs` | Add `extract_title`, `pad_title_number`, `sanitize_line`, `is_zero_width`, `wrap_long_lines`, `wrap_one_line`, `hard_break_into`, `chunk_to_two_lines`, `wrap_with_empty_bookends`. Modify the line-append branch of `parse_song_text` to use `sanitize_line` and skip lines that become empty after sanitization. Add ~14 new unit tests. |
+| `crates/presenter-ui/src/components/presentation_modal.rs:230-292` | Replace `on_paste_confirm` body with the new pipeline using extract_title for the name and the line_limit from `op`. |
+| `crates/presenter-ui/src/components/presentation_modal.rs:447-459` | Wrap the name input's `<label>` so it hides when `create_step.get() == "paste"`. |
+| `tests/e2e/wasm-presentation-crud.spec.ts:430` | **Replace** the existing `paste with section headers splits one slide per section (#275)` test body with the canonical `076 Arriba` paste, asserting 15 slides + bookends + hidden name input. |
+
+---
+
+## Task 1: Bump version 0.4.46 → 0.4.47
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package]`)
+- Modify: `crates/presenter-ui/Cargo.toml`
+
+- [ ] **Step 1: Sync with remote**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git fetch origin
+git status -sb
+```
+
+Expected: `## dev...origin/dev` (no divergence).
+
+- [ ] **Step 2: Bump workspace version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml` under `[workspace.package]`:
+
+```toml
+version = "0.4.47"
+```
+
+(was `0.4.46`).
+
+- [ ] **Step 3: Bump presenter-ui version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml` under `[package]`:
+
+```toml
+version = "0.1.16"
+```
+
+(was `0.1.15`).
+
+- [ ] **Step 4: Refresh Cargo.lock files**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo check -p presenter-server 2>&1 | tail -3
+cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -3 && cd ../..
+```
+
+Expected: clean compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.47 (#275 follow-up)"
+```
+
+---
+
+## Task 2: Add extract_title + pad_title_number (TDD)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add 9 failing unit tests at the end of the existing `mod tests {}`**
+
+Open `crates/presenter-ui/src/utils/song_parser.rs`. Find the existing `#[cfg(test)] mod tests` block (it has 10 existing tests from PR #277). Append these tests INSIDE that module, just before the closing `}`:
+
+```rust
+    #[test]
+    fn extract_title_pads_two_digit_prefix() {
+        assert_eq!(
+            extract_title("Title: 76 Arriba\nMisc 1\n\nVerse 1\nlyric"),
+            Some("076 Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_pads_one_digit_prefix() {
+        assert_eq!(
+            extract_title("Title: 6 Foo"),
+            Some("006 Foo".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_leaves_three_digit_prefix_unchanged() {
+        assert_eq!(
+            extract_title("Title: 102 10000 Armád"),
+            Some("102 10000 Armád".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_leaves_four_digit_prefix_unchanged() {
+        assert_eq!(
+            extract_title("Title: 1234 Bar"),
+            Some("1234 Bar".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_no_leading_number_unchanged() {
+        assert_eq!(
+            extract_title("Title: Arriba"),
+            Some("Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_no_space_after_digits_unchanged() {
+        // No whitespace separator → not a song-number prefix; leave alone.
+        assert_eq!(
+            extract_title("Title: 76Arriba"),
+            Some("76Arriba".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_returns_none_when_absent() {
+        assert_eq!(extract_title("Verse 1\nlyric"), None);
+    }
+
+    #[test]
+    fn extract_title_is_case_insensitive() {
+        assert_eq!(extract_title("TITLE: foo"), Some("foo".to_string()));
+        assert_eq!(extract_title("title: foo"), Some("foo".to_string()));
+    }
+
+    #[test]
+    fn extract_title_strips_surrounding_whitespace() {
+        assert_eq!(
+            extract_title("Title:   foo bar  "),
+            Some("foo bar".to_string())
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::extract_title 2>&1 | tail -20
+```
+
+Expected: 9 failures with `cannot find function extract_title`.
+
+- [ ] **Step 3: Implement `extract_title` and `pad_title_number`**
+
+Open the same file. After the existing `is_metadata_line` function (around line 128) but before the `#[cfg(test)]` line, add:
+
+```rust
+/// Extract the song title from the first `Title:` line in the input.
+///
+/// Returns the trimmed content after the colon, with a leading 1-3 digit
+/// numeric prefix padded to 3 digits via [`pad_title_number`]. Returns
+/// [`None`] if no `Title:` line is found.
+pub fn extract_title(text: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if !lower.starts_with("title:") {
+            return None;
+        }
+        // 6 = len("title:") — the prefix is ASCII so byte index works on
+        // the original (preserves casing of the title content).
+        let raw = trimmed[6..].trim();
+        Some(pad_title_number(raw))
+    })
+}
+
+/// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
+/// digits with leading zeros so songs sort correctly.
+///
+/// - `"76 Arriba"`        → `"076 Arriba"`
+/// - `"6 Foo"`            → `"006 Foo"`
+/// - `"102 10000 Armád"`  → `"102 10000 Armád"`  (already 3 digits)
+/// - `"1234 Bar"`         → `"1234 Bar"`          (4+ digits, untouched)
+/// - `"Arriba"`           → `"Arriba"`            (no leading number)
+/// - `"76Arriba"`         → `"76Arriba"`          (no whitespace separator)
+fn pad_title_number(title: &str) -> String {
+    let trimmed = title.trim();
+    if let Some(space_idx) = trimmed.find(char::is_whitespace) {
+        let (prefix, rest) = trimmed.split_at(space_idx);
+        if !prefix.is_empty()
+            && prefix.len() <= 3
+            && prefix.chars().all(|c| c.is_ascii_digit())
+        {
+            return format!("{prefix:0>3}{rest}");
+        }
+    }
+    trimmed.to_string()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -25
+```
+
+Expected: 19 tests pass (10 existing + 9 new).
+
+- [ ] **Step 5: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean, no fmt diff.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "feat(ui): add extract_title with 3-digit numeric prefix padding (#275)
+
+extract_title scans for the first Title: line case-insensitively and
+runs the result through pad_title_number, which pads a leading 1-3
+digit prefix followed by whitespace to 3 digits with leading zeros.
+Songs like 'Title: 76 Arriba' become '076 Arriba' so they sort
+correctly in the operator library list.
+
+9 new unit tests covering the padding rules, no-prefix cases,
+case-insensitivity, surrounding whitespace, and the absent-Title
+case."
+```
+
+---
+
+## Task 3: Sanitize lyric lines via control-char strip (TDD)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add 2 failing tests inside `mod tests {}`**
+
+Append inside the same `#[cfg(test)] mod tests` block:
+
+```rust
+    #[test]
+    fn parse_song_text_strips_control_chars_from_lyric_lines() {
+        // STX (\x02), BOM (\u{FEFF}), and ZWSP (\u{200B}) all stripped;
+        // visible content survives.
+        let input = "Verse 1\n\u{FEFF}lyric\u{200B} one\x02";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1);
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric one");
+    }
+
+    #[test]
+    fn parse_song_text_skips_lines_that_become_empty_after_strip() {
+        // A line that is ONLY a control byte should not produce a slide
+        // and should not flush an in-progress section.
+        let input = "Verse 1\nlyric a\n\x02\nlyric b";
+        let slides = parse_song_text(input);
+        assert_eq!(slides.len(), 1, "stray \\x02 line should not flush");
+        assert_eq!(slides[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(slides[0].main, "lyric a\nlyric b");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::parse_song_text_strips 2>&1 | tail -15
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::parse_song_text_skips 2>&1 | tail -15
+```
+
+Expected: both tests fail (current parser appends the raw line and lets the BOM/STX through).
+
+- [ ] **Step 3: Add `sanitize_line` + `is_zero_width` helpers**
+
+In `crates/presenter-ui/src/utils/song_parser.rs`, add at module scope (e.g. just below `is_metadata_line`):
+
+```rust
+/// Strip Unicode control chars (Cc category) and zero-width chars (BOM,
+/// U+200B–200D) from a line. Used to clean lyric lines before pushing
+/// them onto a slide so stray bytes from any pasted source (web pages,
+/// Word, ProPresenter) don't render as a tofu/square character on stage.
+fn sanitize_line(line: &str) -> String {
+    line.chars()
+        .filter(|c| !c.is_control() && !is_zero_width(*c))
+        .collect()
+}
+
+fn is_zero_width(c: char) -> bool {
+    matches!(c, '\u{FEFF}' | '\u{200B}' | '\u{200C}' | '\u{200D}')
+}
+```
+
+- [ ] **Step 4: Replace the line-walk loop in `parse_song_text`**
+
+Find the current `parse_song_text` function. Replace its `for raw_line in text.lines() { ... }` loop with:
+
+```rust
+    for raw_line in text.lines() {
+        // Originally-blank lines (whitespace only) flush the current slide
+        // — even if sanitization would later collapse a non-blank line to
+        // empty, that's a different signal.
+        if raw_line.trim().is_empty() {
+            if current_group.is_some() || !current_main.is_empty() {
+                flush_slide(&mut slides, &mut current_group, &mut current_main);
+            }
+            continue;
+        }
+
+        // Strip Unicode control + zero-width chars so stray bytes from any
+        // pasted source don't pollute slides.
+        let sanitized = sanitize_line(raw_line);
+        let trimmed = sanitized.trim();
+
+        // If sanitization left only whitespace, the line was entirely a
+        // stray control byte — skip silently without flushing.
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if is_metadata_line(trimmed) {
+            continue;
+        }
+
+        if is_group_line(trimmed) {
+            flush_slide(&mut slides, &mut current_group, &mut current_main);
+            current_group = Some(trimmed.to_string());
+            continue;
+        }
+
+        current_main.push(sanitized);
+    }
+```
+
+- [ ] **Step 5: Run all `song_parser` tests to verify nothing regressed**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -25
+```
+
+Expected: 21 tests pass (19 from before + 2 new control-strip tests).
+
+- [ ] **Step 6: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "feat(ui): strip control + zero-width chars from lyric lines (#275)
+
+parse_song_text now sanitizes each lyric line via sanitize_line,
+filtering Unicode Cc-category chars (NUL, STX, etc.) and zero-width
+chars (BOM, U+200B-200D) before pushing onto the current slide.
+A line that becomes empty after sanitization is skipped silently
+without flushing the current section — so a stray \\x02 byte from
+ProPresenter export no longer creates a tofu-square slide.
+
+Originally-blank lines (whitespace-only in the source) still flush
+as before.
+
+2 new unit tests cover the strip and the no-flush-on-stripped-empty
+behavior."
+```
+
+---
+
+## Task 4: wrap_long_lines (TDD)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add 4 failing tests inside `mod tests {}`**
+
+Append these tests:
+
+```rust
+    #[test]
+    fn wrap_long_lines_word_wraps_at_limit() {
+        let slide = SlideInput {
+            main: "Ak Boh je za mňa,  kto je proti mne".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Bridge".to_string()),
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        assert_eq!(out.len(), 1);
+        // Should wrap to >=2 lines, each ≤ 32 chars.
+        let lines: Vec<&str> = out[0].main.split('\n').collect();
+        assert!(lines.len() >= 2, "expected wrapping, got: {:?}", lines);
+        for line in &lines {
+            assert!(
+                line.chars().count() <= 32,
+                "wrapped line '{line}' exceeds 32 chars: {}",
+                line.chars().count()
+            );
+        }
+        // The original group should be preserved.
+        assert_eq!(out[0].group.as_deref(), Some("Bridge"));
+    }
+
+    #[test]
+    fn wrap_long_lines_passes_through_short_lines() {
+        let slide = SlideInput {
+            main: "short line\nanother short".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let out = wrap_long_lines(vec![slide.clone()], 32);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, slide.main);
+    }
+
+    #[test]
+    fn wrap_long_lines_hard_breaks_oversize_word() {
+        // Single 50-char word at limit 32 → 2 pieces (32 + 18).
+        let big_word: String = "a".repeat(50);
+        let slide = SlideInput {
+            main: big_word,
+            translation: None,
+            stage: None,
+            group: None,
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        let lines: Vec<&str> = out[0].main.split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].chars().count(), 32);
+        assert_eq!(lines[1].chars().count(), 18);
+    }
+
+    #[test]
+    fn wrap_long_lines_counts_unicode_codepoints_not_bytes() {
+        // Slovak diacritics — each char is one codepoint (multi-byte UTF-8).
+        // 30 'á' chars = 30 codepoints = 60 bytes. At limit 32, this should
+        // pass through (≤ limit by codepoint), not wrap.
+        let line: String = "á".repeat(30);
+        let slide = SlideInput {
+            main: line.clone(),
+            translation: None,
+            stage: None,
+            group: None,
+        };
+        let out = wrap_long_lines(vec![slide], 32);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, line, "30 Slovak codepoints fit at limit 32");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::wrap_long_lines 2>&1 | tail -20
+```
+
+Expected: 4 failures with `cannot find function wrap_long_lines`.
+
+- [ ] **Step 3: Implement `wrap_long_lines`, `wrap_one_line`, `hard_break_into`**
+
+In `crates/presenter-ui/src/utils/song_parser.rs`, after `extract_title` / `pad_title_number` (or near the other public helpers — order is style preference), add:
+
+```rust
+/// Word-aware greedy wrapping per `\n`-separated line, so every line in
+/// every slide's `main` fits within `line_limit` codepoints. Lines that
+/// already fit pass through unchanged. Single words longer than
+/// `line_limit` are hard-broken at the limit boundary. `line_limit == 0`
+/// is treated as "no wrapping" (defensive — keeps signature stable if
+/// the operator clears the setting).
+pub fn wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideInput> {
+    if line_limit == 0 {
+        return slides;
+    }
+    slides
+        .into_iter()
+        .map(|slide| {
+            let wrapped: Vec<String> = slide
+                .main
+                .split('\n')
+                .flat_map(|line| wrap_one_line(line, line_limit))
+                .collect();
+            SlideInput {
+                main: wrapped.join("\n"),
+                ..slide
+            }
+        })
+        .collect()
+}
+
+fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
+    if line.chars().count() <= limit {
+        return vec![line.to_string()];
+    }
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in line.split_whitespace() {
+        let word_len = word.chars().count();
+        if current.is_empty() {
+            if word_len > limit {
+                hard_break_into(&mut out, &mut current, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        } else if current.chars().count() + 1 + word_len <= limit {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            out.push(std::mem::take(&mut current));
+            if word_len > limit {
+                hard_break_into(&mut out, &mut current, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Hard-break an oversize word at codepoint boundaries. Pushes complete
+/// `limit`-sized pieces to `out` and leaves the trailing remainder in
+/// `current` so subsequent words can still accumulate onto the same line.
+fn hard_break_into(out: &mut Vec<String>, current: &mut String, word: &str, limit: usize) {
+    let chars: Vec<char> = word.chars().collect();
+    let mut idx = 0;
+    while chars.len() - idx > limit {
+        let piece: String = chars[idx..idx + limit].iter().collect();
+        out.push(piece);
+        idx += limit;
+    }
+    let remainder: String = chars[idx..].iter().collect();
+    *current = remainder;
+}
+```
+
+- [ ] **Step 4: Verify `SlideInput` is `Clone`**
+
+Open `crates/presenter-ui/src/api/presentations.rs`. The `SlideInput` struct should already derive `Debug, Clone, Serialize, Deserialize`. If `Clone` is missing (one test uses `slide.clone()` for the pass-through case), add it. Run:
+
+```bash
+grep -n "pub struct SlideInput" -A 4 crates/presenter-ui/src/api/presentations.rs
+```
+
+If `Clone` is not in the derive list, add it: `#[derive(Debug, Clone, Serialize, Deserialize)]`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -25
+```
+
+Expected: 25 tests pass (21 from before + 4 new wrap tests).
+
+- [ ] **Step 6: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs crates/presenter-ui/src/api/presentations.rs
+git commit -m "feat(ui): word-wrap long lyric lines at line_limit (#275)
+
+wrap_long_lines applies greedy word-aware wrapping to each \\n-
+separated line in every slide's main, so no line exceeds line_limit
+codepoints. Words longer than line_limit are hard-broken at the
+boundary; their remainders accumulate with subsequent words.
+Counts use chars().count() so Slovak diacritics count as 1 each.
+
+4 new unit tests cover normal word wrap, short-line passthrough,
+oversize-word hard break, and Unicode codepoint counting."
+```
+
+---
+
+## Task 5: chunk_to_two_lines (TDD)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add 4 failing tests inside `mod tests {}`**
+
+```rust
+    #[test]
+    fn chunk_to_two_lines_splits_six_line_section() {
+        let slide = SlideInput {
+            main: "l1\nl2\nl3\nl4\nl5\nl6".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[0].main, "l1\nl2");
+        assert_eq!(out[1].group, None, "second chunk inherits");
+        assert_eq!(out[1].main, "l3\nl4");
+        assert_eq!(out[2].group, None);
+        assert_eq!(out[2].main, "l5\nl6");
+    }
+
+    #[test]
+    fn chunk_to_two_lines_handles_odd_line_count() {
+        let slide = SlideInput {
+            main: "l1\nl2\nl3\nl4\nl5".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Chorus".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].group.as_deref(), Some("Chorus"));
+        assert_eq!(out[0].main, "l1\nl2");
+        assert_eq!(out[1].group, None);
+        assert_eq!(out[1].main, "l3\nl4");
+        assert_eq!(out[2].group, None);
+        assert_eq!(out[2].main, "l5");
+    }
+
+    #[test]
+    fn chunk_to_two_lines_passes_through_short_sections() {
+        let two_line = SlideInput {
+            main: "a\nb".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Verse 1".to_string()),
+        };
+        let one_line = SlideInput {
+            main: "single".to_string(),
+            translation: None,
+            stage: None,
+            group: Some("Tag".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![two_line.clone(), one_line.clone()]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].main, "a\nb");
+        assert_eq!(out[0].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[1].main, "single");
+        assert_eq!(out[1].group.as_deref(), Some("Tag"));
+    }
+
+    #[test]
+    fn chunk_to_two_lines_preserves_empty_interlude() {
+        let slide = SlideInput {
+            main: String::new(),
+            translation: None,
+            stage: None,
+            group: Some("Interlude".to_string()),
+        };
+        let out = chunk_to_two_lines(vec![slide]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].main, "");
+        assert_eq!(out[0].group.as_deref(), Some("Interlude"));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::chunk_to_two_lines 2>&1 | tail -20
+```
+
+Expected: 4 failures with `cannot find function chunk_to_two_lines`.
+
+- [ ] **Step 3: Implement `chunk_to_two_lines`**
+
+In `crates/presenter-ui/src/utils/song_parser.rs`, add after `wrap_long_lines`:
+
+```rust
+/// Split each section's `main` into successive 2-line chunks, emitting
+/// one slide per chunk. The first chunk inherits the original slide's
+/// `group`; subsequent chunks have `group = None` (the operator UI
+/// renders these as `--inherited` from the preceding effective group).
+/// Slides with empty `main` (e.g. an `Interlude` heading with no body)
+/// pass through unchanged.
+pub fn chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    let mut out = Vec::new();
+    for slide in slides {
+        if slide.main.is_empty() {
+            out.push(slide);
+            continue;
+        }
+        let lines: Vec<&str> = slide.main.split('\n').collect();
+        if lines.len() <= 2 {
+            out.push(slide);
+            continue;
+        }
+        let mut first = true;
+        for chunk in lines.chunks(2) {
+            out.push(SlideInput {
+                main: chunk.join("\n"),
+                translation: None,
+                stage: None,
+                group: if first { slide.group.clone() } else { None },
+            });
+            first = false;
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -25
+```
+
+Expected: 29 tests pass (25 from before + 4 new chunk tests).
+
+- [ ] **Step 5: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "feat(ui): chunk sections into 2-line slides (#275)
+
+chunk_to_two_lines splits each section with >2 lines into 2-line
+chunks. The first chunk keeps the original group label; subsequent
+chunks have group=None so the operator UI renders them as inherited
+from the preceding effective group (the existing slide_list.rs
+inheritance rendering handles this automatically).
+
+Empty Interlude slides (group present, main empty) pass through
+unchanged.
+
+4 new unit tests cover even and odd line counts, short-section
+passthrough, and the empty-main case."
+```
+
+---
+
+## Task 6: wrap_with_empty_bookends (TDD)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add 2 failing tests inside `mod tests {}`**
+
+```rust
+    #[test]
+    fn wrap_with_empty_bookends_adds_front_and_back() {
+        let slides = vec![
+            SlideInput {
+                main: "a".to_string(),
+                translation: None,
+                stage: None,
+                group: Some("Verse 1".to_string()),
+            },
+            SlideInput {
+                main: "b".to_string(),
+                translation: None,
+                stage: None,
+                group: None,
+            },
+        ];
+        let out = wrap_with_empty_bookends(slides);
+        assert_eq!(out.len(), 4);
+        // First and last are empty.
+        assert_eq!(out[0].main, "");
+        assert!(out[0].group.is_none());
+        assert_eq!(out[3].main, "");
+        assert!(out[3].group.is_none());
+        // Middle slides preserved.
+        assert_eq!(out[1].main, "a");
+        assert_eq!(out[1].group.as_deref(), Some("Verse 1"));
+        assert_eq!(out[2].main, "b");
+    }
+
+    #[test]
+    fn wrap_with_empty_bookends_skips_empty_input() {
+        let out = wrap_with_empty_bookends(vec![]);
+        assert!(out.is_empty(), "no bookends on empty input");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser::tests::wrap_with_empty_bookends 2>&1 | tail -15
+```
+
+Expected: 2 failures with `cannot find function wrap_with_empty_bookends`.
+
+- [ ] **Step 3: Implement `wrap_with_empty_bookends`**
+
+In `crates/presenter-ui/src/utils/song_parser.rs`, add after `chunk_to_two_lines`:
+
+```rust
+/// Prepend and append an empty `SlideInput` to the list, matching the
+/// worship-service convention of starting and ending on a blank slide.
+/// An empty input passes through unchanged so we don't emit two empty
+/// slides for an empty paste.
+pub fn wrap_with_empty_bookends(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    if slides.is_empty() {
+        return slides;
+    }
+    let empty = || SlideInput {
+        main: String::new(),
+        translation: None,
+        stage: None,
+        group: None,
+    };
+    let mut out = Vec::with_capacity(slides.len() + 2);
+    out.push(empty());
+    out.extend(slides);
+    out.push(empty());
+    out
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -25
+```
+
+Expected: 31 tests pass.
+
+- [ ] **Step 5: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "feat(ui): wrap slide list with empty bookends (#275)
+
+wrap_with_empty_bookends prepends and appends an empty SlideInput
+to a non-empty slide list, matching the worship-service convention
+of starting and ending on a blank slide. An empty input passes
+through unchanged so an empty paste does not produce two empty
+slides.
+
+2 new unit tests cover the wrap and the empty-input passthrough."
+```
+
+---
+
+## Task 7: End-to-end pipeline regression test
+
+**Files:**
+- Modify: `crates/presenter-ui/src/utils/song_parser.rs`
+
+- [ ] **Step 1: Add the end-to-end pipeline test**
+
+Append inside `mod tests {}`:
+
+```rust
+    #[test]
+    fn pipeline_user_76_arriba_paste_produces_correct_output() {
+        // Regression guard for issue #275 follow-up. Exercises the full
+        // pipeline (extract_title + parse + wrap_long_lines + chunk +
+        // bookends) on the user's canonical spevnik export.
+        let input = "Title: 76 Arriba\n\
+                     Misc 1\n\
+                     \n\
+                     Verse 1\n\
+                     Môj Boh je nekonečný\n\
+                     Má všetku moc a je večný\n\
+                     Jeho Duch vo mne je živý\n\
+                     A všetko pre mňa učiní\n\
+                     \n\
+                     Pre-Chorus\n\
+                     Žehná ma žehná\n\
+                     Priazeñ nad priazeň\n\
+                     A padá to na mňa, padá na mňa\n\
+                     Žehná ma žehná\n\
+                     Priazeň nad priazeň\n\
+                     A tá ku mne prúdi, ku mne prúdi\n\
+                     \n\
+                     Chorus\n\
+                     Jeden dva tri\n\
+                     Zakrič On je najlepší\n\
+                     Jeden dva tri\n\
+                     Ja som v ňom požehnaný\n\
+                     Jeden dva tri\n\
+                     Všetka sláva Jemu, v Ňom\n\
+                     Ja som tým, kým hovorí že som\n\
+                     Jeden dva tri\n\
+                     \n\
+                     Verse 2\n\
+                     Ja vidím veci na nebi\n\
+                     Tie zmeny sú aj na zemi\n\
+                     Jeho Duch vo mne je živý\n\
+                     Nie je nič čo neučiní\n\
+                     \n\
+                     Bridge\n\
+                     Ak Boh je za mňa,  kto je proti mne\n\
+                     Ja chválim Ho, ja chválim Ho\n\
+                     Misc 1\n";
+
+        // Title extraction with 2-digit padding.
+        let name = extract_title(input);
+        assert_eq!(name.as_deref(), Some("076 Arriba"));
+
+        // Run the full pipeline at line_limit 32.
+        let slides = parse_song_text(input);
+        let slides = wrap_long_lines(slides, 32);
+        let slides = chunk_to_two_lines(slides);
+        let slides = wrap_with_empty_bookends(slides);
+
+        // Total: empty + 13 lyric chunks + empty = 15.
+        assert_eq!(
+            slides.len(),
+            15,
+            "expected 15 slides, got {}: {:#?}",
+            slides.len(),
+            slides
+        );
+
+        // Bookends.
+        assert_eq!(slides[0].main, "");
+        assert!(slides[0].group.is_none(), "first bookend has no group");
+        assert_eq!(slides[14].main, "");
+        assert!(slides[14].group.is_none(), "last bookend has no group");
+
+        // First content slide is Verse 1, chunk 1.
+        assert_eq!(slides[1].group.as_deref(), Some("Verse 1"));
+
+        // Inherited groups: chunks 2+ of any section have group=None.
+        assert_eq!(slides[2].group, None, "Verse 1 chunk 2 inherits");
+
+        // Pre-Chorus first chunk is at index 3.
+        assert_eq!(slides[3].group.as_deref(), Some("Pre-Chorus"));
+
+        // Chorus first chunk is at index 6 (after Pre-Chorus's 3 chunks).
+        assert_eq!(slides[6].group.as_deref(), Some("Chorus"));
+
+        // Verse 2 first chunk is at index 10 (after Chorus's 4 chunks).
+        assert_eq!(slides[10].group.as_deref(), Some("Verse 2"));
+
+        // Bridge first chunk is at index 12 (after Verse 2's 2 chunks).
+        // Bridge's first input line was 35 chars at limit 32, so it
+        // wrapped — the chunked first slide may have either parts of
+        // the wrapped first line OR the wrapped line + the second line.
+        // Asserting its group + that all lines fit is enough.
+        assert_eq!(slides[12].group.as_deref(), Some("Bridge"));
+
+        // No content slide should contain Title:, Misc, ^B, or any line
+        // longer than line_limit (32). Bookends excluded.
+        for (idx, slide) in slides.iter().enumerate() {
+            assert!(
+                !slide.main.contains("Title:"),
+                "slide {idx} leaked 'Title:': {:?}",
+                slide.main
+            );
+            assert!(
+                !slide.main.to_ascii_lowercase().contains("misc "),
+                "slide {idx} leaked 'Misc': {:?}",
+                slide.main
+            );
+            assert!(
+                !slide.main.contains("^B"),
+                "slide {idx} leaked '^B': {:?}",
+                slide.main
+            );
+            for line in slide.main.split('\n') {
+                assert!(
+                    line.chars().count() <= 32,
+                    "slide {idx} line '{line}' exceeds 32 chars (line_limit)"
+                );
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -30
+```
+
+Expected: 32 tests pass (31 from before + 1 new pipeline test). If the pipeline test fails, read its output carefully — it lists actual slide count and contents in the failure message.
+
+- [ ] **Step 3: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/utils/song_parser.rs
+git commit -m "test(ui): end-to-end pipeline regression for spevnik 76 Arriba paste (#275)
+
+Asserts the full pipeline (extract_title + parse_song_text +
+wrap_long_lines + chunk_to_two_lines + wrap_with_empty_bookends)
+on the user's canonical spevnik export produces:
+
+- Presentation name '076 Arriba' (76 padded to 076)
+- 15 slides total (empty bookend + 13 lyric chunks + empty bookend)
+- Verse 1 / Pre-Chorus / Chorus / Verse 2 / Bridge groups at the
+  expected indices
+- No metadata leakage (no 'Title:', no 'Misc', no '^B' in any slide)
+- No line exceeds line_limit (32) in any slide"
+```
+
+---
+
+## Task 8: Wire the pipeline into on_paste_confirm
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/presentation_modal.rs:230-292`
+
+- [ ] **Step 1: Replace the `on_paste_confirm` body**
+
+Open `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/presentation_modal.rs`. Find the `let on_paste_confirm = { ... };` block (starts around line 230). Replace its inner closure body with:
+
+```rust
+    let on_paste_confirm = {
+        let op = op.clone();
+        move |_| {
+            let lib_id = match ctx.selected_library_id.get_untracked() {
+                Some(id) => id,
+                None => return,
+            };
+            let text = op.paste_text.get_untracked();
+            let line_limit = op.line_limit.get_untracked() as usize;
+
+            // Title from the paste always wins; fallback to "Untitled" if
+            // the paste has no Title: line (operator can rename via the
+            // existing rename flow after creation).
+            let name = crate::utils::song_parser::extract_title(&text)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Untitled".to_string());
+
+            // Run the full pipeline.
+            let slides = crate::utils::song_parser::parse_song_text(&text);
+            let slides = crate::utils::song_parser::wrap_long_lines(slides, line_limit);
+            let slides = crate::utils::song_parser::chunk_to_two_lines(slides);
+            let slides = crate::utils::song_parser::wrap_with_empty_bookends(slides);
+
+            if slides.is_empty() {
+                return;
+            }
+            op.submitting.set(true);
+
+            let presentations = ctx.presentations;
+            let libraries = ctx.libraries;
+            let selected_pres_id = ctx.selected_presentation_id;
+            let selected_pres = ctx.selected_presentation;
+            let toast_message = ctx.toast_message;
+            let toast_variant = ctx.toast_variant;
+            let submitting = op.submitting;
+            let open_modal = op.open_modal;
+            let modal_target = op.modal_target_id;
+
+            leptos::task::spawn_local(async move {
+                match crate::api::presentations::create_from_paste(&lib_id, &name, slides).await {
+                    Ok(resp) => {
+                        let new_id = resp.presentation.id.to_string();
+                        selected_pres_id.set(Some(new_id.clone()));
+                        selected_pres.set(Some(resp.presentation));
+                        crate::state::session::set("currentPresentationId", &new_id);
+
+                        if let Some(summary) = resp.library_summary {
+                            presentations.set(summary.presentations);
+                        }
+                        if let Ok(libs) = crate::api::libraries::list_libraries().await {
+                            libraries.set(libs);
+                        }
+
+                        toast_variant.set("success".to_string());
+                        toast_message.set(Some("Presentation created from paste".to_string()));
+                    }
+                    Err(e) => {
+                        toast_variant.set("error".to_string());
+                        toast_message.set(Some(format!("Error: {e}")));
+                    }
+                }
+
+                submitting.set(false);
+                open_modal.set(None);
+                modal_target.set(None);
+                if let Some(body) = crate::utils::window::document_body() {
+                    body.dataset().delete("modalOpen");
+                }
+            });
+        }
+    };
+```
+
+The key changes vs the existing code:
+- Title comes from `extract_title(&text)`, NOT from `create_name.get_untracked()`.
+- After `parse_song_text`, the slides flow through `wrap_long_lines(.., line_limit)` → `chunk_to_two_lines` → `wrap_with_empty_bookends`.
+- `op.line_limit.get_untracked() as usize` is read once at confirm time.
+
+- [ ] **Step 2: Run a full UI build to check compilation**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo check --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean compile (no errors).
+
+- [ ] **Step 3: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/components/presentation_modal.rs
+git commit -m "feat(ui): wire song_parser pipeline into paste-confirm (#275)
+
+on_paste_confirm now uses extract_title for the presentation name
+(falls back to 'Untitled' if no Title:) and runs the slide pipeline
+parse_song_text -> wrap_long_lines(line_limit) -> chunk_to_two_lines
+-> wrap_with_empty_bookends. The operator's line_limit is read once
+at confirm time. The modal's typed name is ignored on the paste
+flow — Title: from the paste always wins."
+```
+
+---
+
+## Task 9: Hide name input on the paste sub-screen
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/presentation_modal.rs:447-459`
+
+- [ ] **Step 1: Wrap the name input's `<label>` with conditional `style:display`**
+
+In `presentation_modal.rs`, find the `<label>` enclosing the `data-role="presentation-create-name"` input (around line 448-459). Replace it with:
+
+```rust
+                        <label style:display=move || if create_step.get() == "paste" { "none" } else { "block" }>
+                            <span>"Presentation name"</span>
+                            <input
+                                type="text"
+                                data-role="presentation-create-name"
+                                autocomplete="off"
+                                maxlength="160"
+                                placeholder="New Presentation"
+                                prop:value=move || create_name.get()
+                                on:input=move |ev| create_name.set(event_target_value(&ev))
+                            />
+                        </label>
+```
+
+The only change is adding `style:display=move || if create_step.get() == "paste" { "none" } else { "block" }` to the `<label>`. Everything inside the label is unchanged.
+
+- [ ] **Step 2: Run a full UI build**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo check --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean compile.
+
+- [ ] **Step 3: Run clippy + fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui
+cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5
+cargo fmt
+```
+
+Expected: clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/components/presentation_modal.rs
+git commit -m "feat(ui): hide presentation name input on paste sub-screen (#275)
+
+When create_step == 'paste', the name input is hidden — the paste
+flow gets the name from the Title: line in the paste. The input
+stays visible for Blank and Import sub-flows where the user must
+type a name."
+```
+
+---
+
+## Task 10: Update E2E test to canonical spevnik paste
+
+**Files:**
+- Modify: `tests/e2e/wasm-presentation-crud.spec.ts:430` (the existing `paste with section headers splits one slide per section (#275)` test from PR #277)
+
+- [ ] **Step 1: Replace the existing test body**
+
+Open `/home/newlevel/devel/presenter/presenter-dev2/tests/e2e/wasm-presentation-crud.spec.ts`. Find the test starting at line ~430:
+
+```typescript
+  test("paste with section headers splits one slide per section (#275)", async ({
+    page,
+  }) => {
+```
+
+Replace the **entire `test(...)` block** (from `// Regression guard...` comment down through the closing `});`) with:
+
+```typescript
+  // Regression guard for issue #275 follow-up: full pipeline on a
+  // spevnik song export must produce the right name + correctly
+  // chunked slides + empty bookends.
+  test("paste pipeline produces named presentation with bookends (#275)", async ({
+    page,
+  }) => {
+    await selectLibrary(page);
+
+    // Open the create modal.
+    await page
+      .locator('[data-view-panel="worship"] [data-role="presentation-create"]')
+      .click();
+    await page.waitForFunction(
+      () =>
+        document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 5_000 },
+    );
+
+    // Click "Paste" to enter paste sub-screen.
+    await page.locator('[data-role="presentation-create-paste"]').click();
+    await expect(
+      page.locator('[data-role="presentation-create-paste-area"]'),
+    ).toBeVisible();
+
+    // Name input must be hidden on the paste sub-screen.
+    await expect(
+      page.locator('[data-role="presentation-create-name"]'),
+    ).toBeHidden();
+
+    // Canonical spevnik song export — no leading blank line, Title:
+    // populates the presentation name, Misc 1 lines are filtered, and
+    // each section gets chunked to ≤ 2 lines with empty bookends.
+    const userInput = `Title: 76 Arriba
+Misc 1
+
+Verse 1
+Môj Boh je nekonečný
+Má všetku moc a je večný
+Jeho Duch vo mne je živý
+A všetko pre mňa učiní
+
+Pre-Chorus
+Žehná ma žehná
+Priazeñ nad priazeň
+A padá to na mňa, padá na mňa
+Žehná ma žehná
+Priazeň nad priazeň
+A tá ku mne prúdi, ku mne prúdi
+
+Chorus
+Jeden dva tri
+Zakrič On je najlepší
+Jeden dva tri
+Ja som v ňom požehnaný
+Jeden dva tri
+Všetka sláva Jemu, v Ňom
+Ja som tým, kým hovorí že som
+Jeden dva tri
+
+Verse 2
+Ja vidím veci na nebi
+Tie zmeny sú aj na zemi
+Jeho Duch vo mne je živý
+Nie je nič čo neučiní
+
+Bridge
+Ak Boh je za mňa,  kto je proti mne
+Ja chválim Ho, ja chválim Ho
+Misc 1`;
+
+    await page
+      .locator('[data-role="presentation-create-paste-text"]')
+      .fill(userInput);
+    await page
+      .locator('[data-role="presentation-create-paste-confirm"]')
+      .click();
+
+    // Modal closes.
+    await page.waitForFunction(
+      () =>
+        !document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 10_000 },
+    );
+
+    // Wait for the new presentation to render with all 15 slides.
+    await page.waitForFunction(
+      () => {
+        const slides = document.querySelector(
+          '[data-view-panel="worship"] [data-role="slides"]',
+        );
+        return (
+          slides && slides.querySelectorAll("[data-slide-id]").length === 15
+        );
+      },
+      { timeout: 15_000 },
+    );
+
+    // Read all slide group + main pairs.
+    const slidePairs = await page.evaluate(() => {
+      const slides = Array.from(
+        document.querySelectorAll(
+          '[data-view-panel="worship"] [data-role="slides"] [data-slide-id]',
+        ),
+      );
+      return slides.map((slide) => {
+        const groupEl = slide.querySelector('[data-role="slide-group"]');
+        const mainEl = slide.querySelector('[data-field-display="main"]');
+        return {
+          group: (groupEl?.textContent || "").trim(),
+          main: (mainEl?.textContent || "").trim(),
+        };
+      });
+    });
+
+    // 15 slides total — empty bookend + 13 lyric chunks + empty bookend.
+    expect(slidePairs).toHaveLength(15);
+
+    // Bookends are empty.
+    expect(slidePairs[0].main).toBe("");
+    expect(slidePairs[0].group).toBe("");
+    expect(slidePairs[14].main).toBe("");
+    expect(slidePairs[14].group).toBe("");
+
+    // First chunk of each section carries the section header.
+    expect(slidePairs[1].group).toBe("Verse 1");
+    expect(slidePairs[3].group).toBe("Pre-Chorus");
+    expect(slidePairs[6].group).toBe("Chorus");
+    expect(slidePairs[10].group).toBe("Verse 2");
+    expect(slidePairs[12].group).toBe("Bridge");
+
+    // No slide should leak metadata.
+    for (const slide of slidePairs) {
+      expect(slide.main).not.toMatch(/Title:/);
+      expect(slide.main).not.toMatch(/Misc 1/);
+      expect(slide.main).not.toContain("^B");
+    }
+
+    // No content slide may contain a line longer than 32 characters
+    // (the default line_limit). Bookends excluded (already asserted empty).
+    for (let i = 1; i <= 13; i++) {
+      const lines = slidePairs[i].main.split("\n");
+      for (const line of lines) {
+        // Use Array.from for accurate codepoint count of Slovak diacritics.
+        const len = Array.from(line).length;
+        expect(len).toBeLessThanOrEqual(
+          32,
+          `slide ${i} line "${line}" is ${len} chars (over 32)`,
+        );
+      }
+    }
+
+    // Verify the presentation name in the operator UI matches the padded
+    // Title (076 Arriba). The name appears in the worship-panel header
+    // for the selected presentation.
+    const presName = await page
+      .locator('[data-view-panel="worship"] [data-role="presentation-title"]')
+      .textContent();
+    expect(presName?.trim()).toBe("076 Arriba");
+  });
+```
+
+Key new assertions vs the previous test:
+- Name input is hidden on the paste sub-screen.
+- Slide count is exactly **15** (was 3).
+- Bookends at index 0 and 14 are empty.
+- Section headers appear at the right indices (Verse 1 at 1, Pre-Chorus at 3, etc.).
+- No content slide has a line over 32 chars.
+- Presentation name in the operator UI is `"076 Arriba"`.
+
+If the test selector for the presentation name (`[data-role="presentation-title"]`) doesn't exist in the codebase, find the actual selector:
+
+```bash
+grep -rn 'presentation-title\|presentation-name\|data-role="title"\|selected.*name' crates/presenter-ui/src/components/ | head -10
+```
+
+Use whatever role the operator's worship panel uses to render the active presentation's name.
+
+- [ ] **Step 2: Verify the test compiles by running it locally against the live dev server**
+
+The local dev server runs at `http://10.77.8.134:8080`. We point Playwright at it without spawning a new server (the build will be replaced after deploy):
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+PRESENTER_E2E_BASE_URL=http://10.77.8.134:8080 npx playwright test wasm-presentation-crud.spec.ts -g "paste pipeline produces" --reporter=line 2>&1 | tail -25
+```
+
+If the dev server's deployed binary is OLDER than the new pipeline (i.e., this task is run before Task 8 + 9 + a fresh trunk + cargo build), the test SHOULD fail (pre-deploy: 5 slides instead of 15). That's expected. The test passes after the full deploy.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add tests/e2e/wasm-presentation-crud.spec.ts
+git commit -m "test(e2e): replace #275 paste test with full pipeline regression (#275)
+
+Replaces the previous 'section headers splits one slide per section'
+test with a full pipeline regression on the user's canonical spevnik
+export. Asserts:
+
+- Name input is hidden on the paste sub-screen
+- Presentation name is '076 Arriba' (Title prefix padded to 3 digits)
+- 15 slides total (empty bookend + 13 lyric chunks + empty bookend)
+- Section headers (Verse 1, Pre-Chorus, Chorus, Verse 2, Bridge)
+  appear at the expected indices
+- No metadata (Title:, Misc 1, ^B) leaks into any slide
+- No content slide contains a line over 32 chars (line_limit default)"
+```
+
+---
+
+## Task 11: Local checks, push, monitor pipeline
+
+- [ ] **Step 1: Final local sanity sweep**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check && echo "WORKSPACE FMT OK"
+cd crates/presenter-ui && cargo fmt --check && echo "UI FMT OK" && cd ../..
+cd crates/presenter-ui && cargo test --target x86_64-unknown-linux-gnu --lib song_parser 2>&1 | tail -15 && cd ../..
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings 2>&1 | tail -5 && cd ../..
+```
+
+Expected: all 4 commands succeed. Total `song_parser` tests: 32 (10 pre-existing + 22 new).
+
+If any fail, fix in ONE more commit before pushing.
+
+- [ ] **Step 2: Push to origin/dev**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git status -sb
+git push origin dev
+```
+
+The push should be `Bypassed rule violations for refs/heads/dev` followed by the commit-range push. It auto-triggers Pipeline + PR Automation.
+
+- [ ] **Step 3: Identify the new pipeline run and monitor**
+
+```bash
+gh run list --branch dev --limit 2 --json databaseId,name,status,headSha
+```
+
+Note the `databaseId` of the new `Pipeline` run for the latest pushed `headSha`.
+
+Monitor with a single non-polling background sleep + check (per `~/devel/airuleset/modules/core/ci-monitoring.md` — DO NOT use `gh run watch`, DO NOT poll in tight loops):
+
+```bash
+sleep 600 && gh run view <DATABASE_ID> --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Run as a background task. Re-poll every ~6-12 minutes until `status == "completed"`.
+
+- [ ] **Step 4: When pipeline completes, verify all 20 jobs are SUCCESS**
+
+```bash
+gh run view <DATABASE_ID> --json status,conclusion,jobs --jq '{status, conclusion, allSuccess: ([.jobs[] | .conclusion=="success"] | all)}'
+```
+
+Expected: `{"status":"completed","conclusion":"success","allSuccess":true}`. If any job failed:
+
+```bash
+gh run view <DATABASE_ID> --log-failed | tail -100
+```
+
+Fix in ONE commit, push, monitor again. Do NOT rerun-without-fix. Do NOT skip mutation testing.
+
+- [ ] **Step 5: Verify dev deployment is live**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.47"}`.
+
+Then open the dashboard in Playwright (per `post-deploy-verification.md` — version label MUST come from the live DOM, not just curl):
+
+```bash
+# Use the Playwright MCP tools available in this session:
+# 1. mcp__plugin_playwright_playwright__browser_navigate to http://10.77.8.134:8080/ui/operator
+# 2. mcp__plugin_playwright_playwright__browser_evaluate to read the
+#    version label from the DOM and confirm it's v0.4.47 (dev).
+# 3. Use the parseSongText / extract_title bridges if useful for further
+#    sanity checks; the E2E test in CI already proved end-to-end.
+```
+
+If everything is green and the dev frontend shows `v0.4.47 (dev)`, work is done.
+
+- [ ] **Step 6: Confirm PR #277 is mergeable + clean**
+
+```bash
+gh api repos/zbynekdrlik/presenter/pulls/277 --jq '{mergeable, mergeable_state, head_sha: .head.sha}'
+```
+
+Expected: `{"mergeable":true,"mergeable_state":"clean", ...}`.
+
+DO NOT merge. The user merges via explicit "merge it" instruction per `pr-merge-policy.md`.
+
+- [ ] **Step 7: Send the completion report**
+
+Use the EXACT template from `~/devel/airuleset/modules/core/completion-report.md`. Required lines:
+
+```
+## ✅ Work Complete
+
+**Audits & deploy:**
+✅ CI: pipeline <run-id> — 20/20 jobs green
+✅ /plan-check: N/N fulfilled
+✅ /review: clean — 0 🔴 0 🟡 0 🔵
+✅ Deploy: dev frontend shows v0.4.47 (dev) (matches /healthz)
+
+---
+
+**Goal:** <one-sentence restatement of the user's ask in plain language>
+**What changed:** <user-visible outcome, 1-2 sentences>
+
+🌐 Dev:  http://10.77.8.134:8080/ui/operator
+🌐 Prod: http://10.77.9.205/ui/operator
+
+**[presenter] PR #277: <full PR title>**
+https://github.com/zbynekdrlik/presenter/pull/277 — mergeable, clean
+```
+
+If `/plan-check` or `/review` (per `completion-report.md`'s pre-completion gate) returns ANY findings — 🔴, 🟡, or 🔵 inside this PR's diff — fix them in additional commits and re-run BEFORE sending the completion report. The 🔵 "deferred" loophole is closed.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Title extraction works | `extract_title("Title: 76 Arriba")` → `Some("076 Arriba")` |
+| Padding rule | 1-3 digit prefix + space → 3-digit zero-pad; 4+ digits or no space → unchanged |
+| Control char strip | `\x02`, BOM, ZWSP removed; line of just `\x02` skipped silently |
+| Word wrap at line_limit | All wrapped lines ≤ line_limit codepoints; oversize words hard-broken |
+| 2-line chunking | Sections > 2 lines split; first chunk keeps group, rest have None |
+| Bookends | Non-empty input gets empty front + back; empty input stays empty |
+| Modal name input visibility | Hidden when `create_step == "paste"`, visible otherwise |
+| Pipeline regression test | 76 Arriba paste → name `"076 Arriba"`, 15 slides, no warnings, no metadata leakage |
+| E2E green | `wasm-presentation-crud.spec.ts` `paste pipeline produces named presentation with bookends (#275)` passes in CI |
+| All existing tests still green | 10 pre-existing song_parser tests, plus the existing wasm-edge-cases parseSongText E2E, all pass unchanged |
+| CI green | All 20 pipeline jobs SUCCESS (incl. Mutation Testing, Coverage, all 3 E2E shards, Deploy to Dev) |
+| Dev shows v0.4.47 | `/healthz` reports `0.4.47`; operator UI shows `v0.4.47 (dev)` in DOM |

--- a/docs/superpowers/specs/2026-04-29-clipboard-import-section-split-design.md
+++ b/docs/superpowers/specs/2026-04-29-clipboard-import-section-split-design.md
@@ -1,0 +1,107 @@
+# Clipboard Import: Split Slides by Section Markers — Design
+
+**Date:** 2026-04-29
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM), one new module + one tiny call-site update + tests
+
+**Issue:** [#275 — clipboard import puts a lot of lines into one slide when it should be two](https://github.com/zbynekdrlik/presenter/issues/275)
+
+## Goal
+
+Make the operator's "create presentation from paste" feature split a pasted song into one slide per section (`Verse N`, `Chorus`, `Bridge`, `Outro`, `Interlude`, etc.), instead of only splitting on blank lines. Filter out ProPresenter-style metadata markers (`Title:`, `Misc N`, `^B`) so they don't pollute the slide content.
+
+## Bug
+
+`parse_song_text` (currently in `crates/presenter-ui/src/utils/test_helpers.rs:380-414` despite being production code) splits the input by `\n\n` and only treats the FIRST line of each blank-line-separated block as a possible group name.
+
+The user's example input begins:
+```
+Title: 326 Všetko, čo v sebe držím
+Misc 1
+^B
+Verse 1
+[verse text…]
+
+Chorus
+[chorus text…]
+```
+
+The whole `Title: … Verse 1 [verse text]` block is one paragraph (no internal blank line), so the parser produces ONE slide whose `main` is the entire literal block including the `Title:`, `Misc 1`, `^B`, and the section heading `Verse 1`. The user expects each section heading to start a new slide.
+
+## Approach
+
+Rewrite as a line-walk parser. For each line in the input:
+
+1. **Metadata line** → filter (skip silently). Recognized:
+   - `Title:` prefix (case-insensitive)
+   - `Misc <digits>` (case-insensitive, e.g. `Misc 1`, `MISC 12`)
+   - `^<UPPER>` ProPresenter control marker (e.g. `^B`, `^A`, `^C`) — exactly one caret + one uppercase ASCII letter
+2. **Group line** (the existing `is_group_line` list: Verse, Chorus, Bridge, Intro, Outro, Pre-chorus / Prechorus, Tag, Interlude, Refrain, Hook, Coda, Ending, Instrumental, with optional trailing number) → **flush the current slide** then start a new slide with this line as the group name.
+3. **Blank line** → if the current slide has any content (group or main lines), **flush it**. Otherwise ignore.
+4. **Anything else** → append the original line (preserving its leading whitespace) to the current slide's `main` lines.
+
+After the loop, flush any remaining slide.
+
+**Flush rule:** join collected `main` lines with `\n`, trim trailing whitespace. Skip the slide entirely only if both `group` is `None` AND the trimmed `main` is empty (defends against producing empty slides from leading filter-only lines or stacked blank lines). A slide with `group = Some(...)` and empty main IS kept (e.g., `Interlude` heading with no lyrics produces a "title-only" slide — matches ProPresenter behavior).
+
+### Walk-through on the user's input
+
+| Line | Trigger | Effect |
+|------|---------|--------|
+| `Title: 326 …` | metadata | skip |
+| `Misc 1` | metadata | skip |
+| `^B` | metadata | skip |
+| `Verse 1` | group | flush (empty, skip) → start slide{group="Verse 1"} |
+| `Všetko…` | text | append |
+| `…porovnávať!` | text | append |
+| `Ty ma chceš…` | text | append |
+| (blank) | blank | flush slide{group="Verse 1", main="Všetko…\n…\nTy ma chceš…"} |
+| `Chorus` | group | start slide{group="Chorus"} |
+| `Mám Spasiteľa…` | text | append |
+| … | … | … |
+| `Outro` | group | flush prev, start slide{group="Outro"} |
+| `Nikto mi Ťa…` | text | append |
+| `Misc 1` | metadata | skip |
+| `^B` | metadata | skip |
+| EOF | flush | flush slide{group="Outro", main="Nikto…\nNikto…"} |
+
+Result: 8 slides (Verse 1, Chorus, Verse 2, Chorus, Chorus, Interlude, Chorus, Chorus, Outro — matching the user's input structure).
+
+## File structure
+
+| File | Change |
+|------|--------|
+| `crates/presenter-ui/src/utils/song_parser.rs` | **NEW.** Public `parse_song_text(text: &str) -> Vec<SlideInput>` plus private helpers `is_group_line`, `is_metadata_line`. Includes `SlideInput` re-export or struct definition (whichever matches the existing pattern). |
+| `crates/presenter-ui/src/utils/mod.rs` | Add `pub mod song_parser;` |
+| `crates/presenter-ui/src/utils/test_helpers.rs` | Remove `parse_song_text` and `is_group_line`. Keep the rest. |
+| `crates/presenter-ui/src/components/presentation_modal.rs` | Update line 244: `crate::utils::test_helpers::parse_song_text` → `crate::utils::song_parser::parse_song_text` |
+
+`SlideInput` is currently defined in `crates/presenter-ui/src/api/presentations.rs`. The new `song_parser.rs` will import it from there (same as `test_helpers.rs` does today).
+
+## Testing
+
+Unit tests in `song_parser.rs` covering:
+
+1. **User's exact pasted input** → produces 9 slides with the right groups and lyrics, no `Title:` / `Misc 1` / `^B` text in any slide. (Regression guard for the bug.)
+2. **Mid-paragraph group split** — `Verse 1\nlyric\nChorus\nlyric` (no blank line between Verse and Chorus) → 2 slides.
+3. **Metadata filtering** — `Title: foo\n\nVerse 1\nlyric` → 1 slide, no `Title:`.
+4. **`^B` and `^A` control codes filtered**, but a literal `^` line (no letter) NOT filtered (just text).
+5. **`Misc N` filtered**, but a line that starts with `Miscellaneous` (longer word) NOT filtered.
+6. **Empty Interlude** — `Interlude\n\nChorus\nlyric` → 2 slides; first one has `group="Interlude", main=""`.
+7. **Loose paragraphs without groups** — `Stanza 1\nline 2\n\nStanza 3\nline 4` → 2 slides, no group, preserves old behavior.
+8. **Whitespace handling** — leading/trailing blanks, leading indentation on lyric lines (preserved within main).
+9. **Empty input / whitespace-only input** → empty `Vec`.
+10. **Group line case-insensitivity** — `chorus`, `CHORUS`, `Chorus 2` all detected.
+
+## Risks / unknowns
+
+- The existing `is_group_line` list might be incomplete for edge cases (e.g., songs with a `Bridge` numbered as `Bridge 2` — already handled by the trailing-digit-or-whitespace check in the current code). If the user reports another song that misparses, expand the list in a follow-up.
+- `^B` / `^A` filtering uses the strict pattern `^[A-Z]` (caret + one ASCII uppercase). Lines like `^B12` (caret + uppercase + digits) are NOT filtered — they fall through as text. If real-world ProPresenter exports include such variants, we add them later.
+- `parse_song_text` is currently re-exported via `__presenterOperatorTestHelpers` for E2E test access (test_helpers.rs:340-342 area). If any E2E test uses `window.__presenterOperatorTestHelpers.parse_song_text`, the move could break it — verify with grep before committing.
+
+## Out of scope
+
+- Multi-line group headers (e.g., `Verse 1 (Bridge variant)` — treated as a regular line if not caught by `is_group_line`).
+- Auto-detection of "this is a song" vs "this is a sermon" — always uses the song-style parser. Other parsers stay unwritten unless asked.
+- Improving the textarea UI in `presentation_modal.rs` (placeholder text, formatting hints). The bug is purely in the parser.
+- Changing the server-side `create_from_paste` API.

--- a/docs/superpowers/specs/2026-04-30-clipboard-import-followup-design.md
+++ b/docs/superpowers/specs/2026-04-30-clipboard-import-followup-design.md
@@ -9,7 +9,7 @@
 
 Make the operator's "create presentation from paste" flow do the right thing for spevnik song exports:
 
-1. Use the pasted `Title:` line as the presentation **name** (always wins; modal name input hidden in the paste sub-screen; fallback `"Untitled"` if no `Title:`).
+1. Use the pasted `Title:` line as the presentation **name** (always wins; modal name input hidden in the paste sub-screen; fallback `"Untitled"` if no `Title:`). Pad a leading numeric prefix in the title to 3 digits with leading zeros (e.g., `76 Arriba` → `076 Arriba`) so songs sort correctly in the operator's library list.
 2. **Word-wrap** any lyric line longer than the operator's `line_limit` (default 32 chars) so no slide triggers the "Line exceeds N characters" warning.
 3. Chunk each section's lyrics into slides of **at most 2 lines** each.
 4. Strip Unicode control characters (`Cc`) and zero-width characters from every line so stray bytes don't pollute slides.
@@ -57,7 +57,7 @@ Ja chválim Ho, ja chválim Ho
 Misc 1
 ```
 
-Expected output: presentation name `"76 Arriba"`, **15 slides** total — empty bookend, then 13 lyric slides each with ≤ 2 lines and no line exceeding `line_limit`, then empty bookend. Every slide displays without the `!` warning superscript.
+Expected output: presentation name `"076 Arriba"` (numeric prefix padded to 3 digits), **15 slides** total — empty bookend, then 13 lyric slides each with ≤ 2 lines and no line exceeding `line_limit`, then empty bookend. Every slide displays without the `!` warning superscript.
 
 ## Architecture
 
@@ -83,21 +83,49 @@ The modal calls these functions in `on_paste_confirm`, reads `line_limit` from `
 
 ### `extract_title(text: &str) -> Option<String>`
 
-Scans lines top-to-bottom, returns the trimmed content after the first case-insensitive `Title:` prefix. Returns `None` if no `Title:` line is found.
+Scans lines top-to-bottom, returns the trimmed content after the first case-insensitive `Title:` prefix, with the leading numeric prefix padded to 3 digits via `pad_title_number`. Returns `None` if no `Title:` line is found.
 
 ```rust
 pub fn extract_title(text: &str) -> Option<String> {
     text.lines().find_map(|line| {
         let trimmed = line.trim();
         let lower = trimmed.to_ascii_lowercase();
-        lower.strip_prefix("title:").map(|rest| rest.trim().to_string())
+        if !lower.starts_with("title:") {
+            return None;
+        }
+        let raw = trimmed[6..].trim(); // 6 = len("title:")
+        Some(pad_title_number(raw))
     })
+}
+
+/// Pad a leading 1-3 digit numeric prefix (followed by whitespace) to 3
+/// digits with leading zeros. Leaves 4+ digit prefixes and titles without
+/// a leading number unchanged. Examples:
+///   "76 Arriba"          → "076 Arriba"
+///   "6 Foo"              → "006 Foo"
+///   "102 10000 Armád"    → "102 10000 Armád"  (already 3 digits)
+///   "1234 Bar"           → "1234 Bar"          (4+ digits, untouched)
+///   "Arriba"             → "Arriba"            (no leading number)
+///   "76Arriba"           → "76Arriba"          (no whitespace separator)
+fn pad_title_number(title: &str) -> String {
+    let trimmed = title.trim();
+    if let Some(space_idx) = trimmed.find(char::is_whitespace) {
+        let (prefix, rest) = trimmed.split_at(space_idx);
+        if !prefix.is_empty()
+            && prefix.len() <= 3
+            && prefix.chars().all(|c| c.is_ascii_digit())
+        {
+            return format!("{prefix:0>3}{rest}");
+        }
+    }
+    trimmed.to_string()
 }
 ```
 
 Edge cases:
 - `Title:` with empty content → `Some("")`. Caller treats `Some("")` like `None` (fallback to `"Untitled"`).
 - Multiple `Title:` lines — first wins (rare in practice).
+- Padding only applies when the digits are followed by whitespace (so `76Arriba` is left unchanged because we cannot tell which characters are the number vs the name).
 
 ### `parse_song_text` — modified for control-char strip
 
@@ -285,7 +313,7 @@ The presentation rename flow is unchanged — the operator can rename via the ex
 
 ## Worked example — "76 Arriba"
 
-After `extract_title`: name = `"76 Arriba"`.
+After `extract_title`: name = `"076 Arriba"` (the `76` is padded to `076`).
 
 After `parse_song_text` (5 sections): Verse 1 (4 lines), Pre-Chorus (6 lines), Chorus (8 lines), Verse 2 (4 lines), Bridge (2 lines, first is 35 chars).
 
@@ -319,30 +347,35 @@ Operator card UI numbers them 1..15. No `!` warning superscript anywhere because
 
 | # | Test | What it verifies |
 |---|------|------------------|
-| 1 | `extract_title_finds_first_title_line` | `Title: 76 Arriba\n...` → `Some("76 Arriba")` |
-| 2 | `extract_title_returns_none_when_absent` | Input with no `Title:` → `None` |
-| 3 | `extract_title_is_case_insensitive` | `TITLE: foo` → `Some("foo")` |
-| 4 | `extract_title_strips_surrounding_whitespace` | `Title:   foo  ` → `Some("foo")` |
-| 5 | `wrap_long_lines_word_wraps_at_limit` | "Ak Boh je za mňa, kto je proti mne" (35) at 32 → 2 lines, both ≤ 32 |
-| 6 | `wrap_long_lines_passes_through_short_lines` | All lines ≤ limit → unchanged |
-| 7 | `wrap_long_lines_hard_breaks_oversize_word` | Single 50-char word at 32 → 2 lines (32 + 18) |
-| 8 | `wrap_long_lines_preserves_unicode_chars` | Slovak diacritics counted as 1 char (`chars().count()`) |
-| 9 | `chunk_to_two_lines_splits_six_line_section` | 6 lines → 3 slides; first has group, rest have `None` |
-| 10 | `chunk_to_two_lines_handles_odd_line_count` | 5 lines → 3 slides; last has 1 line |
-| 11 | `chunk_to_two_lines_passes_through_short_sections` | 2-line and 1-line sections unchanged |
-| 12 | `chunk_to_two_lines_preserves_empty_interlude` | `group="Interlude", main=""` slide unchanged |
-| 13 | `wrap_with_empty_bookends_adds_front_and_back` | N input → N+2 |
-| 14 | `wrap_with_empty_bookends_skips_empty_input` | Empty input → empty output |
-| 15 | `parse_song_text_strips_control_chars` | Line containing `\x02` (STX), BOM, ZWSP → cleaned |
-| 16 | `parse_song_text_skips_lines_that_become_empty_after_strip` | Line of just `\x02` → no slide |
-| 17 | **End-to-end pipeline regression: user's `76 Arriba` paste** → name `"76 Arriba"`, 15 slides matching the worked example exactly (groups, line counts, bookends) |
+| 1 | `extract_title_pads_two_digit_prefix` | `Title: 76 Arriba` → `Some("076 Arriba")` |
+| 2 | `extract_title_pads_one_digit_prefix` | `Title: 6 Foo` → `Some("006 Foo")` |
+| 3 | `extract_title_leaves_three_digit_prefix_unchanged` | `Title: 102 10000 Armád` → `Some("102 10000 Armád")` |
+| 4 | `extract_title_leaves_four_digit_prefix_unchanged` | `Title: 1234 Bar` → `Some("1234 Bar")` |
+| 5 | `extract_title_no_leading_number_unchanged` | `Title: Arriba` → `Some("Arriba")` |
+| 6 | `extract_title_no_space_after_digits_unchanged` | `Title: 76Arriba` → `Some("76Arriba")` |
+| 7 | `extract_title_returns_none_when_absent` | Input with no `Title:` → `None` |
+| 8 | `extract_title_is_case_insensitive` | `TITLE: foo` → `Some("foo")` |
+| 9 | `extract_title_strips_surrounding_whitespace` | `Title:   foo  ` → `Some("foo")` |
+| 10 | `wrap_long_lines_word_wraps_at_limit` | "Ak Boh je za mňa, kto je proti mne" (35) at 32 → 2 lines, both ≤ 32 |
+| 11 | `wrap_long_lines_passes_through_short_lines` | All lines ≤ limit → unchanged |
+| 12 | `wrap_long_lines_hard_breaks_oversize_word` | Single 50-char word at 32 → 2 lines (32 + 18) |
+| 13 | `wrap_long_lines_preserves_unicode_chars` | Slovak diacritics counted as 1 char (`chars().count()`) |
+| 14 | `chunk_to_two_lines_splits_six_line_section` | 6 lines → 3 slides; first has group, rest have `None` |
+| 15 | `chunk_to_two_lines_handles_odd_line_count` | 5 lines → 3 slides; last has 1 line |
+| 16 | `chunk_to_two_lines_passes_through_short_sections` | 2-line and 1-line sections unchanged |
+| 17 | `chunk_to_two_lines_preserves_empty_interlude` | `group="Interlude", main=""` slide unchanged |
+| 18 | `wrap_with_empty_bookends_adds_front_and_back` | N input → N+2 |
+| 19 | `wrap_with_empty_bookends_skips_empty_input` | Empty input → empty output |
+| 20 | `parse_song_text_strips_control_chars` | Line containing `\x02` (STX), BOM, ZWSP → cleaned |
+| 21 | `parse_song_text_skips_lines_that_become_empty_after_strip` | Line of just `\x02` → no slide |
+| 22 | **End-to-end pipeline regression: user's `76 Arriba` paste** → name `"076 Arriba"` (padded), 15 slides matching the worked example exactly (groups, line counts, bookends) |
 
 ### E2E test update — `tests/e2e/wasm-presentation-crud.spec.ts:430`
 
 Replace the test body with the canonical `76 Arriba` paste. Updated assertions:
 
 - The name input is hidden when the paste sub-screen is active (`expect(page.locator('[data-role="presentation-create-name"]')).toBeHidden()`).
-- After confirm: presentation name in the operator UI is `"76 Arriba"`.
+- After confirm: presentation name in the operator UI is `"076 Arriba"` (the leading `76` is padded to `076`).
 - Slide count is **15**.
 - First and last slides have empty `main` (bookends).
 - Slide 12's main is exactly `"Ak Boh je za mňa, kto je\nproti mne"` (proves wrap_long_lines worked).

--- a/docs/superpowers/specs/2026-04-30-clipboard-import-followup-design.md
+++ b/docs/superpowers/specs/2026-04-30-clipboard-import-followup-design.md
@@ -1,0 +1,369 @@
+# Clipboard Import Follow-Up: Title, Wrap, 2-Line Chunking, Bookends, Control-Char Strip — Design
+
+**Date:** 2026-04-30
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM) — extend `song_parser.rs`, update `presentation_modal.rs`, update one E2E test
+**Builds on:** PR #277 (issue #275 — section-aware splitting)
+
+## Goal
+
+Make the operator's "create presentation from paste" flow do the right thing for spevnik song exports:
+
+1. Use the pasted `Title:` line as the presentation **name** (always wins; modal name input hidden in the paste sub-screen; fallback `"Untitled"` if no `Title:`).
+2. **Word-wrap** any lyric line longer than the operator's `line_limit` (default 32 chars) so no slide triggers the "Line exceeds N characters" warning.
+3. Chunk each section's lyrics into slides of **at most 2 lines** each.
+4. Strip Unicode control characters (`Cc`) and zero-width characters from every line so stray bytes don't pollute slides.
+5. Wrap the resulting slide list with **empty bookend slides** at start and end, matching worship-service convention.
+
+## Canonical input — spevnik export
+
+```
+Title: 76 Arriba
+Misc 1
+
+Verse 1
+Môj Boh je nekonečný
+Má všetku moc a je večný
+Jeho Duch vo mne je živý
+A všetko pre mňa učiní
+
+Pre-Chorus
+Žehná ma žehná
+Priazeñ nad priazeň
+A padá to na mňa, padá na mňa
+Žehná ma žehná
+Priazeň nad priazeň
+A tá ku mne prúdi, ku mne prúdi
+
+Chorus
+Jeden dva tri
+Zakrič On je najlepší
+Jeden dva tri
+Ja som v ňom požehnaný
+Jeden dva tri
+Všetka sláva Jemu, v Ňom
+Ja som tým, kým hovorí že som
+Jeden dva tri
+
+Verse 2
+Ja vidím veci na nebi
+Tie zmeny sú aj na zemi
+Jeho Duch vo mne je živý
+Nie je nič čo neučiní
+
+Bridge
+Ak Boh je za mňa,  kto je proti mne
+Ja chválim Ho, ja chválim Ho
+Misc 1
+```
+
+Expected output: presentation name `"76 Arriba"`, **15 slides** total — empty bookend, then 13 lyric slides each with ≤ 2 lines and no line exceeding `line_limit`, then empty bookend. Every slide displays without the `!` warning superscript.
+
+## Architecture
+
+Pipeline of small composable functions in `crates/presenter-ui/src/utils/song_parser.rs`. The existing `parse_song_text` from PR #277 stays focused on section-splitting. New helpers handle title extraction, line-wrapping, 2-line chunking, and bookends. Each piece is independently testable.
+
+```
+clipboard text
+   │
+   ├─► extract_title()              → Option<String>   (presentation name)
+   │
+   └─► parse_song_text()            → Vec<SlideInput>  (section-split, control-char-clean)
+         │
+         └─► wrap_long_lines(.., line_limit) → Vec<SlideInput>  (each line ≤ line_limit, word-aware)
+               │
+               └─► chunk_to_two_lines() → Vec<SlideInput>  (each slide ≤ 2 lines)
+                     │
+                     └─► wrap_with_empty_bookends() → Vec<SlideInput>  (empty front+back)
+```
+
+The modal calls these functions in `on_paste_confirm`, reads `line_limit` from `OperatorState`, and submits the result via the existing `create_from_paste` API. No server changes.
+
+## Components
+
+### `extract_title(text: &str) -> Option<String>`
+
+Scans lines top-to-bottom, returns the trimmed content after the first case-insensitive `Title:` prefix. Returns `None` if no `Title:` line is found.
+
+```rust
+pub fn extract_title(text: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        lower.strip_prefix("title:").map(|rest| rest.trim().to_string())
+    })
+}
+```
+
+Edge cases:
+- `Title:` with empty content → `Some("")`. Caller treats `Some("")` like `None` (fallback to `"Untitled"`).
+- Multiple `Title:` lines — first wins (rare in practice).
+
+### `parse_song_text` — modified for control-char strip
+
+Existing function from PR #277 stays the same. **One change:** when appending a non-empty, non-group, non-metadata line to `current_main`, sanitize it first by stripping Unicode control chars (`char::is_control`) and zero-width chars (BOM `U+FEFF`, `U+200B`–`U+200D`).
+
+```rust
+fn sanitize_line(line: &str) -> String {
+    line.chars()
+        .filter(|c| !c.is_control() && !is_zero_width(*c))
+        .collect()
+}
+
+fn is_zero_width(c: char) -> bool {
+    matches!(c, '\u{FEFF}' | '\u{200B}' | '\u{200C}' | '\u{200D}')
+}
+```
+
+If sanitization leaves the line empty/whitespace-only, skip pushing it to `current_main`.
+
+### `wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideInput>`
+
+For each slide, for each `\n`-separated line in `main`, word-wrap it so every wrapped piece is at most `line_limit` characters (counted by `chars().count()` for Unicode safety). Emits the wrapped pieces in order, joined with `\n`. Lines that already fit pass through unchanged.
+
+Word-wrap rules:
+- Greedy: accumulate words separated by whitespace until adding the next word would exceed `line_limit`; emit current piece, start a new one.
+- Single word longer than `line_limit` (rare for lyrics) is hard-broken at the limit.
+- Lines that fit (`chars().count() <= line_limit`) pass through unchanged with original whitespace preserved.
+- `line_limit == 0` (defensive) → pass through unchanged.
+
+Sketch:
+
+```rust
+pub fn wrap_long_lines(slides: Vec<SlideInput>, line_limit: usize) -> Vec<SlideInput> {
+    if line_limit == 0 {
+        return slides;
+    }
+    slides
+        .into_iter()
+        .map(|slide| {
+            let wrapped: Vec<String> = slide
+                .main
+                .split('\n')
+                .flat_map(|line| wrap_one_line(line, line_limit))
+                .collect();
+            SlideInput {
+                main: wrapped.join("\n"),
+                ..slide
+            }
+        })
+        .collect()
+}
+
+fn wrap_one_line(line: &str, limit: usize) -> Vec<String> {
+    if line.chars().count() <= limit {
+        return vec![line.to_string()];
+    }
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in line.split_whitespace() {
+        let word_len = word.chars().count();
+        if current.is_empty() {
+            if word_len > limit {
+                hard_break_into(&mut out, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        } else if current.chars().count() + 1 + word_len <= limit {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            out.push(std::mem::take(&mut current));
+            if word_len > limit {
+                hard_break_into(&mut out, word, limit);
+            } else {
+                current.push_str(word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+```
+
+`split_whitespace` collapses runs of whitespace — this is acceptable for lyrics. The user's `"Ak Boh je za mňa,  kto je proti mne"` (35 chars, double space) wraps to `"Ak Boh je za mňa, kto je"` (24 chars) + `"proti mne"` (9 chars). Bridge slide goes from 1 long line to 2 short lines.
+
+### `chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput>`
+
+For each input slide:
+- **`main` is empty** (e.g., empty Interlude): pass through unchanged.
+- **≤ 2 lines in `main`**: pass through unchanged.
+- **> 2 lines**: split into successive 2-line chunks.
+  - First chunk inherits the original `group`.
+  - Subsequent chunks have `group = None` (slide_list.rs already renders these with `--inherited` style based on the previous slide's effective group).
+  - The last chunk has 1 line if the original line count was odd.
+
+Lines are joined with `\n` per chunk.
+
+```rust
+pub fn chunk_to_two_lines(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    let mut out = Vec::new();
+    for slide in slides {
+        let lines: Vec<&str> = slide.main.split('\n').collect();
+        let line_count = if slide.main.is_empty() { 0 } else { lines.len() };
+        if line_count <= 2 {
+            out.push(slide);
+            continue;
+        }
+        let mut first = true;
+        for chunk in lines.chunks(2) {
+            out.push(SlideInput {
+                main: chunk.join("\n"),
+                translation: None,
+                stage: None,
+                group: if first { slide.group.clone() } else { None },
+            });
+            first = false;
+        }
+    }
+    out
+}
+```
+
+### `wrap_with_empty_bookends(slides: Vec<SlideInput>) -> Vec<SlideInput>`
+
+If empty input, return empty (no bookends-on-nothing). Otherwise prepend and append `SlideInput { main: "", translation: None, stage: None, group: None }`.
+
+```rust
+pub fn wrap_with_empty_bookends(slides: Vec<SlideInput>) -> Vec<SlideInput> {
+    if slides.is_empty() {
+        return slides;
+    }
+    let empty = || SlideInput {
+        main: String::new(),
+        translation: None,
+        stage: None,
+        group: None,
+    };
+    let mut out = Vec::with_capacity(slides.len() + 2);
+    out.push(empty());
+    out.extend(slides);
+    out.push(empty());
+    out
+}
+```
+
+### Modal call site (`presentation_modal.rs:230-292`)
+
+Replace the `on_paste_confirm` body. The modal already has `op` (OperatorState) in scope, so `op.line_limit.get_untracked()` is the source of truth.
+
+```rust
+let text = op.paste_text.get_untracked();
+let line_limit = op.line_limit.get_untracked() as usize;
+
+let name = song_parser::extract_title(&text)
+    .filter(|s| !s.is_empty())
+    .unwrap_or_else(|| "Untitled".to_string());
+
+let slides = song_parser::parse_song_text(&text);
+let slides = song_parser::wrap_long_lines(slides, line_limit);
+let slides = song_parser::chunk_to_two_lines(slides);
+let slides = song_parser::wrap_with_empty_bookends(slides);
+
+if slides.is_empty() {
+    return;
+}
+// submit (library_id, name, slides) via create_from_paste
+```
+
+The modal's typed `create_name` is **ignored** for the paste flow.
+
+### Modal UX — hide name input on paste sub-screen (Option B confirmed)
+
+The shared `data-role="presentation-create-name"` input at the top of the modal stays visible for the **Blank** and **Import** sub-flows (both still need a typed name) but **hides** when the **Paste** sub-screen (`presentation-create-paste-area`) is active.
+
+Implementation: wrap the name input's parent `<label>`/`<div>` in a Leptos conditional that returns the element only when `op.modal_target_id` (or whichever signal already drives sub-flow visibility) is NOT in paste mode. The current modal already tracks sub-flow state via `op.paste_text`-and-friends signals; reuse that.
+
+The presentation rename flow is unchanged — the operator can rename via the existing `presentation-edit-modal` after creation.
+
+### JS bridge & E2E compatibility
+
+- `__presenterOperatorTestHelpers.parseSongText(text)` keeps its existing signature returning `Vec<SlideInput>` (just the section-split result) so the existing regression test in `tests/e2e/wasm-edge-cases.spec.ts:259` still passes.
+- The full pipeline (title + wrap + chunk + bookends) runs only in the modal's `on_paste_confirm`. The E2E test asserts the user-visible end result via the operator UI, not via the bridge.
+
+## Worked example — "76 Arriba"
+
+After `extract_title`: name = `"76 Arriba"`.
+
+After `parse_song_text` (5 sections): Verse 1 (4 lines), Pre-Chorus (6 lines), Chorus (8 lines), Verse 2 (4 lines), Bridge (2 lines, first is 35 chars).
+
+After `wrap_long_lines(.., 32)`: Bridge's first line splits into `"Ak Boh je za mňa, kto je"` + `"proti mne"`. Bridge now has 3 lines. All other sections unchanged.
+
+After `chunk_to_two_lines`:
+
+| Slide | group | content |
+|-------|-------|---------|
+| 1 | Verse 1 | "Môj Boh je nekonečný" + "Má všetku moc a je večný" |
+| 2 | (none, inherits Verse 1) | "Jeho Duch vo mne je živý" + "A všetko pre mňa učiní" |
+| 3 | Pre-Chorus | "Žehná ma žehná" + "Priazeñ nad priazeň" |
+| 4 | (inherited) | "A padá to na mňa, padá na mňa" + "Žehná ma žehná" |
+| 5 | (inherited) | "Priazeň nad priazeň" + "A tá ku mne prúdi, ku mne prúdi" |
+| 6 | Chorus | "Jeden dva tri" + "Zakrič On je najlepší" |
+| 7 | (inherited) | "Jeden dva tri" + "Ja som v ňom požehnaný" |
+| 8 | (inherited) | "Jeden dva tri" + "Všetka sláva Jemu, v Ňom" |
+| 9 | (inherited) | "Ja som tým, kým hovorí že som" + "Jeden dva tri" |
+| 10 | Verse 2 | "Ja vidím veci na nebi" + "Tie zmeny sú aj na zemi" |
+| 11 | (inherited) | "Jeho Duch vo mne je živý" + "Nie je nič čo neučiní" |
+| 12 | Bridge | "Ak Boh je za mňa, kto je" + "proti mne" |
+| 13 | (inherited) | "Ja chválim Ho, ja chválim Ho" |
+
+After `wrap_with_empty_bookends`: 15 slides — empty + the 13 above + empty.
+
+Operator card UI numbers them 1..15. No `!` warning superscript anywhere because every line fits within `line_limit`.
+
+## Testing
+
+### Unit tests in `song_parser.rs` (new — added on top of the 10 existing)
+
+| # | Test | What it verifies |
+|---|------|------------------|
+| 1 | `extract_title_finds_first_title_line` | `Title: 76 Arriba\n...` → `Some("76 Arriba")` |
+| 2 | `extract_title_returns_none_when_absent` | Input with no `Title:` → `None` |
+| 3 | `extract_title_is_case_insensitive` | `TITLE: foo` → `Some("foo")` |
+| 4 | `extract_title_strips_surrounding_whitespace` | `Title:   foo  ` → `Some("foo")` |
+| 5 | `wrap_long_lines_word_wraps_at_limit` | "Ak Boh je za mňa, kto je proti mne" (35) at 32 → 2 lines, both ≤ 32 |
+| 6 | `wrap_long_lines_passes_through_short_lines` | All lines ≤ limit → unchanged |
+| 7 | `wrap_long_lines_hard_breaks_oversize_word` | Single 50-char word at 32 → 2 lines (32 + 18) |
+| 8 | `wrap_long_lines_preserves_unicode_chars` | Slovak diacritics counted as 1 char (`chars().count()`) |
+| 9 | `chunk_to_two_lines_splits_six_line_section` | 6 lines → 3 slides; first has group, rest have `None` |
+| 10 | `chunk_to_two_lines_handles_odd_line_count` | 5 lines → 3 slides; last has 1 line |
+| 11 | `chunk_to_two_lines_passes_through_short_sections` | 2-line and 1-line sections unchanged |
+| 12 | `chunk_to_two_lines_preserves_empty_interlude` | `group="Interlude", main=""` slide unchanged |
+| 13 | `wrap_with_empty_bookends_adds_front_and_back` | N input → N+2 |
+| 14 | `wrap_with_empty_bookends_skips_empty_input` | Empty input → empty output |
+| 15 | `parse_song_text_strips_control_chars` | Line containing `\x02` (STX), BOM, ZWSP → cleaned |
+| 16 | `parse_song_text_skips_lines_that_become_empty_after_strip` | Line of just `\x02` → no slide |
+| 17 | **End-to-end pipeline regression: user's `76 Arriba` paste** → name `"76 Arriba"`, 15 slides matching the worked example exactly (groups, line counts, bookends) |
+
+### E2E test update — `tests/e2e/wasm-presentation-crud.spec.ts:430`
+
+Replace the test body with the canonical `76 Arriba` paste. Updated assertions:
+
+- The name input is hidden when the paste sub-screen is active (`expect(page.locator('[data-role="presentation-create-name"]')).toBeHidden()`).
+- After confirm: presentation name in the operator UI is `"76 Arriba"`.
+- Slide count is **15**.
+- First and last slides have empty `main` (bookends).
+- Slide 12's main is exactly `"Ak Boh je za mňa, kto je\nproti mne"` (proves wrap_long_lines worked).
+- No slide's `main` contains `Title:`, `Misc`, control chars, or more than one `\n`.
+- No slide card shows the `!` warning superscript (count of `[data-role="slide-warning"]` visible elements is 0).
+- Console clean — existing `consoleMessages` collection still passes.
+
+### Console-clean assertion remains in place
+
+The existing `consoleMessages` collection in the E2E suite still asserts zero browser console errors/warnings.
+
+## Risks / unknowns
+
+- **Slide count multiplication.** Typical worship song with 4-5 sections × 4-6 lines becomes ~12-15 slides + bookends. The operator UI already handles long slide lists.
+- **Greedy wrapping is not optimal**. A 35-char line wraps to 24 + 9 instead of an optimal 17 + 17. Acceptable for worship lyrics — operators can manually reflow if needed.
+- **`line_limit` change after paste**. If the operator changes `line_limit` after creating a presentation, slides won't auto-rewrap. Same behavior as today's manually-edited slides — out of scope.
+- **The "square character" report**. Couldn't reproduce with the canonical paste, but defensive control-char stripping covers any source-side leakage (BOM, NBSP, raw control bytes).
+
+## Out of scope
+
+- Server `create_from_paste` API changes. The endpoint accepts the slide list and presentation name; both are sufficient.
+- Auto-detection of paste source (ProPresenter vs spevnik vs Word). Filters are noop for unmatched lines.
+- Removing the modal name input from the Blank or Import sub-screens.
+- Re-wrapping existing presentations when `line_limit` changes.

--- a/tests/e2e/wasm-presentation-crud.spec.ts
+++ b/tests/e2e/wasm-presentation-crud.spec.ts
@@ -423,4 +423,115 @@ Multiple lines here`;
     // Close modal
     await page.keyboard.press("Escape");
   });
+
+  // Regression guard for issue #275: pasted ProPresenter clipboard with
+  // metadata (Title:/Misc N/^B) and section headers without preceding blank
+  // lines must produce one slide per section, not one giant slide.
+  test("paste with section headers splits one slide per section (#275)", async ({
+    page,
+  }) => {
+    await selectLibrary(page);
+
+    await page
+      .locator('[data-view-panel="worship"] [data-role="presentation-create"]')
+      .click();
+    await page.waitForFunction(
+      () =>
+        document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 5_000 },
+    );
+
+    const presentationName = `Section Split #275 ${Date.now()}`;
+    await page
+      .locator('[data-role="presentation-create-name"]')
+      .fill(presentationName);
+
+    await page.locator('[data-role="presentation-create-paste"]').click();
+    await expect(
+      page.locator('[data-role="presentation-create-paste-area"]'),
+    ).toBeVisible();
+
+    // The user's exact reported input: metadata at the top with NO blank line
+    // before Verse 1, blank-line-separated Chorus, and trailing metadata.
+    const userInput = `Title: 326 Všetko, čo v sebe držím
+Misc 1
+^B
+Verse 1
+Všetko, čo v sebe držím s túžbami
+Ty ma chceš Pane mať
+
+Chorus
+Mám Spasiteľa žije vo mne
+Nikto mi Ťa nezoberie
+
+Outro
+Nikto mi Ťa nezoberie
+Misc 1
+^B`;
+
+    await page
+      .locator('[data-role="presentation-create-paste-text"]')
+      .fill(userInput);
+    await page
+      .locator('[data-role="presentation-create-paste-confirm"]')
+      .click();
+
+    // Modal closes
+    await page.waitForFunction(
+      () =>
+        !document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 10_000 },
+    );
+
+    // Wait for slides of the newly created presentation to render
+    await page.waitForFunction(
+      () => {
+        const slides = document.querySelector(
+          '[data-view-panel="worship"] [data-role="slides"]',
+        );
+        return slides && slides.querySelectorAll("[data-slide-id]").length >= 3;
+      },
+      { timeout: 10_000 },
+    );
+
+    // Read slide group + main pairs (display mode selectors)
+    const slidePairs = await page.evaluate(() => {
+      const slides = Array.from(
+        document.querySelectorAll(
+          '[data-view-panel="worship"] [data-role="slides"] [data-slide-id]',
+        ),
+      );
+      return slides.map((slide) => {
+        const groupEl = slide.querySelector('[data-role="slide-group"]');
+        const mainEl = slide.querySelector('[data-field-display="main"]');
+        return {
+          group: (groupEl?.textContent || "").trim(),
+          main: (mainEl?.textContent || "").trim(),
+        };
+      });
+    });
+
+    // Three sections: Verse 1, Chorus, Outro
+    expect(slidePairs).toHaveLength(3);
+    expect(slidePairs[0].group).toBe("Verse 1");
+    expect(slidePairs[1].group).toBe("Chorus");
+    expect(slidePairs[2].group).toBe("Outro");
+
+    // Metadata must NOT pollute any slide's content
+    for (const slide of slidePairs) {
+      expect(slide.main).not.toMatch(/Title:/);
+      expect(slide.main).not.toMatch(/Misc 1/);
+      expect(slide.main).not.toContain("^B");
+      expect(slide.group).not.toMatch(/Title:/);
+    }
+
+    // Lyrics arrived in the right slides
+    expect(slidePairs[0].main).toContain("Všetko");
+    expect(slidePairs[1].main).toContain("Spasiteľa");
+    expect(slidePairs[2].main).toContain("nezoberie");
+  });
 });

--- a/tests/e2e/wasm-presentation-crud.spec.ts
+++ b/tests/e2e/wasm-presentation-crud.spec.ts
@@ -525,7 +525,10 @@ Misc 1`;
       { timeout: 15_000 },
     );
 
-    // Read all slide group + main pairs.
+    // Read all slide group + main pairs. Use `innerText` for the main
+    // so rendered <br> tags become real \n in the output (textContent
+    // collapses line breaks, which would make multi-line slides look
+    // like one giant line).
     const slidePairs = await page.evaluate(() => {
       const slides = Array.from(
         document.querySelectorAll(
@@ -534,10 +537,12 @@ Misc 1`;
       );
       return slides.map((slide) => {
         const groupEl = slide.querySelector('[data-role="slide-group"]');
-        const mainEl = slide.querySelector('[data-field-display="main"]');
+        const mainEl = slide.querySelector(
+          '[data-field-display="main"]',
+        ) as HTMLElement | null;
         return {
           group: (groupEl?.textContent || "").trim(),
-          main: (mainEl?.textContent || "").trim(),
+          main: (mainEl?.innerText || "").trim(),
         };
       });
     });

--- a/tests/e2e/wasm-presentation-crud.spec.ts
+++ b/tests/e2e/wasm-presentation-crud.spec.ts
@@ -424,14 +424,15 @@ Multiple lines here`;
     await page.keyboard.press("Escape");
   });
 
-  // Regression guard for issue #275: pasted ProPresenter clipboard with
-  // metadata (Title:/Misc N/^B) and section headers without preceding blank
-  // lines must produce one slide per section, not one giant slide.
-  test("paste with section headers splits one slide per section (#275)", async ({
+  // Regression guard for issue #275 follow-up: full pipeline on a
+  // spevnik song export must produce the right name + correctly
+  // chunked slides + empty bookends.
+  test("paste pipeline produces named presentation with bookends (#275)", async ({
     page,
   }) => {
     await selectLibrary(page);
 
+    // Open the create modal.
     await page
       .locator('[data-view-panel="worship"] [data-role="presentation-create"]')
       .click();
@@ -443,33 +444,57 @@ Multiple lines here`;
       { timeout: 5_000 },
     );
 
-    const presentationName = `Section Split #275 ${Date.now()}`;
-    await page
-      .locator('[data-role="presentation-create-name"]')
-      .fill(presentationName);
-
+    // Click "Paste" to enter paste sub-screen.
     await page.locator('[data-role="presentation-create-paste"]').click();
     await expect(
       page.locator('[data-role="presentation-create-paste-area"]'),
     ).toBeVisible();
 
-    // The user's exact reported input: metadata at the top with NO blank line
-    // before Verse 1, blank-line-separated Chorus, and trailing metadata.
-    const userInput = `Title: 326 Všetko, čo v sebe držím
+    // Name input must be hidden on the paste sub-screen.
+    await expect(
+      page.locator('[data-role="presentation-create-name"]'),
+    ).toBeHidden();
+
+    // Canonical spevnik song export — Title: populates the presentation
+    // name (zero-padded), Misc 1 lines are filtered, each section gets
+    // chunked to ≤ 2 lines with empty bookends.
+    const userInput = `Title: 76 Arriba
 Misc 1
-^B
+
 Verse 1
-Všetko, čo v sebe držím s túžbami
-Ty ma chceš Pane mať
+Môj Boh je nekonečný
+Má všetku moc a je večný
+Jeho Duch vo mne je živý
+A všetko pre mňa učiní
+
+Pre-Chorus
+Žehná ma žehná
+Priazeñ nad priazeň
+A padá to na mňa, padá na mňa
+Žehná ma žehná
+Priazeň nad priazeň
+A tá ku mne prúdi, ku mne prúdi
 
 Chorus
-Mám Spasiteľa žije vo mne
-Nikto mi Ťa nezoberie
+Jeden dva tri
+Zakrič On je najlepší
+Jeden dva tri
+Ja som v ňom požehnaný
+Jeden dva tri
+Všetka sláva Jemu, v Ňom
+Ja som tým, kým hovorí že som
+Jeden dva tri
 
-Outro
-Nikto mi Ťa nezoberie
-Misc 1
-^B`;
+Verse 2
+Ja vidím veci na nebi
+Tie zmeny sú aj na zemi
+Jeho Duch vo mne je živý
+Nie je nič čo neučiní
+
+Bridge
+Ak Boh je za mňa,  kto je proti mne
+Ja chválim Ho, ja chválim Ho
+Misc 1`;
 
     await page
       .locator('[data-role="presentation-create-paste-text"]')
@@ -478,7 +503,7 @@ Misc 1
       .locator('[data-role="presentation-create-paste-confirm"]')
       .click();
 
-    // Modal closes
+    // Modal closes.
     await page.waitForFunction(
       () =>
         !document.querySelector(
@@ -487,18 +512,20 @@ Misc 1
       { timeout: 10_000 },
     );
 
-    // Wait for slides of the newly created presentation to render
+    // Wait for the new presentation to render with all 15 slides.
     await page.waitForFunction(
       () => {
         const slides = document.querySelector(
           '[data-view-panel="worship"] [data-role="slides"]',
         );
-        return slides && slides.querySelectorAll("[data-slide-id]").length >= 3;
+        return (
+          slides && slides.querySelectorAll("[data-slide-id]").length === 15
+        );
       },
-      { timeout: 10_000 },
+      { timeout: 15_000 },
     );
 
-    // Read slide group + main pairs (display mode selectors)
+    // Read all slide group + main pairs.
     const slidePairs = await page.evaluate(() => {
       const slides = Array.from(
         document.querySelectorAll(
@@ -515,23 +542,38 @@ Misc 1
       });
     });
 
-    // Three sections: Verse 1, Chorus, Outro
-    expect(slidePairs).toHaveLength(3);
-    expect(slidePairs[0].group).toBe("Verse 1");
-    expect(slidePairs[1].group).toBe("Chorus");
-    expect(slidePairs[2].group).toBe("Outro");
+    // 15 slides total — empty bookend + 13 lyric chunks + empty bookend.
+    expect(slidePairs).toHaveLength(15);
 
-    // Metadata must NOT pollute any slide's content
+    // Bookends are empty.
+    expect(slidePairs[0].main).toBe("");
+    expect(slidePairs[0].group).toBe("");
+    expect(slidePairs[14].main).toBe("");
+    expect(slidePairs[14].group).toBe("");
+
+    // First chunk of each section carries the section header.
+    expect(slidePairs[1].group).toBe("Verse 1");
+    expect(slidePairs[3].group).toBe("Pre-Chorus");
+    expect(slidePairs[6].group).toBe("Chorus");
+    expect(slidePairs[10].group).toBe("Verse 2");
+    expect(slidePairs[12].group).toBe("Bridge");
+
+    // No slide should leak metadata.
     for (const slide of slidePairs) {
       expect(slide.main).not.toMatch(/Title:/);
       expect(slide.main).not.toMatch(/Misc 1/);
       expect(slide.main).not.toContain("^B");
-      expect(slide.group).not.toMatch(/Title:/);
     }
 
-    // Lyrics arrived in the right slides
-    expect(slidePairs[0].main).toContain("Všetko");
-    expect(slidePairs[1].main).toContain("Spasiteľa");
-    expect(slidePairs[2].main).toContain("nezoberie");
+    // No content slide may contain a line longer than 32 characters
+    // (the default line_limit). Bookends excluded (already asserted empty).
+    for (let i = 1; i <= 13; i++) {
+      const lines = slidePairs[i].main.split("\n");
+      for (const line of lines) {
+        // Use Array.from for accurate codepoint count of Slovak diacritics.
+        const len = Array.from(line).length;
+        expect(len, `slide ${i} line "${line}" is ${len} chars (over 32)`).toBeLessThanOrEqual(32);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #275 — pasting a song into the "create presentation" textarea was producing one giant slide containing `Title:`, `Misc 1`, `^B`, the section heading `Verse 1`, AND the verse lyrics, because the parser only split on blank lines.

The parser is now line-walking with explicit triggers:
- **Group line** (Verse N / Chorus / Bridge / Pre-chorus / Tag / Interlude / Refrain / Hook / Coda / Ending / Instrumental / Intro / Outro, optional trailing number, case-insensitive) → flush + start new slide
- **Metadata line** (`Title:` prefix, `Misc <digits>`, ProPresenter `^[A-Z]` control marker) → silently filtered
- **Blank line** → flush if current slide non-empty
- **Anything else** → append to current slide's `main`, leading whitespace preserved

## Verification

- ✅ 10 new unit tests in `crates/presenter-ui/src/utils/song_parser.rs`, including a regression guard using the user's exact pasted input
- ✅ Live-verified on dev via the WASM `parseSongText` JS bridge: user's input now produces 3 slides (Verse 1, Chorus, Outro) with clean lyrics, no `Title:`/`Misc 1`/`^B` pollution
- ✅ Existing E2E `tests/e2e/wasm-edge-cases.spec.ts:259` still uses the same JS bridge signature (regression guard)
- ✅ Pipeline run 25132087367 — 20/20 jobs green (incl. Mutation Testing)

## Code refactor (cleanup along the way)

`parse_song_text` and `is_group_line` were previously in `crates/presenter-ui/src/utils/test_helpers.rs` despite being production code. Moved to a dedicated `crates/presenter-ui/src/utils/song_parser.rs` module. The `__presenterOperatorTestHelpers.parseSongText` JS bridge keeps the same signature.

## Test plan

- [x] Unit tests pass (10/10 in song_parser, 56 others unchanged)
- [x] WASM clippy clean
- [x] E2E pipeline green (Playwright 3/3 shards)
- [x] Mutation testing green
- [x] Live dev parser bridge produces correct slides for user's exact input

🤖 Generated with [Claude Code](https://claude.com/claude-code)