### PR TITLE
ci(import-data): nudge GitHub workflow metadata

### DIFF
--- a/.github/workflows/import-data.yml
+++ b/.github/workflows/import-data.yml
@@ -1,4 +1,5 @@
 name: Import Data
+# Manual trigger only — workflow_dispatch.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Tiny YAML comment to force GitHub to re-scan import-data.yml. The workflow's metadata cache is stale (name shows path instead of YAML's `name:` field), so workflow_dispatch API calls return 422 'workflow does not have workflow_dispatch trigger'. Merging this commit on main re-registers the workflow correctly. Zero functional change.

Needed to run Import Data on prod + companion-pp to apply the fixed parser (PR #285) to existing libraries — the binary has the correct parser since v0.4.50 but the prod DB still holds slides from before the fix (issue: `037 Dokonalá láska` shows 23 slides, should be 26).