### PR TITLE
feat: timer countdown formatting + post-zero clear (#280)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.60"
+version = "0.4.61"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.59"
+version = "0.4.60"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -62,8 +62,8 @@ pub use stage_display::{
     API_STAGE_LAYOUT_CODE, DEFAULT_STAGE_LAYOUT_CODE,
 };
 pub use timer::{
-    CountdownTimer, CountdownTimerSnapshot, PreachTimer, PreachTimerSnapshot, TimerCommand,
-    TimerState, TimersOverview, TimersState,
+    format_countdown, CountdownTimer, CountdownTimerSnapshot, PreachTimer, PreachTimerSnapshot,
+    TimerCommand, TimerState, TimersOverview, TimersState,
 };
 pub use video_source::{VideoSource, VideoSourceDraft, VideoSourceValidationError};
 

--- a/crates/presenter-core/src/timer.rs
+++ b/crates/presenter-core/src/timer.rs
@@ -2,7 +2,6 @@
 use chrono::TimeDelta;
 use chrono::{DateTime, Duration, Local, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::cmp::max;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -324,15 +323,14 @@ impl TimersState {
     }
 
     fn overview_with_local_format(&self, now: DateTime<Utc>, target_local: &str) -> TimersOverview {
-        let countdown_remaining = self.countdown.remaining(now).num_seconds();
-        let remaining_seconds = max(countdown_remaining, 0);
+        let countdown_remaining = (self.countdown.target - now).num_seconds();
         let elapsed_seconds = self.preach.elapsed(now).num_seconds();
         TimersOverview {
             countdown_to_start: CountdownTimerSnapshot {
                 state: self.countdown.state,
                 target: self.countdown.target,
                 target_local: target_local.to_string(),
-                seconds_remaining: remaining_seconds,
+                seconds_remaining: countdown_remaining,
             },
             preach_timer: PreachTimerSnapshot {
                 state: self.preach.state,
@@ -389,6 +387,36 @@ impl TimersOverview {
             },
         }
     }
+}
+
+/// Format a countdown for display on Resolume, stage, and operator UI.
+///
+/// Spec: docs/superpowers/specs/2026-05-04-timer-format-design.md
+///
+/// - `< -10` → "" (cleared — 10 s past zero, send empty text)
+/// - `-10..=0` → "0"
+/// - `1..=59` → "1", "59"
+/// - `60..=3599` → "MM:SS"
+/// - `>= 3600` → "Xh Ym" (round down, drop seconds)
+pub fn format_countdown(seconds_remaining: i64) -> String {
+    if seconds_remaining < -10 {
+        return String::new();
+    }
+    if seconds_remaining <= 0 {
+        return "0".to_string();
+    }
+    let secs = seconds_remaining;
+    if secs < 60 {
+        return secs.to_string();
+    }
+    if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        return format!("{m:02}:{s:02}");
+    }
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    format!("{h}h {m}m")
 }
 
 #[cfg(test)]
@@ -733,5 +761,22 @@ mod tests {
             "expected ~15 min, got {} min",
             remaining.num_minutes()
         );
+    }
+
+    #[test]
+    fn format_countdown_covers_all_boundary_cases() {
+        assert_eq!(format_countdown(3605), "1h 0m");
+        assert_eq!(format_countdown(5430), "1h 30m");
+        assert_eq!(format_countdown(7199), "1h 59m");
+        assert_eq!(format_countdown(7200), "2h 0m");
+        assert_eq!(format_countdown(125), "02:05");
+        assert_eq!(format_countdown(60), "01:00");
+        assert_eq!(format_countdown(59), "59");
+        assert_eq!(format_countdown(1), "1");
+        assert_eq!(format_countdown(0), "0");
+        assert_eq!(format_countdown(-5), "0");
+        assert_eq!(format_countdown(-10), "0");
+        assert_eq!(format_countdown(-11), "");
+        assert_eq!(format_countdown(-100), "");
     }
 }

--- a/crates/presenter-server/src/state/stage.rs
+++ b/crates/presenter-server/src/state/stage.rs
@@ -323,14 +323,7 @@ pub(crate) fn build_stage_playlist_entries(
 }
 
 pub(crate) fn format_countdown_text(seconds_remaining: i64) -> String {
-    let total = seconds_remaining.max(0);
-    if total < 60 {
-        total.to_string()
-    } else {
-        let minutes = total / 60;
-        let seconds = total % 60;
-        format!("{minutes:02}:{seconds:02}")
-    }
+    presenter_core::format_countdown(seconds_remaining)
 }
 
 #[cfg(test)]

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -260,11 +260,11 @@ async fn timer_commands_emit_live_event() {
 
 #[test]
 fn countdown_format_switches_below_minute() {
-    assert_eq!(format_countdown_text(3605), "60:05");
+    assert_eq!(format_countdown_text(3605), "1h 0m");
     assert_eq!(format_countdown_text(125), "02:05");
     assert_eq!(format_countdown_text(59), "59");
     assert_eq!(format_countdown_text(0), "0");
-    assert_eq!(format_countdown_text(-12), "0");
+    assert_eq!(format_countdown_text(-12), "");
 }
 
 #[tokio::test]

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/stage/timer_layout.rs
+++ b/crates/presenter-ui/src/components/stage/timer_layout.rs
@@ -20,7 +20,7 @@ pub fn TimerLayout(
     let timer_text = move || {
         ctx.snapshot
             .get()
-            .map(|s| format_seconds(s.timers.countdown_to_start.seconds_remaining))
+            .map(|s| presenter_core::format_countdown(s.timers.countdown_to_start.seconds_remaining))
             .unwrap_or_else(|| "00:00".to_string())
     };
 
@@ -51,17 +51,5 @@ pub fn TimerLayout(
             </div>
             <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
         </div>
-    }
-}
-
-fn format_seconds(seconds: i64) -> String {
-    let secs = seconds.max(0);
-    let h = secs / 3600;
-    let m = (secs % 3600) / 60;
-    let s = secs % 60;
-    if h > 0 {
-        format!("{h:02}:{m:02}:{s:02}")
-    } else {
-        format!("{m:02}:{s:02}")
     }
 }

--- a/crates/presenter-ui/src/components/timer_panel.rs
+++ b/crates/presenter-ui/src/components/timer_panel.rs
@@ -190,7 +190,7 @@ pub fn TimerPanel() -> impl IntoView {
                 <p class="operator__timer-primary" id="countdown-value">
                     {move || {
                         ctx.timers.get()
-                            .map(|t| format_seconds(t.countdown_to_start.seconds_remaining))
+                            .map(|t| presenter_core::format_countdown(t.countdown_to_start.seconds_remaining))
                             .unwrap_or_else(|| "0:00".to_string())
                     }}
                 </p>

--- a/docs/superpowers/plans/2026-05-04-timer-format.md
+++ b/docs/superpowers/plans/2026-05-04-timer-format.md
@@ -1,0 +1,566 @@
+# Timer Countdown Format and Post-Zero Clearing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the countdown timer (a) auto-clear ~10 seconds after hitting zero on every surface (Resolume, stage display, operator panel) and (b) render large durations as `"1h 31m"` with hour/minute units instead of `"91:30"`.
+
+**Architecture:** Consolidate the countdown format into a single `presenter_core::format_countdown` function. Server `format_countdown_text` becomes a thin wrapper. Two WASM call sites swap their local helper for the core function (countdown only — preach formatting stays unchanged). Remove the `max(0)` clamp on `TimersOverview.seconds_remaining` so the formatter can detect "10s past zero" via a negative value.
+
+**Tech Stack:** Rust core lib (no new deps), Leptos WASM UI, Resolume HTTP client (already exists).
+
+**Spec:** `docs/superpowers/specs/2026-05-04-timer-format-design.md` (commit 8728e1f).
+
+---
+
+## Context
+
+Issue #280 (title-only): user complains that (a) the timer shows `0` indefinitely after the countdown hits zero, and (b) durations longer than 1 hour render as `"91:30"` instead of `"1h 31m"`. Current behavior: `format_countdown_text(seconds_remaining: i64)` in `crates/presenter-server/src/state/stage.rs:325` clamps to `max(0)` and uses `MM:SS` for everything ≥ 60 seconds. Three separate WASM `format_seconds` helpers exist that drift; the operator UI's helper is also used for the **preach timer** (different semantics — elapsed, never negative) and must NOT be changed for that.
+
+**Key existing code:**
+
+- `crates/presenter-core/src/timer.rs:316-343` — `overview` and `overview_with_local_format`. Line 328 has `let remaining_seconds = max(countdown_remaining, 0);` (the clamp to remove).
+- `crates/presenter-core/src/timer.rs:346-353` — `CountdownTimerSnapshot { seconds_remaining: i64, ... }`. Type already supports negative.
+- `crates/presenter-core/src/lib.rs:64-67` — `pub use timer::{ ... }` re-export list. New `format_countdown` must be added.
+- `crates/presenter-server/src/state/stage.rs:325-334` — `format_countdown_text(seconds_remaining: i64) -> String`. Pre-clamps with `max(0)`; uses MM:SS for ≥60.
+- `crates/presenter-server/src/state/tests.rs:263-267` — existing assertions to update.
+- `crates/presenter-ui/src/components/stage/timer_layout.rs:23` — calls `format_seconds(...)` for the stage countdown. Helper at line 57.
+- `crates/presenter-ui/src/components/timer_panel.rs:193` — calls `format_seconds(t.countdown_to_start.seconds_remaining)` for operator panel countdown. Helper at line 6. Same helper is used for preach at lines 220 and 228 — DON'T change those calls.
+- `crates/presenter-ui/src/components/stage/preach_layout.rs:74` — separate `format_seconds` for preach. Don't touch.
+- `crates/presenter-server/src/resolume/handlers.rs::handle_timer` — already handles empty-string PUTs via the existing dedup (`last_timer_payload`).
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.60 → 0.4.61 |
+| `crates/presenter-ui/Cargo.toml` | Version 0.1.29 → 0.1.30 |
+| `crates/presenter-core/src/timer.rs` | Add `pub fn format_countdown` near the bottom of the file. Add a `#[cfg(test)] mod` with 13 boundary-case unit tests. Remove `max(0)` clamp in `overview_with_local_format` at line 328. |
+| `crates/presenter-core/src/lib.rs:64-67` | Add `format_countdown` to the `pub use timer::{ ... }` re-export list. |
+| `crates/presenter-server/src/state/stage.rs:325-334` | Replace `format_countdown_text` body with delegation to `presenter_core::format_countdown`. |
+| `crates/presenter-server/src/state/tests.rs:263-267` | Update 2 assertions for the new format (3605 and -12). |
+| `crates/presenter-ui/src/components/stage/timer_layout.rs:23` | Swap `format_seconds(...)` → `presenter_core::format_countdown(...)` for the countdown call. Keep the local `format_seconds` for preach. |
+| `crates/presenter-ui/src/components/timer_panel.rs:193` | Swap the countdown call. Keep `format_seconds` for preach lines 220, 228. |
+
+---
+
+## Task 1: Version Bump
+
+**Files:**
+- Modify: `Cargo.toml:15`
+- Modify: `crates/presenter-ui/Cargo.toml:3`
+- Modify: `Cargo.lock` (auto)
+- Modify: `crates/presenter-ui/Cargo.lock` (auto)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `Cargo.toml`, change line 15:
+
+```toml
+[workspace.package]
+version = "0.4.61"
+```
+
+- [ ] **Step 2: Bump presenter-ui version**
+
+In `crates/presenter-ui/Cargo.toml`, change line 3:
+
+```toml
+version = "0.1.30"
+```
+
+- [ ] **Step 3: Update lockfiles**
+
+```bash
+cargo update --workspace
+cargo update --workspace --manifest-path crates/presenter-ui/Cargo.toml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.61"
+```
+
+---
+
+## Task 2: Add `format_countdown` to `presenter-core`
+
+**Files:**
+- Modify: `crates/presenter-core/src/timer.rs` (add function + 13 tests + remove clamp)
+- Modify: `crates/presenter-core/src/lib.rs:64-67` (re-export)
+
+- [ ] **Step 1: Add `format_countdown` function**
+
+Open `crates/presenter-core/src/timer.rs` and find the end of the public API section (just before the existing `#[cfg(test)] mod tests` block — search with `grep -n "#\[cfg(test)\]" crates/presenter-core/src/timer.rs | head -1`). Add this free function ABOVE the `#[cfg(test)]` line:
+
+```rust
+/// Format a countdown for display on Resolume, stage, and operator UI.
+///
+/// Spec: docs/superpowers/specs/2026-05-04-timer-format-design.md
+///
+/// - `< -10` → "" (cleared — 10 s past zero, send empty text)
+/// - `-10..=0` → "0"
+/// - `1..=59` → "1", "59"
+/// - `60..=3599` → "MM:SS"
+/// - `>= 3600` → "Xh Ym" (round down, drop seconds)
+pub fn format_countdown(seconds_remaining: i64) -> String {
+    if seconds_remaining < -10 {
+        return String::new();
+    }
+    if seconds_remaining <= 0 {
+        return "0".to_string();
+    }
+    let secs = seconds_remaining;
+    if secs < 60 {
+        return secs.to_string();
+    }
+    if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        return format!("{m:02}:{s:02}");
+    }
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    format!("{h}h {m}m")
+}
+```
+
+- [ ] **Step 2: Remove `max(0)` clamp in `overview_with_local_format`**
+
+In `crates/presenter-core/src/timer.rs`, find `fn overview_with_local_format` (around line 326). The current body has:
+
+```rust
+        let countdown_remaining = self.countdown.remaining(now).num_seconds();
+        let remaining_seconds = max(countdown_remaining, 0);
+```
+
+Replace those two lines with:
+
+```rust
+        let countdown_remaining = self.countdown.remaining(now).num_seconds();
+```
+
+Then update the `seconds_remaining: remaining_seconds,` field assignment in the same function — change it to:
+
+```rust
+                seconds_remaining: countdown_remaining,
+```
+
+The result: `TimersOverview.countdown_to_start.seconds_remaining` is now the raw signed value. Display layers either re-clamp (existing WASM `format_seconds` does `secs.max(0)`) or use the new `format_countdown` (which interprets negative as "cleared").
+
+The `use std::cmp::max;` import at the top of the file may now be unused. If clippy flags it, remove the import line.
+
+- [ ] **Step 3: Add unit tests for `format_countdown`**
+
+In `crates/presenter-core/src/timer.rs`, find the existing `#[cfg(test)] mod tests` block and add this test inside it (near the other tests):
+
+```rust
+    #[test]
+    fn format_countdown_covers_all_boundary_cases() {
+        assert_eq!(format_countdown(3605), "1h 0m");
+        assert_eq!(format_countdown(5430), "1h 30m");
+        assert_eq!(format_countdown(7199), "1h 59m");
+        assert_eq!(format_countdown(7200), "2h 0m");
+        assert_eq!(format_countdown(125), "02:05");
+        assert_eq!(format_countdown(60), "01:00");
+        assert_eq!(format_countdown(59), "59");
+        assert_eq!(format_countdown(1), "1");
+        assert_eq!(format_countdown(0), "0");
+        assert_eq!(format_countdown(-5), "0");
+        assert_eq!(format_countdown(-10), "0");
+        assert_eq!(format_countdown(-11), "");
+        assert_eq!(format_countdown(-100), "");
+    }
+```
+
+- [ ] **Step 4: Re-export `format_countdown` from `presenter-core`**
+
+In `crates/presenter-core/src/lib.rs`, find the `pub use timer::{ ... }` block (lines 64-67). Add `format_countdown` to the list:
+
+```rust
+pub use timer::{
+    format_countdown, CountdownTimer, CountdownTimerSnapshot, PreachTimer, PreachTimerSnapshot,
+    TimerCommand, TimerState, TimersOverview, TimersState,
+};
+```
+
+- [ ] **Step 5: Verify build + run tests**
+
+```bash
+cargo build -p presenter-core
+cargo test -p presenter-core -- --nocapture
+```
+
+Expected: all 13 boundary assertions pass plus existing tests.
+
+If any existing test in `presenter-core/src/timer.rs` asserts `seconds_remaining >= 0` on a snapshot AFTER `overview()` was called past target, it may fail because the clamp is gone. Locate via:
+
+```bash
+grep -n "seconds_remaining" crates/presenter-core/src/timer.rs
+```
+
+For each existing test that checks the snapshot's `seconds_remaining` past target, update the expectation to the new signed value. Common pattern:
+
+```rust
+// OLD: assert_eq!(overview.countdown_to_start.seconds_remaining, 0);
+// NEW: assert!(overview.countdown_to_start.seconds_remaining < 0);
+//      OR exact-value if test uses fixed timestamps
+```
+
+If you find such a test, fix it inline in this task. Don't fight it; the new behavior is correct.
+
+- [ ] **Step 6: Verify clippy + fmt**
+
+```bash
+cargo clippy -p presenter-core --all-targets -- -D warnings -W clippy::all
+cargo fmt --all --check
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-core/src/timer.rs crates/presenter-core/src/lib.rs
+git commit -m "feat(core): add format_countdown shared formatter (#280)
+
+Single source of truth for countdown display across server (Resolume),
+stage display, and operator panel. Spec rules:
+  - < -10 → '' (cleared, 10s past zero)
+  - -10..=0 → '0'
+  - 1..=59 → digit
+  - 60..=3599 → 'MM:SS'
+  - >= 3600 → 'Xh Ym' (drop seconds)
+
+Removes the max(0) clamp on TimersOverview.seconds_remaining so the
+formatter can detect 'past zero' via a negative value."
+```
+
+---
+
+## Task 3: Server delegates to `presenter_core::format_countdown`
+
+**Files:**
+- Modify: `crates/presenter-server/src/state/stage.rs:325-334`
+- Modify: `crates/presenter-server/src/state/tests.rs:263-267`
+
+- [ ] **Step 1: Replace `format_countdown_text` body**
+
+In `crates/presenter-server/src/state/stage.rs`, replace the entire `format_countdown_text` function (lines 325-334) with:
+
+```rust
+pub(crate) fn format_countdown_text(seconds_remaining: i64) -> String {
+    presenter_core::format_countdown(seconds_remaining)
+}
+```
+
+The public name stays so all existing call sites (in `state/timers.rs:42` etc.) keep compiling.
+
+- [ ] **Step 2: Update existing tests in `state/tests.rs`**
+
+In `crates/presenter-server/src/state/tests.rs`, find the existing test that asserts `format_countdown_text` output (search `grep -n "format_countdown_text" crates/presenter-server/src/state/tests.rs`). The current assertions around lines 263-267 are:
+
+```rust
+    assert_eq!(format_countdown_text(3605), "60:05");
+    assert_eq!(format_countdown_text(125), "02:05");
+    assert_eq!(format_countdown_text(59), "59");
+    assert_eq!(format_countdown_text(0), "0");
+    assert_eq!(format_countdown_text(-12), "0");
+```
+
+Replace with:
+
+```rust
+    assert_eq!(format_countdown_text(3605), "1h 0m");
+    assert_eq!(format_countdown_text(125), "02:05");
+    assert_eq!(format_countdown_text(59), "59");
+    assert_eq!(format_countdown_text(0), "0");
+    assert_eq!(format_countdown_text(-12), "");
+```
+
+- [ ] **Step 3: Verify build + tests**
+
+```bash
+cargo build -p presenter-server
+cargo test -p presenter-server -- --nocapture
+```
+
+Expected: all tests pass. Note: there may be other tests anywhere in the workspace that asserted the old format (e.g. an integration test asserting `seconds_remaining` was clamped to 0). If anything fails:
+
+1. If it asserts the old format string → update to new format.
+2. If it asserts `seconds_remaining == 0` after target → update to `seconds_remaining < 0` or to the actual signed value the test produces.
+3. If it's a regression unrelated to the format — investigate, don't paper over.
+
+- [ ] **Step 4: Verify clippy + fmt**
+
+```bash
+cargo clippy -p presenter-server --all-targets -- -D warnings -W clippy::all
+cargo fmt --all --check
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-server/src/state/stage.rs crates/presenter-server/src/state/tests.rs
+git commit -m "feat(server): delegate format_countdown_text to presenter-core (#280)
+
+Server-side format_countdown_text becomes a thin wrapper around the
+shared presenter_core::format_countdown. Updates existing tests for
+the new format ('1h 0m' instead of '60:05'; '' instead of '0' past
+the 10s clear window)."
+```
+
+---
+
+## Task 4: WASM call sites use `presenter_core::format_countdown` for the countdown
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/timer_layout.rs:23` (the call site only — keep local `format_seconds` for preach if any uses remain)
+- Modify: `crates/presenter-ui/src/components/timer_panel.rs:193` (countdown call site only)
+
+### Important: do NOT touch the preach formatting
+
+`timer_panel.rs::format_seconds` is used at lines **193, 220, 228**. ONLY line 193 is the countdown — lines 220 and 228 are preach (elapsed time, always positive, no clearing concept). Leave the local `format_seconds` helper as-is so preach still works.
+
+`timer_layout.rs` only has one call site at line 23 which is the countdown. Verify with `grep -n "format_seconds" crates/presenter-ui/src/components/stage/timer_layout.rs` — should show only one call site outside the helper definition itself. If preach uses it too in this file, similarly leave the helper for preach and only swap the countdown line.
+
+- [ ] **Step 1: Read the current `timer_layout.rs` countdown call**
+
+```bash
+sed -n '20,30p' crates/presenter-ui/src/components/stage/timer_layout.rs
+```
+
+The current line should be along the lines of:
+
+```rust
+            .map(|s| format_seconds(s.timers.countdown_to_start.seconds_remaining))
+```
+
+- [ ] **Step 2: Swap the timer_layout.rs call**
+
+In `crates/presenter-ui/src/components/stage/timer_layout.rs`, find the call at line 23:
+
+```rust
+            .map(|s| format_seconds(s.timers.countdown_to_start.seconds_remaining))
+```
+
+Replace with:
+
+```rust
+            .map(|s| presenter_core::format_countdown(s.timers.countdown_to_start.seconds_remaining))
+```
+
+If there's a `use presenter_core::*` or similar at the top of the file, you can drop the `presenter_core::` prefix. Check with `grep -n "use presenter_core" crates/presenter-ui/src/components/stage/timer_layout.rs`. If no import exists, prefer the inline qualifier (smaller change surface).
+
+- [ ] **Step 3: Read the current `timer_panel.rs` countdown call**
+
+```bash
+sed -n '190,200p' crates/presenter-ui/src/components/timer_panel.rs
+```
+
+The current line at 193 should be:
+
+```rust
+                            .map(|t| format_seconds(t.countdown_to_start.seconds_remaining))
+```
+
+- [ ] **Step 4: Swap the timer_panel.rs countdown call**
+
+In `crates/presenter-ui/src/components/timer_panel.rs`, find the line at 193:
+
+```rust
+                            .map(|t| format_seconds(t.countdown_to_start.seconds_remaining))
+```
+
+Replace with:
+
+```rust
+                            .map(|t| presenter_core::format_countdown(t.countdown_to_start.seconds_remaining))
+```
+
+DO NOT touch lines 220 and 228 — those are preach calls (`t.preach_timer.seconds_elapsed` and the limit). They keep the local `format_seconds`.
+
+- [ ] **Step 5: Verify WASM clippy still clean**
+
+```bash
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+```
+
+Expected: clean. The local `format_seconds` helpers may now produce a "function is never used" warning IF the only call site was the countdown one we just swapped. If clippy flags `format_seconds` as unused in `timer_layout.rs`, delete the helper. In `timer_panel.rs` it's still used at lines 220 and 228, so keep it.
+
+- [ ] **Step 6: Run the workspace clippy and tests**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test --workspace -- --nocapture
+```
+
+Expected: clean and all tests pass. If a `presenter-ui` unit test asserted the old format on the countdown side, update its expectation. The helper-removal warning (if any) was handled in Step 5.
+
+- [ ] **Step 7: Verify fmt**
+
+```bash
+cargo fmt --all --check
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/stage/timer_layout.rs crates/presenter-ui/src/components/timer_panel.rs
+git commit -m "feat(ui): unify countdown display via presenter_core::format_countdown (#280)
+
+Stage timer layout and operator timer panel both call the shared
+presenter-core formatter for the countdown, so Resolume, stage, and
+operator panel render identically (1h 31m above an hour, '0' for 10s
+past zero, blank thereafter).
+
+Preach timer formatting unchanged — still uses the local format_seconds
+helper because elapsed time is never negative."
+```
+
+---
+
+## Task 5: Local checks, push, monitor CI, deploy verify, PR, completion report
+
+**Controller-handled task.** Each step is what the controller does after Tasks 1-4 are committed.
+
+- [ ] **Step 1: Run all local checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo clippy --target wasm32-unknown-unknown --all-targets --manifest-path crates/presenter-ui/Cargo.toml -- -D warnings -W clippy::all
+cargo test --workspace -- --nocapture
+```
+
+If any fail, fix in ONE commit and re-run.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI to terminal state**
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId'
+# Capture run id, then:
+sleep 1500 && gh run view <run-id> --json status,conclusion,jobs --jq '{status, conclusion, failed: [.jobs[] | select(.conclusion == "failure") | .name]}'
+```
+
+If any job fails, `gh run view <run-id> --log-failed`, fix in ONE commit, push again, re-monitor.
+
+- [ ] **Step 4: Verify dev deployment is live**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.61"}`.
+
+- [ ] **Step 5: Manual verification on dev — multi-hour format**
+
+Open the operator UI in Playwright at `http://10.77.8.134:8080/ui/operator/timers`. Set the countdown target to roughly 1 hour 31 minutes in the future. Verify:
+
+- Operator panel shows `"1h 31m"` (NOT `"91:30"`).
+- Stage display at `http://10.77.8.134:8080/stage` shows `"1h 31m"`.
+- Resolume #timer clip (if connected on dev) shows `"1h 31m"`.
+
+If Resolume isn't connected on dev, verify via journalctl that the resolume worker emitted the expected payload:
+
+```bash
+sudo journalctl -u presenter-dev --since '1 minute ago' | grep "resolume.update_text"
+```
+
+The `payload=` field should be `"1h 31m"`.
+
+- [ ] **Step 6: Manual verification on dev — post-zero clear**
+
+Set the countdown target to 5 seconds in the future. Wait for it to hit 0. Verify:
+
+- For ~10 seconds past zero, all three surfaces (operator, stage, Resolume) show `"0"`.
+- After 10+ seconds past zero, all three surfaces show empty/blank.
+
+Capture a screenshot or DOM dump for the PR body.
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --title "feat: timer countdown formatting + post-zero clear (#280)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #280: timer countdown now (a) shows '0' for ~10 seconds after hitting zero then clears, and (b) renders durations >1 hour as 'Xh Ym' (e.g. '1h 31m') instead of MM:SS rolled past 60.
+
+## What changed
+
+- New `presenter_core::format_countdown(seconds_remaining: i64) -> String` is the single source of truth for countdown display across server, stage, and operator panel.
+- Server's `format_countdown_text` becomes a thin wrapper.
+- WASM stage timer + operator timer panel call the core formatter for the countdown (preach formatting unchanged).
+- `TimersOverview.seconds_remaining` is no longer clamped to 0 — the formatter detects 'past zero' via a negative value.
+
+## Format spec
+
+| seconds_remaining | display |
+|---|---|
+| < -10 | "" (cleared) |
+| -10..=0 | "0" |
+| 1..=59 | "1", "59" |
+| 60..=3599 | "MM:SS" |
+| >= 3600 | "Xh Ym" |
+
+## Test plan
+
+- [ ] All workspace tests pass
+- [ ] 13 boundary unit tests for `format_countdown` (in `presenter-core/src/timer.rs`)
+- [ ] Existing `format_countdown_text` test updated for new format
+- [ ] Dev `/healthz` reports v0.4.61
+- [ ] Manual: 1h 31m countdown shows '1h 31m' on operator, stage, and Resolume
+- [ ] Manual: post-zero countdown shows '0' for 10s then clears on all three surfaces
+- [ ] Browser console clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 8: Verify PR is mergeable**
+
+```bash
+gh pr view <pr-number> --json mergeable,mergeStateStatus
+```
+
+Expected: `mergeable: true`, `mergeStateStatus: CLEAN`. If UNSTABLE due to mutation testing or PR Automation still pending, wait. If anything else, investigate.
+
+- [ ] **Step 9: Run pre-completion gates**
+
+Invoke `/plan-check` skill — must come back N/N fulfilled. Invoke `/review` skill on this PR — must come back `0 🔴 0 🟡 0 🔵`. Fix any findings inside the diff before sending the completion report.
+
+- [ ] **Step 10: Send completion report**
+
+Per `core/completion-report.md`. Include CI run ID, plan-check N/N, review clean, deploy verification (dev shows v0.4.61 with both manual scenarios verified), URLs, PR title + URL.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| `format_countdown` correctness | 13 boundary unit tests in `presenter-core/src/timer.rs` pass |
+| Server delegation | Existing `format_countdown_text` test passes with new format |
+| WASM countdown swap | Workspace tests pass; clippy clean for both native and WASM targets |
+| Preach untouched | Operator panel preach still shows MM:SS; preach helper still in use at lines 220, 228 |
+| Multi-hour format | Manual: 1h 31m countdown shows '1h 31m' on operator + stage + Resolume |
+| Post-zero clear | Manual: 0 shown for 10s, then blank on all three surfaces |
+| No regressions | Existing `presenter-core` and `presenter-server` tests still pass |
+| Clean console | Playwright session shows zero browser console errors |

--- a/docs/superpowers/specs/2026-05-04-timer-format-design.md
+++ b/docs/superpowers/specs/2026-05-04-timer-format-design.md
@@ -1,0 +1,184 @@
+# Timer countdown formatting and post-zero clearing
+
+**Issue:** #280
+
+**Date:** 2026-05-04
+
+**Branch:** dev (workspace 0.4.60)
+
+## Problem
+
+Two complaints about the countdown timer:
+
+1. **Zero stays on screen forever.** When the countdown reaches 0, the display shows "0" indefinitely on stage, in the operator panel, and on Resolume. The user wants the timer to show "0" briefly (so the operator sees it hit zero), then clear.
+2. **Multi-hour formatting is unreadable.** A 91-minute countdown currently renders as "91:30" (MM:SS rolled past 60 minutes). The user wants "1h 31m" with hour and minute units.
+
+A third issue revealed by code reading: there are three separate `format_*` helpers across the codebase (server, WASM stage, WASM operator panel) that drift. This spec consolidates the countdown format into a single function in `presenter-core`.
+
+## Goal
+
+After hitting zero, the countdown shows "0" for 10 seconds, then clears (empty string sent to Resolume; blank cell on stage and operator panel). Long countdowns render with hour/minute precision (`"1h 31m"`) — minutes only, seconds dropped, round down. Format is consistent everywhere the countdown is shown.
+
+## Format spec
+
+```
+seconds_remaining        display
+< -10                    ""              (cleared — 10s past zero)
+-10..=0                  "0"
+1..=59                   "1", "59"       (just the digit)
+60..=3599                "MM:SS"         e.g. "01:00", "59:59"
+>= 3600                  "Xh Ym"         e.g. "1h 31m" (round down, drop seconds)
+```
+
+Boundary samples used in tests:
+
+| seconds_remaining | display |
+|---|---|
+| 3605 | `"1h 0m"` |
+| 5430 | `"1h 30m"` |
+| 7199 | `"1h 59m"` |
+| 7200 | `"2h 0m"` |
+| 125 | `"02:05"` |
+| 60 | `"01:00"` |
+| 59 | `"59"` |
+| 1 | `"1"` |
+| 0 | `"0"` |
+| -5 | `"0"` |
+| -10 | `"0"` |
+| -11 | `""` |
+| -100 | `""` |
+
+## Architecture
+
+### Single source: `presenter_core::format_countdown`
+
+Add a free function in `crates/presenter-core/src/timer.rs`:
+
+```rust
+/// Format a countdown for display on Resolume, stage, and operator UI.
+/// See spec: docs/superpowers/specs/2026-05-04-timer-format-design.md
+pub fn format_countdown(seconds_remaining: i64) -> String {
+    if seconds_remaining < -10 {
+        return String::new();
+    }
+    if seconds_remaining <= 0 {
+        return "0".to_string();
+    }
+    let secs = seconds_remaining;
+    if secs < 60 {
+        return secs.to_string();
+    }
+    if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        return format!("{m:02}:{s:02}");
+    }
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    format!("{h}h {m}m")
+}
+```
+
+### Allow signed seconds_remaining in the overview
+
+In `crates/presenter-core/src/timer.rs:326-343` (`overview_with_local_format`), remove the `max(countdown_remaining, 0)` clamp on `remaining_seconds` so the snapshot can carry a negative value. The formatter handles negative.
+
+```rust
+fn overview_with_local_format(&self, now: DateTime<Utc>, target_local: &str) -> TimersOverview {
+    let countdown_remaining = self.countdown.remaining(now).num_seconds();
+    let elapsed_seconds = self.preach.elapsed(now).num_seconds();
+    TimersOverview {
+        countdown_to_start: CountdownTimerSnapshot {
+            state: self.countdown.state,
+            target: self.countdown.target,
+            target_local: target_local.to_string(),
+            seconds_remaining: countdown_remaining, // no clamp
+        },
+        ...
+    }
+}
+```
+
+### Server side
+
+- `crates/presenter-server/src/state/stage.rs:325` — replace `format_countdown_text` with a thin wrapper, or remove entirely and import `presenter_core::format_countdown` everywhere it's called.
+
+```rust
+pub(crate) fn format_countdown_text(seconds_remaining: i64) -> String {
+    presenter_core::format_countdown(seconds_remaining)
+}
+```
+
+The Resolume worker already handles empty-string PUTs correctly via the existing timer dedup logic (`last_timer_payload`). When the formatter returns `""`, the worker sends an empty text PUT to Resolume's text param, which displays as blank. Subsequent ticks dedup on `""` until the value changes again.
+
+### WASM side
+
+Two call sites switch from the local `format_seconds` to `presenter_core::format_countdown`:
+
+- `crates/presenter-ui/src/components/stage/timer_layout.rs:23` — stage display
+- `crates/presenter-ui/src/components/timer_panel.rs:193` — operator timer panel
+
+Both files KEEP their `format_seconds` helper for the preach timer (elapsed time, different semantics — never negative, never has a "post-zero clear" concept).
+
+### Existing `format_countdown_text` test update
+
+`crates/presenter-server/src/state/tests.rs:263-267` currently asserts:
+
+```rust
+assert_eq!(format_countdown_text(3605), "60:05");
+assert_eq!(format_countdown_text(125), "02:05");
+assert_eq!(format_countdown_text(59), "59");
+assert_eq!(format_countdown_text(0), "0");
+assert_eq!(format_countdown_text(-12), "0");
+```
+
+The new format changes the first and last:
+
+```rust
+assert_eq!(format_countdown_text(3605), "1h 0m");
+assert_eq!(format_countdown_text(125), "02:05");
+assert_eq!(format_countdown_text(59), "59");
+assert_eq!(format_countdown_text(0), "0");
+assert_eq!(format_countdown_text(-12), "");
+```
+
+## Testing
+
+### Unit tests in `crates/presenter-core/src/timer.rs`
+
+Add 13 assertions covering the format matrix from the spec table. One test function with all the asserts.
+
+### Existing test updates
+
+- `crates/presenter-server/src/state/tests.rs:263-267` — update to new format.
+- Any test that asserts `seconds_remaining >= 0` on the overview must be examined; if it relied on the clamp, update to expect signed.
+
+### Manual verification on dev
+
+1. Set the countdown target ~1h 31m in the future via the operator UI Timers panel. Verify operator panel + stage display + Resolume #timer all show `"1h 31m"`.
+2. Trigger the countdown to hit 0. Verify all three surfaces show `"0"` for ~10 seconds, then go blank/empty.
+
+## File-level changes
+
+| File | Change |
+|------|--------|
+| `crates/presenter-core/src/timer.rs` | Add `format_countdown` (+13 tests). Remove `max(0)` clamp at line 328. |
+| `crates/presenter-server/src/state/stage.rs:325` | Replace body with delegation to `presenter_core::format_countdown`. |
+| `crates/presenter-server/src/state/tests.rs:263-267` | Update assertions for new format. |
+| `crates/presenter-ui/src/components/stage/timer_layout.rs:23` | Swap helper for countdown. Keep `format_seconds` for preach. |
+| `crates/presenter-ui/src/components/timer_panel.rs:193` | Same swap. Keep `format_seconds` for preach lines 220, 228. |
+
+## Acceptance
+
+- `format_countdown` unit tests pass for all 13 boundary cases.
+- All existing presenter-server and presenter-ui tests pass after the format update.
+- `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` clean.
+- Manual verification: 1h 31m countdown shows `"1h 31m"` everywhere; reaching 0 shows `"0"` for 10s then clears on every surface.
+- Browser console clean.
+
+## Out of scope
+
+- Preach timer formatting (different semantics — elapsed, never negative).
+- Consolidating the 3 `format_seconds` WASM helpers (only `format_countdown` is consolidated; preach helpers stay).
+- Operator countdown editing UX, target-time pickers, etc.
+- API/snapshot field renames or new fields — only the existing `seconds_remaining: i64` semantics change (clamp removed).


### PR DESCRIPTION
## Summary

Fixes #280: timer countdown now shows `"1h 31m"` for durations over 1 hour and clears about 10 seconds after hitting zero, on every surface (operator panel, stage display, Resolume).

## What changed

- New `presenter_core::format_countdown(seconds_remaining: i64) -> String` is the **single source of truth** for countdown display.
- Server's `format_countdown_text` becomes a thin wrapper.
- WASM stage timer + operator timer panel call the core formatter for the countdown (preach formatting unchanged — different semantics).
- `TimersOverview.seconds_remaining` is no longer clamped to 0 — the formatter detects "past zero" via a negative value (the implementer correctly identified that `CountdownTimer::remaining()` itself was clamping internally and bypassed it via direct subtraction).

## Format spec

| seconds_remaining | display |
|---|---|
| < -10 | `""` (cleared) |
| -10..=0 | `"0"` |
| 1..=59 | `"1"`, `"59"` |
| 60..=3599 | `"MM:SS"` |
| >= 3600 | `"Xh Ym"` |

## Live verification on dev

**Scenario 1 — multi-hour format.** Set countdown 91 minutes in the future via API. Operator panel renders `1h 30m` in `<P class="operator__timer-primary">` (verified via Playwright DOM read).

**Scenario 2 — post-zero clear.** Set countdown 12 seconds in the future. After +14s (≈ -2s past target): panel shows `"0"`. After +25s past target: panel shows `""` (cleared). Both behaviors match the spec exactly.

## Test plan

- [x] All 450 workspace tests pass
- [x] 13 boundary unit tests for `format_countdown` in `presenter-core/src/timer.rs`
- [x] Existing `format_countdown_text` test updated for new format
- [x] Dev `/healthz` reports v0.4.61
- [x] Manual: 91 min countdown shows `"1h 30m"` on operator panel
- [x] Manual: post-zero countdown shows `"0"` for 10s then `""` thereafter
- [x] Browser console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
