### PR TITLE
chore: align NDI install across deploy workflows + bump 0.4.71

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,22 +195,6 @@ jobs:
             echo 'CLIProxyAPI already present'
           fi"
 
-      - name: Ensure NDI runtime (#278)
-        run: |
-          # presenter-ndi loads libndi.so.6 at startup; without it /ndi/sources is always empty.
-          if ssh deploy-target 'test -f /usr/lib/ndi/libndi.so.6'; then
-            echo 'NDI runtime already present on target'
-          elif [ -f /usr/lib/ndi/libndi.so.6 ]; then
-            echo 'Copying NDI runtime from runner to target...'
-            tar -C /usr/lib -czf /tmp/ndi-runtime-$$.tar.gz ndi
-            scp -i ~/.ssh/id_deploy /tmp/ndi-runtime-$$.tar.gz deploy-target:/tmp/ndi-runtime.tar.gz
-            rm /tmp/ndi-runtime-$$.tar.gz
-            ssh deploy-target 'sudo tar xzf /tmp/ndi-runtime.tar.gz -C /usr/lib/ && sudo ldconfig && rm /tmp/ndi-runtime.tar.gz'
-            echo 'NDI runtime installed'
-          else
-            echo '::warning::NDI runtime not found on runner (/usr/lib/ndi/libndi.so.6); skipping. Install manually per docs/ops/runbook.md.'
-          fi
-
       - name: Backup database
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,21 +158,36 @@ jobs:
             echo 'CLIProxyAPI already present'
           fi"
 
-      - name: Ensure NDI runtime (#278)
+      - name: Ensure NDI SDK and avahi-daemon are installed
         run: |
-          # presenter-ndi loads libndi.so.6 at startup; without it /ndi/sources is always empty.
-          if ssh deploy-target 'test -f /usr/lib/ndi/libndi.so.6'; then
-            echo 'NDI runtime already present on target'
-          elif [ -f /usr/lib/ndi/libndi.so.6 ]; then
-            echo 'Copying NDI runtime from runner to target...'
-            tar -C /usr/lib -czf /tmp/ndi-runtime-$$.tar.gz ndi
-            scp -i ~/.ssh/id_deploy /tmp/ndi-runtime-$$.tar.gz deploy-target:/tmp/ndi-runtime.tar.gz
-            rm /tmp/ndi-runtime-$$.tar.gz
-            ssh deploy-target 'sudo tar xzf /tmp/ndi-runtime.tar.gz -C /usr/lib/ && sudo ldconfig && rm /tmp/ndi-runtime.tar.gz'
-            echo 'NDI runtime installed'
-          else
-            echo '::warning::NDI runtime not found on runner (/usr/lib/ndi/libndi.so.6); skipping. Install manually per docs/ops/runbook.md.'
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
+          # Install avahi-daemon for mDNS (NDI source discovery)
+          if ! systemctl is-active --quiet avahi-daemon 2>/dev/null; then
+            echo "Installing avahi-daemon..."
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq avahi-daemon
+            sudo systemctl enable avahi-daemon
+            sudo systemctl start avahi-daemon
           fi
+          # Install NDI SDK if not present (#278)
+          if [ ! -f /usr/lib/ndi/libndi.so.6 ]; then
+            echo "Installing NDI SDK v6..."
+            NDI_URL="https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz"
+            curl -sL "$NDI_URL" -o /tmp/ndi_sdk.tar.gz
+            cd /tmp && tar xzf ndi_sdk.tar.gz
+            echo "y" | PAGER=cat sh /tmp/Install_NDI_SDK_v6_Linux.sh
+            sudo mkdir -p /usr/lib/ndi
+            sudo cp "/tmp/NDI SDK for Linux/lib/x86_64-linux-gnu/libndi.so.6.3.1" /usr/lib/ndi/
+            sudo ln -sf libndi.so.6.3.1 /usr/lib/ndi/libndi.so.6
+            sudo ln -sf libndi.so.6 /usr/lib/ndi/libndi.so
+            rm -rf /tmp/ndi_sdk.tar.gz /tmp/Install_NDI_SDK_v6_Linux.sh "/tmp/NDI SDK for Linux"
+            echo "NDI SDK installed"
+          else
+            echo "NDI SDK already present"
+          fi
+          ls -la /usr/lib/ndi/libndi.so.6
+          REMOTE_SCRIPT
 
       - name: Backup database
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "axum",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.70"
+version = "0.4.71"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.70"
+version = "0.4.71"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -154,7 +154,7 @@ scripts/ops/install-ndi-runtime.sh newlevel@<host> --service presenter
 
 The script copies the runtime, runs `ldconfig`, and (when `--service` is given) restarts the service so the library is picked up.
 
-The release (`release.yml`) and main-deploy (`deploy.yml`) workflows now run an **Ensure NDI runtime** step that performs the same idempotent copy from the self-hosted runner to the deploy target. After a clean reinstall, verify with:
+The dev (`pipeline.yml`), main-deploy (`deploy.yml`), and release (`release.yml`) workflows all run an **Ensure NDI SDK and avahi-daemon are installed** step that downloads the SDK from `downloads.ndi.tv` if `/usr/lib/ndi/libndi.so.6` is missing on the target, then verifies presence. The step is idempotent and skips silently when the library is already there. After a clean reinstall, verify with:
 
 ```bash
 curl http://<host>/ndi/status   # → {"available":true}


### PR DESCRIPTION
## Summary

Cleanup of #303 (#278): align the NDI runtime install step across all three deploy workflows and remove the redundant runner-copy step that was added to `deploy.yml` by the previous PR.

`deploy.yml` already had a stronger \"Ensure NDI SDK and avahi-daemon are installed\" step that downloads the SDK from `downloads.ndi.tv` if missing, so the runner-copy step I added there was dead code. `release.yml` had no step at all — it now uses the same download HEREDOC, matching `pipeline.yml` and `deploy.yml`.

## What changed

- **`deploy.yml`** — remove the redundant `Ensure NDI runtime (#278)` runner-copy step
- **`release.yml`** — replace the runner-copy step with the same `Ensure NDI SDK and avahi-daemon are installed` HEREDOC used by `pipeline.yml` and `deploy.yml`. Three workflows now install NDI consistently and don't depend on the self-hosted runner having `/usr/lib/ndi`.
- **`docs/ops/runbook.md`** — update the wording to match the actual download step
- **Bump version** 0.4.70 → 0.4.71

`scripts/ops/install-ndi-runtime.sh` stays — it's still useful for fully offline / non-CI host bootstrap.

## Test plan

- [x] Pipeline `25440092191` green except Mutation Testing (advisory, still running)
- [x] Branch Sync, Format, Clippy, Test, Build, E2E (3/3), Deploy to Dev, Deploy Companion Plugin all ✅
- [ ] After merge, `deploy.yml` runs once on main with the cleanup; `release.yml` change exercised on next companion plugin release

🤖 Generated with [Claude Code](https://claude.com/claude-code)