### PR TITLE
fix(ui): cap wheel delta per event to one row (#301)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.67"
+version = "0.4.68"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.68"
+version = "0.4.69"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/slide_list_scroll.rs
+++ b/crates/presenter-ui/src/components/slide_list_scroll.rs
@@ -160,3 +160,43 @@ pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
     let capped = cap_wheel_delta(delta_y, step);
     container.set_scroll_top((container.scroll_top() as f64 + capped) as i32);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::cap_wheel_delta;
+
+    #[test]
+    fn zero_delta_returns_zero() {
+        assert_eq!(cap_wheel_delta(0.0, 90.0), 0.0);
+    }
+
+    #[test]
+    fn small_positive_delta_passes_through() {
+        assert_eq!(cap_wheel_delta(10.0, 90.0), 10.0);
+    }
+
+    #[test]
+    fn small_negative_delta_passes_through() {
+        assert_eq!(cap_wheel_delta(-10.0, 90.0), -10.0);
+    }
+
+    #[test]
+    fn delta_exactly_at_step_passes_through() {
+        assert_eq!(cap_wheel_delta(90.0, 90.0), 90.0);
+    }
+
+    #[test]
+    fn negative_delta_exactly_at_step_passes_through() {
+        assert_eq!(cap_wheel_delta(-90.0, 90.0), -90.0);
+    }
+
+    #[test]
+    fn large_positive_delta_is_capped_at_step() {
+        assert_eq!(cap_wheel_delta(500.0, 90.0), 90.0);
+    }
+
+    #[test]
+    fn large_negative_delta_is_capped_at_negative_step() {
+        assert_eq!(cap_wheel_delta(-500.0, 90.0), -90.0);
+    }
+}

--- a/crates/presenter-ui/src/components/slide_list_scroll.rs
+++ b/crates/presenter-ui/src/components/slide_list_scroll.rs
@@ -122,13 +122,28 @@ fn step_for_wheel(container: &web_sys::HtmlElement) -> f64 {
     card_height + 14.4
 }
 
+/// Cap a wheel event's vertical delta to one row of cards (`step`) per event,
+/// preserving sign. Returns 0 when `delta_y` is 0 (no-op).
+///
+/// Issue #301: previously the wheel handler discarded `delta_y` magnitude and
+/// always advanced one full row per event, so trackpad gestures (which fire
+/// 20+ events per swipe) blasted through dozens of rows.
+fn cap_wheel_delta(delta_y: f64, step: f64) -> f64 {
+    if delta_y == 0.0 {
+        return 0.0;
+    }
+    delta_y.signum() * delta_y.abs().min(step)
+}
+
 /// Wheel handler for `.operator__slides`: intercepts the native (accelerated)
-/// scroll, applies a deterministic per-notch step instead. Issue #271 concern 2:
-/// neutralises macOS scroll acceleration so each notch advances ~1 row.
+/// scroll and applies a magnitude-respecting cap. Issue #271 concern 2:
+/// neutralises macOS scroll acceleration. Issue #301: per-event delta is
+/// capped at one row so high-frequency trackpad/mouse events can't blast
+/// through the list.
 pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
     ev.prevent_default();
-    let direction = ev.delta_y().signum();
-    if direction == 0.0 {
+    let delta_y = ev.delta_y();
+    if delta_y == 0.0 {
         return;
     }
     let Some(target) = ev.target() else { return };
@@ -142,5 +157,6 @@ pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
         return;
     };
     let step = step_for_wheel(&container);
-    container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
+    let capped = cap_wheel_delta(delta_y, step);
+    container.set_scroll_top((container.scroll_top() as f64 + capped) as i32);
 }

--- a/docs/superpowers/plans/2026-05-06-worship-scroll-speed.md
+++ b/docs/superpowers/plans/2026-05-06-worship-scroll-speed.md
@@ -1,0 +1,428 @@
+# Worship Slide List Scroll Speed Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the worship slide list so a single mouse-wheel or trackpad gesture no longer blasts through dozens of rows.
+
+**Architecture:** Replace the current `direction * step` formula in `handle_wheel_event` with a magnitude-respecting cap: use `delta_y.signum() * delta_y.abs().min(step)`. Extract the cap into a pure helper `cap_wheel_delta` so it's natively unit-testable. No new dependencies, no behavioral change to the catch-all `prevent_default` flow.
+
+**Tech Stack:** Rust / Leptos (WASM), web-sys, native cargo test.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-worship-scroll-speed-design.md` (commit 9c6ed1c).
+
+---
+
+## Context
+
+Issue #301 (title-only): "scrolling is extremally fast in worship slides".
+
+`handle_wheel_event` was added in PR #290 (issue #271) to neutralize macOS scroll acceleration. It calls `ev.prevent_default()` then advances the container scroll by `direction * step` where `direction = ev.delta_y().signum()` (always ±1) and `step ≈ card_height + 14.4 px`. The discarded magnitude means every wheel event — no matter how small — moves one full row. Trackpads stream 20-30+ events per gesture → 20-30+ rows per gesture → "extremely fast".
+
+**Key existing code:**
+
+- `crates/presenter-ui/src/components/slide_list_scroll.rs:128-146` — `handle_wheel_event(ev: web_sys::WheelEvent)`.
+- `crates/presenter-ui/src/components/slide_list_scroll.rs:109-123` — `step_for_wheel(container)` returns `card_height + 14.4` or `DEFAULT_WHEEL_STEP_PX = 120.0` if no card is rendered. Always returns a positive value.
+- `crates/presenter-ui/src/components/slide_list.rs:310` — wired up via `on:wheel=handle_wheel_event`.
+- The file currently has NO `#[cfg(test)] mod tests` block — Task 3 adds one at the file end.
+
+---
+
+## File Structure
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Workspace version 0.4.68 → 0.4.69 |
+| `crates/presenter-ui/Cargo.toml` | Version 0.1.37 → 0.1.38 |
+| `crates/presenter-ui/src/components/slide_list_scroll.rs` | Add `cap_wheel_delta` pure helper; change `handle_wheel_event` to use it; add `#[cfg(test)] mod tests` with 7 boundary-case unit tests |
+
+---
+
+## Task 1: Version Bump
+
+**Files:**
+- Modify: `Cargo.toml:15`
+- Modify: `crates/presenter-ui/Cargo.toml:3`
+- Modify: `Cargo.lock` (auto)
+- Modify: `crates/presenter-ui/Cargo.lock` (auto)
+
+- [ ] **Step 1: Bump workspace version**
+
+In `Cargo.toml`, change line 15:
+
+```toml
+[workspace.package]
+version = "0.4.69"
+```
+
+- [ ] **Step 2: Bump presenter-ui version**
+
+In `crates/presenter-ui/Cargo.toml`, change line 3:
+
+```toml
+version = "0.1.38"
+```
+
+- [ ] **Step 3: Update lockfiles**
+
+```bash
+cargo update --workspace
+cargo update --workspace --manifest-path crates/presenter-ui/Cargo.toml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.toml crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump version to 0.4.69"
+```
+
+---
+
+## Task 2: Extract `cap_wheel_delta` and use it in `handle_wheel_event`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list_scroll.rs:128-146` (handler body) + add helper
+
+- [ ] **Step 1: Read the current state of `handle_wheel_event`**
+
+```bash
+sed -n '125,146p' crates/presenter-ui/src/components/slide_list_scroll.rs
+```
+
+You should see:
+
+```rust
+/// Wheel handler for `.operator__slides`: intercepts the native (accelerated)
+/// scroll, applies a deterministic per-notch step instead. Issue #271 concern 2:
+/// neutralises macOS scroll acceleration so each notch advances ~1 row.
+pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
+    ev.prevent_default();
+    let direction = ev.delta_y().signum();
+    if direction == 0.0 {
+        return;
+    }
+    let Some(target) = ev.target() else { return };
+    let Ok(el) = target.dyn_into::<web_sys::Element>() else {
+        return;
+    };
+    let Ok(Some(container_el)) = el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let step = step_for_wheel(&container);
+    container.set_scroll_top((container.scroll_top() as f64 + direction * step) as i32);
+}
+```
+
+- [ ] **Step 2: Add the `cap_wheel_delta` pure helper**
+
+In `crates/presenter-ui/src/components/slide_list_scroll.rs`, ABOVE `handle_wheel_event` (between `step_for_wheel` and `handle_wheel_event`, so just before the `/// Wheel handler` doc comment at line 125), add:
+
+```rust
+/// Cap a wheel event's vertical delta to one row of cards (`step`) per event,
+/// preserving sign. Returns 0 when `delta_y` is 0 (no-op).
+///
+/// Issue #301: previously the wheel handler discarded `delta_y` magnitude and
+/// always advanced one full row per event, so trackpad gestures (which fire
+/// 20+ events per swipe) blasted through dozens of rows.
+fn cap_wheel_delta(delta_y: f64, step: f64) -> f64 {
+    if delta_y == 0.0 {
+        return 0.0;
+    }
+    delta_y.signum() * delta_y.abs().min(step)
+}
+```
+
+- [ ] **Step 3: Replace the body of `handle_wheel_event`**
+
+Replace the entire `handle_wheel_event` function (lines 128-146 of the original file, before your insertion in Step 2) with:
+
+```rust
+/// Wheel handler for `.operator__slides`: intercepts the native (accelerated)
+/// scroll and applies a magnitude-respecting cap. Issue #271 concern 2:
+/// neutralises macOS scroll acceleration. Issue #301: per-event delta is
+/// capped at one row so high-frequency trackpad/mouse events can't blast
+/// through the list.
+pub(super) fn handle_wheel_event(ev: web_sys::WheelEvent) {
+    ev.prevent_default();
+    let delta_y = ev.delta_y();
+    if delta_y == 0.0 {
+        return;
+    }
+    let Some(target) = ev.target() else { return };
+    let Ok(el) = target.dyn_into::<web_sys::Element>() else {
+        return;
+    };
+    let Ok(Some(container_el)) = el.closest(".operator__slides") else {
+        return;
+    };
+    let Ok(container) = container_el.dyn_into::<web_sys::HtmlElement>() else {
+        return;
+    };
+    let step = step_for_wheel(&container);
+    let capped = cap_wheel_delta(delta_y, step);
+    container.set_scroll_top((container.scroll_top() as f64 + capped) as i32);
+}
+```
+
+The differences from the original:
+1. Read `delta_y` once instead of `direction = signum`.
+2. Early-return when `delta_y == 0.0` (instead of `direction == 0.0`).
+3. Compute `capped` from `cap_wheel_delta(delta_y, step)`.
+4. Add `capped` to scroll top instead of `direction * step`.
+
+- [ ] **Step 4: Build the WASM crate to verify the change compiles**
+
+```bash
+cd crates/presenter-ui && cargo build --target wasm32-unknown-unknown && cd ../..
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Run native + WASM clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Run fmt**
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: silent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/slide_list_scroll.rs
+git commit -m "fix(ui): cap wheel delta per event to one row (#301)
+
+handle_wheel_event used direction * step (always one row per wheel
+event), so trackpad gestures with 20-30 events scrolled 20-30 rows.
+Replace with magnitude-respecting cap: delta.signum() * min(|delta|, step).
+Small gestures advance proportionally; large gestures still bounded at
+one row per event so the original #271 'no macOS acceleration' intent
+is preserved.
+
+Extract cap_wheel_delta as a pure helper for native unit testing."
+```
+
+---
+
+## Task 3: Unit tests for `cap_wheel_delta`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list_scroll.rs` (append `#[cfg(test)] mod tests` at end of file)
+
+- [ ] **Step 1: Append the tests module at the end of the file**
+
+After the closing `}` of `handle_wheel_event` (the very last line of the file), append:
+
+```rust
+
+#[cfg(test)]
+mod tests {
+    use super::cap_wheel_delta;
+
+    #[test]
+    fn zero_delta_returns_zero() {
+        assert_eq!(cap_wheel_delta(0.0, 90.0), 0.0);
+    }
+
+    #[test]
+    fn small_positive_delta_passes_through() {
+        assert_eq!(cap_wheel_delta(10.0, 90.0), 10.0);
+    }
+
+    #[test]
+    fn small_negative_delta_passes_through() {
+        assert_eq!(cap_wheel_delta(-10.0, 90.0), -10.0);
+    }
+
+    #[test]
+    fn delta_exactly_at_step_passes_through() {
+        assert_eq!(cap_wheel_delta(90.0, 90.0), 90.0);
+    }
+
+    #[test]
+    fn negative_delta_exactly_at_step_passes_through() {
+        assert_eq!(cap_wheel_delta(-90.0, 90.0), -90.0);
+    }
+
+    #[test]
+    fn large_positive_delta_is_capped_at_step() {
+        assert_eq!(cap_wheel_delta(500.0, 90.0), 90.0);
+    }
+
+    #[test]
+    fn large_negative_delta_is_capped_at_negative_step() {
+        assert_eq!(cap_wheel_delta(-500.0, 90.0), -90.0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+The presenter-ui crate is excluded from the workspace (per `Cargo.toml:11`), so run the tests from inside the crate dir:
+
+```bash
+cd crates/presenter-ui && cargo test --lib && cd ../..
+```
+
+Expected: 7 new tests pass. Output should include `test result: ok. 7 passed; 0 failed;` (or more if the crate already has other tests).
+
+If the tests don't run because the file isn't picked up by cargo-test, verify the module is exported (it should be — slide_list_scroll is a `mod` declaration in `components/mod.rs` already, since `handle_wheel_event` is used by `slide_list.rs`).
+
+- [ ] **Step 3: Run native clippy + fmt to confirm cleanliness**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+cargo fmt --all --check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/presenter-ui/src/components/slide_list_scroll.rs
+git commit -m "test(ui): cover cap_wheel_delta boundaries (#301)
+
+Seven boundary-case unit tests for the new pure helper:
+zero, small ±, exactly ±step, large ± (capped). Native cargo test
+exercises the cap math without needing a WASM browser environment."
+```
+
+---
+
+## Task 4: Local checks, push, monitor CI, deploy verify, PR, completion report
+
+**Controller-handled task.** Each step is what the controller does after Tasks 1-3 are committed.
+
+- [ ] **Step 1: Run all local checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+cargo test --workspace -- --nocapture
+cd crates/presenter-ui && cargo test --lib && cd ../..
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI to terminal state**
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId'
+sleep 1500 && gh run view <run-id> --json status,conclusion,jobs --jq '{status, conclusion, failed: [.jobs[] | select(.conclusion == "failure") | .name]}'
+```
+
+If any job fails, `gh run view <run-id> --log-failed`, fix in ONE commit, push again, re-monitor.
+
+- [ ] **Step 4: Verify dev deployment is live**
+
+```bash
+curl -s http://10.77.8.134:8080/healthz
+```
+
+Expected: `{"channel":"dev","status":"ok","version":"0.4.69"}`.
+
+- [ ] **Step 5: Manual verification on dev**
+
+Open `http://10.77.8.134:8080/ui/operator` in a browser with at least 30 worship slides loaded. Use a trackpad if available:
+
+1. **Gentle two-finger swipe**: list scrolls smoothly, advancing roughly 1-3 rows for a small gesture. NOT 30 rows.
+2. **Fast flick**: list advances multiple rows but bounded — one row per event. No "blast through to bottom".
+3. **Mouse wheel notch**: each notch advances about one row. Smooth but bounded.
+4. **Browser console clean** (zero errors/warnings).
+
+If trackpad isn't available, use Playwright MCP to fire `page.mouse.wheel(deltaY=200)` and inspect the resulting scroll position to confirm it advanced ≤ one row.
+
+Capture a brief screenshot or DOM dump for the PR body.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "fix(ui): cap wheel delta per event to one row (#301)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #301: scrolling in worship slides was "extremely fast" because the wheel handler discarded the wheel event's `delta_y` magnitude and always advanced exactly one row per event. Trackpads fire 20-30+ events per gesture, so a single swipe blasted through 20-30 rows.
+
+## What changed
+
+- New pure helper `cap_wheel_delta(delta_y, step) -> f64` returns `delta_y.signum() * delta_y.abs().min(step)`. Sign-preserving, magnitude-respecting, capped at one row per event.
+- `handle_wheel_event` now uses the cap instead of `direction * step`.
+- 7 unit tests for the cap function (zero, small ±, exactly ±step, large ± capped).
+
+## Behavior matrix
+
+| `delta_y` | Old | New |
+|---|---|---|
+| `+10` (small swipe) | one full row (~90 px) | 10 px |
+| `+90` (one notch) | one full row | 90 px (≈ row) |
+| `+500` (high-DPI fast event) | one full row | 90 px (capped) |
+| `-200` | one full row up | 90 px up (capped) |
+| `0` | no-op | no-op |
+
+The original #271 fix (no macOS unbounded acceleration) is preserved — the per-event cap is still ~one row.
+
+## Test plan
+
+- [x] 7 new unit tests for `cap_wheel_delta`
+- [x] Workspace tests pass
+- [x] Native + WASM clippy clean
+- [x] Dev `/healthz` reports v0.4.69
+- [x] Manual: trackpad swipe on dev advances proportionally; fast flick still bounded; no console errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Verify PR is mergeable**
+
+```bash
+gh pr view <pr-number> --json mergeable,mergeStateStatus
+```
+
+Expected: `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN` (after Mutation Testing + Label PR finish). If `UNSTABLE` due to checks still pending, wait. If anything failed, fix.
+
+- [ ] **Step 8: Run pre-completion gates**
+
+Invoke `/plan-check` skill — must come back N/N fulfilled. Invoke `/review` skill on this PR — must come back `0 🔴 0 🟡 0 🔵`. Fix any findings inside the diff before sending the completion report.
+
+- [ ] **Step 9: Send completion report**
+
+Per `core/completion-report.md`. Include CI run id, plan-check N/N, review clean, deploy verify (dev shows v0.4.69, manual scroll test passed), URLs, PR title + URL.
+
+---
+
+## Verification Summary
+
+| Check | How to verify |
+|-------|---------------|
+| `cap_wheel_delta` zero / small / boundary / capped | 7 unit tests in `crates/presenter-ui/src/components/slide_list_scroll.rs::tests` |
+| `handle_wheel_event` uses the cap | grep for `cap_wheel_delta` in the handler body |
+| No regressions | Workspace tests + WASM clippy clean |
+| Live behavior on dev | Trackpad swipe scrolls proportionally; fast flick bounded |
+| Original #271 intent preserved | Per-event upper bound is still `step` (~one row) |
+| Clean console | Browser session shows zero errors |

--- a/docs/superpowers/specs/2026-05-06-worship-scroll-speed-design.md
+++ b/docs/superpowers/specs/2026-05-06-worship-scroll-speed-design.md
@@ -1,0 +1,90 @@
+# Worship slide list scroll speed fix
+
+**Issue:** #301
+
+**Date:** 2026-05-06
+
+**Branch:** dev (workspace 0.4.68, presenter-ui 0.1.37)
+
+## Problem
+
+Mouse-wheel and trackpad scrolling in the worship slide list ("`.operator__slides`") is "extremely fast" — a single gesture jumps dozens of rows. Filed by the user on 2026-05-06.
+
+The current `handle_wheel_event` in `crates/presenter-ui/src/components/slide_list_scroll.rs:128-146` was added in PR #290 (issue #271) to neutralize macOS scroll acceleration. It calls `ev.prevent_default()`, then advances the scroll position by `direction * step` where:
+
+- `direction = ev.delta_y().signum()` — only `+1` or `-1`
+- `step = step_for_wheel(container)` — one row of cards (≈ card_height + 14.4 px gap)
+
+The fix in #271 ignored the wheel delta's magnitude and always scrolled exactly one row per event. Browsers / OSes fire many wheel events per gesture (trackpads stream 20-30+ events per swipe; high-DPI mice fire continuously while the wheel turns). One row per event × 30 events = 30 rows per gesture → "extremely fast".
+
+## Goal
+
+Wheel scroll feels natural — small gestures advance a few pixels, big gestures advance multiple rows, but no single event can jump more than one row (which would feel jumpy and bypass the original #271 "no momentum acceleration" intent).
+
+## Architecture
+
+Single-line behavior change in `handle_wheel_event`. Use the wheel's `delta_y` magnitude directly, capped at `step` per event:
+
+```rust
+let delta_y = ev.delta_y();
+if delta_y == 0.0 { return; }
+// ... container lookup unchanged ...
+let step = step_for_wheel(&container);
+let capped = delta_y.signum() * delta_y.abs().min(step);
+container.set_scroll_top((container.scroll_top() as f64 + capped) as i32);
+```
+
+### Behavior matrix
+
+| `delta_y` | Old behavior | New behavior |
+|-----------|--------------|--------------|
+| `+10` (small swipe nudge) | scrolls one full row (~90 px) | scrolls 10 px |
+| `+90` (one notch on a Mighty Mouse) | scrolls one full row | scrolls 90 px (still ≈ one row) |
+| `+500` (high-DPI fast swipe, single event) | scrolls one full row | scrolls one row (capped) |
+| `-200` (negative direction) | scrolls one full row up | scrolls one row up (capped) |
+| `0` | no-op | no-op |
+
+For trackpad gestures that fire 20+ events: each is capped at one row, but small-delta events advance proportionally. A gentle 100-px gesture made of twenty 5-px events advances 100 px (about one row). A fast flick made of ten 50-px events advances 10 rows — appropriate for the gesture intensity.
+
+## Tests
+
+The existing `slide_list_scroll.rs` likely has minimal unit-test coverage for `handle_wheel_event` because it depends on `web_sys::WheelEvent` (browser-only type). Two acceptable approaches:
+
+1. **Extract the cap logic into a pure function** that takes `delta_y` and `step` as floats. Unit-test that. Wire the helper into `handle_wheel_event`.
+2. **Skip unit tests, rely on manual verification** on dev with both a trackpad and a mouse wheel.
+
+Recommend (1) — the math is simple and worth one unit test for the boundary cases (delta = 0, delta < step, delta > step, negative delta).
+
+### Manual verification on dev
+
+After deploy:
+
+1. Open `http://10.77.8.134:8080/ui/operator` in a browser with at least 30 worship slides loaded.
+2. Trackpad: gentle two-finger swipe → list scrolls smoothly, ≈ 1-2 rows for a small gesture, several rows for a larger one. No "blast through 30 rows".
+3. Mouse wheel: each notch advances about one row of cards. Smooth but bounded.
+4. The list does NOT scroll past the last card (browser default behavior).
+5. Browser console clean.
+
+## File-level changes
+
+| File | Change |
+|------|--------|
+| `crates/presenter-ui/src/components/slide_list_scroll.rs` | `handle_wheel_event` uses `delta_y.signum() * delta_y.abs().min(step)` instead of `direction * step`. Optional: extract `cap_wheel_delta(delta_y, step) -> f64` for unit testing. |
+
+## Acceptance
+
+- Manual scroll test on dev passes (smooth, bounded scroll).
+- Workspace tests pass.
+- Native + WASM clippy clean.
+- Browser console clean during E2E.
+- The original #271 fix (no macOS unbounded acceleration) is still in effect — verified by the per-event cap.
+
+## Out of scope
+
+- Other scroll containers (catalog, presentation list, bible). The bug report and the wheel handler both target `.operator__slides` only.
+- Keyboard navigation (arrow keys, Page Up/Down) — handled by separate code paths.
+- Scrollbar behavior — unchanged.
+
+## Risk
+
+Low. Single function body change. The cap preserves the upper bound that #271 wanted; only the lower bound (small gestures) becomes proportional to the gesture rather than always one row.

--- a/tests/e2e/operator-slide-scroll.spec.ts
+++ b/tests/e2e/operator-slide-scroll.spec.ts
@@ -157,7 +157,12 @@ test("lookahead: clicking a slide makes next-row slide visible", async ({
   ).toEqual([]);
 });
 
-test("wheel: each notch scrolls a deterministic step", async ({ page }) => {
+test("wheel: large delta is capped at one row per event", async ({ page }) => {
+  // PR #301: the wheel handler is magnitude-respecting — small deltas pass
+  // through as-is, large deltas are capped at one row (step). This test
+  // verifies the cap by dispatching a deltaY larger than step and asserting
+  // the scroll advanced by step, not deltaY. A passive (broken) handler
+  // would let the native scroll apply deltaY directly.
   const consoleMessages: string[] = [];
   page.on("console", (msg) => {
     if (msg.type() === "error" || msg.type() === "warning") {
@@ -174,43 +179,88 @@ test("wheel: each notch scrolls a deterministic step", async ({ page }) => {
   });
   await page.waitForTimeout(50);
 
-  // Dispatch a WheelEvent with deltaY=100. The wheel handler should ignore the
-  // deltaY magnitude and instead apply step = card_height + 14.4 (grid gap).
-  // If the handler is passive (Leptos on:wheel default), prevent_default is
-  // silently ignored and the browser may apply deltaY=100 instead of the step.
+  // Dispatch a WheelEvent with deltaY=500 (much larger than step ≈ 221.6 px).
+  // The handler must cap the scroll advance at step, not at deltaY.
   const result = await page.evaluate(() => {
     const c = document.querySelector(".operator__slides") as HTMLElement | null;
     if (!c) return null;
     const cardEl = c.querySelector(
       ".operator__slide-card",
     ) as HTMLElement | null;
-    // Compute the expected step from the actual card height.
     const cardHeight = cardEl ? cardEl.getBoundingClientRect().height : 0;
     const expectedStep = cardHeight > 0 ? cardHeight + 14.4 : 120;
 
     const before = c.scrollTop;
     c.dispatchEvent(
-      new WheelEvent("wheel", { deltaY: 100, bubbles: true, cancelable: true }),
+      new WheelEvent("wheel", { deltaY: 500, bubbles: true, cancelable: true }),
     );
     const after = c.scrollTop;
-    return { before, after, expectedStep, deltaY: 100 };
+    return { before, after, expectedStep, deltaY: 500 };
   });
 
   expect(result).not.toBeNull();
 
   const actualDelta = result!.after - result!.before;
 
-  // If actualDelta equals deltaY (100), the handler was passive and
+  // If actualDelta equals deltaY (500), the handler was passive and
   // prevent_default had no effect — the browser applied raw native scroll.
-  // The spec requires escalating this to BLOCKED.
   expect(
     actualDelta,
-    `BLOCKED: wheel handler appears passive — scrollTop delta=${actualDelta} equals deltaY (100) instead of step (${result!.expectedStep.toFixed(1)}). Fix: change on:wheel in slide_list.rs to addEventListener with passive:false.`,
+    `BLOCKED: wheel handler appears passive — scrollTop delta=${actualDelta} equals deltaY (500) instead of being capped at step (${result!.expectedStep.toFixed(1)}). Fix: ensure on:wheel uses addEventListener with passive:false.`,
   ).not.toBe(result!.deltaY);
 
-  // The handler must apply the deterministic step (±2px tolerance for rounding).
+  // The handler must cap the advance at step (±2 px tolerance for rounding).
   expect(actualDelta).toBeGreaterThan(result!.expectedStep - 2);
   expect(actualDelta).toBeLessThan(result!.expectedStep + 2);
+
+  expect(
+    consoleMessages.filter(
+      (m) => !m.includes("favicon") && !m.includes("crbug.com/981419"),
+    ),
+  ).toEqual([]);
+});
+
+test("wheel: small delta passes through proportionally (#301)", async ({
+  page,
+}) => {
+  // PR #301: a small deltaY (smaller than step) advances by exactly that
+  // delta — proportional to the gesture. Without this, trackpad gestures
+  // (which fire 20+ events) blast through the list.
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  await openPresentation(page, presId15);
+
+  await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (c) c.scrollTop = 0;
+  });
+  await page.waitForTimeout(50);
+
+  const result = await page.evaluate(() => {
+    const c = document.querySelector(".operator__slides") as HTMLElement | null;
+    if (!c) return null;
+
+    const before = c.scrollTop;
+    c.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: 50, bubbles: true, cancelable: true }),
+    );
+    const after = c.scrollTop;
+    return { before, after, deltaY: 50 };
+  });
+
+  expect(result).not.toBeNull();
+
+  const actualDelta = result!.after - result!.before;
+
+  // For small deltaY (50 px) less than step, the cap is a no-op — the scroll
+  // advances by deltaY directly (±2 px tolerance for rounding).
+  expect(actualDelta).toBeGreaterThan(48);
+  expect(actualDelta).toBeLessThan(52);
 
   expect(
     consoleMessages.filter(


### PR DESCRIPTION
## Summary

Fixes #301: scrolling in worship slides was "extremely fast" because the wheel handler discarded the wheel event's `delta_y` magnitude and always advanced exactly one row per event. Trackpads fire 20-30+ events per gesture → blast through the list.

## What changed

- New pure helper `cap_wheel_delta(delta_y, step) -> f64` returns `delta_y.signum() * delta_y.abs().min(step)`. Sign-preserving, magnitude-respecting, capped at one row per event.
- `handle_wheel_event` uses the cap instead of `direction * step`.
- 7 unit tests for the helper (zero, small ±, exactly ±step, large ± capped).
- 2 updated Playwright E2E tests in `operator-slide-scroll.spec.ts`:
  - Old `wheel: each notch scrolls a deterministic step` (asserted always-one-row) → replaced by:
  - **`wheel: large delta is capped at one row per event`** (deltaY=500 capped at step)
  - **`wheel: small delta passes through proportionally (#301)`** (deltaY=50 passes through unchanged)

## Behavior matrix

| `delta_y` | Old | New |
|---|---|---|
| `+10` (small swipe) | one full row (~221 px) | 10 px |
| `+90` (one notch) | one full row | 90 px |
| `+500` (high-DPI fast event) | one full row | one row (capped) |
| `-200` | one full row up | one row up (capped) |
| `0` | no-op | no-op |

Original #271 fix (no macOS unbounded acceleration) is preserved — the per-event cap is still ~one row.

## Test plan

- [x] 7 new unit tests for `cap_wheel_delta` (in `crates/presenter-ui/src/components/slide_list_scroll.rs::tests`)
- [x] 2 updated Playwright E2E tests asserting both the cap (500→step) and pass-through (50→50)
- [x] Workspace tests pass
- [x] Native + WASM clippy clean
- [x] Dev `/healthz` reports v0.4.69
- [x] CI green (Pipeline 25430699052 — only Mutation Testing was last to clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
