### PR TITLE
feat(stage): NDI background on timer layout (#306)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.72"
+version = "0.4.73"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/timer_layout.rs
+++ b/crates/presenter-ui/src/components/stage/timer_layout.rs
@@ -14,6 +14,8 @@ pub fn TimerLayout(
     latency_ms: ReadSignal<Option<f64>>,
 ) -> impl IntoView {
     let ctx = use_context::<StageContext>().expect("StageContext not provided");
+    let ndi_active = ctx.ndi_active;
+    let ndi_status = ctx.ndi_status;
 
     let timer_ref = NodeRef::<leptos::html::Div>::new();
 
@@ -43,6 +45,28 @@ pub fn TimerLayout(
 
     view! {
         <div class="stage-container" data-layout="timer">
+            <Show when=move || ndi_active.get()>
+                <img src="/ndi/mjpeg" class="stage-timer__ndi" />
+            </Show>
+
+            <Show when=move || {
+                let status = ndi_status.get();
+                status == "disconnected" || status == "connecting"
+            }>
+                <div class="stage-timer__overlay">
+                    {move || {
+                        let status = ndi_status.get();
+                        if status == "disconnected" {
+                            "Signal Lost — Reconnecting..."
+                        } else if status == "connecting" {
+                            "Connecting..."
+                        } else {
+                            ""
+                        }
+                    }}
+                </div>
+            </Show>
+
             <div class="stage-timer__display">
                 <span class="stage__debug-label">"timer-display"</span>
                 <div node_ref=timer_ref class="stage-timer__text">

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -389,6 +389,7 @@ body.stage {
     align-items: center;
     justify-content: center;
     overflow: hidden;
+    z-index: 2;
 }
 
 .stage-timer__text {
@@ -399,6 +400,30 @@ body.stage {
     width: 100%;
     height: 100%;
     overflow: hidden;
+    text-shadow:
+        0 0 8px rgba(0, 0, 0, 0.9),
+        0 2px 4px rgba(0, 0, 0, 0.7);
+}
+
+/* ===== NDI background for timer layout (#306) ===== */
+.stage-timer__ndi {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.stage-timer__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.7);
+    color: #ef4444;
+    font-size: 1.2rem;
+    z-index: 1;
 }
 
 /* ===== preach layout ===== */

--- a/docs/superpowers/plans/2026-05-07-timer-ndi-background.md
+++ b/docs/superpowers/plans/2026-05-07-timer-ndi-background.md
@@ -1,0 +1,559 @@
+# Timer Stage Layout: NDI Background Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the NDI MJPEG video as a backdrop on the `timer` stage layout, mirroring the existing `api_stage.rs` pattern.
+
+**Architecture:** Add the same `<Show when=ndi_active>` MJPEG `<img>` + connection-status overlay structure to `TimerLayout` that `ApiStage` already uses. Add matching CSS rules. Add a Playwright E2E that verifies the `<img>` is present when an NDI source is active and absent when it isn't, mirroring `tests/e2e/stage-api-ndi.spec.ts`.
+
+**Tech Stack:** Rust + Leptos (WASM), CSS, Playwright (TypeScript).
+
+**Spec:** `docs/superpowers/specs/2026-05-07-timer-ndi-background-design.md` (commit d297b46)
+
+---
+
+## Context
+
+Issue #306: the user wants the same NDI backdrop on `timer` that `api` and `ndi-fullscreen` already have. `StageContext` already exposes `ndi_active` and `ndi_status` signals; `pages/stage.rs` already wires them from live WebSocket events. Only the `timer` layout component, the CSS, and an E2E test need to change.
+
+**Key existing code:**
+
+- `crates/presenter-ui/src/components/stage/api_stage.rs` — canonical pattern (49 lines).
+- `crates/presenter-ui/src/components/stage/timer_layout.rs` — current 53-line component, no NDI integration.
+- `crates/presenter-ui/styles/stage.css:382-447` — existing `.stage-timer__display` and `.stage-timer__text` rules; section to extend.
+- `crates/presenter-ui/styles/stage.css:521-553` — `.stage-api`, `.stage-api__ndi`, `.stage-api__overlay` rules to copy as `.stage-timer__ndi`, `.stage-timer__overlay`.
+- `tests/e2e/stage-api-ndi.spec.ts` — closest analogue test; mirror its structure (server bootstrap, layout switch, video-source activate/deactivate, assertions).
+- `crates/presenter-ui/src/state/stage.rs` (StageContext) — `ndi_active: RwSignal<bool>`, `ndi_status: RwSignal<String>`.
+
+---
+
+## File Structure
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace) | bump `[workspace.package].version` 0.4.72 → 0.4.73 |
+| `crates/presenter-ui/src/components/stage/timer_layout.rs` | bind `ndi_active`/`ndi_status`, add MJPEG `<img>` and status overlay as siblings of the existing timer display |
+| `crates/presenter-ui/styles/stage.css` | add `.stage-timer__ndi`, `.stage-timer__overlay`; extend `.stage-timer__display` and `.stage-timer__text` with z-index + text-shadow |
+
+### Created files
+
+| File | Responsibility |
+|------|----------------|
+| `tests/e2e/stage-timer-ndi.spec.ts` | E2E coverage: timer layout shows `img.stage-timer__ndi` when NDI source active; absent otherwise; timer text remains visible; clean console |
+
+---
+
+## Task 1: Version bump 0.4.72 → 0.4.73
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package].version`)
+
+- [ ] **Step 1: Edit version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml`, change:
+
+```toml
+version = "0.4.72"
+```
+
+to:
+
+```toml
+version = "0.4.73"
+```
+
+- [ ] **Step 2: Refresh Cargo.lock**
+
+Run: `cargo update -w`
+
+Expected output: lines for each workspace member updating from `v0.4.72` → `v0.4.73`. No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.4.73"
+```
+
+---
+
+## Task 2: TimerLayout component change
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/timer_layout.rs` (whole component body)
+
+- [ ] **Step 1: Replace the component**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/stage/timer_layout.rs`, replace the entire `pub fn TimerLayout` body. The final file content is:
+
+```rust
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::HtmlElement;
+
+use crate::state::stage::StageContext;
+use crate::utils::autofit::autofit_text;
+use crate::ws::stage::StageWsState;
+
+const TIMER_MAX_FONT: f64 = 300.0;
+
+#[component]
+pub fn TimerLayout(
+    ws_state: ReadSignal<StageWsState>,
+    latency_ms: ReadSignal<Option<f64>>,
+) -> impl IntoView {
+    let ctx = use_context::<StageContext>().expect("StageContext not provided");
+    let ndi_active = ctx.ndi_active;
+    let ndi_status = ctx.ndi_status;
+
+    let timer_ref = NodeRef::<leptos::html::Div>::new();
+
+    let timer_text = move || {
+        ctx.snapshot
+            .get()
+            .map(|s| presenter_core::format_countdown(s.timers.countdown_to_start.seconds_remaining))
+            .unwrap_or_else(|| "00:00".to_string())
+    };
+
+    {
+        let r = timer_ref;
+        Effect::new(move |_| {
+            let _t = timer_text();
+            if let Some(el) = r.get() {
+                let html_el: &HtmlElement = &el;
+                let el_clone = html_el.clone();
+                let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
+                    autofit_text(&el_clone, TIMER_MAX_FONT);
+                });
+                let _ = web_sys::window()
+                    .expect("window")
+                    .request_animation_frame(cb.as_ref().unchecked_ref());
+            }
+        });
+    }
+
+    view! {
+        <div class="stage-container" data-layout="timer">
+            <Show when=move || ndi_active.get()>
+                <img src="/ndi/mjpeg" class="stage-timer__ndi" />
+            </Show>
+
+            <Show when=move || {
+                let status = ndi_status.get();
+                status == "disconnected" || status == "connecting"
+            }>
+                <div class="stage-timer__overlay">
+                    {move || {
+                        let status = ndi_status.get();
+                        if status == "disconnected" {
+                            "Signal Lost — Reconnecting..."
+                        } else if status == "connecting" {
+                            "Connecting..."
+                        } else {
+                            ""
+                        }
+                    }}
+                </div>
+            </Show>
+
+            <div class="stage-timer__display">
+                <span class="stage__debug-label">"timer-display"</span>
+                <div node_ref=timer_ref class="stage-timer__text">
+                    {timer_text}
+                </div>
+            </div>
+            <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
+        </div>
+    }
+}
+```
+
+The diff vs. current:
+- Two new `let` bindings after `let ctx = ...` for `ndi_active` and `ndi_status`.
+- Two new `<Show>` blocks inserted as siblings BEFORE the existing `.stage-timer__display` div.
+- Existing `.stage-timer__display`, `.stage-timer__text`, and `<StatusBar>` markup unchanged.
+
+- [ ] **Step 2: Native + WASM build**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all`
+
+Expected: `Finished` with zero warnings. If `unused_imports` or similar fires, fix and re-run.
+
+- [ ] **Step 3: Workspace clippy**
+
+Run from repo root: `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
+
+Expected: `Finished` with zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/stage/timer_layout.rs
+git commit -m "feat(stage): NDI background on timer layout (#306)"
+```
+
+---
+
+## Task 3: CSS additions for `.stage-timer__ndi` and overlay
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/stage.css` (add new rules; extend existing `.stage-timer__display` and `.stage-timer__text`)
+
+- [ ] **Step 1: Add new rules**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/stage.css`, find the timer section. The existing rules for `.stage-timer__display` and `.stage-timer__text` start near line 382. Add the new rules immediately after the existing timer rules (before the next `/* ===== ... ===== */` comment block).
+
+Append:
+
+```css
+/* ===== NDI background for timer layout (#306) ===== */
+.stage-timer__ndi {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.stage-timer__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.7);
+    color: #ef4444;
+    font-size: 1.2rem;
+    z-index: 1;
+}
+```
+
+- [ ] **Step 2: Extend `.stage-timer__display`**
+
+In the same file, find the existing `.stage-timer__display { ... }` rule (near line 382). Add `position: relative;` and `z-index: 2;` to its declarations so the timer text sits above the NDI img. The block becomes:
+
+```css
+.stage-timer__display {
+    /* keep all existing properties */
+    position: relative;
+    z-index: 2;
+}
+```
+
+If `position: relative` is already present, leave it; just add `z-index: 2`. Do not remove or change any existing property.
+
+- [ ] **Step 3: Extend `.stage-timer__text`**
+
+In the same file, find `.stage-timer__text { ... }` (near line 394). Add a `text-shadow` so digits stay readable over varied video. Append (do not replace existing properties):
+
+```css
+.stage-timer__text {
+    /* keep all existing properties */
+    text-shadow:
+        0 0 8px rgba(0, 0, 0, 0.9),
+        0 2px 4px rgba(0, 0, 0, 0.7);
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/styles/stage.css
+git commit -m "style(stage): NDI backdrop CSS for timer layout (#306)"
+```
+
+---
+
+## Task 4: Playwright E2E test
+
+**Files:**
+- Create: `tests/e2e/stage-timer-ndi.spec.ts`
+
+- [ ] **Step 1: Create the test file**
+
+Create `/home/newlevel/devel/presenter/presenter-dev2/tests/e2e/stage-timer-ndi.spec.ts` with:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(
+  page: import("@playwright/test").Page,
+  extraAllowed: RegExp[] = [],
+): string[] {
+  const messages: string[] = [];
+  const allowed = [...ALLOWED_CONSOLE_NOISE, ...extraAllowed];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!allowed.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("timer layout renders without NDI image when no source is active", async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+
+  await page.request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "timer" } },
+  );
+
+  await page.goto(new URL("/stage", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('body[data-layout-code="timer"]', {
+    timeout: 10_000,
+  });
+
+  // Timer wrapper present
+  const wrapper = page.locator('div.stage-container[data-layout="timer"]');
+  await expect(wrapper).toBeAttached();
+
+  // Timer display still rendered
+  await expect(wrapper.locator(".stage-timer__display")).toBeAttached();
+  await expect(wrapper.locator(".stage-timer__text")).toBeVisible();
+
+  // No NDI image when no source is active
+  await expect(wrapper.locator("img.stage-timer__ndi")).toHaveCount(0);
+
+  // Timer text has the legibility shadow we added
+  const textShadow = await wrapper
+    .locator(".stage-timer__text")
+    .evaluate((el) => window.getComputedStyle(el).textShadow);
+  expect(textShadow).not.toBe("none");
+  expect(textShadow).not.toBe("");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("timer layout renders NDI image when an NDI source is active", async ({ page }) => {
+  // The /ndi/mjpeg endpoint returns 503 for a bogus source name; that 503 is
+  // expected noise for this scenario only. See stage-api-ndi.spec.ts for the
+  // same allowance.
+  const consoleMessages = collectConsoleErrors(page, [
+    /Failed to load resource.*503/i,
+  ]);
+
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+
+  await page.request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "timer" } },
+  );
+
+  await page.goto(new URL("/stage", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('body[data-layout-code="timer"]', {
+    timeout: 10_000,
+  });
+
+  // Create + activate a bogus NDI source so the WS event flips ndi_active.
+  const createResp = await page.request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { name: "test-ndi-source", ndi_name: "BOGUS-FOR-TIMER-TEST" } },
+  );
+  expect(createResp.ok()).toBeTruthy();
+  const source = await createResp.json();
+
+  try {
+    const activateResp = await page.request.post(
+      new URL(
+        `/integrations/video-sources/${source.id}/activate`,
+        baseURL,
+      ).toString(),
+    );
+    expect(activateResp.ok()).toBeTruthy();
+
+    const wrapper = page.locator('div.stage-container[data-layout="timer"]');
+    await expect(wrapper.locator("img.stage-timer__ndi")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Timer text remains visible and is on top of the video
+    await expect(wrapper.locator(".stage-timer__text")).toBeVisible();
+
+    const zIndex = await wrapper
+      .locator(".stage-timer__display")
+      .evaluate((el) => window.getComputedStyle(el).zIndex);
+    expect(Number(zIndex)).toBeGreaterThanOrEqual(2);
+  } finally {
+    await page.request.post(
+      new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+    );
+    await page.request.delete(
+      new URL(
+        `/integrations/video-sources/${source.id}`,
+        baseURL,
+      ).toString(),
+    );
+  }
+
+  expect(consoleMessages).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run the new test locally on dev**
+
+The project uses a Playwright config that bootstraps its own server. Run:
+
+```bash
+npm run test:playwright -- stage-timer-ndi
+```
+
+Expected: 2 tests pass. If `npm run test:playwright` is not the right command, check `package.json` `scripts` for `playwright`/`test:e2e`/`pw` and use that. If it requires the dev server to be running, start it per `docs/ops/runbook.md` first.
+
+If a video-source create/delete step fails because of a different API shape on this branch, inspect `tests/e2e/stage-api-ndi.spec.ts:171-208` — it uses the same endpoints; copy the exact request shape from there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/stage-timer-ndi.spec.ts
+git commit -m "test(e2e): timer layout NDI background coverage (#306)"
+```
+
+---
+
+## Task 5: Push, monitor CI, manual verify on dev, open PR (controller-handled)
+
+This task is performed by the orchestrator, not a subagent.
+
+- [ ] **Step 1: Final local checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cargo test --workspace -- --nocapture
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+```
+
+All must pass.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+If the push reports `Branch Sync Check` will fail, sync first:
+
+```bash
+git fetch origin
+git merge origin/main --no-edit
+git push origin dev
+```
+
+- [ ] **Step 3: Capture the run id and monitor**
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId
+# Then in a single background bash:
+sleep 1500 && gh run view <run-id> --json status,conclusion,jobs
+```
+
+Wait until ALL jobs (including Mutation Testing) report `success`. If any fail, run `gh run view <run-id> --log-failed`, fix in ONE commit, push once.
+
+- [ ] **Step 4: Verify on dev**
+
+After Deploy to Dev is green:
+
+```bash
+curl -s 'http://10.77.8.134:8080/healthz'
+# Expect: {"channel":"dev","status":"ok","version":"0.4.73"}
+```
+
+Then in Playwright (or by opening a real browser pointed at the dev IP):
+
+1. POST `http://10.77.8.134:8080/stage/layout` with `{"code":"timer"}`.
+2. Open `http://10.77.8.134:8080/stage`.
+3. If a real NDI source is configured on dev, activate it; assert visually that countdown digits sit over the live video. If no real NDI source is reachable, the unit/E2E coverage from Task 4 is the canonical proof.
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --base main --head dev --title "feat(stage): NDI background on timer layout (#306)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #306: the `timer` stage layout now renders the live NDI MJPEG video as a backdrop, the same way `api` and `ndi-fullscreen` already do.
+
+## What changed
+
+- `TimerLayout` (Leptos) — added `<Show when=ndi_active>` MJPEG `<img>` and a connection-status overlay as siblings of the existing timer display. Mirrors `ApiStage` exactly.
+- `stage.css` — new `.stage-timer__ndi` and `.stage-timer__overlay` rules; extended `.stage-timer__display` with `z-index: 2` and `.stage-timer__text` with a text-shadow for legibility over varied video.
+- New Playwright E2E `stage-timer-ndi.spec.ts` — covers active-NDI image render, no-NDI image absence, timer text visibility, browser-console-zero-errors.
+- Version bump 0.4.72 → 0.4.73.
+
+## Verification
+
+- All local checks green (`cargo test`, native + WASM clippy, fmt).
+- CI green incl. Mutation Testing.
+- Dev `/healthz` reports v0.4.73.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Wait for `mergeStateStatus: CLEAN` and `mergeable: MERGEABLE` before reporting. Do NOT merge until the user says "merge it".
+
+---
+
+## Verification summary
+
+| Check | How to verify |
+|-------|---------------|
+| TimerLayout renders NDI img when active | `npm run test:playwright -- stage-timer-ndi` |
+| TimerLayout omits NDI img when inactive | Same test |
+| Timer text remains visible and elevated | Same test (z-index assertion) |
+| Browser console clean | Same test (`expect(consoleMessages).toEqual([])`) |
+| Workspace builds | `cargo build --workspace` green |
+| Native clippy clean | `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` |
+| WASM clippy clean | from `crates/presenter-ui`: `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` |
+| Version bump | `Cargo.toml` workspace version is `0.4.73` |
+| Dev deploy | `/healthz` shows v0.4.73 |

--- a/docs/superpowers/specs/2026-05-07-timer-ndi-background-design.md
+++ b/docs/superpowers/specs/2026-05-07-timer-ndi-background-design.md
@@ -1,0 +1,120 @@
+# Timer Stage Layout: NDI Background (Design)
+
+> **Status:** Approved
+> **Issue:** #306
+> **Created:** 2026-05-07
+
+## Problem
+
+The `api` and `ndi-fullscreen` stage layouts render the live NDI MJPEG video as a backdrop. The `timer` layout currently shows the countdown digits on a black background. The user wants the same NDI backdrop on `timer` so the audience sees a single visual scene whether the operator is showing the timer or other content.
+
+## Goal
+
+Match the existing `api_stage` pattern in `timer_layout.rs`. When an NDI source is active, render `<img src="/ndi/mjpeg">` covering the viewport, with the timer digits sitting on top.
+
+## Approach
+
+Mirror `api_stage.rs` exactly. No refactor, no shared component — the existing two-layout duplication of the MJPEG `<img>` + status overlay is small and survives one more copy.
+
+## Components
+
+### `crates/presenter-ui/src/components/stage/timer_layout.rs`
+
+Add inside the existing `<div class="stage-container" data-layout="timer">`:
+
+1. `<Show when=ndi_active>` → `<img src="/ndi/mjpeg" class="stage-timer__ndi" />`
+2. `<Show when=status==connecting||disconnected>` → status overlay (same copy as `ApiStage`: `"Connecting..."` / `"Signal Lost — Reconnecting..."`)
+3. The existing `.stage-timer__display` block, unchanged in markup but elevated above the NDI img via `z-index`.
+
+Bind `let ndi_active = ctx.ndi_active;` and `let ndi_status = ctx.ndi_status;` from the already-fetched `StageContext`. No new context fields, no new API calls — `pages/stage.rs` is already wiring `LiveEvent::NdiSourceActivated/Deactivated/ConnectionStatus` into these signals.
+
+### `crates/presenter-ui/styles/stage.css`
+
+Add to the timer section (around line 382):
+
+```css
+.stage-timer__ndi {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.stage-timer__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.7);
+    color: #ef4444;
+    font-size: 1.2rem;
+    z-index: 1;
+}
+```
+
+Modify the existing `.stage-timer__display` and `.stage-timer__text` rules to ensure the timer text sits above the video and stays legible:
+
+```css
+.stage-timer__display {
+    /* existing rules + */
+    position: relative;
+    z-index: 2;
+}
+
+.stage-timer__text {
+    /* existing rules + */
+    text-shadow:
+        0 0 8px rgba(0, 0, 0, 0.9),
+        0 2px 4px rgba(0, 0, 0, 0.7);
+}
+```
+
+`.stage-container` already provides `position: relative; width: 100vw; height: 100vh; overflow: hidden;` — the absolute-positioned NDI img inherits the right containment.
+
+### No server changes
+
+`StageContext.ndi_active` and `ndi_status` are already populated by `pages/stage.rs` from live WebSocket events and the initial `api::ndi::list_video_sources()` fetch. No router or state changes needed.
+
+## Tests
+
+### Playwright (E2E)
+
+New test file: `tests/e2e/stage-timer-ndi.spec.ts`. No dedicated stage-timer test exists today; mirror the structure of `tests/e2e/stage-api-ndi.spec.ts` (which is the closest analogue: it covers `api` layout with active/inactive NDI source).
+
+Scenarios:
+
+1. **Active NDI source → backdrop visible.** Activate a video source via the API. Open `/stage` with `layout_code=timer`. Assert `[class="stage-timer__ndi"]` exists, is visible, and has a non-zero `naturalWidth` after 2 seconds (proves the MJPEG stream is actually loading frames).
+2. **No NDI source → no backdrop.** Open `/stage` with `layout_code=timer` and no active NDI source. Assert `[class="stage-timer__ndi"]` does NOT exist (the `<Show when=ndi_active>` block is gated).
+3. **Timer text visible over backdrop.** With active NDI source, assert `[data-role="timer-display"]` (or whichever selector the existing test uses for the timer) is visible and readable.
+4. **Browser-console-zero-errors.** Per global rule, every E2E test ends with `expect(consoleMessages).toEqual([])`.
+
+### Manual verification
+
+After deploy to dev, browse to `http://10.77.8.134:8080/stage?layout=timer` (or set the layout via the operator), trigger an NDI source on the dev presenter, and confirm by eye that the countdown sits over the video.
+
+## Out of scope
+
+- `preach` layout NDI background (not requested in #306). If desired, separate issue.
+- Refactoring `api_stage.rs` and `ndi_fullscreen.rs` to share an `NdiBackdrop` component. The existing duplication survives one more copy; refactor when there's a fourth or when behavior diverges.
+- Any change to how the operator selects the NDI source.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Timer text becomes unreadable over bright/busy video | Text-shadow added (same approach as `ApiStage` slide text). |
+| `<img src="/ndi/mjpeg">` mounts and disconnects rapidly when `ndi_active` toggles | Same `<Show>` gating as `ApiStage` and `NdiFullscreen` — no observed issues there. |
+| Existing timer E2E tests break because of the new wrapper markup | The existing `.stage-timer__display` and `.stage-timer__text` selectors are preserved. Test selectors that target those classes continue to work. |
+
+## Verification checklist
+
+| Check | Method |
+|---|---|
+| `<img class="stage-timer__ndi">` renders when NDI active | Playwright E2E |
+| `<img class="stage-timer__ndi">` absent when NDI inactive | Playwright E2E |
+| Timer digits visible and unobscured | Playwright + manual on dev |
+| Browser console clean | Playwright `expect(consoleMessages).toEqual([])` |
+| Version bump 0.4.72 → 0.4.73 | `Cargo.toml` workspace version |
+| WASM clippy clean | `cargo clippy --target wasm32-unknown-unknown -p presenter-ui` |

--- a/tests/e2e/stage-timer-ndi.spec.ts
+++ b/tests/e2e/stage-timer-ndi.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(
+  page: import("@playwright/test").Page,
+  extraAllowed: RegExp[] = [],
+): string[] {
+  const messages: string[] = [];
+  const allowed = [...ALLOWED_CONSOLE_NOISE, ...extraAllowed];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!allowed.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("timer layout renders without NDI image when no source is active", async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+
+  await page.request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "timer" } },
+  );
+
+  await page.goto(new URL("/stage", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('body[data-layout-code="timer"]', {
+    timeout: 10_000,
+  });
+
+  const wrapper = page.locator('div.stage-container[data-layout="timer"]');
+  await expect(wrapper).toBeAttached();
+
+  await expect(wrapper.locator(".stage-timer__display")).toBeAttached();
+  await expect(wrapper.locator(".stage-timer__text")).toBeVisible();
+
+  await expect(wrapper.locator("img.stage-timer__ndi")).toHaveCount(0);
+
+  const textShadow = await wrapper
+    .locator(".stage-timer__text")
+    .evaluate((el) => window.getComputedStyle(el).textShadow);
+  expect(textShadow).not.toBe("none");
+  expect(textShadow).not.toBe("");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("timer layout renders NDI image when an NDI source is active", async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page, [
+    /Failed to load resource.*503/i,
+  ]);
+
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+
+  await page.request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "timer" } },
+  );
+
+  await page.goto(new URL("/stage", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('body[data-layout-code="timer"]', {
+    timeout: 10_000,
+  });
+
+  const createResp = await page.request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { label: "E2E Stage Timer NDI Test", ndiName: "BOGUS-FOR-TIMER-TEST" } },
+  );
+  const source = await createResp.json();
+
+  try {
+    await page.request.post(
+      new URL(
+        `/integrations/video-sources/${source.id}/activate`,
+        baseURL,
+      ).toString(),
+      { failOnStatusCode: false },
+    );
+
+    const wrapper = page.locator('div.stage-container[data-layout="timer"]');
+    await expect(wrapper.locator("img.stage-timer__ndi")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(wrapper.locator(".stage-timer__text")).toBeVisible();
+
+    const zIndex = await wrapper
+      .locator(".stage-timer__display")
+      .evaluate((el) => window.getComputedStyle(el).zIndex);
+    expect(Number(zIndex)).toBeGreaterThanOrEqual(2);
+  } finally {
+    await page.request.post(
+      new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+      { failOnStatusCode: false },
+    );
+    await page.request.delete(
+      new URL(
+        `/integrations/video-sources/${source.id}`,
+        baseURL,
+      ).toString(),
+      { failOnStatusCode: false },
+    );
+  }
+
+  expect(consoleMessages).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Closes #306: the `timer` stage layout now renders the live NDI MJPEG video as a backdrop, matching how `api` and `ndi-fullscreen` layouts already work.

## What changed

- **`TimerLayout`** (Leptos) — added `<Show when=ndi_active>` MJPEG `<img class="stage-timer__ndi">` plus a connection-status overlay as siblings of the existing timer display. Mirrors `api_stage.rs` exactly. `StageContext.ndi_active` and `ndi_status` were already populated by `pages/stage.rs`; no plumbing needed.
- **`stage.css`** — new `.stage-timer__ndi` and `.stage-timer__overlay` rules (copy of the `.stage-api__*` pattern). Existing `.stage-timer__display` extended with `z-index: 2` (kept its existing `position: absolute`); `.stage-timer__text` extended with `text-shadow` for legibility over varied video.
- **New Playwright E2E** `tests/e2e/stage-timer-ndi.spec.ts` — two scenarios covering `img.stage-timer__ndi` absent when no source, visible when active, plus the `z-index >= 2` and clean-console assertions.
- **Version bump** 0.4.72 → 0.4.73.

## Verification

- All local checks green: `cargo test`, native + WASM clippy, fmt.
- CI green except Mutation Testing (still running, advisory): Test ✅, Coverage ✅, Build ✅, Playwright E2E (3/3) ✅, Deploy to Dev ✅.
- Dev `/healthz` reports v0.4.73 with `channel: dev`.
- New E2E (`stage-timer-ndi`) passed locally (`2 passed (33.3s)`) and on CI's E2E shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)