### PR TITLE
feat(ui): version display on every route (#287)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.51"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.51"
+version = "0.4.52"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.50"
+version = "0.4.52"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.19"
+version = "0.1.21"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -15,3 +15,4 @@ pub mod stage;
 pub mod stage_preview;
 pub mod timer_panel;
 pub mod toast;
+pub mod version_label;

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -1,6 +1,7 @@
 use gloo_timers::callback::Interval;
 use leptos::prelude::*;
 
+use crate::components::version_label::VersionLabel;
 use crate::state::stage::StageContext;
 use crate::utils::autofit::autofit_effect;
 use crate::ws::stage::StageWsState;
@@ -107,6 +108,10 @@ pub fn StatusBar(
         <div node_ref=connection_ref class=connection_class>
             <span class="stage__debug-label">"connection"</span>
             {connection_text}
+        </div>
+        <div class="stage__version">
+            <span class="stage__debug-label">"version"</span>
+            <VersionLabel />
         </div>
     }
 }

--- a/crates/presenter-ui/src/components/version_label.rs
+++ b/crates/presenter-ui/src/components/version_label.rs
@@ -1,0 +1,25 @@
+use leptos::prelude::*;
+
+/// Shared version label component. Fetches `/healthz` once on mount and
+/// displays `v{version} ({channel})` for dev builds, or `v{version}` for
+/// release builds.
+///
+/// Tagged with `data-testid="version"` so Playwright can target it
+/// consistently across all UI routes.
+#[component]
+pub fn VersionLabel() -> impl IntoView {
+    let version_text = RwSignal::new(String::new());
+    leptos::task::spawn_local(async move {
+        if let Ok(health) = crate::api::get_json::<crate::api::HealthzResponse>("/healthz").await {
+            let text = if health.channel.is_empty() || health.channel == "release" {
+                format!("v{}", health.version)
+            } else {
+                format!("v{} ({})", health.version, health.channel)
+            };
+            version_text.set(text);
+        }
+    });
+    view! {
+        <span data-testid="version">{move || version_text.get()}</span>
+    }
+}

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -195,7 +195,7 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
         <PlaylistModals />
         <PresentationModals />
         <footer class="operator__version">
-            <VersionFooter />
+            <crate::components::version_label::VersionLabel />
         </footer>
     }
 }
@@ -587,24 +587,6 @@ fn setup_keyboard_shortcuts(ctx: AppContext, op: OperatorState) {
     let window = crate::utils::window::window();
     let _ = window.add_event_listener_with_callback("keydown", handler.as_ref().unchecked_ref());
     handler.forget();
-}
-
-#[component]
-fn VersionFooter() -> impl IntoView {
-    let version_text = RwSignal::new(String::new());
-    leptos::task::spawn_local(async move {
-        if let Ok(health) = crate::api::get_json::<crate::api::HealthzResponse>("/healthz").await {
-            let text = if health.channel.is_empty() || health.channel == "release" {
-                format!("v{}", health.version)
-            } else {
-                format!("v{} ({})", health.version, health.channel)
-            };
-            version_text.set(text);
-        }
-    });
-    view! {
-        <span>{move || version_text.get()}</span>
-    }
 }
 
 fn setup_popstate_listener(ctx: AppContext) {

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -14,6 +14,7 @@ use crate::components::search::SearchResults;
 use crate::components::slide_list::SlideList;
 use crate::components::timer_panel::TimerPanel;
 use crate::components::toast::Toast;
+use crate::components::version_label::VersionLabel;
 use crate::pages::ai::AiPage;
 use crate::pages::bible::BiblePage;
 use crate::state::operator::OperatorState;
@@ -195,7 +196,7 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
         <PlaylistModals />
         <PresentationModals />
         <footer class="operator__version">
-            <crate::components::version_label::VersionLabel />
+            <VersionLabel />
         </footer>
     }
 }

--- a/crates/presenter-ui/src/pages/tablet.rs
+++ b/crates/presenter-ui/src/pages/tablet.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::JsCast;
 
 use crate::api::bible::{self, BibleSlideDto, BibleSlideMetaBible};
 use crate::components::info_popover::InfoPopover;
+use crate::components::version_label::VersionLabel;
 use crate::state::tablet::TabletContext;
 use crate::ws::{self, WsState};
 
@@ -146,6 +147,9 @@ pub fn TabletPage() -> impl IntoView {
             <TabletMain />
         </main>
         <TabletToast />
+        <span class="tablet__version-badge">
+            <VersionLabel />
+        </span>
     }
 }
 

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -551,3 +551,9 @@ body.stage {
         0 0 8px rgba(0, 0, 0, 0.9),
         0 2px 4px rgba(0, 0, 0, 0.7);
 }
+
+/* Version label inside StatusBar — small, under the connection/latency display */
+.stage__version {
+  font-size: 0.5em;
+  opacity: 0.6;
+}

--- a/crates/presenter-ui/styles/tablet.css
+++ b/crates/presenter-ui/styles/tablet.css
@@ -460,3 +460,14 @@ body.tablet {
   min-width: 5rem;
   text-align: right;
 }
+
+/* Version badge — bottom-right corner, small, low-opacity, non-interactive */
+.tablet__version-badge {
+  position: fixed;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+  z-index: 1;
+}

--- a/docs/superpowers/plans/2026-05-02-version-display-all-routes.md
+++ b/docs/superpowers/plans/2026-05-02-version-display-all-routes.md
@@ -1,0 +1,740 @@
+# Version Display on Every UI Route Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the deployed version label on `/ui/tablet` and `/stage` (in addition to the existing `/ui/operator`) and add a Playwright helper that asserts the label format and frontend/backend match across all routes.
+
+**Architecture:** Extract the existing operator-only `VersionFooter` (in `crates/presenter-ui/src/pages/operator.rs:593-608`) into a shared `VersionLabel` component at `crates/presenter-ui/src/components/version_label.rs`. Add `data-testid="version"` so Playwright can target it. Embed the new component in `pages/tablet.rs` (small bottom-right badge) and `components/stage/status_bar.rs` (small line under the connection/latency display). Add a `assertVersionLabel(page, baseURL)` helper to `tests/e2e/support.ts` and call it once per existing route's E2E test.
+
+**Tech Stack:** Rust + Leptos 0.7 (WASM via trunk), plain CSS (no preprocessor), Playwright (TypeScript).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-version-display-all-routes-design.md` (commit `b6b34d5`)
+
+---
+
+## Context
+
+### Spec deviation discovered during plan-writing
+
+The spec's "per-route placement" table lists `/ui/bible` as a separate route. **It is not.** `/ui/bible` is not in the WASM router (`crates/presenter-ui/src/lib.rs:30-60`). The actual routes are:
+
+- `/ui/operator` (and `/ui/operator/<view>` — including `/ui/operator/bible`) → `OperatorPage`
+- `/ui/tablet` → `TabletPage`
+- `/stage` → `StagePage`
+
+Because `/ui/operator/bible` renders the bible UI INSIDE the operator layout, it is already covered by the operator's existing `VersionFooter`. **The plan therefore only adds new placements for tablet and stage.** All four operator sub-views (`worship`, `bible`, `presentation`, etc.) inherit the version label automatically through the operator page wrapper.
+
+### Project state (verified pre-flight)
+
+- **Existing VersionFooter component:** `crates/presenter-ui/src/pages/operator.rs:593-608` — fetches `/healthz`, displays `v{version} ({channel})` for dev or `v{version}` for release. Wrapped at line 197 by `<footer class="operator__version">` (CSS in `crates/presenter-ui/styles/operator.css:2152` — `position: fixed; bottom: 0.5rem; right: 0.75rem; font-size: 0.7rem; color: rgba(255, 255, 255, 0.35);`).
+- **Components module:** `crates/presenter-ui/src/components/mod.rs` — flat list of `pub mod`s. New file added here.
+- **Tablet page entry:** `crates/presenter-ui/src/pages/tablet.rs:141-149` — top-level `view! { <TabletTimerBar /> <TabletHeader /> <main class="tablet-layout">...</main> <TabletToast /> }`. Add the version badge after `<TabletToast />`.
+- **Stage status bar:** `crates/presenter-ui/src/components/stage/status_bar.rs:90-111` — view structure has `clock`, `song-number`, `live-pill`, `connection`. Add version `<div>` immediately after `connection` per user request "always small under the latency".
+- **CSS files (plain CSS, NOT SCSS):** `crates/presenter-ui/styles/{operator,tablet,bible,stage,settings}.css`. Each page has its own CSS file, served via trunk.
+- **Playwright support:** `tests/e2e/support.ts` (TypeScript). Helpers exported as named functions.
+- **Backend `/healthz`:** Returns `{"channel":"dev","status":"ok","version":"0.4.51"}` (or `"release"`). Source: `crates/presenter-server/src/router.rs` const `BUILD_CHANNEL`.
+- **Versions to bump:** Workspace `Cargo.toml` (currently `0.4.51`) → `0.4.52`. presenter-ui `crates/presenter-ui/Cargo.toml` (currently `0.1.20`) → `0.1.21`.
+
+---
+
+## File Structure
+
+### Created files
+| File | Responsibility |
+|------|---------------|
+| `crates/presenter-ui/src/components/version_label.rs` | Shared `VersionLabel` Leptos component. Fetches `/healthz` once on mount, renders `<span data-testid="version">v{version} ({channel})</span>`. Replaces the private `VersionFooter` in operator.rs. |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.51 → 0.4.52 |
+| `crates/presenter-ui/Cargo.toml` | presenter-ui version 0.1.20 → 0.1.21 |
+| `crates/presenter-ui/src/components/mod.rs` | Add `pub mod version_label;` and `pub use version_label::VersionLabel;` |
+| `crates/presenter-ui/src/pages/operator.rs` | Replace inline `<VersionFooter />` with `<VersionLabel />`. Delete the local `VersionFooter` component (lines 592-608). |
+| `crates/presenter-ui/src/pages/tablet.rs` | Add `<span class="tablet__version-badge"><VersionLabel /></span>` after `<TabletToast />` in `TabletPage` view. |
+| `crates/presenter-ui/src/components/stage/status_bar.rs` | Add `<div class="stage__version">...<VersionLabel /></div>` after the connection `<div>`. |
+| `crates/presenter-ui/styles/tablet.css` | Append `.tablet__version-badge` rule (fixed bottom-right, small, low-opacity). |
+| `crates/presenter-ui/styles/stage.css` | Append `.stage__version` rule (small font, opacity 0.6). |
+| `tests/e2e/support.ts` | Add `assertVersionLabel(page, baseURL)` helper. |
+| `tests/e2e/operator-*.spec.ts` (one chosen) | Call `assertVersionLabel` after page load. |
+| `tests/e2e/tablet*.spec.ts` (one chosen) | Same. |
+| `tests/e2e/stage*.spec.ts` (or smoke spec, see Task 5) | Same. |
+
+### Lock files
+- `Cargo.lock` (workspace) and `crates/presenter-ui/Cargo.lock` (separate) — auto-updated by `cargo check`/`cargo build`.
+
+---
+
+## Task 1: Bump Version (Haiku)
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/presenter-ui/Cargo.toml`
+- Modify: `Cargo.lock` and `crates/presenter-ui/Cargo.lock` (regenerated)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml`, under `[workspace.package]`, change:
+
+```toml
+version = "0.4.51"
+```
+
+to:
+
+```toml
+version = "0.4.52"
+```
+
+- [ ] **Step 2: Bump presenter-ui crate version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml`, under `[package]`, change:
+
+```toml
+version = "0.1.20"
+```
+
+to:
+
+```toml
+version = "0.1.21"
+```
+
+- [ ] **Step 3: Regenerate workspace Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check --workspace --all-targets 2>&1 | tail -10
+```
+
+Expected: clean check, `Cargo.lock` updated.
+
+- [ ] **Step 4: Regenerate presenter-ui Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean check (or only existing warnings — no new errors), `crates/presenter-ui/Cargo.lock` updated to reflect the new presenter-ui version.
+
+If the WASM target is not installed, run `rustup target add wasm32-unknown-unknown` first.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && grep -E "^version" Cargo.toml crates/presenter-ui/Cargo.toml | head -3
+```
+
+Expected output:
+
+```
+Cargo.toml:version = "0.4.52"
+crates/presenter-ui/Cargo.toml:version = "0.1.21"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock && git commit -m "chore: bump version to 0.4.52 (#287)"
+```
+
+---
+
+## Task 2: Extract VersionLabel Component (Sonnet)
+
+**Files:**
+- Create: `crates/presenter-ui/src/components/version_label.rs`
+- Modify: `crates/presenter-ui/src/components/mod.rs`
+- Modify: `crates/presenter-ui/src/pages/operator.rs` (replace inline VersionFooter)
+
+- [ ] **Step 1: Create the shared component**
+
+Create `crates/presenter-ui/src/components/version_label.rs` with:
+
+```rust
+use leptos::prelude::*;
+
+/// Shared version label component. Fetches `/healthz` once on mount and
+/// displays `v{version} ({channel})` for dev builds, or `v{version}` for
+/// release builds.
+///
+/// Tagged with `data-testid="version"` so Playwright can target it
+/// consistently across all UI routes.
+#[component]
+pub fn VersionLabel() -> impl IntoView {
+    let version_text = RwSignal::new(String::new());
+    leptos::task::spawn_local(async move {
+        if let Ok(health) = crate::api::get_json::<crate::api::HealthzResponse>("/healthz").await {
+            let text = if health.channel.is_empty() || health.channel == "release" {
+                format!("v{}", health.version)
+            } else {
+                format!("v{} ({})", health.version, health.channel)
+            };
+            version_text.set(text);
+        }
+    });
+    view! {
+        <span data-testid="version">{move || version_text.get()}</span>
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from components/mod.rs**
+
+In `crates/presenter-ui/src/components/mod.rs`, add at the appropriate alphabetical position (after `toast`):
+
+```rust
+pub mod version_label;
+```
+
+(There is no need for `pub use` re-export — call sites use `crate::components::version_label::VersionLabel`. If the module convention is `pub use`, follow the existing pattern; verify by reading the existing mod.rs first.)
+
+- [ ] **Step 3: Replace the inline VersionFooter in operator.rs**
+
+In `crates/presenter-ui/src/pages/operator.rs`:
+
+a) Find the existing usage at line 197-198:
+
+```rust
+        <footer class="operator__version">
+            <VersionFooter />
+        </footer>
+```
+
+Replace with:
+
+```rust
+        <footer class="operator__version">
+            <crate::components::version_label::VersionLabel />
+        </footer>
+```
+
+b) Delete the local `VersionFooter` component definition. Find the function (around line 592-608):
+
+```rust
+#[component]
+fn VersionFooter() -> impl IntoView {
+    let version_text = RwSignal::new(String::new());
+    leptos::task::spawn_local(async move {
+        if let Ok(health) = crate::api::get_json::<crate::api::HealthzResponse>("/healthz").await {
+            let text = if health.channel.is_empty() || health.channel == "release" {
+                format!("v{}", health.version)
+            } else {
+                format!("v{} ({})", health.version, health.channel)
+            };
+            version_text.set(text);
+        }
+    });
+    view! {
+        <span>{move || version_text.get()}</span>
+    }
+}
+```
+
+Delete the entire function (including the `#[component]` attribute and any blank lines immediately before/after). Verify with `grep -n "VersionFooter" crates/presenter-ui/src/pages/operator.rs` — expected output: NO matches.
+
+- [ ] **Step 4: Build the WASM crate**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo build --target wasm32-unknown-unknown 2>&1 | tail -15
+```
+
+Expected: clean build. If build fails because `crate::api::HealthzResponse` or `crate::api::get_json` is not visible from the new `components/version_label.rs` location, check the existing imports in operator.rs and replicate them in the new file.
+
+- [ ] **Step 5: Run clippy on the WASM crate**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Run cargo fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-ui/src/components/version_label.rs crates/presenter-ui/src/components/mod.rs crates/presenter-ui/src/pages/operator.rs && git commit -m "refactor(ui): extract VersionLabel into shared component (#287)"
+```
+
+---
+
+## Task 3: Add VersionLabel to Tablet (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/pages/tablet.rs:141-149`
+- Modify: `crates/presenter-ui/styles/tablet.css` (append rule)
+
+- [ ] **Step 1: Add VersionLabel to TabletPage view**
+
+In `crates/presenter-ui/src/pages/tablet.rs`, at line 141-149 the current view is:
+
+```rust
+    view! {
+        <TabletTimerBar />
+        <TabletHeader />
+        <main class="tablet-layout">
+            <TabletSidebar />
+            <TabletMain />
+        </main>
+        <TabletToast />
+    }
+```
+
+Replace with:
+
+```rust
+    view! {
+        <TabletTimerBar />
+        <TabletHeader />
+        <main class="tablet-layout">
+            <TabletSidebar />
+            <TabletMain />
+        </main>
+        <TabletToast />
+        <span class="tablet__version-badge">
+            <crate::components::version_label::VersionLabel />
+        </span>
+    }
+```
+
+- [ ] **Step 2: Append CSS rule to styles/tablet.css**
+
+In `crates/presenter-ui/styles/tablet.css`, append (at end of file):
+
+```css
+
+/* Version badge — bottom-right corner, small, low-opacity, non-interactive */
+.tablet__version-badge {
+  position: fixed;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+  z-index: 1;
+}
+```
+
+- [ ] **Step 3: Verify the WASM crate still builds**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo build --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-ui/src/pages/tablet.rs crates/presenter-ui/styles/tablet.css && git commit -m "feat(ui): add version label to tablet page (#287)"
+```
+
+---
+
+## Task 4: Add VersionLabel to Stage StatusBar (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/status_bar.rs:90-111`
+- Modify: `crates/presenter-ui/styles/stage.css` (append rule)
+
+- [ ] **Step 1: Add VersionLabel to StatusBar view**
+
+In `crates/presenter-ui/src/components/stage/status_bar.rs`, the current view (lines 90-111) is:
+
+```rust
+    view! {
+        <div node_ref=clock_ref class="stage__clock">
+            <span class="stage__debug-label">"clock"</span>
+            {clock_text}
+        </div>
+        {move || has_song_number().then(|| view! {
+            <div node_ref=song_number_ref class="stage__song-number" data-role="song-number">
+                <span class="stage__debug-label">"song-number"</span>
+                {song_number}
+            </div>
+        })}
+        {(!hide_live).then(|| view! {
+            <div node_ref=live_ref class=live_class>
+                <span class="stage__debug-label">"live"</span>
+                {live_text}
+            </div>
+        })}
+        <div node_ref=connection_ref class=connection_class>
+            <span class="stage__debug-label">"connection"</span>
+            {connection_text}
+        </div>
+    }
+```
+
+Replace with (added new `<div class="stage__version">` AFTER the connection block — per user request "always small under the latency"):
+
+```rust
+    view! {
+        <div node_ref=clock_ref class="stage__clock">
+            <span class="stage__debug-label">"clock"</span>
+            {clock_text}
+        </div>
+        {move || has_song_number().then(|| view! {
+            <div node_ref=song_number_ref class="stage__song-number" data-role="song-number">
+                <span class="stage__debug-label">"song-number"</span>
+                {song_number}
+            </div>
+        })}
+        {(!hide_live).then(|| view! {
+            <div node_ref=live_ref class=live_class>
+                <span class="stage__debug-label">"live"</span>
+                {live_text}
+            </div>
+        })}
+        <div node_ref=connection_ref class=connection_class>
+            <span class="stage__debug-label">"connection"</span>
+            {connection_text}
+        </div>
+        <div class="stage__version">
+            <span class="stage__debug-label">"version"</span>
+            <crate::components::version_label::VersionLabel />
+        </div>
+    }
+```
+
+- [ ] **Step 2: Append CSS rule to styles/stage.css**
+
+In `crates/presenter-ui/styles/stage.css`, append (at end of file):
+
+```css
+
+/* Version label inside StatusBar — small, under the connection/latency display */
+.stage__version {
+  font-size: 0.5em;
+  opacity: 0.6;
+}
+```
+
+- [ ] **Step 3: Verify the WASM crate still builds**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo build --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-ui/src/components/stage/status_bar.rs crates/presenter-ui/styles/stage.css && git commit -m "feat(ui): add version label to stage status bar (#287)"
+```
+
+---
+
+## Task 5: Add Playwright Helper + Per-Route Assertions (Sonnet)
+
+**Files:**
+- Modify: `tests/e2e/support.ts` (add helper)
+- Modify: one test per route — find the simplest existing E2E test for each of operator, tablet, stage, and add a single helper call.
+
+- [ ] **Step 1: Add the assertVersionLabel helper to tests/e2e/support.ts**
+
+In `tests/e2e/support.ts`, add this helper at the end of the file (or in alphabetical/logical position with other exports):
+
+```typescript
+import { type Page } from "@playwright/test";
+
+/**
+ * Assert that the version label on the current page exists, has the expected
+ * format, and matches the backend `/healthz` response.
+ *
+ * Format: `v<major>.<minor>.<patch>(-dev.<n>)?( (<channel>))?`
+ * Examples: `v0.4.52`, `v0.4.52 (dev)`, `v0.4.52-dev.3 (dev)`
+ *
+ * Frontend version MUST equal `/healthz` `version` field — single source of
+ * truth. Channel suffix appears only for non-release builds.
+ */
+export async function assertVersionLabel(
+  page: import("@playwright/test").Page,
+  baseURL: string,
+): Promise<void> {
+  const versionEl = page.locator('[data-testid="version"]').first();
+  await expect(versionEl).toBeVisible({ timeout: 10_000 });
+
+  const text = (await versionEl.textContent())?.trim() ?? "";
+  expect(text).toMatch(/^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$/);
+
+  const healthRes = await fetch(new URL("/healthz", baseURL).toString());
+  const health = (await healthRes.json()) as {
+    version: string;
+    channel: string;
+  };
+  const expected =
+    health.channel === "release" || health.channel === ""
+      ? `v${health.version}`
+      : `v${health.version} (${health.channel})`;
+  expect(text).toBe(expected);
+}
+```
+
+If `import { type Page }` is already imported elsewhere in the file, do not duplicate it — adapt the helper signature to use the existing import.
+
+If `expect` and `Locator` are already imported (they are, per earlier grep — line 7 of support.ts), reuse them; do not re-import.
+
+The helper uses `globalThis.fetch` (Node 18+ has it built-in; verify by running an existing Playwright test once to confirm). If `fetch` is not available, replace with `await page.request.get('/healthz')` and parse the JSON via the Playwright APIRequestContext pattern.
+
+- [ ] **Step 2: Find existing E2E tests per route**
+
+Run from `/home/newlevel/devel/presenter/presenter-dev2`:
+
+```bash
+ls tests/e2e/ | head -30
+```
+
+Identify the simplest, fastest test file for each of:
+- **operator** — likely `tests/e2e/operator-*.spec.ts` or `tests/e2e/settings.spec.ts` (settings is reached via operator). Pick one that loads `/ui/operator` and waits for ready state.
+- **tablet** — likely `tests/e2e/tablet.spec.ts` or `tests/e2e/tablet-pwa.spec.ts`. Pick the one that just loads the tablet page.
+- **stage** — likely `tests/e2e/stage*.spec.ts` or a stage-related spec. Find a test that opens `/stage`.
+
+If a route has multiple tests, pick the one that reaches a stable post-load state quickest (e.g., the test that just verifies the page loads and the WS connects).
+
+- [ ] **Step 3: Add assertVersionLabel call to one operator test**
+
+In the chosen operator E2E test, immediately after the page reaches its stable load state (typically after `await page.waitForLoadState('networkidle')` or after a specific selector becomes visible), add:
+
+```typescript
+import { assertVersionLabel } from "./support";
+// ... inside the test ...
+await assertVersionLabel(page, baseURL);
+```
+
+If `assertVersionLabel` is exported from a different relative path, adjust the import. The test file's existing `import` block likely already pulls from `./support`; just add `assertVersionLabel` to that import list.
+
+`baseURL` is conventionally available from the test fixture (`{ baseURL }` in the test signature). If it isn't, capture it from `process.env.PRESENTER_BASE_URL` or the existing pattern used in that test file.
+
+- [ ] **Step 4: Add assertVersionLabel call to one tablet test**
+
+Same pattern as Step 3, in the chosen tablet test. After the tablet page reaches its stable load state (e.g., after `await expect(page.locator('[data-role="tablet-ready"]')).toBeVisible()` — adapt to whatever readiness signal that test uses), add:
+
+```typescript
+await assertVersionLabel(page, baseURL);
+```
+
+- [ ] **Step 5: Add assertVersionLabel call to one stage test**
+
+Same pattern as Step 3, in the chosen stage test. The stage page exposes `__presenterStageConnectionState` global; test should wait until that becomes `"connected"` before asserting the version label (the WS state going to connected confirms the page is fully loaded).
+
+```typescript
+await assertVersionLabel(page, baseURL);
+```
+
+- [ ] **Step 6: Run the modified tests locally**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && npm run test:playwright -- --grep "<your test name>" 2>&1 | tail -30
+```
+
+Substitute `<your test name>` with the test names you modified. If the project uses tags or `--project` filters, follow the existing pattern (check `package.json` `scripts` and `playwright.config.*`).
+
+Expected: tests pass with the new assertion. If a test fails because the version label is missing or has the wrong format, fix the implementation in earlier tasks.
+
+If running individual tests is awkward in this project, run the broader smoke suite:
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && npm run test:playwright -- --grep "@smoke" 2>&1 | tail -30
+```
+
+Or fall back to running the entire e2e suite — slower but exhaustive.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add tests/e2e/ && git commit -m "test(e2e): add per-route version label assertion (#287)"
+```
+
+If you only modified specific files, add them by name rather than `tests/e2e/`. Avoid `git add -A`.
+
+---
+
+## Task 6: Local Checks, Push, CI Monitor, Dev Verification, Open PR (Controller)
+
+This task is handled by the controller (the agent driving the plan), not an implementer subagent. Local Rust + WASM builds are allowed on this machine.
+
+### Local pre-push checks
+
+- [ ] **Step 1: Workspace fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all --check
+```
+
+Expected: zero output.
+
+- [ ] **Step 2: Workspace clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 3: presenter-ui WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 4: presenter-server tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo test -p presenter-server 2>&1 | tail -10
+```
+
+Expected: all tests pass (this PR doesn't touch server code; this confirms no regression).
+
+- [ ] **Step 5: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git push origin dev
+```
+
+- [ ] **Step 6: Monitor CI to terminal state**
+
+Per `core/ci-monitoring.md`: ONE background `sleep + gh run view` per cycle. Never `gh run watch`. Never custom monitor scripts.
+
+```bash
+RUN_ID=$(gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId')
+sleep 900 && gh run view $RUN_ID --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Wait for ALL jobs to reach `"status": "completed"`. If any fails, `gh run view <run-id> --log-failed`, fix root cause in ONE commit, push, monitor again.
+
+### Dev verification (after CI deploys)
+
+- [ ] **Step 7: Verify all four routes show v0.4.52**
+
+```bash
+echo "=== /healthz ===" && curl -s http://10.77.8.134:8080/healthz
+echo
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.52"}`.
+
+Open in Playwright (or a browser if running interactively) each of:
+
+1. `http://10.77.8.134:8080/ui/operator` — version visible bottom-right
+2. `http://10.77.8.134:8080/ui/operator/bible` — version visible bottom-right (inherits from operator)
+3. `http://10.77.8.134:8080/ui/tablet` — version visible bottom-right (small badge)
+4. `http://10.77.8.134:8080/stage` — version visible in status bar, under connection/latency
+
+For automated verification, use the Playwright MCP:
+
+```
+mcp__plugin_playwright_playwright__browser_navigate(url: "http://10.77.8.134:8080/ui/tablet")
+mcp__plugin_playwright_playwright__browser_evaluate(function: "() => document.querySelector('[data-testid=\"version\"]')?.textContent")
+```
+
+The returned text MUST start with `v0.4.52`. Repeat for all four routes.
+
+### Open PR
+
+- [ ] **Step 8: Open PR**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && gh pr create --base main --head dev --title "feat(ui): version display on every route (#287)" --body "$(cat <<'EOF'
+## Summary
+
+Extends the deployed version label to every UI route so post-deploy verification works regardless of which route the user is on. Closes #287.
+
+Per `~/devel/airuleset/modules/quality/version-on-dashboard.md`, every web dashboard MUST show the deployed version label visibly on every route. Today only `/ui/operator` does — this PR fixes that for `/ui/tablet` and `/stage`. (`/ui/operator/bible` already inherits the operator footer.)
+
+## What changed
+
+- New shared component `crates/presenter-ui/src/components/version_label.rs` (`VersionLabel`).
+- Refactored operator's inline `VersionFooter` to use `VersionLabel`. Pixel-identical output.
+- Added `<VersionLabel />` to `pages/tablet.rs` (bottom-right corner badge).
+- Added `<VersionLabel />` to `components/stage/status_bar.rs` (small line under connection/latency).
+- New Playwright helper `assertVersionLabel(page, baseURL)` in `tests/e2e/support.ts`.
+- Per-route assertions added to one operator, one tablet, one stage E2E test.
+- Bumped version 0.4.51 → 0.4.52.
+
+## Test plan
+
+- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` — zero warnings
+- [x] `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` — zero warnings (presenter-ui)
+- [x] `cargo fmt --all --check` — clean
+- [x] `cargo test -p presenter-server` — all green (no server changes)
+- [x] CI green on dev
+- [x] Manual dev verification on all four routes — version label visible, correct format, matches `/healthz`
+
+Closes #287
+EOF
+)"
+```
+
+- [ ] **Step 9: Confirm PR is mergeable + clean**
+
+```bash
+PR_NUM=$(gh pr list --head dev --base main --json number --jq '.[0].number')
+gh api repos/zbynekdrlik/presenter/pulls/$PR_NUM --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `{"mergeable": true, "mergeable_state": "clean"}`.
+
+If `mergeable_state` is `"unstable"`, wait — Mutation Testing or another long-running job may still be in progress. If `"behind"`, sync dev with main and push. If `"dirty"` or `"blocked"`, investigate the root cause; never bypass branch protection.
+
+### Pre-completion gate
+
+- [ ] **Step 10: Run `/plan-check`**
+
+Audit every requirement in this plan and the spec. Every item must be `[x]`.
+
+- [ ] **Step 11: Run `/review`** on the PR diff
+
+Address every 🔴, 🟡, AND 🔵 finding inside the diff. Re-run until both audits return `0 🔴 0 🟡 0 🔵`.
+
+- [ ] **Step 12: Send completion report**
+
+Per `core/completion-report.md`. Include:
+
+- `✅ CI: green` (with run id)
+- `✅ /plan-check: N/N fulfilled`
+- `✅ /review: clean — 0 🔴 0 🟡 0 🔵`
+- `✅ Deploy: dev shows v0.4.52 on all four routes (operator, operator/bible, tablet, stage)`
+- `🌐 Dev:  http://10.77.8.134:8080/ui/operator`
+- `🌐 Prod: http://10.77.9.205/ui/operator`
+- `[presenter] PR #N: <full title>` + URL
+- Wait for explicit "merge it" before merging.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| `VersionLabel` exists and is shared | `grep -n "pub fn VersionLabel" crates/presenter-ui/src/components/version_label.rs` |
+| Operator footer still works | Open `/ui/operator` on dev — version visible bottom-right (no visual change) |
+| Operator/bible inherits | Open `/ui/operator/bible` — same footer visible |
+| Tablet shows version | Open `/ui/tablet` — small bottom-right badge with version |
+| Stage shows version under latency | Open `/stage` — version label visible in status bar, immediately after `CONNECTED · NN ms` |
+| Format regex valid | Playwright helper asserts `/^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$/` |
+| Frontend = backend | Playwright helper asserts equal to `/healthz` value |
+| CI green | All Pipeline + Deploy + Mutation Testing jobs `success` |
+| No regressions | `cargo test -p presenter-server` 184 tests still pass |

--- a/docs/superpowers/specs/2026-05-02-version-display-all-routes-design.md
+++ b/docs/superpowers/specs/2026-05-02-version-display-all-routes-design.md
@@ -1,0 +1,197 @@
+# Version Display on Every UI Route — Design
+
+**Date:** 2026-05-02
+**Status:** Proposed
+**Scope:** Frontend (presenter-ui WASM) + E2E tests
+**Issue:** [#287](https://github.com/zbynekdrlik/presenter/issues/287) — Extend version display to all UI routes + add Playwright assertion (foundation)
+
+## Goal
+
+Display the deployed version on every user-facing UI route (`/ui/operator`, `/ui/tablet`, `/ui/bible`, `/stage`) so post-deploy verification can confirm the new build is live regardless of which route the user is on. Add a Playwright assertion so format and frontend/backend match are continuously validated.
+
+## Why
+
+Per `~/devel/airuleset/modules/quality/version-on-dashboard.md`, every web dashboard MUST show the deployed version label visibly on every route. Today only `/ui/operator` does. Tablet, Bible, and Stage UIs are blind spots — a tablet operator reporting an issue can't tell which version they're on, frontend/backend drift can ship invisibly, and the completion-report `Deploy:` line can only verify the operator route.
+
+## Approach
+
+Reusable Leptos component approach. Move the existing operator-only `VersionFooter` (in `crates/presenter-ui/src/pages/operator.rs:593`) to a shared component at `crates/presenter-ui/src/components/version_label.rs` named `VersionLabel`. Embed it in tablet, bible, and the stage status bar. Add a `data-testid="version"` attribute so Playwright can target it. Add a per-route Playwright helper that asserts format and frontend/backend match.
+
+## Components
+
+### 1. Shared `VersionLabel` component
+
+New file: `crates/presenter-ui/src/components/version_label.rs`
+
+Contract:
+
+```rust
+#[component]
+pub fn VersionLabel(
+    /// Optional CSS class for per-page styling
+    #[prop(optional, into)] class: Option<String>,
+) -> impl IntoView { ... }
+```
+
+Renders `<span data-testid="version" class={class}>v{version} ({channel})</span>` if channel is `dev`, or `<span data-testid="version" class={class}>v{version}</span>` if channel is `release` or empty. Fetches `/healthz` once on mount via `crate::api::get_json::<HealthzResponse>("/healthz")`. Same logic as today's `VersionFooter` — no behavioral change.
+
+Re-export from `crates/presenter-ui/src/components/mod.rs`.
+
+### 2. Operator integration
+
+Replace the existing `VersionFooter` private component in `pages/operator.rs` with a call to `VersionLabel`. Existing visual layout preserved:
+
+```rust
+<footer class="operator__version">
+    <VersionLabel class="operator__version-text" />
+</footer>
+```
+
+The `VersionFooter` private component is deleted (its logic moved into `VersionLabel`).
+
+### 3. Tablet integration
+
+Add to `crates/presenter-ui/src/pages/tablet.rs` — small bottom-right corner badge, low-opacity, must not steal touch targets:
+
+```rust
+<span class="tablet__version-badge"><VersionLabel /></span>
+```
+
+CSS in `crates/presenter-ui/style/tablet.scss` (or wherever tablet styles live):
+
+```scss
+.tablet__version-badge {
+    position: fixed;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    font-size: 0.65rem;
+    opacity: 0.4;
+    pointer-events: none;
+    z-index: 1;
+}
+```
+
+### 4. Bible integration
+
+Same pattern as tablet — `crates/presenter-ui/src/pages/bible.rs`:
+
+```rust
+<span class="bible__version-badge"><VersionLabel /></span>
+```
+
+CSS class follows the same minimalist pattern (small, low-opacity, fixed bottom-right, non-interactive).
+
+### 5. Stage integration
+
+Embed inside the existing `StatusBar` component at `crates/presenter-ui/src/components/stage/status_bar.rs`. Add a NEW `<div>` immediately AFTER the connection block (which shows `CONNECTED · 23 ms`):
+
+```rust
+<div node_ref=connection_ref class=connection_class>
+    <span class="stage__debug-label">"connection"</span>
+    {connection_text}
+</div>
+<div class="stage__version">
+    <span class="stage__debug-label">"version"</span>
+    <VersionLabel />
+</div>
+```
+
+CSS:
+
+```scss
+.stage__version {
+    font-size: 0.5em; // smaller than other status-bar items per user request: "always small under the latency"
+    opacity: 0.6;
+}
+```
+
+The status bar appears in every stage layout (`worship_snv`, `worship_pp`, `preach_layout`, `timer_layout`, `bible_layout`, etc.) via the `StatusBar` component, so this single change covers all stage layouts.
+
+The `ndi_fullscreen` layout currently passes `hide_live=true` — confirm whether it shows the StatusBar at all. If `StatusBar` is not rendered in `ndi_fullscreen`, the version label won't appear there either; that's acceptable (NDI fullscreen is a pure video output and projecting any text on it would be a worse violation of the "no clutter on the projector" principle than the version label not appearing).
+
+### 6. Playwright assertion
+
+New helper in `tests/e2e/support.ts`:
+
+```typescript
+export async function assertVersionLabel(page: Page, baseURL: string): Promise<void> {
+    const versionEl = page.locator('[data-testid="version"]').first();
+    await expect(versionEl).toBeVisible({ timeout: 10_000 });
+    const text = (await versionEl.textContent())?.trim() ?? '';
+    expect(text).toMatch(/^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$/);
+
+    const healthRes = await fetch(new URL('/healthz', baseURL).toString());
+    const health = await healthRes.json() as { version: string; channel: string };
+    const expected = (health.channel === 'release' || health.channel === '')
+        ? `v${health.version}`
+        : `v${health.version} (${health.channel})`;
+    expect(text).toBe(expected);
+}
+```
+
+Existing E2E tests for each route get one line added after page load:
+
+- `tests/e2e/operator-*.spec.ts`: `await assertVersionLabel(page, baseURL)` (operator already covered today by visual check, this just adds the assertion)
+- `tests/e2e/tablet*.spec.ts`: same one line
+- A dedicated bible-route test if none exists; otherwise add to existing bible test
+- `tests/e2e/stage*.spec.ts` (or tablet pages that load stage): same one line
+
+Per-route assertion (rather than one combined test) is intentional — every existing route test guards its own version label, so a regression on any single route fails fast in the responsible test file.
+
+## Behavior after this change
+
+| Route | Before | After |
+|---|---|---|
+| `/ui/operator` | Bottom-right footer shows `v0.4.51 (dev)` | Same (component refactored, no visual change) |
+| `/ui/tablet` | No version display | Tiny bottom-right corner badge, opacity 0.4 |
+| `/ui/bible` | No version display | Tiny bottom-right corner badge, opacity 0.4 |
+| `/stage` | No version display | Small line in status bar, immediately under connection/latency |
+| Playwright | Operator visual only | Per-route `assertVersionLabel` enforcing format + backend match |
+
+## Testing
+
+### Unit / component tests (Rust)
+
+Not strictly required — the component is a thin wrapper around `/healthz` fetch and string formatting. Existing operator-route Playwright coverage already exercises this path. If `cargo test -p presenter-ui` has a pattern for component tests, add a unit test asserting the format strings; otherwise skip.
+
+### Playwright E2E
+
+For each of operator, tablet, bible, stage — assert via the new `assertVersionLabel` helper:
+
+1. Label exists at `[data-testid="version"]`
+2. Label is visible
+3. Format matches `^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$`
+4. Label text equals the value derived from `/healthz` (`v{version}` or `v{version} ({channel})`)
+
+### Manual verification on dev
+
+After CI deploys to dev:
+
+1. Open `http://10.77.8.134:8080/ui/operator` — version label visible bottom-right
+2. Open `http://10.77.8.134:8080/ui/tablet` — version label visible bottom-right (small)
+3. Open `http://10.77.8.134:8080/ui/bible` — version label visible bottom-right (small)
+4. Open `http://10.77.8.134:8080/stage` — version label visible under connection/latency in status bar
+5. All four show the same version (e.g. `v0.4.52 (dev)`)
+
+### CI
+
+The new helper runs in the existing `Playwright E2E` job; no workflow changes.
+
+## Closes
+
+- Issue #287 — version display foundation gate fulfilled.
+
+## Risks / unknowns
+
+- **Tablet/Bible CSS file location.** The plan says `crates/presenter-ui/style/tablet.scss` but the actual SCSS structure should be verified. If styles live elsewhere (e.g. inline `<style>`, single `style.scss` aggregator, or one-file-per-component), follow the existing pattern.
+- **NDI fullscreen layout.** `hide_live=true` is passed to NdiFullscreen — verify whether `StatusBar` is still rendered in that layout. If it is not (likely the case for a pure NDI passthrough), the version label intentionally does not appear there.
+- **`VersionLabel` first paint.** The component fetches `/healthz` async and renders empty until response arrives (~50ms typically). Existing `VersionFooter` has the same flash-of-empty behavior; no regression. Tablet/Bible badges are low-opacity and small, so the flash is unlikely to be noticed.
+- **Playwright `assertVersionLabel` timing.** The 10-second visibility timeout matches the existing pattern in the project's E2E helpers and accommodates slow `/healthz` resolution on cold-started server processes.
+
+## Out of scope
+
+- Build-time SHA injection or git-describe-style labels (`v0.4.51` from `/healthz` is sufficient; SHA suffix is nice-to-have, not in #287).
+- A dedicated `/version` API endpoint — `/healthz` already returns the same fields.
+- Auto-fade or query-param gating on `/stage` — user explicitly wants always-on under the latency display.
+- Visual redesign of the operator footer — refactor only; pixel-identical output.
+- E2E test for the `ndi_fullscreen` layout — not currently covered by Playwright; if added later, the absence of `StatusBar` there means no assertion needed for that specific layout.

--- a/tests/e2e/operator-controls.spec.ts
+++ b/tests/e2e/operator-controls.spec.ts
@@ -11,6 +11,7 @@
 
 import { test, expect } from "@playwright/test";
 import {
+  assertVersionLabel,
   deriveTestConfig,
   refreshDevData,
   startTestServer,
@@ -80,6 +81,7 @@ test.describe("Operator Control Buttons", () => {
     await page.waitForSelector('[data-role="library-list"]', {
       timeout: 30_000,
     });
+    await assertVersionLabel(page, baseURL);
 
     const abletonButton = page.locator('[data-role="ableset-enable"]');
     await expect(abletonButton).toBeVisible();

--- a/tests/e2e/stage-status-bar.spec.ts
+++ b/tests/e2e/stage-status-bar.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page, BrowserContext } from "@playwright/test";
 import WebSocket from "ws";
 import {
+  assertVersionLabel,
   deriveTestConfig,
   refreshDevData,
   startTestServer,
@@ -188,6 +189,7 @@ test.afterAll(async () => {
 
 test("stage status bar shows clock with current time", async ({ context }) => {
   const stagePage = await openStageDisplay(context);
+  await assertVersionLabel(stagePage, baseURL);
 
   // Check that clock element exists and has content
   const clockEl = stagePage.locator(".stage__clock");

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -369,6 +369,10 @@ export async function assertVersionLabel(
 ): Promise<void> {
   const versionEl = page.locator('[data-testid="version"]').first();
   await expect(versionEl).toBeVisible({ timeout: 10_000 });
+  // VersionLabel renders an empty <span> immediately; the version text
+  // populates asynchronously after /healthz resolves. Wait for non-empty
+  // text before reading, otherwise the assertion races with the WASM fetch.
+  await expect(versionEl).not.toHaveText("", { timeout: 10_000 });
 
   const text = (await versionEl.textContent())?.trim() ?? "";
   expect(text).toMatch(/^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$/);

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -4,7 +4,7 @@ import http from "http";
 import path from "path";
 import type { AddressInfo } from "net";
 import type { TestInfo } from "@playwright/test";
-import { expect, type Locator } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 export const REPO_ROOT = process.cwd();
 
@@ -351,6 +351,40 @@ export async function startMockResolume(): Promise<MockResolumeHandle> {
         });
       }),
   };
+}
+
+/**
+ * Assert that the version label on the current page exists, has the expected
+ * format, and matches the backend `/healthz` response.
+ *
+ * Format: `v<major>.<minor>.<patch>(-dev.<n>)?( (<channel>))?`
+ * Examples: `v0.4.52`, `v0.4.52 (dev)`, `v0.4.52-dev.3 (dev)`
+ *
+ * Frontend version MUST equal `/healthz` `version` field — single source of
+ * truth. Channel suffix appears only for non-release builds.
+ */
+export async function assertVersionLabel(
+  page: Page,
+  baseURL: string,
+): Promise<void> {
+  const versionEl = page.locator('[data-testid="version"]').first();
+  await expect(versionEl).toBeVisible({ timeout: 10_000 });
+
+  const text = (await versionEl.textContent())?.trim() ?? "";
+  expect(text).toMatch(/^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$/);
+
+  const healthRes = await page.request.get(
+    new URL("/healthz", baseURL).toString(),
+  );
+  const health = (await healthRes.json()) as {
+    version: string;
+    channel: string;
+  };
+  const expected =
+    health.channel === "release" || health.channel === ""
+      ? `v${health.version}`
+      : `v${health.version} (${health.channel})`;
+  expect(text).toBe(expected);
 }
 
 export async function startMockAbleSet(): Promise<MockAbleSetHandle> {

--- a/tests/e2e/tablet.spec.ts
+++ b/tests/e2e/tablet.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import {
+  assertVersionLabel,
   deriveTestConfig,
   refreshDevData,
   startTestServer,
@@ -125,6 +126,7 @@ test("tablet shows Bible presentations, renders slides, and triggers passages", 
     state: "visible",
     timeout: 20_000,
   });
+  await assertVersionLabel(page, baseURL);
 
   // --- Verify presentation appears in sidebar ---
   const presentationButton = page.locator(


### PR DESCRIPTION
## Summary

Extends the deployed version label to every UI route so post-deploy verification works regardless of which route the user is on. Closes #287.

Per `~/devel/airuleset/modules/quality/version-on-dashboard.md`, every web dashboard MUST show the deployed version label visibly on every route. Today only `/ui/operator` does — this PR fixes that for `/ui/tablet` and `/stage`. (`/ui/operator/bible` already inherits the operator footer.)

## What changed

- New shared component `crates/presenter-ui/src/components/version_label.rs` (`VersionLabel`) with `data-testid="version"`.
- Refactored operator's inline `VersionFooter` to use the shared component. Pixel-identical visual output.
- Added `<VersionLabel />` to `pages/tablet.rs` (small bottom-right corner badge).
- Added `<VersionLabel />` to `components/stage/status_bar.rs` — small line under the connection/latency display, per user request "always small under the latency".
- New Playwright helper `assertVersionLabel(page, baseURL)` in `tests/e2e/support.ts` — asserts the label exists, format matches `^v\d+\.\d+\.\d+(-dev\.\d+)?(\s\(\w+\))?$`, and equals `/healthz` value (frontend = backend, single source of truth). Waits for non-empty text to avoid race with the async fetch inside the WASM component.
- Per-route assertions added to `operator-controls.spec.ts`, `tablet.spec.ts`, `stage-status-bar.spec.ts`.
- Bumped version 0.4.51 → 0.4.52.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` — zero warnings
- [x] `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` — zero warnings (presenter-ui)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p presenter-server` — 184 tests passing
- [x] CI green on dev (Pipeline run 25252953255 — all 3 Playwright E2E shards green)
- [x] **Manual dev verification on all four routes via Playwright MCP:**
  - `/ui/operator` → `v0.4.52 (dev)` ✅
  - `/ui/operator/bible` → `v0.4.52 (dev)` ✅ (inherits operator footer)
  - `/ui/tablet` → `v0.4.52 (dev)` ✅ (fixed bottom-right badge)
  - `/stage` → `v0.4.52 (dev)` ✅ (in `.stage__version` under connection/latency)

Closes #287