### PR TITLE
fix(server): gate api-stage publish on current layout (#281)

### DIFF
--- a/.github/workflows/import-data.yml
+++ b/.github/workflows/import-data.yml
@@ -1,4 +1,5 @@
 name: Import Data
+# Manual trigger only — workflow_dispatch.
 
 on:
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.54"
+version = "0.4.55"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -59,7 +59,7 @@ pub use slide::{resolve_sequence, ResolvedSlide, Slide, SlideContent, SlideGroup
 pub use stage_client::{StageClientSnapshot, StageClientStatus};
 pub use stage_display::{
     StageDisplayLayout, StageDisplaySlide, StageDisplaySnapshot, StagePlaylistEntry, StageState,
-    DEFAULT_STAGE_LAYOUT_CODE,
+    API_STAGE_LAYOUT_CODE, DEFAULT_STAGE_LAYOUT_CODE,
 };
 pub use timer::{
     CountdownTimer, CountdownTimerSnapshot, PreachTimer, PreachTimerSnapshot, TimerCommand,

--- a/crates/presenter-core/src/stage_display.rs
+++ b/crates/presenter-core/src/stage_display.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 /// Default stage layout code used across the application.
 pub const DEFAULT_STAGE_LAYOUT_CODE: &str = "worship-snv";
 
+/// API-driven stage layout code. The `/api/stage` endpoint and its gate
+/// in `presenter-server` reference this code.
+pub const API_STAGE_LAYOUT_CODE: &str = "api";
+
 /// Built-in stage display layouts exposed by the Presenter server.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -50,7 +50,8 @@ use chrono::Utc;
 use presenter_core::{
     BibleBroadcast, BibleSlideOutput, OscSettings, OscSettingsDraft, PlaylistId, Presentation,
     PresentationId, Slide, SlideId, StageClientSnapshot, StageDisplayLayout, StageDisplaySlide,
-    StageDisplaySnapshot, StageState, TimersOverview, DEFAULT_STAGE_LAYOUT_CODE,
+    StageDisplaySnapshot, StageState, TimersOverview, API_STAGE_LAYOUT_CODE,
+    DEFAULT_STAGE_LAYOUT_CODE,
 };
 use presenter_persistence::{DatabaseSettings, Repository};
 use std::{
@@ -740,7 +741,7 @@ impl AppState {
         // does not affect the live preview, mirroring the existing inverse
         // gate in `broadcasting.rs::publish_stage_context` (which skips
         // non-api updates when api layout is selected).
-        if self.stage_layout_code().await == "api" {
+        if self.stage_layout_code().await == API_STAGE_LAYOUT_CODE {
             self.live_hub.publish(LiveEvent::Stage { snapshot });
         }
         Ok(())

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -735,7 +735,14 @@ impl AppState {
     pub(crate) async fn update_api_stage(&self, state: ApiStageState) -> anyhow::Result<()> {
         let snapshot = self.build_api_stage_snapshot(&state).await;
         *self.api_stage.write().await = state;
-        self.live_hub.publish(LiveEvent::Stage { snapshot });
+        // Issue #281: only publish a Stage event when the operator's
+        // current layout is "api". Otherwise the api state is stored but
+        // does not affect the live preview, mirroring the existing inverse
+        // gate in `broadcasting.rs::publish_stage_context` (which skips
+        // non-api updates when api layout is selected).
+        if self.stage_layout_code().await == "api" {
+            self.live_hub.publish(LiveEvent::Stage { snapshot });
+        }
         Ok(())
     }
 

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -59,7 +59,18 @@ impl AppState {
         self.live_hub.publish(LiveEvent::StageLayout {
             code: layout.code.clone(),
         });
-        self.broadcast_stage_snapshots().await?;
+        if layout.code == "api" {
+            // Issue #281: when switching TO api, publish the stored
+            // api_stage snapshot so the operator preview reflects the
+            // most recent PUT instead of waiting for the next one.
+            // `broadcast_stage_snapshots` short-circuits on api layout
+            // anyway (see broadcasting.rs::publish_stage_context), so we
+            // replace it with the api snapshot publish here.
+            let snapshot = self.api_stage_snapshot().await;
+            self.live_hub.publish(LiveEvent::Stage { snapshot });
+        } else {
+            self.broadcast_stage_snapshots().await?;
+        }
         Ok(layout)
     }
 

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -3,7 +3,7 @@
 use super::stage::build_stage_snapshot;
 use super::AppState;
 use crate::live::LiveEvent;
-use presenter_core::{StageDisplayLayout, StageDisplaySnapshot};
+use presenter_core::{StageDisplayLayout, StageDisplaySnapshot, API_STAGE_LAYOUT_CODE};
 
 impl AppState {
     // Stage display methods
@@ -59,7 +59,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::StageLayout {
             code: layout.code.clone(),
         });
-        if layout.code == "api" {
+        if layout.code == API_STAGE_LAYOUT_CODE {
             // Issue #281: when switching TO api, publish the stored
             // api_stage snapshot so the operator preview reflects the
             // most recent PUT instead of waiting for the next one.

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -365,3 +365,154 @@ async fn from_config_against_empty_db_leaves_libraries_empty() {
         libraries.len()
     );
 }
+
+#[tokio::test]
+async fn api_input_does_not_leak_when_layout_is_worship() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("worship-snv")
+        .await
+        .expect("set worship-snv");
+
+    let mut rx = state.live_hub().subscribe();
+
+    let api_state = ApiStageState {
+        current_text: "test main".to_string(),
+        current_group: "test group".to_string(),
+        current_song: "test song".to_string(),
+        ..Default::default()
+    };
+    state
+        .update_api_stage(api_state)
+        .await
+        .expect("update_api_stage");
+
+    // Drain any non-Stage events for a short window. Assert no
+    // LiveEvent::Stage arrives within the timeout — that's the no-leak invariant.
+    let saw_stage = async {
+        loop {
+            match rx.recv().await {
+                Ok(LiveEvent::Stage { .. }) => return true,
+                Ok(_) => continue,
+                Err(_) => return false,
+            }
+        }
+    };
+    let result = timeout(Duration::from_millis(150), saw_stage).await;
+    assert!(
+        result.is_err(),
+        "expected NO LiveEvent::Stage when layout is worship-snv"
+    );
+
+    // Sanity: the api_stage state IS stored (not silently discarded).
+    let stored = state.api_stage.read().await.clone();
+    assert_eq!(stored.current_text, "test main");
+}
+
+#[tokio::test]
+async fn api_input_publishes_when_layout_is_api() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("api")
+        .await
+        .expect("set api layout");
+
+    // Subscribe AFTER the layout switch so we don't see leftover events
+    // from set_stage_layout_code.
+    let mut rx = state.live_hub().subscribe();
+
+    let api_state = ApiStageState {
+        current_text: "live api content".to_string(),
+        ..Default::default()
+    };
+    state
+        .update_api_stage(api_state)
+        .await
+        .expect("update_api_stage");
+
+    let stage_event = async {
+        loop {
+            match rx.recv().await {
+                Ok(LiveEvent::Stage { snapshot }) => return Some(snapshot),
+                Ok(_) => continue,
+                Err(_) => return None,
+            }
+        }
+    };
+    let snapshot = timeout(Duration::from_millis(500), stage_event)
+        .await
+        .expect("Stage event arrived within timeout")
+        .expect("Stage event payload");
+
+    assert_eq!(
+        snapshot.layout.code, "api",
+        "snapshot must use the api layout"
+    );
+}
+
+#[tokio::test]
+async fn switching_to_api_publishes_stored_api_state() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("worship-snv")
+        .await
+        .expect("set worship-snv");
+
+    // Pre-store API content while not in api layout (the gate prevents
+    // an event from publishing here).
+    state
+        .update_api_stage(ApiStageState {
+            current_text: "stored content".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("update_api_stage");
+
+    // Subscribe AFTER the pre-store, BEFORE the switch.
+    let mut rx = state.live_hub().subscribe();
+
+    state
+        .set_stage_layout_code("api")
+        .await
+        .expect("switch to api");
+
+    // Expect at least one StageLayout event AND one Stage event with api
+    // layout within the timeout.
+    let mut saw_layout = false;
+    let mut saw_stage_with_api = false;
+    let collect = async {
+        for _ in 0..10 {
+            if let Ok(ev) = rx.recv().await {
+                match ev {
+                    LiveEvent::StageLayout { code } if code == "api" => saw_layout = true,
+                    LiveEvent::Stage { snapshot } if snapshot.layout.code == "api" => {
+                        saw_stage_with_api = true;
+                    }
+                    _ => {}
+                }
+                if saw_layout && saw_stage_with_api {
+                    return;
+                }
+            }
+        }
+    };
+    let _ = timeout(Duration::from_millis(500), collect).await;
+
+    assert!(
+        saw_layout,
+        "expected LiveEvent::StageLayout for api after switch"
+    );
+    assert!(
+        saw_stage_with_api,
+        "expected LiveEvent::Stage with api layout after switch"
+    );
+}

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/docs/superpowers/plans/2026-05-03-api-stage-layout-gate.md
+++ b/docs/superpowers/plans/2026-05-03-api-stage-layout-gate.md
@@ -1,0 +1,752 @@
+# API Stage Layout Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `PUT /api/stage` from leaking into the operator preview when the current stage layout is not `api`. Add a gate in `update_api_stage` and a switch-to-api refresh in `set_stage_layout_code` so the api-stage state stays in lockstep with operator-controlled layout changes.
+
+**Architecture:** Two surgical changes in `crates/presenter-server/src/state/`. (1) `update_api_stage` (mod.rs:735) reads `stage_layout_code()` and only publishes `LiveEvent::Stage` when the code is `"api"` — state always stored. (2) `set_stage_layout_code` (stage_display.rs:47) handles the symmetric case: when switching TO `"api"`, fetch the stored api_stage snapshot and publish it; otherwise `broadcast_stage_snapshots` runs as today.
+
+**Tech Stack:** Rust + tokio (async state), axum (HTTP), tokio::sync::broadcast (LiveHub), Playwright TS for E2E.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-api-stage-layout-gate-design.md` (commit `e67c2be`)
+
+**Closes:** Issue #281 — api worship input switching preview when layout = worship-snv.
+
+---
+
+## Context
+
+### Verified pre-flight
+
+- `crates/presenter-server/src/state/mod.rs:735-740` — `update_api_stage` publishes unconditionally. The fix injects a gate.
+- `crates/presenter-server/src/state/stage_display.rs:43-45` — `stage_layout_code()` returns `String` via `RwLock::read().await.clone()`.
+- `crates/presenter-server/src/state/stage_display.rs:47-65` — `set_stage_layout_code` already publishes `LiveEvent::StageLayout` then calls `broadcast_stage_snapshots`. The `broadcast_stage_snapshots` call moves into the non-api branch.
+- `crates/presenter-server/src/state/mod.rs:742-745` — `api_stage_snapshot()` (already public) returns `StageDisplaySnapshot` for the api layout.
+- `crates/presenter-server/src/state/broadcasting.rs:82-88` — existing inverse gate (skip publish when layout=api). The new gate is symmetric.
+- `LiveEvent::Stage`, `LiveEvent::StageLayout` — both already exist; no new variants.
+- `tests/e2e/api-stage.spec.ts` — 258 lines, exists since PR #255. Has `openApiStage(context)` helper that POSTs `/stage/layout` with `{ code: "api" }` and waits for `__presenterStageLayout === "api"`.
+- `state/tests.rs` LiveHub pattern: `let mut rx = state.live_hub().subscribe(); ... rx.recv().await.unwrap();` (e.g. line 273-285).
+- `ApiStageState` struct fields: `current_text`, `current_group`, `current_song`, `next_text`, `next_group`, `next_song`, all `String`. Default = empty strings.
+- Stage layout codes seen in code: `"api"`, `"worship-snv"`, `"worship-pp"`, `"preach"`, `"timer"`, `"bible"`, `"ndi-fullscreen"`. Default = `DEFAULT_STAGE_LAYOUT_CODE`.
+
+---
+
+## File Structure
+
+### Modified files
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.54 → 0.4.55 |
+| `crates/presenter-ui/Cargo.toml` | presenter-ui version 0.1.23 → 0.1.24 |
+| `crates/presenter-server/src/state/mod.rs` | Gate `LiveEvent::Stage` publish in `update_api_stage` on `stage_layout_code() == "api"` |
+| `crates/presenter-server/src/state/stage_display.rs` | In `set_stage_layout_code`, publish stored api_stage snapshot when target layout is `"api"`; move `broadcast_stage_snapshots` into the `else` branch |
+| `crates/presenter-server/src/state/tests.rs` | 3 new tests |
+| `tests/e2e/api-stage.spec.ts` | 1 new test for the layout-isolation behavior |
+
+### Lock files
+- `Cargo.lock` and `crates/presenter-ui/Cargo.lock` — auto-updated.
+
+---
+
+## Task 1: Bump Version (Haiku)
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/presenter-ui/Cargo.toml`
+- Modify: `Cargo.lock`, `crates/presenter-ui/Cargo.lock` (regenerated)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml`, under `[workspace.package]`, change `version = "0.4.54"` to `version = "0.4.55"`.
+
+- [ ] **Step 2: Bump presenter-ui version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/Cargo.toml`, under `[package]`, change `version = "0.1.23"` to `version = "0.1.24"`.
+
+- [ ] **Step 3: Regenerate workspace Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo check --workspace --all-targets 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Regenerate presenter-ui Cargo.lock**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo check --target wasm32-unknown-unknown 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && grep -E "^version" Cargo.toml crates/presenter-ui/Cargo.toml | head -3
+```
+
+Expected:
+```
+Cargo.toml:version = "0.4.55"
+crates/presenter-ui/Cargo.toml:version = "0.1.24"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock && git commit -m "chore: bump version to 0.4.55 (#281)"
+```
+
+---
+
+## Task 2: Apply the Gate + Switch-to-API Refresh (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/mod.rs:735-740`
+- Modify: `crates/presenter-server/src/state/stage_display.rs:47-65`
+
+### Step 1: Read current state
+
+```bash
+sed -n '733,745p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/mod.rs
+sed -n '47,65p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/stage_display.rs
+```
+
+Confirm the bodies match the snippets in the spec context above.
+
+### Step 2: Add the gate to `update_api_stage`
+
+In `crates/presenter-server/src/state/mod.rs`, replace the entire `update_api_stage` function (lines 735-740) with:
+
+```rust
+    pub(crate) async fn update_api_stage(&self, state: ApiStageState) -> anyhow::Result<()> {
+        let snapshot = self.build_api_stage_snapshot(&state).await;
+        *self.api_stage.write().await = state;
+        // Issue #281: only publish a Stage event when the operator's
+        // current layout is "api". Otherwise the api state is stored but
+        // does not affect the live preview, mirroring the existing inverse
+        // gate in `broadcasting.rs::publish_stage_context` (which skips
+        // non-api updates when api layout is selected).
+        if self.stage_layout_code().await == "api" {
+            self.live_hub.publish(LiveEvent::Stage { snapshot });
+        }
+        Ok(())
+    }
+```
+
+### Step 3: Add switch-to-api refresh to `set_stage_layout_code`
+
+In `crates/presenter-server/src/state/stage_display.rs`, the current function reads:
+
+```rust
+    pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {
+        let layout = StageDisplayLayout::built_in()
+            .into_iter()
+            .find(|layout| layout.code == code)
+            .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))?;
+        {
+            let mut guard = self.stage_layout.write().await;
+            if *guard == layout.code {
+                return Ok(layout);
+            }
+            *guard = layout.code.clone();
+        }
+        self.live_hub.publish(LiveEvent::StageLayout {
+            code: layout.code.clone(),
+        });
+        self.broadcast_stage_snapshots().await?;
+        Ok(layout)
+    }
+```
+
+Replace it with:
+
+```rust
+    pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {
+        let layout = StageDisplayLayout::built_in()
+            .into_iter()
+            .find(|layout| layout.code == code)
+            .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))?;
+        {
+            let mut guard = self.stage_layout.write().await;
+            if *guard == layout.code {
+                return Ok(layout);
+            }
+            *guard = layout.code.clone();
+        }
+        self.live_hub.publish(LiveEvent::StageLayout {
+            code: layout.code.clone(),
+        });
+        if layout.code == "api" {
+            // Issue #281: when switching TO api, publish the stored
+            // api_stage snapshot so the operator preview reflects the most
+            // recent PUT instead of waiting for the next one.
+            // `broadcast_stage_snapshots` short-circuits on api layout
+            // anyway, so we replace it with the api snapshot publish here.
+            let snapshot = self.api_stage_snapshot().await;
+            self.live_hub.publish(LiveEvent::Stage { snapshot });
+        } else {
+            self.broadcast_stage_snapshots().await?;
+        }
+        Ok(layout)
+    }
+```
+
+### Step 4: Verify build
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo build --workspace 2>&1 | tail -5
+```
+
+Expected: clean build.
+
+If `api_stage_snapshot` is not visible from `stage_display.rs` (it's defined on the same `impl AppState` block in `mod.rs:742`), it should resolve via `self.api_stage_snapshot()`. If the visibility is `pub(crate)` and the call site is in the same crate, this works. If the build fails on visibility, change `api_stage_snapshot` from `pub(crate)` to `pub(super)` or `pub` to broaden access — but `pub(crate)` should be sufficient.
+
+### Step 5: Run clippy
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+### Step 6: Run cargo fmt
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all
+```
+
+### Step 7: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-server/src/state/mod.rs crates/presenter-server/src/state/stage_display.rs && git commit -m "fix(server): gate api-stage publish on current layout (#281)
+
+update_api_stage now only publishes LiveEvent::Stage when the operator's
+selected layout is api. State is still stored on every PUT so the next
+switch to api shows the latest content.
+
+set_stage_layout_code now publishes the stored api_stage snapshot when
+switching TO api, so the preview reflects recent API pushes immediately
+instead of waiting for the next PUT."
+```
+
+---
+
+## Task 3: Unit Tests (Sonnet)
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/tests.rs` — add 3 new tests at the end of the file.
+
+The existing test pattern uses `let mut rx = state.live_hub().subscribe()` then `rx.recv().await.unwrap()` to consume events. There are usually OTHER events fired alongside the one under test (initial state, timers ticks, etc.), so tests loop over a small bounded number of `recv` calls and assert that the expected event arrives. For "no event" tests, use `tokio::time::timeout` to bound the wait.
+
+### Step 1: Read the existing test patterns
+
+```bash
+sed -n '1,30p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/tests.rs
+sed -n '270,320p' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/tests.rs
+```
+
+Confirm:
+- `AppState::in_memory()` is the test fixture
+- `state.live_hub().subscribe()` returns a broadcast receiver
+- `LiveEvent::Stage { snapshot }` and `LiveEvent::StageLayout { code }` are the variants
+
+### Step 2: Add the three tests at the end of `crates/presenter-server/src/state/tests.rs`
+
+Append:
+
+```rust
+#[tokio::test]
+async fn api_input_does_not_leak_when_layout_is_worship() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("worship-snv")
+        .await
+        .expect("set worship-snv");
+
+    let mut rx = state.live_hub().subscribe();
+
+    let api_state = ApiStageState {
+        current_text: "test main".to_string(),
+        current_group: "test group".to_string(),
+        current_song: "test song".to_string(),
+        ..Default::default()
+    };
+    state
+        .update_api_stage(api_state.clone())
+        .await
+        .expect("update_api_stage");
+
+    // Drain non-Stage events for a short window. Assert no LiveEvent::Stage
+    // arrives within the timeout — that's the "no leak" invariant.
+    let saw_stage = async {
+        loop {
+            match rx.recv().await {
+                Ok(LiveEvent::Stage { .. }) => return true,
+                Ok(_) => continue,
+                Err(_) => return false,
+            }
+        }
+    };
+    let result = timeout(Duration::from_millis(150), saw_stage).await;
+    assert!(
+        result.is_err(),
+        "expected NO LiveEvent::Stage when layout is worship-snv (got: {:?})",
+        result
+    );
+
+    // Sanity: the api_stage IS stored (not silently discarded).
+    let stored = state.api_stage.read().await.clone();
+    assert_eq!(stored.current_text, "test main");
+}
+
+#[tokio::test]
+async fn api_input_publishes_when_layout_is_api() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("api")
+        .await
+        .expect("set api layout");
+
+    let mut rx = state.live_hub().subscribe();
+
+    let api_state = ApiStageState {
+        current_text: "live api content".to_string(),
+        ..Default::default()
+    };
+    state
+        .update_api_stage(api_state)
+        .await
+        .expect("update_api_stage");
+
+    let stage_event = async {
+        loop {
+            match rx.recv().await {
+                Ok(LiveEvent::Stage { snapshot }) => return Some(snapshot),
+                Ok(_) => continue,
+                Err(_) => return None,
+            }
+        }
+    };
+    let snapshot = timeout(Duration::from_millis(500), stage_event)
+        .await
+        .expect("Stage event arrived")
+        .expect("Stage event payload");
+
+    assert_eq!(
+        snapshot.layout.code, "api",
+        "snapshot must use the api layout"
+    );
+}
+
+#[tokio::test]
+async fn switching_to_api_publishes_stored_api_state() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .set_stage_layout_code("worship-snv")
+        .await
+        .expect("set worship-snv");
+
+    // Pre-store API content while not in api layout.
+    state
+        .update_api_stage(ApiStageState {
+            current_text: "stored content".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("update_api_stage");
+
+    let mut rx = state.live_hub().subscribe();
+
+    state
+        .set_stage_layout_code("api")
+        .await
+        .expect("switch to api");
+
+    // Expect at least one StageLayout and one Stage event within the timeout.
+    let mut saw_layout = false;
+    let mut saw_stage_with_stored_content = false;
+    let collect = async {
+        for _ in 0..10 {
+            if let Ok(ev) = rx.recv().await {
+                match ev {
+                    LiveEvent::StageLayout { code } if code == "api" => saw_layout = true,
+                    LiveEvent::Stage { snapshot } => {
+                        if snapshot.layout.code == "api" {
+                            saw_stage_with_stored_content = true;
+                        }
+                    }
+                    _ => {}
+                }
+                if saw_layout && saw_stage_with_stored_content {
+                    return ();
+                }
+            }
+        }
+    };
+    let _ = timeout(Duration::from_millis(500), collect).await;
+
+    assert!(
+        saw_layout,
+        "expected LiveEvent::StageLayout for api after switch"
+    );
+    assert!(
+        saw_stage_with_stored_content,
+        "expected LiveEvent::Stage with api layout after switch"
+    );
+}
+```
+
+The tests assume `ApiStageState` is accessible from this test module. It's `pub(crate)` per `state/mod.rs:83`, and `tests.rs` is `mod tests` inside `crate::state`, so `super::ApiStageState` works. If the existing imports at the top of `tests.rs` don't already pull `ApiStageState` in, add it.
+
+### Step 3: Verify imports in tests.rs
+
+Run:
+
+```bash
+head -10 /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-server/src/state/tests.rs
+```
+
+If `ApiStageState` is not in the imports, add it:
+
+```rust
+use super::{AppState, ApiStageState};
+```
+
+(Or extend the existing `use super::*;` if that's the pattern.)
+
+### Step 4: Run the new tests
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo test -p presenter-server --lib api_input_does_not_leak_when_layout_is_worship api_input_publishes_when_layout_is_api switching_to_api_publishes_stored_api_state 2>&1 | tail -15
+```
+
+Expected: 3 passed.
+
+If any test times out (saw_stage assertion fires the wrong way), investigate:
+- `api_input_does_not_leak`: did `set_stage_layout_code("worship-snv")` actually take effect? Verify `state.stage_layout_code().await == "worship-snv"` before the api_state update.
+- `api_input_publishes`: is `set_stage_layout_code("api")` itself emitting an extra Stage event before the test subscribes? The subscribe must happen AFTER the layout switch; check ordering.
+- `switching_to_api`: the subscribe must happen AFTER `update_api_stage` (so no leftover events from the gate test).
+
+### Step 5: Run the full presenter-server test suite
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo test -p presenter-server 2>&1 | tail -10
+```
+
+Expected: all tests pass (185+ — the existing 184 plus 3 new ones, or whatever the current count is).
+
+### Step 6: Run clippy
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+```
+
+Expected: zero warnings.
+
+### Step 7: cargo fmt
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all
+```
+
+### Step 8: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add crates/presenter-server/src/state/tests.rs && git commit -m "test(server): api stage layout gate + switch-to-api refresh (#281)"
+```
+
+---
+
+## Task 4: Playwright E2E (Sonnet)
+
+**Files:**
+- Modify: `tests/e2e/api-stage.spec.ts` — add 1 new test for layout isolation.
+
+The existing file has an `openApiStage(context)` helper that sets layout to api. We need a complementary helper that sets layout to a non-api layout, plus a test that verifies the api PUT does NOT affect the operator preview.
+
+### Step 1: Read existing helpers and test shape
+
+```bash
+cat /home/newlevel/devel/presenter/presenter-dev2/tests/e2e/api-stage.spec.ts | head -100
+```
+
+Confirm:
+- The `/stage/layout` POST endpoint is used to set layout (with body `{ code: <code> }`).
+- The operator preview is at `/ui/operator/worship` (or similar).
+- The stage WS endpoint is `/stage` and exposes `__presenterStageLayout` and `__presenterStageConnectionState` globals.
+
+### Step 2: Add the test at the end of `tests/e2e/api-stage.spec.ts`
+
+Append:
+
+```typescript
+test("api put does not switch preview when layout is worship-snv", async ({
+  request,
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      // Existing operator E2E filters this Chrome integrity-preload warning.
+      if (!text.includes("crbug.com/981419")) {
+        consoleMessages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+
+  // 1. Set layout to worship-snv (a non-api layout).
+  const setLayoutRes = await request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "worship-snv" } },
+  );
+  expect(setLayoutRes.ok()).toBeTruthy();
+
+  // 2. Snapshot the current api_stage state on the server (before the PUT).
+  const beforeRes = await request.get(
+    new URL("/api/stage", baseURL).toString(),
+  );
+  // /api/stage may or may not exist as GET; if not, skip the snapshot step
+  // and rely solely on the WS event check below.
+  let beforeText = "";
+  if (beforeRes.ok()) {
+    const before = (await beforeRes.json()) as { current_text?: string };
+    beforeText = before.current_text ?? "";
+  }
+
+  // 3. Open the operator UI worship view; subscribe to the stage WS via the
+  // page's existing __presenterStageConnectionState global.
+  await page.goto(new URL("/ui/operator/worship", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  // Capture current rendered stage preview (the snapshot displayed in
+  // operator UI). The exact selector depends on the operator's preview
+  // component; data-role="stage-preview" or similar is conventional.
+  const previewSelector = "[data-role=\"stage-preview\"]";
+  const previewBefore = await page
+    .locator(previewSelector)
+    .first()
+    .textContent()
+    .catch(() => null);
+
+  // 4. PUT api/stage with new content. With the gate, this MUST NOT cause
+  // the operator preview to update.
+  const putRes = await request.put(
+    new URL("/api/stage", baseURL).toString(),
+    {
+      data: {
+        current_text: "should not appear in worship-snv preview",
+        current_group: "",
+        current_song: "",
+        next_text: "",
+        next_group: "",
+        next_song: "",
+      },
+    },
+  );
+  expect(putRes.ok()).toBeTruthy();
+
+  // 5. Wait briefly for any potential leak event to land.
+  await page.waitForTimeout(500);
+
+  // 6. Verify the operator preview did NOT change.
+  const previewAfter = await page
+    .locator(previewSelector)
+    .first()
+    .textContent()
+    .catch(() => null);
+  expect(previewAfter).toBe(previewBefore);
+
+  // 7. Switch to api layout — operator preview SHOULD now reflect the
+  // stored api content.
+  const switchRes = await request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "api" } },
+  );
+  expect(switchRes.ok()).toBeTruthy();
+
+  await page.waitForTimeout(500);
+
+  const previewAfterSwitch = await page
+    .locator(previewSelector)
+    .first()
+    .textContent()
+    .catch(() => null);
+  // Either the preview now contains the api content, OR if the operator
+  // preview pulls from a different field, hit /api/stage again and assert
+  // the stored value matches what we PUT.
+  if (previewAfterSwitch) {
+    expect(previewAfterSwitch).toContain("should not appear in worship-snv preview");
+  }
+
+  // Console must be clean (modulo the filtered Chrome integrity warning).
+  expect(consoleMessages).toEqual([]);
+
+  // Reference unused beforeText to silence lint if it stays unused.
+  void beforeText;
+});
+```
+
+If `data-role="stage-preview"` isn't the actual selector for the operator preview, find it by reading the operator UI:
+
+```bash
+grep -rn 'data-role="stage-preview"\|stage-preview\|StagePreview' /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/ /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/pages/ | head -10
+```
+
+Adjust the test selector to whatever is actually rendered. If the operator preview's DOM structure is too dynamic to reliably assert text, fall back to subscribing to the stage WS directly via `page.evaluate()` and counting Stage messages — assert ZERO Stage messages arrived between the layout=worship-snv set and the api PUT, and at least one after the switch to api.
+
+### Step 3: Run the new test locally
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && npx playwright test tests/e2e/api-stage.spec.ts --reporter=list 2>&1 | tail -20
+```
+
+Expected: all api-stage tests pass (the existing ones plus the new layout-isolation test).
+
+If the test fails because the preview selector doesn't exist, fix per Step 2 fallback.
+
+If the `/api/stage` GET endpoint doesn't exist, the `beforeText` block is harmless (only logs the value, doesn't gate any assertion).
+
+### Step 4: Commit
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git add tests/e2e/api-stage.spec.ts && git commit -m "test(e2e): api stage layout isolation (#281)"
+```
+
+---
+
+## Task 5: Local Checks, Push, CI Monitor, Dev Verification, Open PR (Controller)
+
+This task is handled by the controller. Local Rust + WASM builds are allowed.
+
+### Local pre-push checks
+
+- [ ] **Step 1: Workspace fmt**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo fmt --all --check
+```
+
+- [ ] **Step 2: Workspace clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+```
+
+- [ ] **Step 3: presenter-ui WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Workspace tests**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo test -p presenter-server 2>&1 | tail -5
+```
+
+Expected: all tests pass including the 3 new ones.
+
+- [ ] **Step 5: Push**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && git push origin dev
+```
+
+- [ ] **Step 6: Monitor CI**
+
+```bash
+RUN_ID=$(gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId')
+sleep 1500 && gh run view $RUN_ID --json status,conclusion,jobs --jq '{status, conclusion, jobs: [.jobs[] | {name, status, conclusion}]}'
+```
+
+Wait for ALL jobs `completed`. If any fails, fix root cause in ONE commit, push, monitor again.
+
+### Dev verification
+
+- [ ] **Step 7: Verify dev shows v0.4.55**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.55"}`.
+
+- [ ] **Step 8: Manual UX verification on dev via Playwright MCP**
+
+1. Open `http://10.77.8.134:8080/ui/operator/worship`.
+2. Use the operator UI to switch the stage layout to `worship-snv`.
+3. PUT `/api/stage` with sample content via curl: `curl -X PUT -H 'Content-Type: application/json' -d '{"current_text":"test"}' http://10.77.8.134:8080/api/stage`.
+4. Confirm the operator preview did NOT switch to api content (stays on worship-snv).
+5. Switch the stage layout to `api`.
+6. Confirm the operator preview NOW shows the test content.
+
+### Open PR
+
+- [ ] **Step 9: Open PR**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && gh pr create --base main --head dev --title "fix(server): gate api-stage publish on current layout (#281)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #281 — \`PUT /api/stage\` was switching the operator preview even when the current stage layout was something other than \`api\` (e.g. \`worship-snv\`).
+
+## What changed
+
+- **\`update_api_stage\`** (state/mod.rs): now only publishes \`LiveEvent::Stage\` when \`stage_layout_code() == \"api\"\`. State is still stored on every PUT.
+- **\`set_stage_layout_code\`** (state/stage_display.rs): when switching TO \`api\`, publishes the stored api_stage snapshot via \`LiveEvent::Stage\` so the preview reflects the most recent PUT instead of waiting for the next one. Switching to other layouts continues to call \`broadcast_stage_snapshots\` as before.
+- 3 unit tests covering both gate paths + switch-to-api refresh.
+- 1 Playwright E2E test asserting layout-isolation.
+- Bumped version 0.4.54 → 0.4.55.
+
+## Test plan
+
+- [x] \`cargo test -p presenter-server\` — all green incl. 3 new tests
+- [x] \`cargo clippy --workspace --all-targets -- -D warnings -W clippy::all\` — zero warnings
+- [x] \`cargo fmt --all --check\` — clean
+- [x] CI green on dev
+- [x] **Manual dev verification:**
+  - Layout=worship-snv, PUT /api/stage → operator preview unchanged ✅
+  - Switch layout to api → preview shows the previously-PUT content ✅
+
+Closes #281
+EOF
+)"
+```
+
+- [ ] **Step 10: Confirm PR clean**
+
+```bash
+PR_NUM=$(gh pr list --head dev --base main --json number --jq '.[0].number')
+gh api repos/zbynekdrlik/presenter/pulls/$PR_NUM --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `{"mergeable": true, "mergeable_state": "clean"}`.
+
+### Pre-completion gate
+
+- [ ] **Step 11: Run /plan-check**
+
+- [ ] **Step 12: Run /review** on the PR diff
+
+- [ ] **Step 13: Send completion report**
+
+Per `core/completion-report.md`. Include CI run id, /plan-check fulfillment, /review 0🔴 0🟡 0🔵, dev verification, dev + prod URLs, PR URL.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Gate prevents leak | Layout=worship-snv, PUT /api/stage → operator preview unchanged (Playwright + manual) |
+| Gate state still stored | Sanity: `state.api_stage.read()` reflects the PUT even when no event fires |
+| Api publishes when layout=api | Layout=api, PUT /api/stage → Stage event fires (unit test) |
+| Switch-to-api refresh | Pre-store api state, switch worship-snv→api → Stage event with stored content fires (unit test + manual) |
+| No regressions | All existing tests still pass; CI green |

--- a/docs/superpowers/specs/2026-05-03-api-stage-layout-gate-design.md
+++ b/docs/superpowers/specs/2026-05-03-api-stage-layout-gate-design.md
@@ -1,0 +1,156 @@
+# API Stage Layout Gate — Design
+
+**Date:** 2026-05-03
+**Status:** Proposed
+**Scope:** Backend (`presenter-server`) — server-side gate on the api-stage update path
+**Issue:** [#281](https://github.com/zbynekdrlik/presenter/issues/281) — `PUT /api/stage` switches operator preview even when stage layout ≠ `api`
+
+## Goal
+
+Stop `PUT /api/stage` from leaking into the operator preview when the operator has selected a non-`api` stage layout (e.g. `worship-snv`). The api-stage state continues to be **stored** so it's ready when the operator switches to `api` layout, but it must not **publish** a `LiveEvent::Stage` while another layout is active. Additionally, when the operator switches TO `api` layout, the preview should immediately reflect the most recent api-stage state instead of waiting for the next PUT.
+
+## Why
+
+The codebase already has the inverse direction handled: `publish_stage_context` (in `state/broadcasting.rs:82-88`) skips publishing regular stage updates when `stage_layout == "api"` — the comment says *"The 'api' layout is driven by PUT /api/stage, not by internal state. Skip normal broadcasting to avoid overwriting API-pushed data."* The mirror gate is missing on the api-update path: `update_api_stage` (in `state/mod.rs:735-740`) publishes unconditionally.
+
+The bug surface in `update_api_stage`:
+
+```rust
+pub(crate) async fn update_api_stage(&self, state: ApiStageState) -> anyhow::Result<()> {
+    let snapshot = self.build_api_stage_snapshot(&state).await;
+    *self.api_stage.write().await = state;
+    self.live_hub.publish(LiveEvent::Stage { snapshot });   // ← always publishes
+    Ok(())
+}
+```
+
+When external integrations (AbleSet, custom REST clients) push to `/api/stage` continuously, the operator's preview gets switched away from whatever layout (e.g. `worship-snv`) they intentionally selected.
+
+## Approach
+
+### Component 1 — gate the publish
+
+In `crates/presenter-server/src/state/mod.rs`, modify `update_api_stage` to read the current layout and only publish when it's `"api"`:
+
+```rust
+pub(crate) async fn update_api_stage(&self, state: ApiStageState) -> anyhow::Result<()> {
+    let snapshot = self.build_api_stage_snapshot(&state).await;
+    *self.api_stage.write().await = state;
+    if self.stage_layout_code().await == "api" {
+        self.live_hub.publish(LiveEvent::Stage { snapshot });
+    }
+    Ok(())
+}
+```
+
+The state is still stored (the `*self.api_stage.write().await = state` line). External integrations PUT successfully (200 OK). No Stage event fires while non-api layouts are active.
+
+### Component 2 — refresh on switch-to-api
+
+In `crates/presenter-server/src/state/stage_display.rs`, extend `set_stage_layout_code` so that when transitioning to `"api"`, the most recent api state is published:
+
+```rust
+pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {
+    let layout = StageDisplayLayout::built_in()
+        .into_iter()
+        .find(|layout| layout.code == code)
+        .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))?;
+    let previous_code = {
+        let mut guard = self.stage_layout.write().await;
+        if *guard == layout.code {
+            return Ok(layout);
+        }
+        let prev = guard.clone();
+        *guard = layout.code.clone();
+        prev
+    };
+    self.live_hub.publish(LiveEvent::StageLayout {
+        code: layout.code.clone(),
+    });
+    if layout.code == "api" {
+        // Just switched TO api — publish stored api_stage so the preview
+        // reflects the most recent PUT instead of waiting for the next one.
+        let snapshot = self.api_stage_snapshot().await;
+        self.live_hub.publish(LiveEvent::Stage { snapshot });
+    } else {
+        self.broadcast_stage_snapshots().await?;
+    }
+    let _ = previous_code; // reserved for future use; not needed today.
+    Ok(layout)
+}
+```
+
+The `broadcast_stage_snapshots` call moves into the `else` branch — it's the regular flow's source of Stage events for non-api layouts and already short-circuits when layout is api (per the existing gate at `broadcasting.rs:82-88`). Adding the `api_stage_snapshot` publish in the if branch makes the switch-to-api flow consistent.
+
+## Testing
+
+### Unit tests (Rust, in `crates/presenter-server/src/state/tests.rs`)
+
+Three new tests:
+
+1. **`api_input_does_not_leak_when_layout_is_worship`**
+   - Setup: `AppState::in_memory()`, set layout to `"worship-snv"`.
+   - Subscribe to live_hub.
+   - Call `update_api_stage` with non-empty content.
+   - Assert no `LiveEvent::Stage` is received within a small timeout.
+   - Assert the api_stage state IS stored (read it back via `api_stage.read().await`).
+
+2. **`api_input_publishes_when_layout_is_api`**
+   - Setup: layout = `"api"`.
+   - Subscribe.
+   - `update_api_stage(content)`.
+   - Assert a `LiveEvent::Stage` arrives with the api layout in its snapshot.
+
+3. **`switching_to_api_publishes_stored_api_state`**
+   - Setup: layout = `"worship-snv"`.
+   - Pre-store api state via `update_api_stage` (which won't publish — gate in component 1).
+   - Subscribe.
+   - `set_stage_layout_code("api")`.
+   - Assert events arrive in order: `LiveEvent::StageLayout { code: "api" }`, then `LiveEvent::Stage` with the stored api content.
+
+### Playwright E2E
+
+Add to `tests/e2e/api-stage.spec.ts` (existing file from PR #255):
+- Flip layout to `worship-snv`, PUT `/api/stage`, assert operator preview does NOT change to api content.
+- Flip layout to `api`, assert preview now reflects the previously-stored api state.
+
+### Manual verification on dev
+
+Per spec template after deploy:
+1. Open `/ui/operator/worship` on dev (10.77.8.134:8080).
+2. Curl `PUT /api/stage` with sample content.
+3. Verify operator preview stays on the current worship layout (no flash to api content).
+4. Switch operator's stage to `api` via the layout selector.
+5. Verify preview NOW shows the api content from step 2.
+
+## File structure
+
+### Modified files
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.54 → 0.4.55 |
+| `crates/presenter-ui/Cargo.toml` | presenter-ui version 0.1.23 → 0.1.24 |
+| `crates/presenter-server/src/state/mod.rs` | Gate `LiveEvent::Stage` publish in `update_api_stage` on `stage_layout_code == "api"` |
+| `crates/presenter-server/src/state/stage_display.rs` | In `set_stage_layout_code`, publish stored api state when switching TO `api`; move existing `broadcast_stage_snapshots` call into the non-api branch |
+| `crates/presenter-server/src/state/tests.rs` | 3 new unit tests covering both gate paths + switch-to-api refresh |
+| `tests/e2e/api-stage.spec.ts` | New layout-isolation test |
+
+### Lock files
+- `Cargo.lock` and `crates/presenter-ui/Cargo.lock` — auto-updated.
+
+## Out of scope
+
+- **Companion variables** (`crates/presenter-server/src/companion/variables.rs`) consume `LiveEvent::Stage` independently. After this fix it no longer receives api snapshots while non-api layouts are active — that matches the operator-preview behavior and is the desired outcome. No companion code change.
+- **Resolume / AbleSet outbound integrations** push stage updates through the regular `publish_stage_context` path, which already gates on the api layout. Unaffected.
+- **Stage WebSocket renderers** at `/stage` reflect whatever LiveEvent::Stage they receive. They become consistent with the operator preview once the gate is in place. No client change needed.
+- **Returning a 409 Conflict from `PUT /api/stage`** when layout != api — rejected (Approach 3 from brainstorm). Brittle for integrations that push continuously regardless of operator state.
+
+## Closes
+
+- Issue #281 — api worship input switching preview when layout = worship-snv.
+
+## Risks / unknowns
+
+- **Companion behavior depends on stage events.** When layout flips to `worship-snv`, companion no longer sees api snapshots. Verify by reading `companion/variables.rs:32` (`apply_stage_snapshot`) — if companion variables track api content separately, the change is observable but correct: companion now sees the layout-relevant snapshot only.
+- **Test setup for layout switching.** `AppState::in_memory()` initializes the layout from `DEFAULT_STAGE_LAYOUT_CODE` (currently `worship-snv`-equivalent — verify before writing tests). If the default isn't `worship-snv`, test 1 must explicitly set it.
+- **The `previous_code` capture in `set_stage_layout_code`** is included for symmetry but unused. If clippy flags it as dead code, replace with `let _ = guard.clone();` or remove the local binding entirely.

--- a/tests/e2e/api-stage.spec.ts
+++ b/tests/e2e/api-stage.spec.ts
@@ -256,3 +256,104 @@ test("API stage does not interfere with normal stage", async ({
   await normalPage.close();
   expect(consoleMessages).toEqual([]);
 });
+
+test("api put does not switch preview when layout is worship-snv", async ({
+  request,
+  page,
+  context,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      // Existing operator E2E filters this Chrome integrity-preload warning.
+      if (!text.includes("crbug.com/981419")) {
+        consoleMessages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+
+  // 1. Set layout to worship-snv (a non-api layout).
+  const setLayoutRes = await request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "worship-snv" } },
+  );
+  expect(setLayoutRes.ok()).toBeTruthy();
+
+  // 2. Open the operator UI; wait for WASM ready.
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForLoadState("networkidle");
+
+  // 3. Snapshot the current preview text BEFORE the api PUT.
+  const currentSelector =
+    '[data-role="stage-current"] .operator__stage-preview-text';
+  const previewBefore = await page
+    .locator(currentSelector)
+    .first()
+    .textContent()
+    .catch(() => "");
+
+  // 4. PUT api/stage with distinctive content. With the gate, this MUST NOT
+  // cause the operator preview to update.
+  const distinctiveText = "should-not-appear-in-worship-snv-preview-281";
+  const putRes = await request.put(
+    new URL("/api/stage", baseURL).toString(),
+    {
+      data: {
+        currentText: distinctiveText,
+        nextText: "",
+        currentGroup: "",
+        nextGroup: "",
+        currentSong: "",
+        nextSong: "",
+      },
+    },
+  );
+  expect(putRes.ok()).toBeTruthy();
+
+  // 5. Wait briefly for any potential leak event to land.
+  await page.waitForTimeout(500);
+
+  // 6. Verify the operator preview did NOT change.
+  const previewAfterPut = await page
+    .locator(currentSelector)
+    .first()
+    .textContent()
+    .catch(() => "");
+  expect(previewAfterPut ?? "").not.toContain(distinctiveText);
+  expect(previewAfterPut).toBe(previewBefore);
+
+  // 7. Switch to api layout — operator preview SHOULD now reflect the
+  // stored api content (per the switch-to-api refresh in
+  // set_stage_layout_code).
+  const switchRes = await request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "api" } },
+  );
+  expect(switchRes.ok()).toBeTruthy();
+
+  // 8. Wait for the preview to update with the stored api content.
+  await expect
+    .poll(
+      async () => {
+        const text = await page
+          .locator(currentSelector)
+          .first()
+          .textContent()
+          .catch(() => "");
+        return text ?? "";
+      },
+      { timeout: 5_000 },
+    )
+    .toContain(distinctiveText);
+
+  // Console must be clean.
+  expect(consoleMessages).toEqual([]);
+
+  // Suppress unused warnings for context (we keep it in the signature for
+  // symmetry with other tests in this file that use it).
+  void context;
+});


### PR DESCRIPTION
## Summary

Fixes #281 — \`PUT /api/stage\` was switching the operator preview even when the current stage layout was something other than \`api\` (e.g. \`worship-snv\`).

The bug was an asymmetry: the regular stage update flow already gated on layout (\`broadcasting.rs::publish_stage_context\` skips publishing when layout=api), but the api-update path (\`update_api_stage\`) published unconditionally. This PR mirrors the gate.

## What changed

- **\`update_api_stage\`** (state/mod.rs): only publishes \`LiveEvent::Stage\` when \`stage_layout_code() == API_STAGE_LAYOUT_CODE\`. State is still stored unconditionally on every PUT.
- **\`set_stage_layout_code\`** (state/stage_display.rs): when switching TO \`api\`, publishes the stored \`api_stage_snapshot()\` via \`LiveEvent::Stage\` so the preview reflects the most recent PUT immediately. Switching to other layouts still calls \`broadcast_stage_snapshots()\` as before.
- **New \`API_STAGE_LAYOUT_CODE\` const** in presenter-core, re-exported via \`presenter_core::API_STAGE_LAYOUT_CODE\` (alongside the existing \`DEFAULT_STAGE_LAYOUT_CODE\`). Used by the two new gate sites.
- 3 unit tests (state/tests.rs):
  - \`api_input_does_not_leak_when_layout_is_worship\`
  - \`api_input_publishes_when_layout_is_api\`
  - \`switching_to_api_publishes_stored_api_state\`
- 1 Playwright E2E test (api-stage.spec.ts) — layout-isolation roundtrip.
- Bumped version 0.4.54 → 0.4.55.

## Test plan

- [x] \`cargo test -p presenter-server\` — 187 tests passing (was 184; +3 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings -W clippy::all\` — zero warnings
- [x] \`cargo fmt --all --check\` — clean
- [x] CI green on dev (Pipeline 25277840396 — all jobs incl. 3/3 Playwright shards + Mutation Testing)
- [x] **Manual dev verification via Playwright MCP:**
  - Layout=worship-snv, PUT /api/stage with distinctive text → operator preview unchanged ✅
  - Switch to api → preview now shows the previously-PUT text ✅

Closes #281