### PR TITLE
feat(ui): operator slide-list scroll UX (#271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.53"
+version = "0.4.54"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -10,6 +10,7 @@ mod presentation_list_drag;
 pub mod presentation_modal;
 pub mod search;
 pub mod slide_list;
+mod slide_list_scroll;
 mod slide_list_utils;
 pub mod stage;
 pub mod stage_preview;

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -9,8 +9,10 @@ use crate::state::operator::OperatorState;
 use crate::state::AppContext;
 use crate::utils::color::group_pill_style;
 
+use super::slide_list_scroll::{handle_wheel_event, scroll_slide_into_view, scroll_slides_to_top};
 use super::slide_list_utils::{
-    apply_focused_class, field_has_warning, format_multiline, slide_has_any_warning,
+    apply_focused_class, field_has_warning, format_multiline, reorder_slide_ids,
+    slide_has_any_warning,
 };
 
 /// Get a textarea/input value from the DOM by slide_id and field name.
@@ -305,22 +307,7 @@ pub fn SlideList() -> impl IntoView {
                         <div
                             class="operator__slides"
                             data-role="slides"
-                            on:wheel=move |ev: web_sys::WheelEvent| {
-                                // Issue #271 concern 2: neutralise macOS scroll
-                                // acceleration by intercepting wheel events and
-                                // applying a deterministic per-notch scroll.
-                                ev.prevent_default();
-                                let direction = ev.delta_y().signum();
-                                if direction == 0.0 {
-                                    return;
-                                }
-                                let Some(target) = ev.target() else { return; };
-                                let Ok(el) = target.dyn_into::<web_sys::Element>() else { return; };
-                                let Ok(Some(container_el)) = el.closest(".operator__slides") else { return; };
-                                let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else { return; };
-                                let step = step_for_wheel(&container);
-                                container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
-                            }
+                            on:wheel=handle_wheel_event
                         on:dragover=move |ev: web_sys::DragEvent| {
                             if op_dragover.dragging_slide_id.get_untracked().is_some() {
                                 ev.prevent_default();
@@ -931,209 +918,5 @@ pub fn SlideList() -> impl IntoView {
                 }
             </div>
         </section>
-    }
-}
-
-/// Number of columns in the `.operator__slides` grid (CSS:
-/// `grid-template-columns: repeat(3, minmax(0, 1fr))`). The next-row anchor
-/// for an active slide at DOM index N is the slide at index N + COLUMNS_PER_ROW.
-const COLUMNS_PER_ROW: usize = 3;
-
-/// Lookahead-aware scroll: ensures the active slide AND the next row of
-/// slides are visible in the `.operator__slides` container. If the active
-/// slide is on the last row (no next-row anchor), falls back to "ensure
-/// active is visible". If the active slide is above the viewport (backward
-/// navigation), top-aligns it.
-///
-/// Issue #271 concern 1.
-fn scroll_slide_into_view(slide_id: &str) {
-    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-        return;
-    };
-    let active_selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
-    let Ok(Some(active_el)) = document.query_selector(&active_selector) else {
-        return;
-    };
-    let Ok(Some(container_el)) = active_el.closest(".operator__slides") else {
-        return;
-    };
-    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
-        return;
-    };
-    let Ok(active_html) = active_el.dyn_into::<web_sys::HtmlElement>() else {
-        return;
-    };
-
-    let container_rect = container.get_bounding_client_rect();
-    let active_rect = active_html.get_bounding_client_rect();
-    let scroll_top = container.scroll_top() as f64;
-
-    // Backward navigation: top-align the active slide if it's above the viewport.
-    if active_rect.top() < container_rect.top() {
-        let delta = container_rect.top() - active_rect.top();
-        container.set_scroll_top((scroll_top - delta) as i32);
-        return;
-    }
-
-    // Find the next-row anchor: the slide at active_index + COLUMNS_PER_ROW
-    // in DOM order within the same container.
-    let cards = container.query_selector_all("[data-slide-id]").ok();
-    let next_row_el: Option<web_sys::HtmlElement> = cards.and_then(|nodes| {
-        let mut active_index: Option<usize> = None;
-        for i in 0..nodes.length() {
-            if let Some(node) = nodes.item(i) {
-                if let Ok(el) = node.dyn_into::<web_sys::Element>() {
-                    if el.get_attribute("data-slide-id").as_deref() == Some(slide_id) {
-                        active_index = Some(i as usize);
-                        break;
-                    }
-                }
-            }
-        }
-        let target_index = active_index? + COLUMNS_PER_ROW;
-        nodes
-            .item(target_index as u32)
-            .and_then(|n| n.dyn_into::<web_sys::HtmlElement>().ok())
-    });
-
-    if let Some(anchor) = next_row_el {
-        // Scroll so the next-row anchor's bottom is at the container's bottom.
-        let anchor_rect = anchor.get_bounding_client_rect();
-        if anchor_rect.bottom() > container_rect.bottom() {
-            let delta = anchor_rect.bottom() - container_rect.bottom();
-            container.set_scroll_top((scroll_top + delta) as i32);
-        }
-    } else if active_rect.bottom() > container_rect.bottom() {
-        // No next-row anchor (last row) — fall back to bottom-aligning active.
-        let delta = active_rect.bottom() - container_rect.bottom();
-        container.set_scroll_top((scroll_top + delta) as i32);
-    }
-}
-
-/// Scrolls the `.operator__slides` container to its top. Used when the
-/// operator opens a new presentation so the first slide is visible without
-/// manual scroll-up. Issue #271 concern 3.
-fn scroll_slides_to_top() {
-    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-        return;
-    };
-    let Ok(Some(container_el)) = document.query_selector(".operator__slides") else {
-        return;
-    };
-    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
-        return;
-    };
-    container.set_scroll_top(0);
-}
-
-/// Default fallback step for wheel scroll (pixels) when no slide card is
-/// rendered yet to measure.
-const DEFAULT_WHEEL_STEP_PX: f64 = 120.0;
-
-/// Returns the pixel distance one wheel notch should scroll the
-/// `.operator__slides` container. Measures the first rendered slide card's
-/// height + the grid row gap so the step adapts to user font-size scaling.
-/// Falls back to `DEFAULT_WHEEL_STEP_PX` if no card is rendered.
-///
-/// Issue #271 concern 2: linearises wheel scrolling to neutralise macOS
-/// scroll acceleration.
-fn step_for_wheel(container: &web_sys::HtmlElement) -> f64 {
-    let Ok(Some(card_el)) = container.query_selector(".operator__slide-card") else {
-        return DEFAULT_WHEEL_STEP_PX;
-    };
-    let Ok(card) = card_el.dyn_into::<web_sys::HtmlElement>() else {
-        return DEFAULT_WHEEL_STEP_PX;
-    };
-    let card_height = card.get_bounding_client_rect().height();
-    if card_height <= 0.0 {
-        return DEFAULT_WHEEL_STEP_PX;
-    }
-    // Grid row gap from operator.css `.operator__slides`: `gap: 0.9rem`.
-    // 0.9rem at 16px base = 14.4px. Hardcoded — if CSS changes, update here.
-    card_height + 14.4
-}
-
-/// Pure reorder: given a slide id list and a drag/target pair, returns the new
-/// ordering, or `None` if the drag is a no-op (same id, missing ids).
-///
-/// Direction-based insertion: forward drags land AFTER the target, backward
-/// drags land BEFORE. This guarantees every distinct drag visibly moves the
-/// slide (the previous drop-position heuristic could be a no-op on forward
-/// drags into a target's upper half).
-fn reorder_slide_ids(ids: Vec<String>, dragged: &str, target: &str) -> Option<Vec<String>> {
-    if dragged == target {
-        return None;
-    }
-    let drag_pos = ids.iter().position(|id| id == dragged)?;
-    let target_pos = ids.iter().position(|id| id == target)?;
-    let forward = drag_pos < target_pos;
-    let mut new_ids = ids;
-    new_ids.remove(drag_pos);
-    // After removal, target_pos shifts down by 1 if the dragged slide was before it.
-    let adjusted_target = if forward { target_pos - 1 } else { target_pos };
-    let insert_idx = if forward {
-        adjusted_target + 1
-    } else {
-        adjusted_target
-    };
-    new_ids.insert(insert_idx, dragged.to_string());
-    Some(new_ids)
-}
-
-#[cfg(test)]
-mod reorder_tests {
-    use super::reorder_slide_ids;
-
-    fn ids(items: &[&str]) -> Vec<String> {
-        items.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn forward_drag_lands_after_target() {
-        // Drag "a" (pos 0) onto "d" (pos 3) → "a" ends up at pos 3.
-        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "d").unwrap();
-        assert_eq!(result, ids(&["b", "c", "d", "a", "e"]));
-    }
-
-    #[test]
-    fn backward_drag_lands_on_target_position() {
-        // Drag "d" (pos 3) onto "a" (pos 0) → "d" ends up at pos 0.
-        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "d", "a").unwrap();
-        assert_eq!(result, ids(&["d", "a", "b", "c", "e"]));
-    }
-
-    #[test]
-    fn adjacent_forward_swap() {
-        // Drag "b" onto "c" → "b" and "c" swap.
-        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "b", "c").unwrap();
-        assert_eq!(result, ids(&["a", "c", "b", "d"]));
-    }
-
-    #[test]
-    fn adjacent_backward_swap() {
-        // Drag "c" onto "b" → "c" and "b" swap.
-        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "c", "b").unwrap();
-        assert_eq!(result, ids(&["a", "c", "b", "d"]));
-    }
-
-    #[test]
-    fn same_id_returns_none() {
-        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "a").is_none());
-    }
-
-    #[test]
-    fn missing_dragged_returns_none() {
-        assert!(reorder_slide_ids(ids(&["a", "b"]), "z", "a").is_none());
-    }
-
-    #[test]
-    fn missing_target_returns_none() {
-        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "z").is_none());
-    }
-
-    #[test]
-    fn preserves_length() {
-        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "e").unwrap();
-        assert_eq!(result.len(), 5);
     }
 }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -305,6 +305,22 @@ pub fn SlideList() -> impl IntoView {
                         <div
                             class="operator__slides"
                             data-role="slides"
+                            on:wheel=move |ev: web_sys::WheelEvent| {
+                                // Issue #271 concern 2: neutralise macOS scroll
+                                // acceleration by intercepting wheel events and
+                                // applying a deterministic per-notch scroll.
+                                ev.prevent_default();
+                                let direction = ev.delta_y().signum();
+                                if direction == 0.0 {
+                                    return;
+                                }
+                                let Some(target) = ev.target() else { return; };
+                                let Ok(el) = target.dyn_into::<web_sys::Element>() else { return; };
+                                let Ok(Some(container_el)) = el.closest(".operator__slides") else { return; };
+                                let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else { return; };
+                                let step = step_for_wheel(&container);
+                                container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
+                            }
                         on:dragover=move |ev: web_sys::DragEvent| {
                             if op_dragover.dragging_slide_id.get_untracked().is_some() {
                                 ev.prevent_default();
@@ -1008,6 +1024,33 @@ fn scroll_slides_to_top() {
         return;
     };
     container.set_scroll_top(0);
+}
+
+/// Default fallback step for wheel scroll (pixels) when no slide card is
+/// rendered yet to measure.
+const DEFAULT_WHEEL_STEP_PX: f64 = 120.0;
+
+/// Returns the pixel distance one wheel notch should scroll the
+/// `.operator__slides` container. Measures the first rendered slide card's
+/// height + the grid row gap so the step adapts to user font-size scaling.
+/// Falls back to `DEFAULT_WHEEL_STEP_PX` if no card is rendered.
+///
+/// Issue #271 concern 2: linearises wheel scrolling to neutralise macOS
+/// scroll acceleration.
+fn step_for_wheel(container: &web_sys::HtmlElement) -> f64 {
+    let Ok(Some(card_el)) = container.query_selector(".operator__slide-card") else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let Ok(card) = card_el.dyn_into::<web_sys::HtmlElement>() else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let card_height = card.get_bounding_client_rect().height();
+    if card_height <= 0.0 {
+        return DEFAULT_WHEEL_STEP_PX;
+    }
+    // Grid row gap from operator.css `.operator__slides`: `gap: 0.9rem`.
+    // 0.9rem at 16px base = 14.4px. Hardcoded — if CSS changes, update here.
+    card_height + 14.4
 }
 
 /// Pure reorder: given a slide id list and a drag/target pair, returns the new

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -232,6 +232,20 @@ pub fn SlideList() -> impl IntoView {
         });
     }
 
+    // Scroll to top when the operator opens a different presentation.
+    // Issue #271 concern 3: new song should load with the first slide
+    // visible, not at the previous song's scroll position.
+    {
+        let selected_presentation_id = ctx.selected_presentation_id;
+        Effect::new(move |prev_id: Option<Option<String>>| {
+            let current_id = selected_presentation_id.get();
+            if current_id != prev_id.flatten() && current_id.is_some() {
+                gloo_timers::callback::Timeout::new(0, scroll_slides_to_top).forget();
+            }
+            current_id
+        });
+    }
+
     let trigger_slide = move |pres_id: String, slide_id: String, next_slide_id: Option<String>| {
         let playlist_id = ctx.selected_playlist_id.get_untracked();
         op.triggering_slide_id.set(Some(slide_id.clone()));
@@ -904,43 +918,96 @@ pub fn SlideList() -> impl IntoView {
     }
 }
 
-/// Assumes a vertically scrolling container (`.operator__slides`). If the list
-/// ever becomes horizontally scrollable, this function needs a companion branch.
+/// Number of columns in the `.operator__slides` grid (CSS:
+/// `grid-template-columns: repeat(3, minmax(0, 1fr))`). The next-row anchor
+/// for an active slide at DOM index N is the slide at index N + COLUMNS_PER_ROW.
+const COLUMNS_PER_ROW: usize = 3;
+
+/// Lookahead-aware scroll: ensures the active slide AND the next row of
+/// slides are visible in the `.operator__slides` container. If the active
+/// slide is on the last row (no next-row anchor), falls back to "ensure
+/// active is visible". If the active slide is above the viewport (backward
+/// navigation), top-aligns it.
+///
+/// Issue #271 concern 1.
 fn scroll_slide_into_view(slide_id: &str) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
-    let selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
-    let Ok(Some(el)) = document.query_selector(&selector) else {
+    let active_selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
+    let Ok(Some(active_el)) = document.query_selector(&active_selector) else {
         return;
     };
-    // Compute scroll position on the container so the active slide is in view.
-    // Find the scrollable ancestor (.operator__slides).
-    let Ok(Some(container)) = el.closest(".operator__slides") else {
+    let Ok(Some(container_el)) = active_el.closest(".operator__slides") else {
         return;
     };
-    let Ok(container) = container.dyn_into::<web_sys::HtmlElement>() else {
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
         return;
     };
-    let Ok(el_html) = el.dyn_into::<web_sys::HtmlElement>() else {
+    let Ok(active_html) = active_el.dyn_into::<web_sys::HtmlElement>() else {
         return;
     };
-    let el_rect = el_html.get_bounding_client_rect();
+
     let container_rect = container.get_bounding_client_rect();
-    let el_top = el_rect.top();
-    let el_bottom = el_rect.bottom();
-    let c_top = container_rect.top();
-    let c_bottom = container_rect.bottom();
+    let active_rect = active_html.get_bounding_client_rect();
     let scroll_top = container.scroll_top() as f64;
-    // If above viewport, scroll so element top is at container top.
-    if el_top < c_top {
-        let delta = c_top - el_top;
+
+    // Backward navigation: top-align the active slide if it's above the viewport.
+    if active_rect.top() < container_rect.top() {
+        let delta = container_rect.top() - active_rect.top();
         container.set_scroll_top((scroll_top - delta) as i32);
-    } else if el_bottom > c_bottom {
-        // If below viewport, scroll so element bottom is at container bottom.
-        let delta = el_bottom - c_bottom;
+        return;
+    }
+
+    // Find the next-row anchor: the slide at active_index + COLUMNS_PER_ROW
+    // in DOM order within the same container.
+    let cards = container.query_selector_all("[data-slide-id]").ok();
+    let next_row_el: Option<web_sys::HtmlElement> = cards.and_then(|nodes| {
+        let mut active_index: Option<usize> = None;
+        for i in 0..nodes.length() {
+            if let Some(node) = nodes.item(i) {
+                if let Ok(el) = node.dyn_into::<web_sys::Element>() {
+                    if el.get_attribute("data-slide-id").as_deref() == Some(slide_id) {
+                        active_index = Some(i as usize);
+                        break;
+                    }
+                }
+            }
+        }
+        let target_index = active_index? + COLUMNS_PER_ROW;
+        nodes
+            .item(target_index as u32)
+            .and_then(|n| n.dyn_into::<web_sys::HtmlElement>().ok())
+    });
+
+    if let Some(anchor) = next_row_el {
+        // Scroll so the next-row anchor's bottom is at the container's bottom.
+        let anchor_rect = anchor.get_bounding_client_rect();
+        if anchor_rect.bottom() > container_rect.bottom() {
+            let delta = anchor_rect.bottom() - container_rect.bottom();
+            container.set_scroll_top((scroll_top + delta) as i32);
+        }
+    } else if active_rect.bottom() > container_rect.bottom() {
+        // No next-row anchor (last row) — fall back to bottom-aligning active.
+        let delta = active_rect.bottom() - container_rect.bottom();
         container.set_scroll_top((scroll_top + delta) as i32);
     }
+}
+
+/// Scrolls the `.operator__slides` container to its top. Used when the
+/// operator opens a new presentation so the first slide is visible without
+/// manual scroll-up. Issue #271 concern 3.
+fn scroll_slides_to_top() {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Ok(Some(container_el)) = document.query_selector(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    container.set_scroll_top(0);
 }
 
 /// Pure reorder: given a slide id list and a drag/target pair, returns the new

--- a/crates/presenter-ui/src/components/slide_list_scroll.rs
+++ b/crates/presenter-ui/src/components/slide_list_scroll.rs
@@ -1,0 +1,146 @@
+//! Operator slide-list scroll behavior. Extracted from `slide_list.rs` to
+//! keep that file under the project's 1000-line cap.
+//!
+//! Issue #271: lookahead scroll, deterministic wheel scroll, scroll-to-top
+//! on song open.
+
+use wasm_bindgen::JsCast;
+
+/// Number of columns in the `.operator__slides` grid (CSS:
+/// `grid-template-columns: repeat(3, minmax(0, 1fr))`). The next-row anchor
+/// for an active slide at DOM index N is the slide at index N + COLUMNS_PER_ROW.
+const COLUMNS_PER_ROW: usize = 3;
+
+/// Default fallback step for wheel scroll (pixels) when no slide card is
+/// rendered yet to measure.
+const DEFAULT_WHEEL_STEP_PX: f64 = 120.0;
+
+/// Lookahead-aware scroll: ensures the active slide AND the next row of
+/// slides are visible in the `.operator__slides` container. If the active
+/// slide is on the last row (no next-row anchor), falls back to "ensure
+/// active is visible". If the active slide is above the viewport (backward
+/// navigation), top-aligns it.
+///
+/// Issue #271 concern 1.
+pub(super) fn scroll_slide_into_view(slide_id: &str) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let active_selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
+    let Ok(Some(active_el)) = document.query_selector(&active_selector) else {
+        return;
+    };
+    let Ok(Some(container_el)) = active_el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let Ok(active_html) = active_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+
+    let container_rect = container.get_bounding_client_rect();
+    let active_rect = active_html.get_bounding_client_rect();
+    let scroll_top = container.scroll_top() as f64;
+
+    // Backward navigation: top-align the active slide if it's above the viewport.
+    if active_rect.top() < container_rect.top() {
+        let delta = container_rect.top() - active_rect.top();
+        container.set_scroll_top((scroll_top - delta) as i32);
+        return;
+    }
+
+    // Find the next-row anchor: the slide at active_index + COLUMNS_PER_ROW
+    // in DOM order within the same container.
+    let cards = container.query_selector_all("[data-slide-id]").ok();
+    let next_row_el: Option<web_sys::HtmlElement> = cards.and_then(|nodes| {
+        let mut active_index: Option<usize> = None;
+        for i in 0..nodes.length() {
+            if let Some(node) = nodes.item(i) {
+                if let Ok(el) = node.dyn_into::<web_sys::Element>() {
+                    if el.get_attribute("data-slide-id").as_deref() == Some(slide_id) {
+                        active_index = Some(i as usize);
+                        break;
+                    }
+                }
+            }
+        }
+        let target_index = active_index? + COLUMNS_PER_ROW;
+        nodes
+            .item(target_index as u32)
+            .and_then(|n| n.dyn_into::<web_sys::HtmlElement>().ok())
+    });
+
+    if let Some(anchor) = next_row_el {
+        // Scroll so the next-row anchor's bottom is at the container's bottom.
+        let anchor_rect = anchor.get_bounding_client_rect();
+        if anchor_rect.bottom() > container_rect.bottom() {
+            let delta = anchor_rect.bottom() - container_rect.bottom();
+            container.set_scroll_top((scroll_top + delta) as i32);
+        }
+    } else if active_rect.bottom() > container_rect.bottom() {
+        // No next-row anchor (last row) — fall back to bottom-aligning active.
+        let delta = active_rect.bottom() - container_rect.bottom();
+        container.set_scroll_top((scroll_top + delta) as i32);
+    }
+}
+
+/// Scrolls the `.operator__slides` container to its top. Used when the
+/// operator opens a new presentation so the first slide is visible without
+/// manual scroll-up. Issue #271 concern 3.
+pub(super) fn scroll_slides_to_top() {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Ok(Some(container_el)) = document.query_selector(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    container.set_scroll_top(0);
+}
+
+/// Returns the pixel distance one wheel notch should scroll the
+/// `.operator__slides` container. Measures the first rendered slide card's
+/// height + the grid row gap so the step adapts to user font-size scaling.
+/// Falls back to `DEFAULT_WHEEL_STEP_PX` if no card is rendered.
+fn step_for_wheel(container: &web_sys::HtmlElement) -> f64 {
+    let Ok(Some(card_el)) = container.query_selector(".operator__slide-card") else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let Ok(card) = card_el.dyn_into::<web_sys::HtmlElement>() else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let card_height = card.get_bounding_client_rect().height();
+    if card_height <= 0.0 {
+        return DEFAULT_WHEEL_STEP_PX;
+    }
+    // Grid row gap from operator.css `.operator__slides`: `gap: 0.9rem`.
+    // 0.9rem at 16px base = 14.4px. Hardcoded — if CSS changes, update here.
+    card_height + 14.4
+}
+
+/// Wheel handler for `.operator__slides`: intercepts the native (accelerated)
+/// scroll, applies a deterministic per-notch step instead. Issue #271 concern 2:
+/// neutralises macOS scroll acceleration so each notch advances ~1 row.
+pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
+    ev.prevent_default();
+    let direction = ev.delta_y().signum();
+    if direction == 0.0 {
+        return;
+    }
+    let Some(target) = ev.target() else { return };
+    let Ok(el) = target.dyn_into::<web_sys::Element>() else {
+        return;
+    };
+    let Ok(Some(container_el)) = el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let step = step_for_wheel(&container);
+    container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
+}

--- a/crates/presenter-ui/src/components/slide_list_utils.rs
+++ b/crates/presenter-ui/src/components/slide_list_utils.rs
@@ -55,6 +55,37 @@ pub(super) fn apply_focused_class(slide_id: &str) {
     }
 }
 
+/// Pure reorder: given a slide id list and a drag/target pair, returns the new
+/// ordering, or `None` if the drag is a no-op (same id, missing ids).
+///
+/// Direction-based insertion: forward drags land AFTER the target, backward
+/// drags land BEFORE. This guarantees every distinct drag visibly moves the
+/// slide (the previous drop-position heuristic could be a no-op on forward
+/// drags into a target's upper half).
+pub(super) fn reorder_slide_ids(
+    ids: Vec<String>,
+    dragged: &str,
+    target: &str,
+) -> Option<Vec<String>> {
+    if dragged == target {
+        return None;
+    }
+    let drag_pos = ids.iter().position(|id| id == dragged)?;
+    let target_pos = ids.iter().position(|id| id == target)?;
+    let forward = drag_pos < target_pos;
+    let mut new_ids = ids;
+    new_ids.remove(drag_pos);
+    // After removal, target_pos shifts down by 1 if the dragged slide was before it.
+    let adjusted_target = if forward { target_pos - 1 } else { target_pos };
+    let insert_idx = if forward {
+        adjusted_target + 1
+    } else {
+        adjusted_target
+    };
+    new_ids.insert(insert_idx, dragged.to_string());
+    Some(new_ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +160,58 @@ mod tests {
     fn zero_limit_disables_warnings() {
         let long = "abcdefghijklmnopqrstuvwxyz0123456";
         assert!(!field_has_warning(long, 0));
+    }
+
+    fn ids(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn reorder_forward_drag_lands_after_target() {
+        // Drag "a" (pos 0) onto "d" (pos 3) → "a" ends up at pos 3.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "d").unwrap();
+        assert_eq!(result, ids(&["b", "c", "d", "a", "e"]));
+    }
+
+    #[test]
+    fn reorder_backward_drag_lands_on_target_position() {
+        // Drag "d" (pos 3) onto "a" (pos 0) → "d" ends up at pos 0.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "d", "a").unwrap();
+        assert_eq!(result, ids(&["d", "a", "b", "c", "e"]));
+    }
+
+    #[test]
+    fn reorder_adjacent_forward_swap() {
+        // Drag "b" onto "c" → "b" and "c" swap.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "b", "c").unwrap();
+        assert_eq!(result, ids(&["a", "c", "b", "d"]));
+    }
+
+    #[test]
+    fn reorder_adjacent_backward_swap() {
+        // Drag "c" onto "b" → "c" and "b" swap.
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d"]), "c", "b").unwrap();
+        assert_eq!(result, ids(&["a", "c", "b", "d"]));
+    }
+
+    #[test]
+    fn reorder_same_id_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "a").is_none());
+    }
+
+    #[test]
+    fn reorder_missing_dragged_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "z", "a").is_none());
+    }
+
+    #[test]
+    fn reorder_missing_target_returns_none() {
+        assert!(reorder_slide_ids(ids(&["a", "b"]), "a", "z").is_none());
+    }
+
+    #[test]
+    fn reorder_preserves_length() {
+        let result = reorder_slide_ids(ids(&["a", "b", "c", "d", "e"]), "a", "e").unwrap();
+        assert_eq!(result.len(), 5);
     }
 }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1081,6 +1081,7 @@ body.operator {
 .operator__slides {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0.35rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/docs/superpowers/plans/2026-05-02-operator-slide-scroll.md
+++ b/docs/superpowers/plans/2026-05-02-operator-slide-scroll.md
@@ -1,0 +1,870 @@
+# Operator Slide-List Scroll UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three operator slide-list scroll fixes for live worship: lookahead scroll keeps next row visible, wheel scroll becomes deterministic per-notch (neutralising macOS acceleration), and opening a new song scrolls to the first slide.
+
+**Architecture:** All changes inside `crates/presenter-ui/src/components/slide_list.rs` and one CSS line in `operator.css`. Three coordinated changes: (1) rewrite `scroll_slide_into_view` for lookahead using DOM order arithmetic (next-row anchor at active+3), (2) new Effect watching `ctx.selected_presentation_id` change → scroll-to-top, (3) `on:wheel` handler on the slides container with `prevent_default()` + linear `scroll_by`.
+
+**Tech Stack:** Rust + Leptos 0.7 (WASM via trunk), web_sys/WheelEvent, plain CSS, Playwright (TypeScript).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-operator-slide-scroll-design.md` (commit `a0bb145`)
+
+**Closes:** Issue #271 — operator slide-list scroll behavior during live worship.
+
+---
+
+## Context
+
+### Verified pre-flight findings
+
+- **Existing function:** `scroll_slide_into_view` at `crates/presenter-ui/src/components/slide_list.rs:909` — reactive scroll (top-align if above, bottom-align if below).
+- **Existing Effect:** `slide_list.rs:215-234` watches `ctx.stage_snapshot.current_slide_id`, calls `scroll_slide_into_view` via `Timeout(0)`. Use this pattern as the template for the new presentation-change Effect.
+- **Signal for load-at-start:** `ctx.selected_presentation_id: RwSignal<Option<String>>` at `crates/presenter-ui/src/state/mod.rs:42`. Watching the ID (cheap String comparison) is preferable to watching the full `selected_presentation: RwSignal<Option<Presentation>>` (deep struct compare).
+- **Slides container element:** `<div class="operator__slides" data-role="slides">` at `slide_list.rs:291-293`. Already has `on:dragover` and `on:drop` handlers. Add `on:wheel` here.
+- **CSS:** `.operator__slides` at `crates/presenter-ui/styles/operator.css:1081` — `display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.9rem; overflow-y: auto`. 3 columns hardcoded.
+- **Per-slide card:** `<article data-slide-id=...>` rendered at `slide_list.rs:473`. The first such article inside `.operator__slides` provides a reliable "card height" measurement for the wheel STEP.
+- **`gloo_timers::callback::Timeout::new(0, ...)`** is the project pattern for "run after next render".
+- **WheelEvent in web_sys:** `delta_y() -> f64`, `prevent_default() -> ()`. Available via `web_sys::WheelEvent`.
+
+### Three concerns share the same code surface
+
+All three fixes live in slide_list.rs's component setup block. Tasks 2 and 3 each contribute different scroll-control code to the same file. Test in Task 4 covers all three behaviors.
+
+---
+
+## File Structure
+
+### Modified files
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.53 → 0.4.54 |
+| `crates/presenter-ui/Cargo.toml` | presenter-ui version 0.1.22 → 0.1.23 |
+| `crates/presenter-ui/src/components/slide_list.rs` | Rewrite `scroll_slide_into_view` for lookahead; add `scroll_slides_to_top` helper, `step_for_wheel` helper, presentation-change Effect, and `on:wheel` handler on the `.operator__slides` div. |
+| `crates/presenter-ui/styles/operator.css` | Append `overscroll-behavior: contain` to `.operator__slides` rule at line 1081. |
+
+### Created files
+| File | Responsibility |
+|------|---------------|
+| `tests/e2e/operator-slide-scroll.spec.ts` | Playwright E2E — 3 tests covering lookahead, wheel linearisation, load-at-start. Uses existing `support.ts` helpers. |
+
+### Lock files
+- `Cargo.lock` (workspace) and `crates/presenter-ui/Cargo.lock` — auto-updated.
+
+---
+
+## Task 1: Bump Version (Haiku)
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/presenter-ui/Cargo.toml`
+- Modify: `Cargo.lock`, `crates/presenter-ui/Cargo.lock` (regenerated)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml`, under `[workspace.package]`, change:
+
+```toml
+version = "0.4.53"
+```
+
+to:
+
+```toml
+version = "0.4.54"
+```
+
+- [ ] **Step 2: Bump presenter-ui crate version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml`, under `[package]`, change:
+
+```toml
+version = "0.1.22"
+```
+
+to:
+
+```toml
+version = "0.1.23"
+```
+
+- [ ] **Step 3: Regenerate workspace Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check --workspace --all-targets 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Regenerate presenter-ui Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && grep -E "^version" Cargo.toml crates/presenter-ui/Cargo.toml | head -3
+```
+
+Expected:
+```
+Cargo.toml:version = "0.4.54"
+crates/presenter-ui/Cargo.toml:version = "0.1.23"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock && git commit -m "chore: bump version to 0.4.54 (#271)"
+```
+
+---
+
+## Task 2: Lookahead Scroll + Load-at-Start (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs` — rewrite `scroll_slide_into_view`, add `scroll_slides_to_top` helper, add presentation-change Effect.
+
+### Step 1: Read the current scroll function and Effect
+
+Run:
+
+```bash
+sed -n '215,234p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs
+sed -n '905,945p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs
+```
+
+Confirm the existing structure matches what's described in the plan context.
+
+### Step 2: Rewrite `scroll_slide_into_view` with lookahead
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, replace the entire function (currently lines 905-944, starting `/// Assumes a vertically scrolling container...` and ending at the closing `}` of `fn scroll_slide_into_view`) with:
+
+```rust
+/// Number of columns in the `.operator__slides` grid (CSS:
+/// `grid-template-columns: repeat(3, minmax(0, 1fr))`). The next-row anchor
+/// for an active slide at index N is the slide at index N + COLUMNS_PER_ROW
+/// in DOM order.
+const COLUMNS_PER_ROW: usize = 3;
+
+/// Lookahead-aware scroll: ensures the active slide AND the next row of
+/// slides are visible in the `.operator__slides` container. If the active
+/// slide is on the last row (no next-row anchor exists), falls back to
+/// "ensure active is visible" behavior.
+fn scroll_slide_into_view(slide_id: &str) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let active_selector = format!(".operator__slides [data-slide-id=\"{slide_id}\"]");
+    let Ok(Some(active_el)) = document.query_selector(&active_selector) else {
+        return;
+    };
+    let Ok(Some(container_el)) = active_el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let Ok(active_html) = active_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+
+    let container_rect = container.get_bounding_client_rect();
+    let active_rect = active_html.get_bounding_client_rect();
+    let scroll_top = container.scroll_top() as f64;
+
+    // If the active slide is above the viewport, top-align it first
+    // (covers backward navigation).
+    if active_rect.top() < container_rect.top() {
+        let delta = container_rect.top() - active_rect.top();
+        container.set_scroll_top((scroll_top - delta) as i32);
+        return;
+    }
+
+    // Find the next-row anchor: the slide whose DOM position is
+    // active_index + COLUMNS_PER_ROW within the same container.
+    let cards = container.query_selector_all("[data-slide-id]").ok();
+    let next_row_el: Option<web_sys::HtmlElement> = cards.and_then(|nodes| {
+        let mut active_index: Option<usize> = None;
+        for i in 0..nodes.length() {
+            if let Some(node) = nodes.item(i) {
+                if let Ok(el) = node.dyn_into::<web_sys::Element>() {
+                    if el.get_attribute("data-slide-id").as_deref() == Some(slide_id) {
+                        active_index = Some(i as usize);
+                        break;
+                    }
+                }
+            }
+        }
+        let target_index = active_index? + COLUMNS_PER_ROW;
+        nodes
+            .item(target_index as u32)
+            .and_then(|n| n.dyn_into::<web_sys::HtmlElement>().ok())
+    });
+
+    if let Some(anchor) = next_row_el {
+        // Scroll so the next-row anchor's bottom is at the container's bottom.
+        let anchor_rect = anchor.get_bounding_client_rect();
+        if anchor_rect.bottom() > container_rect.bottom() {
+            let delta = anchor_rect.bottom() - container_rect.bottom();
+            container.set_scroll_top((scroll_top + delta) as i32);
+        }
+    } else if active_rect.bottom() > container_rect.bottom() {
+        // No next-row anchor (last row) — fall back to bottom-aligning the active.
+        let delta = active_rect.bottom() - container_rect.bottom();
+        container.set_scroll_top((scroll_top + delta) as i32);
+    }
+}
+```
+
+Imports already present at the top of `slide_list.rs` should cover `web_sys`, `wasm_bindgen::JsCast` (for `dyn_into`). If a new import is needed, add `use wasm_bindgen::JsCast;` to the top of the file (verify it's not already imported with `grep "use wasm_bindgen::JsCast" crates/presenter-ui/src/components/slide_list.rs`).
+
+### Step 3: Add `scroll_slides_to_top` helper
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, immediately AFTER the `scroll_slide_into_view` function (just added), append:
+
+```rust
+/// Scrolls the `.operator__slides` container to its top. Used when the
+/// operator opens a new presentation so the first slide is visible without
+/// manual scroll-up. Issue #271 concern 3.
+fn scroll_slides_to_top() {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Ok(Some(container_el)) = document.query_selector(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    container.set_scroll_top(0);
+}
+```
+
+### Step 4: Add presentation-change Effect
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, find the existing Effect block at lines 215-234 (the one that watches `stage_snapshot.current_slide_id`). Immediately AFTER that closing brace (after line 234), insert this new Effect block:
+
+```rust
+    // Scroll to top when the operator opens a different presentation.
+    // Issue #271 concern 3: new song should load with the first slide
+    // visible, not at the previous song's scroll position.
+    {
+        let selected_presentation_id = ctx.selected_presentation_id;
+        Effect::new(move |prev_id: Option<Option<String>>| {
+            let current_id = selected_presentation_id.get();
+            if current_id != prev_id.flatten() && current_id.is_some() {
+                gloo_timers::callback::Timeout::new(0, scroll_slides_to_top).forget();
+            }
+            current_id
+        });
+    }
+```
+
+The `Timeout(0)` defers to the next event-loop tick so the new presentation's slides have rendered before the scroll. Same pattern as the existing scroll-into-view Effect.
+
+### Step 5: Build the WASM crate
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo build --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean build. If `JsCast` or `web_sys::HtmlElement` is unimported, add `use wasm_bindgen::JsCast;` at the top of slide_list.rs (the file already uses `web_sys::window()` etc., so most imports should be in place).
+
+### Step 6: Run clippy
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+### Step 7: Run cargo fmt
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all
+```
+
+### Step 8: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-ui/src/components/slide_list.rs && git commit -m "feat(ui): lookahead slide scroll + scroll-to-top on song open (#271)"
+```
+
+---
+
+## Task 3: Wheel Handler + CSS Boundary Guard (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs` — add `step_for_wheel` helper + `on:wheel` handler on the `.operator__slides` div.
+- Modify: `crates/presenter-ui/styles/operator.css` — add `overscroll-behavior: contain` to `.operator__slides`.
+
+### Step 1: Add `step_for_wheel` helper
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, immediately AFTER the `scroll_slides_to_top` function (added in Task 2), append:
+
+```rust
+/// Default fallback step for wheel scroll (pixels) when no slide card is
+/// rendered yet to measure.
+const DEFAULT_WHEEL_STEP_PX: f64 = 120.0;
+
+/// Returns the pixel distance one wheel notch should scroll the
+/// `.operator__slides` container. Measures the first rendered slide card's
+/// height + the grid row gap so the step adapts to user font-size scaling.
+/// Falls back to `DEFAULT_WHEEL_STEP_PX` if no card is rendered.
+///
+/// Issue #271 concern 2: linearises wheel scrolling to neutralise macOS
+/// scroll acceleration.
+fn step_for_wheel(container: &web_sys::HtmlElement) -> f64 {
+    let Ok(Some(card_el)) = container.query_selector(".operator__slide-card") else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let Ok(card) = card_el.dyn_into::<web_sys::HtmlElement>() else {
+        return DEFAULT_WHEEL_STEP_PX;
+    };
+    let card_height = card.get_bounding_client_rect().height();
+    if card_height <= 0.0 {
+        return DEFAULT_WHEEL_STEP_PX;
+    }
+    // Grid row gap from operator.css `.operator__slides`: `gap: 0.9rem`.
+    // 0.9rem at 16px base = 14.4px. Hardcoded — if CSS changes, update here.
+    card_height + 14.4
+}
+```
+
+### Step 2: Add `on:wheel` handler to `.operator__slides`
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, find the `.operator__slides` `<div>` at line 291-293 (it has `class="operator__slides"`, `data-role="slides"`, `on:dragover`, `on:drop`). Add an `on:wheel` handler in the SAME element (between `data-role="slides"` and the existing `on:dragover`).
+
+The current element opens (line 291) as:
+
+```rust
+                    <div
+                        class="operator__slides"
+                        data-role="slides"
+                    on:dragover=move |ev: web_sys::DragEvent| {
+```
+
+Insert the new handler immediately AFTER `data-role="slides"` and BEFORE the existing `on:dragover`. The full new block:
+
+```rust
+                    <div
+                        class="operator__slides"
+                        data-role="slides"
+                        on:wheel=move |ev: web_sys::WheelEvent| {
+                            // Issue #271 concern 2: neutralise macOS scroll
+                            // acceleration by intercepting wheel events and
+                            // applying a deterministic per-notch scroll.
+                            ev.prevent_default();
+                            let direction = ev.delta_y().signum();
+                            if direction == 0.0 {
+                                return;
+                            }
+                            let Some(target) = ev.target() else { return; };
+                            let Ok(el) = target.dyn_into::<web_sys::Element>() else { return; };
+                            let Ok(Some(container_el)) = el.closest(".operator__slides") else { return; };
+                            let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else { return; };
+                            let step = step_for_wheel(&container);
+                            container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
+                        }
+                    on:dragover=move |ev: web_sys::DragEvent| {
+```
+
+The handler reads the wheel direction (sign of deltaY), looks up the active container via the event target's closest ancestor (this works whether the wheel happened on a slide card or directly on the container), measures the step, and applies a single `set_scroll_top` call. Calling `prevent_default()` blocks the native accelerated scroll.
+
+### Step 3: Verify Leptos's `on:wheel` is non-passive
+
+Leptos 0.7's `on:` directive should default to passive=false for wheel events, but verify by running the dev binary after build. If `prevent_default()` is silently ignored (the native scroll still fires), Leptos may have set passive=true; in that case, switch to attaching the listener via `web_sys::Element::add_event_listener_with_callback_and_add_event_listener_options` with `passive: false`.
+
+For Step 4's smoke test, this verification happens implicitly: if scroll feels accelerated still, prevent_default isn't working. Note the result in the report.
+
+### Step 4: Add `overscroll-behavior: contain` to operator.css
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/operator.css`, find the `.operator__slides` rule at line 1081. Currently it reads:
+
+```css
+.operator__slides {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.35rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  min-height: 0;
+}
+```
+
+Add `overscroll-behavior: contain;` immediately after `overflow-y: auto;`:
+
+```css
+.operator__slides {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.35rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  min-height: 0;
+}
+```
+
+This prevents wheel events that exhaust the container's scroll from bubbling to the parent (which would scroll the page or cause the chrome rubber-band effect).
+
+### Step 5: Build the WASM crate
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo build --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean build.
+
+### Step 6: Run clippy
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings. If clippy flags `dyn_into` chains with `let Ok(...)` patterns, those are the project's existing style — accept and move on.
+
+### Step 7: Run cargo fmt
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all
+```
+
+### Step 8: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-ui/src/components/slide_list.rs crates/presenter-ui/styles/operator.css && git commit -m "feat(ui): linear wheel scroll + overscroll-behavior contain on slides (#271)"
+```
+
+---
+
+## Task 4: Playwright E2E (Sonnet)
+
+**Files:**
+- Create: `tests/e2e/operator-slide-scroll.spec.ts`
+
+The test exercises a 12+ slide worship song. The dev's seeded data includes `TYMY` library with 289 presentations of varying slide counts; the existing `support.ts` `refreshDevData` helper imports it. Pick a presentation with at least 10 slides (we'll find one at runtime).
+
+### Step 1: Inspect existing E2E patterns
+
+```bash
+ls /home/newlevel/devel/presenter/presenter-dev2/tests/e2e/ | head -30
+head -50 /home/newlevel/devel/presenter/presenter-dev2/tests/e2e/operator-controls.spec.ts
+```
+
+Confirm:
+- Pattern uses `startTestServer`/`refreshDevData`/`stopServer` from `support.ts` in `beforeAll`/`afterAll`.
+- `test.describe.configure({ timeout: 180_000 })` sets per-suite timeout.
+- Each test captures console messages and asserts `consoleMessages.toEqual([])` at the end.
+- Tests target `/ui/operator/worship` for the worship page.
+
+### Step 2: Create the E2E test file
+
+Create `/home/newlevel/devel/presenter/presenter-dev2/tests/e2e/operator-slide-scroll.spec.ts` with:
+
+```typescript
+/**
+ * E2E tests for issue #271 — operator slide-list scroll UX.
+ *
+ * Three concerns:
+ * 1. Lookahead: clicking a slide ensures the next row is visible below.
+ * 2. Linear wheel: each wheel notch scrolls a deterministic step regardless
+ *    of deltaY magnitude (neutralises macOS acceleration).
+ * 3. Load-at-start: opening a new presentation scrolls the slide list to top.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl, config.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+/**
+ * Helper: pick the first presentation with at least `minSlides` slides
+ * from the libraries summary endpoint.
+ */
+async function pickPresentationWithSlides(
+  request: import("@playwright/test").APIRequestContext,
+  baseURL: string,
+  minSlides: number,
+): Promise<{ libraryId: string; presentationId: string; slideCount: number }> {
+  const libsRes = await request.get(
+    new URL("/libraries/summary", baseURL).toString(),
+  );
+  const libs = (await libsRes.json()) as Array<{
+    id: string;
+    presentations: Array<{ id: string; slide_count: number }>;
+  }>;
+  for (const lib of libs) {
+    for (const p of lib.presentations) {
+      if (p.slide_count >= minSlides) {
+        return { libraryId: lib.id, presentationId: p.id, slideCount: p.slide_count };
+      }
+    }
+  }
+  throw new Error(`No presentation with >= ${minSlides} slides found`);
+}
+
+test("lookahead: clicking a slide makes next row visible", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  const target = await pickPresentationWithSlides(request, baseURL, 12);
+
+  await page.goto(new URL("/ui/operator/worship", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  // Open the presentation programmatically by setting the selected_presentation
+  // via the playlist API (reuses operator's normal flow). Simpler approach:
+  // navigate via the URL/state pattern the operator UI uses. If a direct API
+  // exists, prefer that; otherwise click through the library list to select.
+  await page.evaluate(([presId]) => {
+    // Project's session storage pattern stores currentPresentationId.
+    sessionStorage.setItem("currentPresentationId", presId);
+    location.reload();
+  }, [target.presentationId]);
+
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector(".operator__slides [data-slide-id]", { state: "visible" });
+
+  const cards = await page.locator(".operator__slides [data-slide-id]").all();
+  expect(cards.length).toBeGreaterThanOrEqual(12);
+
+  // Click the slide at index 3 (start of row 2 — 0-indexed: row 1 = 0-2, row 2 = 3-5).
+  await cards[3].click();
+
+  // Wait for the click to settle and the lookahead scroll to apply.
+  await page.waitForTimeout(200);
+
+  // Slide at index 6 (start of row 3) should be at least partially visible
+  // (its bounding rect's bottom should be within the container's bottom).
+  const visible = await page.evaluate(() => {
+    const cards = document.querySelectorAll(".operator__slides [data-slide-id]");
+    const container = document.querySelector(".operator__slides");
+    if (!container || cards.length < 7) return null;
+    const cRect = container.getBoundingClientRect();
+    const lookahead = cards[6].getBoundingClientRect();
+    return {
+      lookaheadVisible: lookahead.bottom <= cRect.bottom + 1 && lookahead.top >= cRect.top - 1,
+      lookaheadBottom: lookahead.bottom,
+      containerBottom: cRect.bottom,
+    };
+  });
+  expect(visible).not.toBeNull();
+  expect(visible!.lookaheadVisible).toBeTruthy();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("wheel: each notch scrolls a deterministic step", async ({ page, request }) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  const target = await pickPresentationWithSlides(request, baseURL, 12);
+
+  await page.goto(new URL("/ui/operator/worship", baseURL).toString());
+  await page.evaluate(([presId]) => {
+    sessionStorage.setItem("currentPresentationId", presId);
+    location.reload();
+  }, [target.presentationId]);
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector(".operator__slides [data-slide-id]", { state: "visible" });
+
+  // Reset scroll to top.
+  await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (c) c.scrollTop = 0;
+  });
+  await page.waitForTimeout(50);
+
+  // Dispatch a wheel event with deltaY=100. Capture the resulting scrollTop
+  // delta and the measured step (card height + 14.4). The scroll delta should
+  // equal the step, NOT 100 (i.e. our handler ignored deltaY magnitude).
+  const result = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (!c) return null;
+    const cardEl = c.querySelector(".operator__slide-card") as HTMLElement | null;
+    const expectedStep = cardEl ? cardEl.getBoundingClientRect().height + 14.4 : 120;
+    const before = c.scrollTop;
+    const ev = new WheelEvent("wheel", {
+      deltaY: 100,
+      bubbles: true,
+      cancelable: true,
+    });
+    c.dispatchEvent(ev);
+    return { before, after: c.scrollTop, expectedStep };
+  });
+  expect(result).not.toBeNull();
+  // Scroll should advance by approximately expectedStep, not by 100.
+  // Tolerance ±2px for sub-pixel rounding.
+  const actualDelta = result!.after - result!.before;
+  expect(actualDelta).toBeGreaterThan(result!.expectedStep - 2);
+  expect(actualDelta).toBeLessThan(result!.expectedStep + 2);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("load-at-start: opening a new presentation scrolls slide list to top", async ({
+  page,
+  request,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  // Pick TWO presentations so we can switch.
+  const libsRes = await request.get(
+    new URL("/libraries/summary", baseURL).toString(),
+  );
+  const libs = (await libsRes.json()) as Array<{
+    id: string;
+    presentations: Array<{ id: string; slide_count: number }>;
+  }>;
+  const candidates: string[] = [];
+  for (const lib of libs) {
+    for (const p of lib.presentations) {
+      if (p.slide_count >= 10) candidates.push(p.id);
+      if (candidates.length >= 2) break;
+    }
+    if (candidates.length >= 2) break;
+  }
+  expect(candidates.length).toBeGreaterThanOrEqual(2);
+
+  await page.goto(new URL("/ui/operator/worship", baseURL).toString());
+  await page.evaluate(([presId]) => {
+    sessionStorage.setItem("currentPresentationId", presId);
+    location.reload();
+  }, [candidates[0]]);
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector(".operator__slides [data-slide-id]", { state: "visible" });
+
+  // Scroll the slide list to the bottom.
+  await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (c) c.scrollTop = c.scrollHeight;
+  });
+  await page.waitForTimeout(50);
+  const scrolledDown = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    return c?.scrollTop ?? 0;
+  });
+  expect(scrolledDown).toBeGreaterThan(0);
+
+  // Switch to the second presentation. The presentation-change Effect should
+  // schedule scrollTop=0 after the new slides render.
+  await page.evaluate(([presId]) => {
+    // Trigger the same flow the operator uses to switch presentations.
+    // Setting selected_presentation_id directly via the WASM context isn't
+    // exposed; instead, we use sessionStorage + reload OR we click a different
+    // presentation in the catalog. Here we use sessionStorage for determinism.
+    sessionStorage.setItem("currentPresentationId", presId);
+    location.reload();
+  }, [candidates[1]]);
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector(".operator__slides [data-slide-id]", { state: "visible" });
+  // Wait for the Timeout(0) scroll-to-top to settle.
+  await page.waitForTimeout(200);
+
+  const scrollAfterSwitch = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    return c?.scrollTop ?? -1;
+  });
+  expect(scrollAfterSwitch).toBe(0);
+
+  expect(consoleMessages).toEqual([]);
+});
+```
+
+### Step 3: Run the test locally
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && npx playwright test tests/e2e/operator-slide-scroll.spec.ts --reporter=list 2>&1 | tail -30
+```
+
+Expected: 3 tests pass.
+
+If a test fails because:
+- `sessionStorage` + `location.reload()` doesn't trigger the WASM router to load the presentation: fall back to clicking through the library catalog. The existing `operator-controls.spec.ts` may show how to programmatically select a presentation; mirror that pattern.
+- `selected_presentation_id` isn't reactive on session-storage change: this is an internal WASM detail. If you discover the test pattern doesn't exercise the same code path as a real user click, switch to clicking through the catalog UI.
+- `slide_count` field name in the libraries summary is different (e.g. `slideCount` due to camelCase rename): adjust the field access.
+
+If the test reveals that Leptos's `on:wheel` IS passive and `prevent_default()` is silently ignored (the wheel test sees scroll delta of `100` not the step): escalate to Task 3's implementer; the fix is to use a manual `addEventListener` with `passive: false`.
+
+### Step 4: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add tests/e2e/operator-slide-scroll.spec.ts && git commit -m "test(e2e): operator slide-list scroll UX (#271)"
+```
+
+---
+
+## Task 5: Local Checks, Push, CI Monitor, Dev Verification, Open PR (Controller)
+
+This task is handled by the controller. Local Rust + WASM builds allowed.
+
+### Local pre-push checks
+
+- [ ] **Step 1: Workspace fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all --check
+```
+
+- [ ] **Step 2: Workspace clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+- [ ] **Step 3: presenter-ui WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Workspace tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo test -p presenter-server 2>&1 | tail -5
+```
+
+Expected: all 187 tests pass (no server changes; this is a regression check).
+
+- [ ] **Step 5: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git push origin dev
+```
+
+- [ ] **Step 6: Monitor CI**
+
+Per `core/ci-monitoring.md`: ONE background `sleep + gh run view`.
+
+```bash
+RUN_ID=$(gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId')
+sleep 1500 && gh run view $RUN_ID --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Wait for ALL jobs `completed`. If any fails, fix root cause in ONE commit, push, monitor again.
+
+### Dev verification
+
+- [ ] **Step 7: Verify dev shows v0.4.54**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.54"}`.
+
+- [ ] **Step 8: Manual UX verification on dev via Playwright MCP**
+
+Open `http://10.77.8.134:8080/ui/operator/worship` with a multi-slide song. Test:
+
+1. **Lookahead:** click a slide on row 2. Verify row 3 is visible.
+2. **Wheel:** scroll the slide list with the wheel. Verify each notch advances ~1 row deterministically.
+3. **Load-at-start:** scroll to bottom of one song, then switch to another. Verify the new song's slide list is at top.
+
+### Open PR
+
+- [ ] **Step 9: Open PR**
+
+```bash
+gh pr create --base main --head dev --title "feat(ui): operator slide-list scroll UX (#271)" --body "$(cat <<'EOF'
+## Summary
+
+Three operator slide-list scroll fixes for live worship services. Closes #271.
+
+## What changed
+
+- **Lookahead scroll:** when the active slide moves to a new row, the next row is now visible below it. `scroll_slide_into_view` now finds the next-row anchor (DOM index +3) and scrolls so its bottom is in view.
+- **Linear wheel scroll:** new `on:wheel` handler on `.operator__slides` calls `prevent_default()` and applies a deterministic per-notch scroll (card height + row gap). Neutralises macOS scroll acceleration.
+- **Load-at-start:** new Effect watches `ctx.selected_presentation_id`; on change, scrolls the slide list to top so the first slide is always visible when opening a new song.
+- **CSS:** `overscroll-behavior: contain` on `.operator__slides` prevents wheel events at boundary from scrolling the page.
+- Bumped version 0.4.53 → 0.4.54.
+
+## Test plan
+
+- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` — zero warnings
+- [x] `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` (presenter-ui) — zero warnings
+- [x] `cargo fmt --all --check` — clean
+- [x] `cargo test -p presenter-server` — all green (no server changes)
+- [x] CI green on dev
+- [x] **Manual dev verification:**
+  - Click slide on row 2 → row 3 visible ✅
+  - Wheel scroll → 1 row per notch deterministic ✅
+  - Switch songs → new song at top ✅
+
+Closes #271
+EOF
+)"
+```
+
+- [ ] **Step 10: Confirm PR clean**
+
+```bash
+PR_NUM=$(gh pr list --head dev --base main --json number --jq '.[0].number')
+gh api repos/zbynekdrlik/presenter/pulls/$PR_NUM --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `{"mergeable": true, "mergeable_state": "clean"}`.
+
+### Pre-completion gate
+
+- [ ] **Step 11: Run /plan-check**
+
+- [ ] **Step 12: Run /review** on the PR diff
+
+- [ ] **Step 13: Send completion report**
+
+Per `core/completion-report.md`. Include CI run id, /plan-check fulfillment, /review 0🔴 0🟡 0🔵, dev verification of all 3 fixes, dev + prod URLs, PR URL.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Lookahead scroll | Click slide on row 2 → row 3 visible (Playwright + manual) |
+| Linear wheel | dispatchEvent wheel → scrollTop delta = card height + 14.4 (not deltaY) |
+| Load-at-start | Switch presentations → scrollTop = 0 |
+| Wheel preventDefault works | If wheel test asserts deltaY-magnitude scroll, Leptos's on:wheel was passive — escalate |
+| CSS guard | overscroll-behavior: contain prevents page bleed at scroll boundary |
+| No regressions | All existing E2E tests still pass |

--- a/docs/superpowers/specs/2026-05-02-operator-slide-scroll-design.md
+++ b/docs/superpowers/specs/2026-05-02-operator-slide-scroll-design.md
@@ -1,0 +1,139 @@
+# Operator Slide-List Scroll UX — Design
+
+**Date:** 2026-05-02
+**Status:** Proposed
+**Scope:** Frontend (`presenter-ui`) — `crates/presenter-ui/src/components/slide_list.rs` + minor CSS
+**Issue:** [#271](https://github.com/zbynekdrlik/presenter/issues/271) — slide-list scroll behavior during live worship
+
+## Goal
+
+Three operator-UX fixes to the `/ui/operator` slide-list during live worship services:
+
+1. **Lookahead scroll:** when the active slide moves to a new row, ensure exactly one row of upcoming slides is visible BELOW the active row (proactive, not reactive).
+2. **Linear wheel scroll:** intercept mouse wheel events and apply a fixed-step `scrollBy`, neutralising macOS scroll acceleration so each notch advances ~1 row deterministically.
+3. **Load-at-start on song open:** when the operator selects a new presentation, scroll to the top so the first slide is visible — not the bottom of the previous song's scroll position.
+
+## Why
+
+The user reports during live services that:
+
+1. Clicking the next slide only causes the slide-list to scroll once the active slide is already off-screen — there's no lookahead. The operator can't see what's coming up.
+2. Wheel scrolling feels "exponential, first slow then fast" on the iMac+mouse setup. macOS applies scroll acceleration before browser delivery; for the operator's deliberate "scroll to next slide" gesture, this is jumpy and distracting.
+3. Opening a new worship song lands the slide-list scrolled near the bottom (whatever the previous scroll state was), forcing the operator to scroll back to slide 1 every time they switch songs.
+
+These three concerns share the same code surface (`slide_list.rs` + the `.operator__slides` container in `operator.css`) and the same mental model — "the operator should always be able to see what's next without manual scrolling".
+
+## Approach
+
+All changes inside `crates/presenter-ui/src/components/slide_list.rs`. No new files, no new public APIs. CSS unchanged unless the wheel handler needs `overscroll-behavior: contain` to prevent page scroll bleed-through.
+
+### Concern 1 — Lookahead scroll
+
+Replace the reactive logic in `scroll_slide_into_view` (currently `slide_list.rs:909`) with proactive lookahead. After locating the active slide element:
+
+- Find the slide whose `data-slide-id` matches the slide at the active index + 3 (next row, since the grid is `grid-template-columns: repeat(3, ...)` — confirmed in `operator.css:1081`).
+- If that "next-row anchor" element exists and its bottom edge sits below the container's bottom, scroll the container so the anchor's bottom is flush with the container's bottom.
+- If the active slide itself is above the container's top, top-align it (existing behavior preserved as a fallback when navigating backward).
+- If no next-row anchor exists (last row), fall back to the current "ensure active is visible" logic (bottom-align if below).
+
+The arithmetic uses the slide's *position in the rendered list*, not Cartesian coordinates — Leptos renders slides in DOM order, and the next row is always 3 DOM siblings later in the grid. This adapts automatically if the responsive breakpoint changes column count, because the next-row anchor jump is `+columns_per_row`. For now `columns_per_row = 3` is hardcoded; if a future redesign uses a different count, the constant is one place.
+
+### Concern 2 — Linear wheel scroll
+
+Add an `on:wheel` handler attached to the `.operator__slides` container (or its closest scrollable ancestor inside the slide list view). The handler:
+
+```rust
+on:wheel=move |ev: WheelEvent| {
+    ev.prevent_default();
+    let direction = ev.delta_y().signum();        // -1, 0, or +1
+    if direction == 0.0 { return; }
+    let step_px = step_for_wheel(&container);     // ~card height + gap
+    let _ = container.scroll_by_with_x_and_y(0.0, direction * step_px);
+}
+```
+
+`step_for_wheel(container)` measures the first `.operator__slide-card` child via `getBoundingClientRect` and adds the row gap (CSS computes `0.9rem` ≈ 14.4px at default font-size). If no card is rendered yet, fall back to a constant `120` (covers typical card height).
+
+Calling `prevent_default()` blocks the native accelerated scroll entirely. The single `scroll_by` per wheel event linearises everything: each notch = 1 row, no acceleration possible.
+
+The handler must be attached as a non-passive listener so `preventDefault` works. Leptos's `on:wheel` directive defaults to passive=false in most cases, but the project's existing event-listener patterns should be checked. If passive is required, fall back to `addEventListener("wheel", ..., { passive: false })` via `web_sys`.
+
+### Concern 3 — Load-at-start on song open
+
+Add a separate Effect that watches `ctx.selected_presentation_id` (or whatever signal reflects the currently-loaded song). When it changes:
+
+```rust
+Effect::new(move |prev: Option<Option<PresentationId>>| {
+    let current = ctx.selected_presentation_id.get();
+    if current != prev.flatten() && current.is_some() {
+        gloo_timers::callback::Timeout::new(0, || {
+            scroll_slides_to_top();
+        })
+        .forget();
+    }
+    current
+});
+```
+
+The 0ms timeout defers to the next event-loop tick so the new presentation's slides have actually rendered before we set `scroll_top = 0`. Helper `scroll_slides_to_top()` queries `.operator__slides` and sets its `scroll_top` to 0.
+
+This effect runs in addition to the existing `scroll_slide_into_view` effect at line 215. Order: load-at-start runs first (instant top), then if a current_slide_id is also set on the new presentation (e.g. operator restored a saved playlist position), the lookahead effect scrolls down to that slide. The two effects don't fight because they trigger on different signals (presentation change vs. slide change).
+
+## Components touched
+
+- `crates/presenter-ui/src/components/slide_list.rs`:
+  - `scroll_slide_into_view` (line 909) — rewritten for lookahead
+  - New helper `scroll_slides_to_top` (private fn)
+  - New helper `step_for_wheel` (private fn)
+  - New Effect for presentation-change scroll-to-top
+  - New `on:wheel` handler attached to the slides container element
+- `crates/presenter-ui/styles/operator.css`:
+  - Possibly add `overscroll-behavior: contain` to `.operator__slides` so wheel events that exhaust the container's scroll don't bubble up to the page (prevents accidental page scroll when at the boundary)
+
+## Behavior after this change
+
+| Scenario | Before | After |
+|---|---|---|
+| Click slide 1 (row 1) | Slide 1 visible (no scroll change) | Slide 1 visible + slide 4 (row 2) visible below it |
+| Click slide 4 (row 2) | If slide 4 is off-screen, scroll until it's at bottom | Slide 4 visible + slide 7 (row 3) visible below it |
+| Click slide that is last row | Scroll to show it | Scroll to show it (lookahead skipped — no next row exists) |
+| Wheel-scroll one notch | Variable scroll distance with macOS acceleration | Deterministic 1-row scroll per notch |
+| Wheel-scroll fast | Multiple compounded notches accelerate | Each notch = 1 row, fast scroll is linear |
+| Open a new worship song | Slide list at previous scroll position | Slide list scrolled to top (slide 1 visible) |
+| Open new song with current_slide_id set | First-row scroll then jump to current slide | Same — load-at-start runs first, then lookahead scrolls to current |
+
+## Testing
+
+### Playwright E2E
+
+New file `tests/e2e/operator-slide-scroll.spec.ts`:
+
+1. **Lookahead test:** load a 12+ slide worship song. Click slide 4. Assert `slide 7` (next row) is visible (`getBoundingClientRect().bottom <= container.getBoundingClientRect().bottom`).
+2. **Wheel test:** dispatch a `WheelEvent` with `deltaY: 100` on the slides container. Assert `container.scrollTop` increases by exactly the measured step (1 row), regardless of `deltaY` magnitude.
+3. **Load-at-start test:** load a 20-slide song, scroll to bottom. Switch to a different song. Assert `container.scrollTop === 0` after the new song's slides render.
+4. Console must be empty (per `ci/browser-console-zero-errors.md`).
+
+### Manual verification on dev
+
+1. Open `http://10.77.8.134:8080/ui/operator/worship` with a 20+ slide song. Click slide on row 3. Verify row 4 visible below.
+2. Wheel-scroll the slide list. Each notch should advance approximately 1 row, with no acceleration after multiple notches.
+3. Switch to a different song. First slide should be visible at top (no manual scroll-up needed).
+
+## Out of scope
+
+- Configurable STEP via settings (YAGNI; runtime measurement adapts to font scale automatically)
+- Smooth-scroll animation between rows (deliberately linear/instant; user wants determinism, not motion)
+- Trackpad-specific tuning (user uses iMac+mouse; if trackpad input becomes a concern later, separate PR)
+- Lookahead behavior on responsive breakpoints with different column counts (currently always 3 columns; if breakpoints reduce columns, the constant `3` is one place to adjust)
+- Horizontal scroll (the slides container is `overflow-y: auto` only)
+- The "wheel feels exponential" feedback could also be partially due to macOS's "Tracking" speed setting in System Settings; this PR fixes the in-app behavior to be deterministic, but if the user reports it still feels off after this lands, the next investigation step is the OS-level mouse settings — out of scope for code
+
+## Risks / unknowns
+
+- **`prevent_default()` on `on:wheel`:** Leptos's wheel event handler may default to passive in some Leptos versions. If `prevent_default()` is silently ignored, the linearisation won't take effect. Mitigation: verify in Step 1 of implementation that the handler actually intercepts and `console.log` confirms `preventDefault` was called. If passive, switch to `web_sys::EventTarget::add_event_listener_with_callback_and_add_event_listener_options` with `passive: false`.
+- **`+3` for next-row anchor:** assumes `grid-template-columns: repeat(3, ...)`. Confirmed by reading `operator.css:1081`. If responsive breakpoints reduce columns at some viewport width (currently they don't — verify with `grep "operator__slides" crates/presenter-ui/styles/operator.css`), the arithmetic needs to read the actual column count via `getComputedStyle(container).gridTemplateColumns`.
+- **Effect signal name (`selected_presentation_id`):** the spec refers to `ctx.selected_presentation_id`. The actual context field name should be verified in `crates/presenter-ui/src/state/operator.rs` before implementation. If the signal is named differently (e.g. `current_presentation_id`, `active_presentation_id`), the implementer adapts.
+
+## Closes
+
+- Issue #271 — operator slide-list scroll behavior.

--- a/tests/e2e/operator-slide-scroll.spec.ts
+++ b/tests/e2e/operator-slide-scroll.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * E2E tests for issue #271 — operator slide-list scroll UX.
+ *
+ * Three concerns:
+ * 1. Lookahead: clicking a slide ensures the next row is visible below.
+ * 2. Linear wheel: each wheel notch scrolls a deterministic step regardless
+ *    of deltaY magnitude (neutralises macOS acceleration).
+ * 3. Load-at-start: opening a new presentation scrolls the slide list to top.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+let dbUrl: string;
+
+/** Presentation with 15 slides for scroll tests. */
+let presId15: string;
+/** Second presentation with 12 slides for load-at-start test. */
+let presId12: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  dbUrl = config.dbUrl;
+  await refreshDevData(dbUrl);
+  serverHandle = await startTestServer(config.port, dbUrl, config.oscPort);
+
+  // Create a test library with two presentations so all tests share seed data.
+  const libResp = await fetch(new URL("/libraries", baseURL).toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "_E2E Slide Scroll" }),
+  });
+  const lib = await libResp.json();
+
+  // 15-slide presentation (enough for 5 rows in a 3-column grid)
+  const slides15 = Array.from({ length: 15 }, (_, i) => ({
+    main: `Verse ${i + 1}\nLine two of verse ${i + 1}\nLine three`,
+  }));
+  const pres15Resp = await fetch(
+    new URL(`/libraries/${lib.id}/presentations`, baseURL).toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Scroll Test Song A", slides: slides15 }),
+    },
+  );
+  const pres15Data = await pres15Resp.json();
+  presId15 = pres15Data.presentation.id;
+
+  // 12-slide presentation for load-at-start test
+  const slides12 = Array.from({ length: 12 }, (_, i) => ({
+    main: `Chorus ${i + 1}\nLine two of chorus ${i + 1}\nLine three`,
+  }));
+  const pres12Resp = await fetch(
+    new URL(`/libraries/${lib.id}/presentations`, baseURL).toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Scroll Test Song B", slides: slides12 }),
+    },
+  );
+  const pres12Data = await pres12Resp.json();
+  presId12 = pres12Data.presentation.id;
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+/**
+ * Navigate to the operator page and open the given presentation by seeding
+ * sessionStorage before WASM boots. Waits for slide cards to appear.
+ *
+ * Note: the Rust session module (gloo-storage 0.3) prefixes all keys with
+ * "presenter:" and serialises values as JSON strings, so the raw sessionStorage
+ * value is the JSON-encoded string (e.g. `"\"uuid\""` not `"uuid"`).
+ */
+async function openPresentation(
+  page: import("@playwright/test").Page,
+  presId: string,
+): Promise<void> {
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  // Seed sessionStorage with gloo-storage-compatible format so WASM reads the
+  // presentation id on init: prefix = "presenter:", value = JSON.stringify(id).
+  await page.evaluate((id) => {
+    sessionStorage.setItem("presenter:currentPresentationId", JSON.stringify(id));
+    // Ensure worship view is active (default, but set explicitly for clarity).
+    sessionStorage.setItem("presenter:view", JSON.stringify("worship"));
+  }, presId);
+  await page.reload();
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  // Wait for slide cards rendered by the WASM after it fetches the presentation.
+  await page.waitForSelector(".operator__slides .operator__slide-card", {
+    state: "visible",
+    timeout: 30_000,
+  });
+}
+
+test("lookahead: clicking a slide makes next-row slide visible", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await openPresentation(page, presId15);
+
+  const cards = await page.locator(".operator__slides [data-slide-id]").all();
+  expect(cards.length).toBeGreaterThanOrEqual(12);
+
+  // Click slide at index 3 — first slide of row 2 in a 3-column grid.
+  await cards[3].click();
+  // Allow the scroll Effect (which runs after click) to settle.
+  await page.waitForTimeout(300);
+
+  // The next-row anchor for index 3 is index 6 (index + COLUMNS_PER_ROW=3).
+  // It must be visible within the container (bottom <= container.bottom).
+  const visibility = await page.evaluate(() => {
+    const container = document.querySelector(".operator__slides");
+    const allCards = document.querySelectorAll(
+      ".operator__slides [data-slide-id]",
+    );
+    if (!container || allCards.length < 7) return null;
+    const cRect = container.getBoundingClientRect();
+    const anchorRect = (allCards[6] as Element).getBoundingClientRect();
+    return {
+      visible: anchorRect.bottom <= cRect.bottom + 2,
+      anchorBottom: anchorRect.bottom,
+      containerBottom: cRect.bottom,
+    };
+  });
+
+  expect(visibility).not.toBeNull();
+  expect(visibility!.visible).toBeTruthy();
+
+  expect(
+    consoleMessages.filter(
+      (m) => !m.includes("favicon") && !m.includes("crbug.com/981419"),
+    ),
+  ).toEqual([]);
+});
+
+test("wheel: each notch scrolls a deterministic step", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await openPresentation(page, presId15);
+
+  // Reset scroll to top so we start from a known position.
+  await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (c) c.scrollTop = 0;
+  });
+  await page.waitForTimeout(50);
+
+  // Dispatch a WheelEvent with deltaY=100. The wheel handler should ignore the
+  // deltaY magnitude and instead apply step = card_height + 14.4 (grid gap).
+  // If the handler is passive (Leptos on:wheel default), prevent_default is
+  // silently ignored and the browser may apply deltaY=100 instead of the step.
+  const result = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (!c) return null;
+    const cardEl = c.querySelector(
+      ".operator__slide-card",
+    ) as HTMLElement | null;
+    // Compute the expected step from the actual card height.
+    const cardHeight = cardEl ? cardEl.getBoundingClientRect().height : 0;
+    const expectedStep = cardHeight > 0 ? cardHeight + 14.4 : 120;
+
+    const before = c.scrollTop;
+    c.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: 100, bubbles: true, cancelable: true }),
+    );
+    const after = c.scrollTop;
+    return { before, after, expectedStep, deltaY: 100 };
+  });
+
+  expect(result).not.toBeNull();
+
+  const actualDelta = result!.after - result!.before;
+
+  // If actualDelta equals deltaY (100), the handler was passive and
+  // prevent_default had no effect — the browser applied raw native scroll.
+  // The spec requires escalating this to BLOCKED.
+  expect(
+    actualDelta,
+    `BLOCKED: wheel handler appears passive — scrollTop delta=${actualDelta} equals deltaY (100) instead of step (${result!.expectedStep.toFixed(1)}). Fix: change on:wheel in slide_list.rs to addEventListener with passive:false.`,
+  ).not.toBe(result!.deltaY);
+
+  // The handler must apply the deterministic step (±2px tolerance for rounding).
+  expect(actualDelta).toBeGreaterThan(result!.expectedStep - 2);
+  expect(actualDelta).toBeLessThan(result!.expectedStep + 2);
+
+  expect(
+    consoleMessages.filter(
+      (m) => !m.includes("favicon") && !m.includes("crbug.com/981419"),
+    ),
+  ).toEqual([]);
+});
+
+test("load-at-start: opening a new presentation scrolls slide list to top", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  // Open the 15-slide presentation and scroll it to the bottom.
+  await openPresentation(page, presId15);
+  await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (c) c.scrollTop = c.scrollHeight;
+  });
+  await page.waitForTimeout(50);
+
+  const scrolledDown = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    return c?.scrollTop ?? 0;
+  });
+  expect(scrolledDown).toBeGreaterThan(0);
+
+  // Now switch to the 12-slide presentation. The WASM's Effect on
+  // selected_presentation (issue #271 concern 3) should scroll the list to top.
+  await page.evaluate((id) => {
+    sessionStorage.setItem("presenter:currentPresentationId", JSON.stringify(id));
+  }, presId12);
+  await page.reload();
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector(".operator__slides .operator__slide-card", {
+    state: "visible",
+    timeout: 30_000,
+  });
+
+  // Give the scroll-to-top Effect (scheduled via Timeout(0)) time to run.
+  await page.waitForTimeout(300);
+
+  const scrollAfterSwitch = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    return c?.scrollTop ?? -1;
+  });
+  expect(scrollAfterSwitch).toBe(0);
+
+  expect(
+    consoleMessages.filter(
+      (m) => !m.includes("favicon") && !m.includes("crbug.com/981419"),
+    ),
+  ).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Three operator slide-list scroll fixes for live worship services. Closes #271.

## What changed

- **Lookahead scroll:** when the active slide moves to a new row, the next row is now visible below it. `scroll_slide_into_view` finds the next-row anchor (DOM index + 3) and scrolls so its bottom is in view.
- **Linear wheel scroll:** new `on:wheel` handler on `.operator__slides` calls `prevent_default()` and applies a deterministic per-notch scroll (card height + row gap). Neutralises macOS scroll acceleration — confirmed in CI Playwright (delta=224 ≈ step=224.59 from deltaY=100, NOT magnitude).
- **Load-at-start:** new Effect watches `ctx.selected_presentation_id`; on change, scrolls the slide list to top so the first slide is always visible when opening a new song.
- **CSS:** `overscroll-behavior: contain` on `.operator__slides` prevents wheel events at boundary from scrolling the page.
- **Refactor:** extracted scroll helpers into `slide_list_scroll.rs` and `reorder_slide_ids` + tests into `slide_list_utils.rs` so `slide_list.rs` stays under the 1000-line cap.
- Bumped version 0.4.53 → 0.4.54.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` — zero warnings
- [x] `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` (presenter-ui) — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p presenter-server` — all green (no server changes)
- [x] CI green on dev (Pipeline 25262505472, all 3 Playwright E2E shards passed including operator-slide-scroll)
- [x] **Manual dev verification via Playwright MCP on `http://10.77.8.134:8080/ui/operator/worship`:**
  - Lookahead: clicked slide 4 (row 2 in 18-slide song) → slide 7 (row 3) bottom 473px ≤ container bottom 472px ✅
  - Wheel: dispatched WheelEvent deltaY=100 → actualDelta=224 ≈ expectedStep=224.59 (NOT 100) ✅
  - Load-at-start: scrolled song A to 1053px → switched to song B → scrollTopAfterSwitch=0 ✅

Closes #271