### PR TITLE
fix(ui): isolate worship UI from other operator views (#295)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.61"
+version = "0.4.62"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.62"
+version = "0.4.63"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/stage_preview.rs
+++ b/crates/presenter-ui/src/components/stage_preview.rs
@@ -167,7 +167,7 @@ pub fn StagePreview() -> impl IntoView {
                 data-role="worship-preview"
                 class="operator__worship-preview-wrap"
                 style=move || {
-                    if ctx.view.get() == "bible" { "display:none" } else { "" }
+                    if ctx.view.get() == "worship" { "" } else { "display:none" }
                 }
             >
                 <div class="operator__stage-preview-stack">

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1411,6 +1411,10 @@ body.operator[data-view="worship"] [data-view-panel="worship"] {
   display: flex;
 }
 
+body.operator:not([data-view="worship"]) [data-view-panel="worship"] {
+  display: none;
+}
+
 body.operator[data-view="bible"] [data-view-panel="bible"],
 body.operator[data-view="timers"] [data-view-panel="timers"],
 body.operator[data-view="ai"] [data-view-panel="ai"] {

--- a/docs/superpowers/plans/2026-05-04-operator-view-isolation.md
+++ b/docs/superpowers/plans/2026-05-04-operator-view-isolation.md
@@ -1,0 +1,519 @@
+# Operator View Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide worship-specific UI elements (song name, Ableton/Follow buttons, libraries / playlists / presentations panels with their `+` buttons) on the bible / timers / ai / settings views so the operator only sees them on the worship view.
+
+**Architecture:** Two surgical changes — a Leptos inline-style condition flip in `stage_preview.rs` and one new CSS rule in `operator.css`. No new components, no logic changes. Add a Playwright E2E spec asserting the visibility matrix per view.
+
+**Tech Stack:** Rust/Leptos (WASM), CSS, Playwright TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-operator-view-isolation-design.md` (commit 3965546).
+
+---
+
+## Context
+
+Issue #295 (title-only): "worship song name and plus sign it is bleeding to all pages bible, timer setting it is on top, and it should be only in worship".
+
+Two CSS-level leaks:
+
+1. `crates/presenter-ui/src/components/stage_preview.rs:166-172` — the `worship-preview-wrap` div (song name, Ableton/Follow buttons, current/next slide preview) is rendered with `style="display:none"` only when view is `bible`. It stays visible on `timers`, `ai`, `settings` (BUG).
+2. `crates/presenter-ui/src/pages/operator.rs:166` — `<section class="operator__worship" data-view-panel="worship">` lacks the `.operator__panel { display: none; ... }` default that the bible / timers / ai / settings sections inherit. The CSS rule at `operator.css:1410` only sets `display: flex` when view IS worship; never hides on other views.
+
+User confirmed (brainstorming Q1) that the diagnostic `[data-role="stage-monitor"]` and the `[data-role="clear-slide"]` (🧹) button stay visible on every view.
+
+**Key existing code:**
+
+- `crates/presenter-ui/src/components/stage_preview.rs:166-228` — the `<div data-role="worship-preview" class="operator__worship-preview-wrap">` block.
+- `crates/presenter-ui/styles/operator.css:1402-1422` — current panel-display rules.
+- `crates/presenter-ui/src/components/header.rs:187` — view names: `worship`, `bible`, `timers`, `ai`, `settings`.
+- `crates/presenter-ui/src/pages/operator.rs:49, 277` — both call `body.set_attribute("data-view", ...)`.
+- `tests/e2e/api-stage.spec.ts:1-50` — establishes the project's E2E pattern: `startTestServer` + `deriveTestConfig` + `refreshDevData` from `./support`, console filtering for the chrome `crbug.com/981419` warning, `expect(consoleMessages).toEqual([])` at the end of each test.
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.62 → 0.4.63 |
+| `crates/presenter-ui/Cargo.toml` | Version 0.1.31 → 0.1.32 |
+| `crates/presenter-ui/src/components/stage_preview.rs:170` | Flip the inline-style condition: show `worship-preview-wrap` only on `worship` view |
+| `crates/presenter-ui/styles/operator.css` | Add a new `body.operator:not([data-view="worship"]) [data-view-panel="worship"] { display: none; }` rule after the existing show-on-worship rule |
+
+### Created Files
+
+| File | Responsibility |
+|------|----------------|
+| `tests/e2e/operator-view-isolation.spec.ts` | Playwright E2E: visibility matrix for all 5 operator views. Asserts worship UI hidden on non-worship views; stage-monitor + clear-slide stay visible. Browser console clean. |
+
+---
+
+## Task 1: Version Bump
+
+**Files:**
+- Modify: `Cargo.toml:15`
+- Modify: `crates/presenter-ui/Cargo.toml:3`
+- Modify: `Cargo.lock` (auto)
+- Modify: `crates/presenter-ui/Cargo.lock` (auto)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `Cargo.toml`, change line 15:
+
+```toml
+[workspace.package]
+version = "0.4.63"
+```
+
+- [ ] **Step 2: Bump presenter-ui version**
+
+In `crates/presenter-ui/Cargo.toml`, change line 3:
+
+```toml
+version = "0.1.32"
+```
+
+- [ ] **Step 3: Update lockfiles**
+
+```bash
+cargo update --workspace
+cargo update --workspace --manifest-path crates/presenter-ui/Cargo.toml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.63"
+```
+
+---
+
+## Task 2: Apply the two CSS-level fixes
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage_preview.rs:170` (one-line condition flip)
+- Modify: `crates/presenter-ui/styles/operator.css` (after line 1412, add 3-line rule)
+
+- [ ] **Step 1: Read the current StagePreview condition**
+
+```bash
+sed -n '166,172p' crates/presenter-ui/src/components/stage_preview.rs
+```
+
+You should see:
+
+```rust
+            <div
+                data-role="worship-preview"
+                class="operator__worship-preview-wrap"
+                style=move || {
+                    if ctx.view.get() == "bible" { "display:none" } else { "" }
+                }
+            >
+```
+
+- [ ] **Step 2: Flip the condition**
+
+Replace the closure body. Find:
+
+```rust
+                style=move || {
+                    if ctx.view.get() == "bible" { "display:none" } else { "" }
+                }
+```
+
+Replace with:
+
+```rust
+                style=move || {
+                    if ctx.view.get() == "worship" { "" } else { "display:none" }
+                }
+```
+
+The result: the div is `display:none` on every view except `worship`.
+
+- [ ] **Step 3: Read the current CSS panel rules**
+
+```bash
+sed -n '1410,1422p' crates/presenter-ui/styles/operator.css
+```
+
+You should see the existing rule:
+
+```css
+body.operator[data-view="worship"] [data-view-panel="worship"] {
+  display: flex;
+}
+
+body.operator[data-view="bible"] [data-view-panel="bible"],
+body.operator[data-view="timers"] [data-view-panel="timers"],
+body.operator[data-view="ai"] [data-view-panel="ai"] {
+  display: block;
+}
+
+body.operator[data-view="settings"] [data-view-panel="settings"] {
+  display: block;
+}
+```
+
+- [ ] **Step 4: Add the new hide-on-non-worship rule**
+
+In `crates/presenter-ui/styles/operator.css`, immediately after the existing show-on-worship rule (between line 1412 and 1414, or wherever the closing `}` of the show-on-worship rule is), add:
+
+```css
+body.operator:not([data-view="worship"]) [data-view-panel="worship"] {
+  display: none;
+}
+```
+
+The result: the worship section (libraries / playlists / presentations + their `+` buttons) is hidden on every view except worship. The existing show-on-worship rule continues to display it as flex when the view is worship.
+
+- [ ] **Step 5: Build the WASM crate**
+
+```bash
+cd crates/presenter-ui && cargo build --target wasm32-unknown-unknown && cd ../..
+```
+
+Expected: build passes.
+
+- [ ] **Step 6: Run workspace clippy + fmt**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+cargo fmt --all --check
+```
+
+Expected: clean. Zero warnings.
+
+- [ ] **Step 7: Run workspace tests**
+
+```bash
+cargo test --workspace -- --nocapture
+```
+
+Expected: all tests pass. No tests should rely on the buggy old condition.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/stage_preview.rs crates/presenter-ui/styles/operator.css
+git commit -m "fix(ui): worship-only UI elements isolated from other views (#295)
+
+Two CSS-level fixes:
+- Inline-style on the StagePreview worship-preview-wrap now shows
+  on view='worship' and hides on every other view (was: hide on
+  'bible' only, leaking onto timers/ai/settings).
+- New CSS rule hides the worship section ([data-view-panel='worship']
+  containing libraries/playlists/presentations + their + buttons)
+  when the view is not 'worship'.
+
+The existing show-on-worship rule continues to apply. Diagnostic
+elements (stage-monitor counter, clear-slide button) stay visible
+on every view, as confirmed in the spec."
+```
+
+---
+
+## Task 3: Playwright E2E for the visibility matrix
+
+**Files:**
+- Create: `tests/e2e/operator-view-isolation.spec.ts`
+
+- [ ] **Step 1: Inspect existing E2E patterns**
+
+Read `tests/e2e/api-stage.spec.ts` lines 1-30 and 55-80 to see how the project sets up `beforeAll`/`afterAll` with `startTestServer`, navigates with `page.goto(new URL("/...", baseURL).toString())`, waits for `body[data-wasm-ready="true"]`, and how it collects/asserts console messages.
+
+```bash
+sed -n '1,30p' tests/e2e/api-stage.spec.ts
+sed -n '55,90p' tests/e2e/api-stage.spec.ts
+sed -n '210,225p' tests/e2e/api-stage.spec.ts
+```
+
+The project pattern uses helpers from `./support`:
+- `deriveTestConfig(testInfo)` returns `{ baseURL, dbUrl, port, oscPort }`
+- `startTestServer(port, dbUrl, oscPort)` returns a `ServerHandle`
+- `stopServer(server)` shuts it down
+- Console filter: skip messages containing `crbug.com/981419`
+
+- [ ] **Step 2: Create the new test file**
+
+Create `tests/e2e/operator-view-isolation.spec.ts` with this content:
+
+```typescript
+import { test, expect, type Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+function collectConsoleMessages(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() !== "error" && msg.type() !== "warning") return;
+    // Filter the known chromium "Untrusted Types" warning
+    if (msg.text().includes("crbug.com/981419")) return;
+    messages.push(`[${msg.type()}] ${msg.text()}`);
+  });
+  return messages;
+}
+
+async function openOperator(page: Page, viewPath: string): Promise<void> {
+  await page.goto(new URL(`/ui/operator${viewPath}`, baseURL).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+}
+
+test("worship view shows worship UI", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "");
+
+  await expect(page.locator('[data-role="worship-preview"]')).toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("bible view hides worship UI, shows bible panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/bible");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="bible"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("timers view hides worship UI, shows timers panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/timers");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="timers"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("ai view hides worship UI, shows ai panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/ai");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="ai"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("settings view hides worship UI, shows settings panel", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/settings");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="settings"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run the new spec locally**
+
+```bash
+npx playwright test tests/e2e/operator-view-isolation.spec.ts
+```
+
+Expected: all 5 tests pass.
+
+If a test fails because `[data-role="stage-monitor"]` or `[data-role="clear-slide"]` is hidden on a particular view (e.g. bible), that means the spec assumption "they stay on every view" is wrong. Inspect with `npx playwright test --debug`. The likely fix is to remove those assertions on the affected view rather than change the implementation, since the goal is only to hide WORSHIP-specific elements.
+
+If a test fails because `[data-view-panel="bible"]` (or another non-worship panel) is not visible on its own view, that means the existing CSS rule at `operator.css:1414-1418` isn't matching. Verify the body has `data-view="<view>"` set:
+
+```bash
+# In the failing test, add a temporary diagnostic:
+console.log(await page.evaluate(() => document.body.getAttribute("data-view")));
+```
+
+If the body doesn't have the attribute set, that's a separate bug — escalate.
+
+- [ ] **Step 4: Verify console messages stay clean**
+
+The 5 tests collect console errors and warnings (filtered for the known chromium `crbug.com/981419` warning per project convention). If any test fails on the `expect(consoleMessages).toEqual([])` assertion, look at the failure output to see what message leaked. Common causes:
+
+- A new uncaught exception introduced by the CSS / Rust change → fix it.
+- An existing console warning that wasn't there before → check whether the WASM build is generating it; if it's pre-existing and not a regression, add it to the filter list.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/operator-view-isolation.spec.ts
+git commit -m "test(e2e): operator view isolation matrix (#295)
+
+Five new Playwright tests asserting the visibility matrix per view:
+worship + bible + timers + ai + settings. Worship-specific elements
+(worship-preview-wrap, libraries/playlists/presentations panel) hidden
+on non-worship views; stage-monitor and clear-slide stay visible
+everywhere; the matching panel for each view shows. Browser console
+must stay clean (per ci/browser-console-zero-errors)."
+```
+
+---
+
+## Task 4: Local checks, push, monitor CI, deploy verify, PR, completion report
+
+**Controller-handled task.** Each step is what the controller does after Tasks 1-3 are committed.
+
+- [ ] **Step 1: Run all local checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+cargo test --workspace -- --nocapture
+npx playwright test tests/e2e/operator-view-isolation.spec.ts
+```
+
+If any fail, fix in ONE commit and re-run.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI to terminal state**
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId'
+# Capture run id, then:
+sleep 1500 && gh run view <run-id> --json status,conclusion,jobs --jq '{status, conclusion, failed: [.jobs[] | select(.conclusion == "failure") | .name]}'
+```
+
+If any job fails, `gh run view <run-id> --log-failed`, fix in ONE commit, push again, re-monitor.
+
+- [ ] **Step 4: Verify dev deployment is live**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.63"}`.
+
+- [ ] **Step 5: Manual verification on dev**
+
+Use Playwright MCP (`browser_navigate` + `browser_evaluate`) to navigate through all 5 operator views on `http://10.77.8.134:8080/ui/operator/<view>`. For each view, assert visibility:
+
+| URL | worship-preview | worship panel | matching panel |
+|---|---|---|---|
+| `/ui/operator` | visible | visible | (worship is the active view) |
+| `/ui/operator/bible` | hidden | hidden | bible panel visible |
+| `/ui/operator/timers` | hidden | hidden | timers panel visible |
+| `/ui/operator/ai` | hidden | hidden | ai panel visible |
+| `/ui/operator/settings` | hidden | hidden | settings panel visible |
+
+For each view, also check that `[data-role="stage-monitor"]` and `[data-role="clear-slide"]` are visible.
+
+Capture a screenshot or DOM dump of one of the non-worship views (e.g. `/ui/operator/bible`) for the PR body, showing the worship UI is no longer present at the top.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "fix(ui): isolate worship UI from other operator views (#295)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #295: worship-specific UI elements (song name, Ableton/Follow buttons, libraries/playlists/presentations panels with their `+` buttons) no longer appear on bible, timers, ai, or settings views. They render only when the active view is worship. Diagnostic elements (stage-monitor health counter, clear-slide button) stay visible on every view.
+
+## What changed
+
+Two CSS-level fixes, no new components, no logic changes:
+
+1. **stage_preview.rs:170** — flipped the inline-style condition on `[data-role="worship-preview"]` from `if view == "bible" { hide } else { show }` to `if view == "worship" { show } else { hide }`.
+2. **operator.css** — added `body.operator:not([data-view="worship"]) [data-view-panel="worship"] { display: none; }` to hide the worship section (which lacks the default `.operator__panel { display: none; }` base).
+
+## Test plan
+
+- [x] All workspace tests pass
+- [x] 5 new Playwright E2E tests in `tests/e2e/operator-view-isolation.spec.ts` (worship + bible + timers + ai + settings)
+- [x] Each test asserts: worship UI hidden on non-worship views; stage-monitor + clear-slide visible everywhere; the matching panel for each view shows; browser console clean.
+- [x] Dev `/healthz` reports v0.4.63
+- [x] Manual: navigated all 5 views on dev via Playwright; visibility matrix confirmed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Verify PR is mergeable**
+
+```bash
+gh pr view <pr-number> --json mergeable,mergeStateStatus
+```
+
+Expected: `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`. If `UNSTABLE` due to mutation testing or PR Automation still pending, wait. If anything else, investigate.
+
+- [ ] **Step 8: Run pre-completion gates**
+
+Invoke `/plan-check` skill — must come back N/N fulfilled. Invoke `/review` skill on this PR — must come back `0 🔴 0 🟡 0 🔵`. Fix any findings inside the diff before sending the completion report.
+
+- [ ] **Step 9: Send completion report**
+
+Per `core/completion-report.md`. Include CI run ID, plan-check N/N, review clean, deploy verification (dev shows v0.4.63 with all 5 views verified), URLs, PR title + URL.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| Worship-preview-wrap hidden on non-worship | E2E tests for bible/timers/ai/settings assert `:not(:visible)` |
+| Worship section hidden on non-worship | Same E2E tests assert `[data-view-panel="worship"]:not(:visible)` |
+| Worship-preview-wrap visible on worship | Worship E2E test asserts `:visible` |
+| Worship section visible on worship | Same E2E test asserts `:visible` |
+| Stage-monitor + clear-slide stay visible everywhere | All 5 E2E tests assert both visible |
+| Matching panel visible per view | Each non-worship E2E test asserts the specific panel visible |
+| No regressions | Workspace tests still pass; WASM clippy clean |
+| Clean console | All 5 E2E tests assert `consoleMessages.length === 0` |
+| Live behavior on dev | Manual Playwright tour through all 5 views |

--- a/docs/superpowers/specs/2026-05-04-operator-view-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-04-operator-view-isolation-design.md
@@ -1,0 +1,125 @@
+# Operator view isolation: keep worship-only UI off bible/timer/ai/settings
+
+**Issue:** #295
+
+**Date:** 2026-05-04
+
+**Branch:** dev (workspace 0.4.62)
+
+## Problem
+
+The operator UI shows worship-specific elements at the top of every view, not just the worship view. Two leaks:
+
+1. The "stage preview" panel in the operator header — song name, Ableton ON / Follow OFF toggles, and the current/next slide text — currently displays on `worship`, `timers`, `ai`, and `settings`. It is correctly hidden only on `bible`.
+2. The worship section that contains the **libraries / playlists / presentations** panels (with their `+` buttons) is rendered on every view because its CSS lacks the default `display: none` from `.operator__panel`. The bible / timers / ai / settings panels each have a `.operator__panel` base class that hides them by default; the worship section does not.
+
+Result: a user navigating to bible / timers / ai / settings still sees the worship song name plus Ableton/Follow buttons in the header AND the libraries/playlists/presentations panels with their `+` buttons.
+
+## Goal
+
+Worship-specific elements appear only when the operator's view is `worship`. The diagnostic / utility elements in the operator header (`stage-monitor` health counter, `clear-slide` 🧹 button, `bible-preview`) remain visible on the views they currently target.
+
+## Architecture
+
+Two trivial CSS / Rust changes. No logic changes. No new components.
+
+### Fix 1 — `crates/presenter-ui/src/components/stage_preview.rs:170`
+
+Flip the inline-style condition on the `[data-role="worship-preview"]` div.
+
+Current:
+
+```rust
+style=move || {
+    if ctx.view.get() == "bible" { "display:none" } else { "" }
+}
+```
+
+New:
+
+```rust
+style=move || {
+    if ctx.view.get() == "worship" { "" } else { "display:none" }
+}
+```
+
+### Fix 2 — `crates/presenter-ui/styles/operator.css`
+
+After the existing rule at line 1410:
+
+```css
+body.operator[data-view="worship"] [data-view-panel="worship"] {
+  display: flex;
+}
+```
+
+Add:
+
+```css
+body.operator:not([data-view="worship"]) [data-view-panel="worship"] {
+  display: none;
+}
+```
+
+The existing show-on-worship rule continues to apply when the view IS worship. The new hide rule applies on every other view. Specificity is symmetric across the two rules; declaration order keeps the show-on-worship rule winning when both could match (which never happens because they're mutually exclusive).
+
+## Surfaces affected
+
+| Element | Currently shown on | After fix |
+|---|---|---|
+| StagePreview `worship-preview-wrap` (song name, Ableton/Follow buttons, current/next text) | worship, timers, ai, settings | worship only |
+| StagePreview `bible-preview` | bible | bible (unchanged) |
+| StagePreview `stage-monitor` (health counter) | all views | all views (unchanged) |
+| StagePreview `clear-slide` (🧹) | all views | all views (unchanged) |
+| operator__worship section (libraries / playlists / presentations + their `+` buttons) | all views | worship only |
+| operator__panel--bible / timers / ai / settings | their respective view | unchanged |
+
+## Testing
+
+### Playwright E2E
+
+One new test file `tests/e2e/operator-view-isolation.spec.ts` (or extend an existing operator spec if the project prefers grouping). Asserts the visibility matrix above.
+
+For each non-worship view (bible, timers, ai, settings):
+
+1. Navigate to `/ui/operator/{view}`
+2. Wait for WASM ready (`body[data-wasm-ready="true"]`)
+3. Assert `[data-role="worship-preview"]` is not visible
+4. Assert `[data-view-panel="worship"]` is not visible (the libraries / playlists / presentations section)
+5. Assert `[data-role="stage-monitor"]` IS visible
+6. Assert `[data-role="clear-slide"]` IS visible
+7. Assert the matching panel `[data-view-panel="{view}"]` IS visible (sanity)
+
+For the worship view:
+
+1. Navigate to `/ui/operator`
+2. Assert `[data-role="worship-preview"]` IS visible
+3. Assert `[data-view-panel="worship"]` IS visible
+4. Assert the libraries panel renders (`[data-role="library-list"]` or equivalent visible)
+
+Per project rule (`ci/browser-console-zero-errors.md`), the test must collect `console.error` and `console.warning` messages and assert the array is empty at the end of each test.
+
+### Manual verification on dev
+
+After deploy, open `http://10.77.8.134:8080/ui/operator` (worship) and visually verify the song name and `+` buttons are present. Then click into Bible, Timers, AI, and Settings; verify both elements disappear from the header and main area.
+
+## Files
+
+| File | Change |
+|---|---|
+| `crates/presenter-ui/src/components/stage_preview.rs:170` | Flip inline-style condition (`bible` hide → `worship` show) |
+| `crates/presenter-ui/styles/operator.css` (after line 1413) | Add 3-line `:not([data-view="worship"])` rule |
+| `tests/e2e/operator-view-isolation.spec.ts` | New E2E test |
+
+## Acceptance
+
+- Playwright E2E test passes locally and on CI.
+- Workspace tests still pass (`cargo test --workspace`, WASM clippy).
+- Browser console stays clean throughout the E2E test.
+- Manual verification on dev confirms the fix on every view.
+
+## Out of scope
+
+- Refactoring `worship-preview-wrap` into its own gated component.
+- Auditing other potentially-leaky UI elements outside StagePreview (none identified during code reading).
+- Server-side or persistence changes (none required).

--- a/tests/e2e/operator-controls.spec.ts
+++ b/tests/e2e/operator-controls.spec.ts
@@ -78,7 +78,7 @@ test.describe("Operator Control Buttons", () => {
     await ensureAblesetSettings(page.request, true);
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
     await assertVersionLabel(page, baseURL);
@@ -138,7 +138,7 @@ test.describe("Operator Control Buttons", () => {
     });
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -190,7 +190,7 @@ test.describe("Operator Control Buttons", () => {
     });
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -232,7 +232,7 @@ test.describe("Operator Control Buttons", () => {
     });
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -248,7 +248,7 @@ test.describe("Operator Control Buttons", () => {
 
     // Reload
     await page.reload();
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -280,7 +280,7 @@ test.describe("Operator Control Buttons", () => {
     });
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 

--- a/tests/e2e/operator-view-isolation.spec.ts
+++ b/tests/e2e/operator-view-isolation.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+function collectConsoleMessages(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() !== "error" && msg.type() !== "warning") return;
+    if (msg.text().includes("crbug.com/981419")) return;
+    messages.push(`[${msg.type()}] ${msg.text()}`);
+  });
+  return messages;
+}
+
+async function openOperator(page: Page, viewPath: string): Promise<void> {
+  await page.goto(new URL(`/ui/operator${viewPath}`, baseURL).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+}
+
+test("worship view shows worship UI", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "");
+
+  await expect(page.locator('[data-role="worship-preview"]')).toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("bible view hides worship UI, shows bible panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/bible");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="bible"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("timers view hides worship UI, shows timers panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/timers");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="timers"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("ai view hides worship UI, shows ai panel", async ({ page }) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/ai");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="ai"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("settings view hides worship UI, shows settings panel", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleMessages(page);
+  await openOperator(page, "/settings");
+
+  await expect(page.locator('[data-role="worship-preview"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="worship"]')).not.toBeVisible();
+  await expect(page.locator('[data-view-panel="settings"]')).toBeVisible();
+  await expect(page.locator('[data-role="stage-monitor"]')).toBeVisible();
+  await expect(page.locator('[data-role="clear-slide"]')).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});

--- a/tests/e2e/wasm-ai-chat.spec.ts
+++ b/tests/e2e/wasm-ai-chat.spec.ts
@@ -36,7 +36,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 }
 
 async function navigateToAi(page: import("@playwright/test").Page) {

--- a/tests/e2e/wasm-bible.spec.ts
+++ b/tests/e2e/wasm-bible.spec.ts
@@ -34,7 +34,7 @@ test.afterAll(async () => {
 /** Navigate to operator and switch to Bible view. */
 async function navigateToBible(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 
   // Navigate to bible view
   const bibleButton = page.locator(
@@ -91,7 +91,7 @@ test.describe("WASM Operator Bible Tests", () => {
 
   test("bible tab is visible and navigable", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -2407,7 +2407,7 @@ test.describe("WASM Operator Bible Tests", () => {
     page,
   }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -2453,7 +2453,7 @@ test.describe("WASM Operator Bible Tests", () => {
     page,
   }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 

--- a/tests/e2e/wasm-drag-drop.spec.ts
+++ b/tests/e2e/wasm-drag-drop.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
 }
 

--- a/tests/e2e/wasm-edge-cases.spec.ts
+++ b/tests/e2e/wasm-edge-cases.spec.ts
@@ -32,7 +32,7 @@ test.afterAll(async () => {
 test.describe("WASM Operator Edge Cases", () => {
   test("empty library shows message", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -57,7 +57,7 @@ test.describe("WASM Operator Edge Cases", () => {
 
   test("empty playlist shows message", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="playlist-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -71,7 +71,7 @@ test.describe("WASM Operator Edge Cases", () => {
 
   test("no presentation selected shows prompt", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -87,7 +87,7 @@ test.describe("WASM Operator Edge Cases", () => {
 
   test("toast appears on element", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -105,7 +105,7 @@ test.describe("WASM Operator Edge Cases", () => {
     });
 
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
     await page.waitForSelector('[data-role="library-item"]', {
@@ -168,12 +168,12 @@ test.describe("WASM Operator Edge Cases", () => {
 
     // Reload page
     await page.reload();
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
     // Wait for data to load
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 10_000,
     });
 
@@ -225,7 +225,7 @@ test.describe("WASM Operator Edge Cases", () => {
 
   test("test helpers are exposed", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -258,7 +258,7 @@ test.describe("WASM Operator Edge Cases", () => {
 
   test("parseSongText handles verse markers", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -284,7 +284,7 @@ More content`);
 
   test("stage monitor baseline can be reset", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 

--- a/tests/e2e/wasm-keyboard.spec.ts
+++ b/tests/e2e/wasm-keyboard.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function loadPresentation(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
 
   // Click library
@@ -54,7 +54,7 @@ async function loadPresentation(page: import("@playwright/test").Page) {
 test.describe("WASM Operator Keyboard Shortcuts", () => {
   test("space focuses search in live mode", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -76,7 +76,7 @@ test.describe("WASM Operator Keyboard Shortcuts", () => {
 
   test("space does not focus search in edit mode", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -100,7 +100,7 @@ test.describe("WASM Operator Keyboard Shortcuts", () => {
 
   test("escape closes modals", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
     await page.waitForSelector('[data-role="library-item"]', {
@@ -130,7 +130,7 @@ test.describe("WASM Operator Keyboard Shortcuts", () => {
 
   test("escape closes search", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -260,7 +260,7 @@ test.describe("WASM Operator Keyboard Shortcuts", () => {
 
   test("Tab navigation in modals", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
     await page.waitForSelector('[data-role="library-item"]', {

--- a/tests/e2e/wasm-modals.spec.ts
+++ b/tests/e2e/wasm-modals.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
 }
 

--- a/tests/e2e/wasm-operator-smoke.spec.ts
+++ b/tests/e2e/wasm-operator-smoke.spec.ts
@@ -39,7 +39,7 @@ test.describe("WASM Operator Smoke Tests", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
     // Wait for initial load - libraries should appear
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
   });
@@ -225,7 +225,7 @@ test.describe("WASM Operator Smoke Tests", () => {
 
     // Navigate fresh to catch all console output
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 
@@ -256,7 +256,7 @@ test.describe("WASM Operator Smoke Tests", () => {
     // by making an API call to a non-existent endpoint via evaluate
 
     // First, ensure the page is loaded
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
 

--- a/tests/e2e/wasm-playlist-operations.spec.ts
+++ b/tests/e2e/wasm-playlist-operations.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="playlist-list"]', {
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
     timeout: 30_000,
   });
 }

--- a/tests/e2e/wasm-presentation-crud.spec.ts
+++ b/tests/e2e/wasm-presentation-crud.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
 }
 

--- a/tests/e2e/wasm-search.spec.ts
+++ b/tests/e2e/wasm-search.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
   // Wait for data to load
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
 }

--- a/tests/e2e/wasm-slide-editing.spec.ts
+++ b/tests/e2e/wasm-slide-editing.spec.ts
@@ -35,7 +35,7 @@ async function loadPresentationInEditMode(
   page: import("@playwright/test").Page,
 ) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 
   // Wait for libraries to load
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
@@ -375,7 +375,7 @@ test.describe("WASM Slide Editing - Persistence", () => {
 test.describe("WASM Slide Editing - Visual Feedback", () => {
   test("is-loading class appears during trigger", async ({ page }) => {
     await page.goto(`${baseURL}/ui/operator`);
-    await page.waitForSelector('[data-role="library-list"]', {
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,
     });
     await page.waitForSelector('[data-role="library-item"]', {

--- a/tests/e2e/wasm-slide-interactions.spec.ts
+++ b/tests/e2e/wasm-slide-interactions.spec.ts
@@ -33,7 +33,7 @@ async function loadPresentationWithSlides(
   page: import("@playwright/test").Page,
 ) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 
   // Wait for libraries to load
   await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });

--- a/tests/e2e/wasm-stage.spec.ts
+++ b/tests/e2e/wasm-stage.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 }
 
 test.describe("WASM Operator Stage Monitor Tests", () => {

--- a/tests/e2e/wasm-timers.spec.ts
+++ b/tests/e2e/wasm-timers.spec.ts
@@ -230,8 +230,9 @@ test.describe("WASM Operator Timer Tests", () => {
     await expect(countdownValue).toBeVisible();
 
     const text = await countdownValue.textContent();
-    // Should show a time format like "0:00" or "-1:23:45"
-    expect(text).toMatch(/^-?\d+:\d{2}(:\d{2})?$/);
+    // Accepts all format_countdown outputs: empty (cleared), digit (< 60s),
+    // MM:SS (1-59 min), or "Xh Ym" (≥1h). See presenter_core::format_countdown.
+    expect(text ?? "").toMatch(/^(|\d+|\d{2}:\d{2}|\d+h \d+m)$/);
   });
 
   test("timer overlay opens in new window", async ({ page, context }) => {

--- a/tests/e2e/wasm-timers.spec.ts
+++ b/tests/e2e/wasm-timers.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function navigateToTimers(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 
   // Navigate to timers view
   const timersButton = page.locator(

--- a/tests/e2e/wasm-view-routing.spec.ts
+++ b/tests/e2e/wasm-view-routing.spec.ts
@@ -133,7 +133,7 @@ test.describe("WASM Operator View Routing Tests", () => {
 
       // Refresh the page
       await page.reload();
-      await page.waitForSelector('[data-role="library-list"]', {
+      await page.waitForSelector('body[data-wasm-ready="true"]', {
         timeout: 30_000,
       });
 

--- a/tests/e2e/wasm-view-routing.spec.ts
+++ b/tests/e2e/wasm-view-routing.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async () => {
 
 async function initPage(page: import("@playwright/test").Page) {
   await page.goto(`${baseURL}/ui/operator`);
-  await page.waitForSelector('[data-role="library-list"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
 }
 
 test.describe("WASM Operator View Routing Tests", () => {
@@ -187,7 +187,7 @@ test.describe("WASM Operator View Routing Tests", () => {
 
       // Refresh the page
       await page.reload();
-      await page.waitForSelector('[data-role="library-list"]', {
+      await page.waitForSelector('body[data-wasm-ready="true"]', {
         timeout: 30_000,
       });
 


### PR DESCRIPTION
## Summary

Fixes #295: worship-specific UI elements (song name + Ableton/Follow buttons in the header, libraries / playlists / presentations panels with their `+` buttons) no longer render on bible, timers, ai, or settings views. They appear only when the active view is worship. The diagnostic stage-monitor counter and clear-slide (🧹) button stay visible on every view.

## What changed

Two CSS-level fixes, no logic changes:

1. **`stage_preview.rs:170`** — flipped the inline-style condition on `[data-role="worship-preview"]` from `if view == "bible" { hide } else { show }` to `if view == "worship" { show } else { hide }`.
2. **`operator.css`** — added `body.operator:not([data-view="worship"]) [data-view-panel="worship"] { display: none; }`. The worship section lacks the `.operator__panel { display: none; }` default that bible/timers/ai/settings sections inherit; the new rule supplies it.

Plus 5 new Playwright E2E tests in `tests/e2e/operator-view-isolation.spec.ts` asserting the visibility matrix for all 5 views.

## Pre-existing E2E test regressions fixed in the same PR

The view-isolation fix exposed two classes of pre-existing test fragility that needed fixes:

1. **Stale countdown-format regex** (`wasm-timers.spec.ts:234`) — used `/^-?\d+:\d{2}(:\d{2})?$/` which doesn't accept the new `"Xh Ym"` output from PR #297's `format_countdown`. Updated to accept all five output shapes.
2. **`waitForSelector('[data-role="library-list"]')` after `goto(/ui/operator)`** — relied on library-list being visible regardless of view. With session-storage view persistence across tests in a worker, prior tests setting view=bible caused the wait to time out after the new CSS hides library-list on non-worship views. Audited all 16 affected test files (42 sites) and switched to `body[data-wasm-ready="true"]` (view-agnostic readiness signal).

## Live verification on dev

Manually toured all 5 views via Playwright on dev (v0.4.63):

| URL | view | worship-preview | worship panel | matching panel | stage-monitor | clear-slide |
|---|---|---|---|---|---|---|
| `/ui/operator` | worship | ✅ visible | ✅ visible | (worship is active) | ✅ visible | ✅ visible |
| `/ui/operator/bible` | bible | ✅ hidden | ✅ hidden | bible visible | ✅ visible | ✅ visible |
| `/ui/operator/timers` | timers | ✅ hidden | ✅ hidden | timers visible | ✅ visible | ✅ visible |

(ai and settings exercise the identical CSS path — same outcome.)

## Test plan

- [x] All workspace tests pass
- [x] 5 new Playwright E2E tests in `tests/e2e/operator-view-isolation.spec.ts`
- [x] 17 pre-existing E2E spec files updated to use `body[data-wasm-ready="true"]` instead of `[data-role="library-list"]` after navigation
- [x] Dev `/healthz` reports v0.4.63
- [x] Manual: 3 representative views verified live on dev
- [x] Browser console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
