### PR TITLE
ops(ndi): install NDI runtime on deploy targets if missing (#278)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,6 +195,22 @@ jobs:
             echo 'CLIProxyAPI already present'
           fi"
 
+      - name: Ensure NDI runtime (#278)
+        run: |
+          # presenter-ndi loads libndi.so.6 at startup; without it /ndi/sources is always empty.
+          if ssh deploy-target 'test -f /usr/lib/ndi/libndi.so.6'; then
+            echo 'NDI runtime already present on target'
+          elif [ -f /usr/lib/ndi/libndi.so.6 ]; then
+            echo 'Copying NDI runtime from runner to target...'
+            tar -C /usr/lib -czf /tmp/ndi-runtime-$$.tar.gz ndi
+            scp -i ~/.ssh/id_deploy /tmp/ndi-runtime-$$.tar.gz deploy-target:/tmp/ndi-runtime.tar.gz
+            rm /tmp/ndi-runtime-$$.tar.gz
+            ssh deploy-target 'sudo tar xzf /tmp/ndi-runtime.tar.gz -C /usr/lib/ && sudo ldconfig && rm /tmp/ndi-runtime.tar.gz'
+            echo 'NDI runtime installed'
+          else
+            echo '::warning::NDI runtime not found on runner (/usr/lib/ndi/libndi.so.6); skipping. Install manually per docs/ops/runbook.md.'
+          fi
+
       - name: Backup database
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,22 @@ jobs:
             echo 'CLIProxyAPI already present'
           fi"
 
+      - name: Ensure NDI runtime (#278)
+        run: |
+          # presenter-ndi loads libndi.so.6 at startup; without it /ndi/sources is always empty.
+          if ssh deploy-target 'test -f /usr/lib/ndi/libndi.so.6'; then
+            echo 'NDI runtime already present on target'
+          elif [ -f /usr/lib/ndi/libndi.so.6 ]; then
+            echo 'Copying NDI runtime from runner to target...'
+            tar -C /usr/lib -czf /tmp/ndi-runtime-$$.tar.gz ndi
+            scp -i ~/.ssh/id_deploy /tmp/ndi-runtime-$$.tar.gz deploy-target:/tmp/ndi-runtime.tar.gz
+            rm /tmp/ndi-runtime-$$.tar.gz
+            ssh deploy-target 'sudo tar xzf /tmp/ndi-runtime.tar.gz -C /usr/lib/ && sudo ldconfig && rm /tmp/ndi-runtime.tar.gz'
+            echo 'NDI runtime installed'
+          else
+            echo '::warning::NDI runtime not found on runner (/usr/lib/ndi/libndi.so.6); skipping. Install manually per docs/ops/runbook.md.'
+          fi
+
       - name: Backup database
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.69"
+version = "0.4.70"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ui"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presenter-ui"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -141,6 +141,28 @@ Set `PRESENTER_BACKUP_ROOT` (e.g., `/var/lib/presenter/backups`) before calling 
 - Enable Companion’s “Run Macro on Connection State” option and tie the provided `macro_presenter_alert` to the Presenter module instance so operators see a red panic indicator whenever `live_ws_connected` flips to false.
 - After modifying Presenter commands or adding new cues, run `npm run test:playwright -- --grep @companion` to exercise the simulated Companion session and verify acks/variable updates still flow end-to-end.
 
+## NDI Runtime
+
+NDI source discovery (`/ndi/sources`, the operator's "Scan" button) requires the **NDI Advanced SDK v6 runtime** at `/usr/lib/ndi/libndi.so.6` on the presenter host. The library is loaded via `libloading` at startup; without it the binary still runs but `/ndi/status` reports `{"available":false}` and `/ndi/sources` always returns `[]`. NewTek does not allow redistribution, so it is not bundled with the build.
+
+Bootstrap a host (one-time, idempotent):
+
+```bash
+# From a machine that already has /usr/lib/ndi populated
+scripts/ops/install-ndi-runtime.sh newlevel@<host> --service presenter
+```
+
+The script copies the runtime, runs `ldconfig`, and (when `--service` is given) restarts the service so the library is picked up.
+
+The release (`release.yml`) and main-deploy (`deploy.yml`) workflows now run an **Ensure NDI runtime** step that performs the same idempotent copy from the self-hosted runner to the deploy target. After a clean reinstall, verify with:
+
+```bash
+curl http://<host>/ndi/status   # → {"available":true}
+curl http://<host>/ndi/sources  # → [{...}, ...] when senders are reachable
+```
+
+Source discovery uses mDNS, so `avahi-daemon` must be running on the host (`systemctl is-active avahi-daemon`). An empty list with `available:true` means the library is loaded but no NDI senders are reachable on the target's LAN — verify Resolume / cameras are powered on and not isolated by VLAN/Tailscale.
+
 ## Troubleshooting Checklist
 
 - **Service fails to start on port 80:** ensure the unit runs as a user with `CAP_NET_BIND_SERVICE`. The templated unit already applies this capability; if you override it, re-add `AmbientCapabilities=CAP_NET_BIND_SERVICE`.

--- a/scripts/ops/install-ndi-runtime.sh
+++ b/scripts/ops/install-ndi-runtime.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Install the NDI runtime library on a remote presenter host.
+#
+# Background: presenter-ndi loads libndi.so.6 at startup via libloading.
+# Without it the binary still runs, but `/ndi/status` reports
+# `{"available":false}` and source discovery returns []. The NDI SDK is
+# proprietary and must be obtained from NewTek; we do not redistribute it.
+#
+# This script copies an existing NDI runtime (typically /usr/lib/ndi) from
+# the local machine to the remote host. Idempotent: skips the copy if the
+# library is already present, and never restarts a service unless asked.
+#
+# Usage:
+#   scripts/ops/install-ndi-runtime.sh <ssh-target> [--service NAME] [--source DIR]
+#
+# Examples:
+#   scripts/ops/install-ndi-runtime.sh newlevel@companion-pp.lan --service presenter
+#   scripts/ops/install-ndi-runtime.sh deploy-target --source /usr/lib/ndi
+
+set -euo pipefail
+
+SOURCE_DIR="/usr/lib/ndi"
+TARGET=""
+SERVICE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      SOURCE_DIR="$2"; shift 2 ;;
+    --service)
+      SERVICE="$2"; shift 2 ;;
+    -h|--help)
+      grep -E '^# ' "$0" | sed 's/^# //'; exit 0 ;;
+    *)
+      if [[ -z "$TARGET" ]]; then
+        TARGET="$1"; shift
+      else
+        echo "[install-ndi] unexpected argument: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  echo "[install-ndi] missing <ssh-target>; run with --help for usage." >&2
+  exit 2
+fi
+
+if [[ ! -f "$SOURCE_DIR/libndi.so.6" ]]; then
+  echo "[install-ndi] $SOURCE_DIR/libndi.so.6 not found on local machine." >&2
+  echo "[install-ndi] Install the NDI Advanced SDK v6 for Linux first (https://ndi.video/sdk/)." >&2
+  exit 1
+fi
+
+if ssh "$TARGET" 'test -f /usr/lib/ndi/libndi.so.6' 2>/dev/null; then
+  echo "[install-ndi] /usr/lib/ndi/libndi.so.6 already present on $TARGET; skipping copy."
+else
+  echo "[install-ndi] Copying $SOURCE_DIR -> $TARGET:/usr/lib/ndi"
+  STAGE="$(mktemp -d)"
+  trap 'rm -rf "$STAGE"' EXIT
+  tar -C "$(dirname "$SOURCE_DIR")" -czf "$STAGE/ndi-runtime.tar.gz" "$(basename "$SOURCE_DIR")"
+  scp -q "$STAGE/ndi-runtime.tar.gz" "$TARGET:/tmp/ndi-runtime.tar.gz"
+  ssh "$TARGET" 'sudo tar xzf /tmp/ndi-runtime.tar.gz -C /usr/lib/ && sudo ldconfig && rm /tmp/ndi-runtime.tar.gz'
+  echo "[install-ndi] Library installed."
+fi
+
+if [[ -n "$SERVICE" ]]; then
+  echo "[install-ndi] Restarting $SERVICE on $TARGET to pick up the library."
+  ssh "$TARGET" "sudo systemctl restart $SERVICE"
+fi
+
+echo "[install-ndi] Done. Verify with: curl http://<host>/ndi/status"


### PR DESCRIPTION
## Summary

Closes #278: NDI scan returned no sources on `companion-pp.lan` because the NDI runtime library was missing on that host. `presenter-ndi` loads `libndi.so.6` at startup via `libloading`; without it, `/ndi/status` reports `available:false` and `/ndi/sources` is always `[]`.

`pipeline.yml` (dev deploy) already installs the SDK by downloading from NewTek, but `release.yml` (companion-pp) and `deploy.yml` (production) had no equivalent step. companion-pp was therefore deployed without it.

## What changed

- **`scripts/ops/install-ndi-runtime.sh`** — idempotent one-shot bootstrap script that copies an existing `/usr/lib/ndi` from the local machine to a remote target via tar + scp + ldconfig, with optional service restart.
- **`release.yml` + `deploy.yml`** — new "Ensure NDI runtime" step that performs the same idempotent copy from the self-hosted runner to the deploy target during every release / main deploy. Skips silently if already present.
- **`docs/ops/runbook.md`** — new "NDI Runtime" section documenting the dependency, bootstrap script usage, and verification commands.

## Verification

`companion-pp.lan` was bootstrapped manually before this commit using the same tar+scp pattern that the new CI step uses:

```
curl http://companion-pp.lan/ndi/status   # → {"available":true}    (was {"available":false})
curl http://companion-pp.lan/ndi/sources  # → []
```

The empty source list is expected: companion-pp's physical LAN has no NDI senders broadcasting at this moment (it's reached via Tailscale, not the same physical network as SNV's Resolume). When Resolume on PP is broadcasting, sources will appear.

## Test plan

- [x] Dev pipeline green (run 25435147012)
- [x] `companion-pp.lan` `/ndi/status` reports `available:true` after manual bootstrap
- [x] `scripts/ops/install-ndi-runtime.sh --help` works; bash syntax check passes
- [ ] Release deploy will exercise the new "Ensure NDI runtime" step on the next companion plugin release; idempotent path will report "already present" since manual bootstrap is in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)