### PR TITLE
feat(operator): drop Save button + add Saved indicator on worship slides (#313)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.73"
+version = "0.4.74"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -607,6 +607,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1250,7 +1252,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 uuid = { version = "1.8", features = ["serde", "v4", "js"] }
 gloo-net = { version = "0.6", features = ["websocket", "http"] }
 gloo-storage = "0.3"
-gloo-timers = "0.3"
+gloo-timers = { version = "0.3", features = ["futures"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
     "Blob",

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -12,6 +12,7 @@ pub mod search;
 pub mod slide_list;
 mod slide_list_scroll;
 mod slide_list_utils;
+mod slide_save;
 pub mod stage;
 pub mod stage_preview;
 pub mod timer_panel;

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -514,6 +514,9 @@ pub fn SlideList() -> impl IntoView {
                         // Clone for class closure (is-loading check)
                         let slide_id_class = slide_id.clone();
 
+                        // Clone for save-status badge in slide header
+                        let slide_id_for_badge = slide_id.clone();
+
                         view! {
                             <article
                                 class=move || {
@@ -650,35 +653,52 @@ pub fn SlideList() -> impl IntoView {
                                             <span class=class style=color_style data-role="slide-group">{g}</span>
                                         }
                                     })}
+                                    {
+                                        let sid_for_when = slide_id_for_badge.clone();
+                                        let sid_for_render = slide_id_for_badge.clone();
+                                        let save_status = op.save_status;
+                                        view! {
+                                            <Show when=move || save_status.get().contains_key(&sid_for_when)>
+                                                {
+                                                    let sid_for_render = sid_for_render.clone();
+                                                    move || {
+                                                        let map = save_status.get();
+                                                        let Some((status, _)) = map.get(&sid_for_render).copied() else {
+                                                            return view! { <span></span> }.into_any();
+                                                        };
+                                                        match status {
+                                                            SaveStatus::Saving => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="saving"
+                                                                >"Saving…"</span>
+                                                            }.into_any(),
+                                                            SaveStatus::Saved => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="saved"
+                                                                >"Saved ✓"</span>
+                                                            }.into_any(),
+                                                            SaveStatus::Failed => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="failed"
+                                                                >"Save failed"</span>
+                                                            }.into_any(),
+                                                        }
+                                                    }
+                                                }
+                                            </Show>
+                                        }
+                                    }
                                     {is_edit.then(|| {
-                                        let pres_id_save = pres_id_edit.clone();
-                                        let slide_id_save = slide_id_edit.clone();
-                                        // Capture signal OUTSIDE async blocks
-                                        let selected_pres_save = ctx.selected_presentation;
                                         let selected_pres_dup = ctx.selected_presentation;
                                         let selected_pres_del = ctx.selected_presentation;
                                         view! {
                                             <div class="operator__slide-controls">
-                                                <button type="button" data-action="save"
-                                                    on:click=move |_| {
-                                                        let pres_id = pres_id_save.clone();
-                                                        let sid = slide_id_save.clone();
-                                                        let selected_pres = selected_pres_save;
-                                                        leptos::task::spawn_local(async move {
-                                                            let p = selected_pres.get_untracked();
-                                                            if let Some(p) = &p {
-                                                                if let Some(s) = p.slides.iter().find(|s| s.id.to_string() == sid) {
-                                                                    let _ = api::presentations::update_slide(
-                                                                        &pres_id, &sid,
-                                                                        s.content.main.value(),
-                                                                        s.content.translation.value(),
-                                                                        s.content.stage.value(),
-                                                                    ).await;
-                                                                }
-                                                            }
-                                                        });
-                                                    }
-                                                >"Save"</button>
                                                 <button type="button" data-action="duplicate"
                                                     on:click=move |_| {
                                                         let pres_id = pres_id_dup.clone();

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use gloo_timers::future::TimeoutFuture;
 use leptos::prelude::*;
 use presenter_core::{resolve_sequence, ResolvedSlide};
 use wasm_bindgen::JsCast;
 
 use crate::api;
-use crate::state::operator::OperatorState;
+use crate::state::operator::{OperatorState, SaveStatus};
 use crate::state::AppContext;
 use crate::utils::color::group_pill_style;
 
@@ -14,6 +16,11 @@ use super::slide_list_utils::{
     apply_focused_class, field_has_warning, format_multiline, reorder_slide_ids,
     slide_has_any_warning,
 };
+
+/// Monotonic token used to invalidate stale fade timers (#313).
+/// Each save increments this and stamps the per-slide save_status entry;
+/// the 2s fade timer only removes the entry if the token still matches.
+static SAVE_TOKEN: AtomicU64 = AtomicU64::new(0);
 
 /// Get a textarea/input value from the DOM by slide_id and field name.
 fn get_field_value(doc: &web_sys::Document, slide_id: &str, field: &str) -> String {
@@ -86,11 +93,10 @@ fn save_all_fields_from_dom(
     _sel_start: u32,
     _sel_end: u32,
     selected_pres: RwSignal<Option<presenter_core::Presentation>>,
-    _op: &OperatorState,
+    op: &OperatorState,
 ) {
     let doc = crate::utils::window::document();
 
-    // Get ALL field values from the DOM (not from signals which may be stale)
     let main = get_field_value(&doc, slide_id, "main");
     let translation = get_field_value(&doc, slide_id, "translation");
     let stage = get_field_value(&doc, slide_id, "stage");
@@ -101,7 +107,7 @@ fn save_all_fields_from_dom(
         Some(group_val.trim().to_string())
     };
 
-    // Compare to signal to skip no-op saves
+    // Skip no-op saves.
     let pres = selected_pres.get_untracked();
     if let Some(p) = &pres {
         if let Some(slide) = p.slides.iter().find(|s| s.id.to_string() == slide_id) {
@@ -117,27 +123,67 @@ fn save_all_fields_from_dom(
         }
     }
 
-    let pres_id = pres_id.to_string();
-    let sid = slide_id.to_string();
+    save_with_status(
+        pres_id.to_string(),
+        slide_id.to_string(),
+        main,
+        translation,
+        stage,
+        group,
+        op.save_status,
+    );
+}
 
+/// Wraps the slide-update PUT with save_status updates for the per-slide
+/// "Saved" indicator (#313). Sets `Saving` immediately, then `Saved`
+/// (auto-fades after 2s) on success or `Failed` (sticky) on error. Uses
+/// a monotonic token so an older fade timer can't clear a newer save.
+fn save_with_status(
+    pres_id: String,
+    slide_id: String,
+    main: String,
+    translation: String,
+    stage: String,
+    group: Option<String>,
+    save_status: RwSignal<std::collections::HashMap<String, (SaveStatus, u64)>>,
+) {
+    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
+    let key_saving = slide_id.clone();
+    save_status.update(|map| {
+        map.insert(key_saving, (SaveStatus::Saving, token));
+    });
+
+    let key_done = slide_id.clone();
     leptos::task::spawn_local(async move {
-        // Save all fields atomically. Do NOT update the selected_pres signal
-        // after save — that triggers a Leptos re-render which recreates textarea
-        // elements with prop:value from the signal, destroying any in-progress
-        // DOM edits the user is making in another field. The signal data becomes
-        // stale but is refreshed on presentation switch or page reload.
-        // Do NOT call restore_pending_focus — it refocuses the blurred field,
-        // which then triggers another blur on whatever field Playwright/user
-        // moved to, creating a race condition with concurrent saves.
-        let _ = api::presentations::update_slide_with_group(
+        let result = api::presentations::update_slide_with_group(
             &pres_id,
-            &sid,
+            &slide_id,
             &main,
             &translation,
             &stage,
-            group.clone(),
+            group,
         )
         .await;
+
+        match result {
+            Ok(_) => {
+                let key_for_saved = key_done.clone();
+                save_status.update(|map| {
+                    map.insert(key_for_saved, (SaveStatus::Saved, token));
+                });
+                TimeoutFuture::new(2_000).await;
+                save_status.update(|map| {
+                    if map.get(&key_done).map(|(_, t)| *t) == Some(token) {
+                        map.remove(&key_done);
+                    }
+                });
+            }
+            Err(_) => {
+                save_status.update(|map| {
+                    map.insert(key_done.clone(), (SaveStatus::Failed, token));
+                });
+            }
+        }
     });
 }
 
@@ -866,8 +912,6 @@ pub fn SlideList() -> impl IntoView {
                                                             let selected_pres = ctx.selected_presentation;
                                                             move |ev| {
                                                                 let (sel_start, sel_end) = capture_selection(&ev);
-                                                                // For group changes, we need to refetch full presentation
-                                                                // to update group inheritance across all slides
                                                                 op.pending_focus.set(Some((sid.clone(), "group".to_string(), sel_start, sel_end)));
 
                                                                 let doc = crate::utils::window::document();
@@ -875,21 +919,30 @@ pub fn SlideList() -> impl IntoView {
                                                                 let translation = get_field_value(&doc, &sid, "translation");
                                                                 let stage = get_field_value(&doc, &sid, "stage");
                                                                 let group_val = get_field_value(&doc, &sid, "group");
-                                                                let group = if group_val.trim().is_empty() { None } else { Some(group_val.trim().to_string()) };
+                                                                let group = if group_val.trim().is_empty() {
+                                                                    None
+                                                                } else {
+                                                                    Some(group_val.trim().to_string())
+                                                                };
 
-                                                                let pres_id = pres_id.clone();
-                                                                let sid = sid.clone();
-                                                                let op = op.clone();
+                                                                save_with_status(
+                                                                    pres_id.clone(),
+                                                                    sid.clone(),
+                                                                    main,
+                                                                    translation,
+                                                                    stage,
+                                                                    group,
+                                                                    op.save_status,
+                                                                );
+
+                                                                // Refetch for group inheritance display, then restore focus.
+                                                                let pres_id_for_refetch = pres_id.clone();
+                                                                let op_for_restore = op.clone();
                                                                 leptos::task::spawn_local(async move {
-                                                                    let _ = api::presentations::update_slide_with_group(
-                                                                        &pres_id, &sid,
-                                                                        &main, &translation, &stage, group,
-                                                                    ).await;
-                                                                    // Refetch to update group inheritance display
-                                                                    if let Ok(detail) = api::presentations::get_presentation(&pres_id).await {
+                                                                    if let Ok(detail) = api::presentations::get_presentation(&pres_id_for_refetch).await {
                                                                         selected_pres.set(Some(detail.presentation));
                                                                     }
-                                                                    restore_pending_focus(&op);
+                                                                    restore_pending_focus(&op_for_restore);
                                                                 });
                                                             }
                                                         }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -134,10 +134,46 @@ fn save_all_fields_from_dom(
     );
 }
 
-/// Wraps the slide-update PUT with save_status updates for the per-slide
-/// "Saved" indicator (#313). Sets `Saving` immediately, then `Saved`
-/// (auto-fades after 2s) on success or `Failed` (sticky) on error. Uses
-/// a monotonic token so an older fade timer can't clear a newer save.
+/// Status-map signal alias used by the save-status helpers (#313).
+type SaveStatusMap = RwSignal<std::collections::HashMap<String, (SaveStatus, u64)>>;
+
+/// Mark a slide as `Saving` and return its monotonic token. Callers pass the
+/// token to `finish_save_status_ok` / `finish_save_status_err` to ensure a
+/// stale completion can't overwrite a newer save's entry (#313).
+fn start_save_status(slide_id: &str, save_status: SaveStatusMap) -> u64 {
+    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
+    let key = slide_id.to_string();
+    save_status.update(|map| {
+        map.insert(key, (SaveStatus::Saving, token));
+    });
+    token
+}
+
+/// Mark a slide save as `Saved` and schedule the 2s fade-removal. The fade
+/// only clears the entry when the token still matches — guards against an
+/// older fade timer clearing a newer save's badge.
+async fn finish_save_status_ok(slide_id: String, save_status: SaveStatusMap, token: u64) {
+    let key_for_saved = slide_id.clone();
+    save_status.update(|map| {
+        map.insert(key_for_saved, (SaveStatus::Saved, token));
+    });
+    TimeoutFuture::new(2_000).await;
+    save_status.update(|map| {
+        if map.get(&slide_id).map(|(_, t)| *t) == Some(token) {
+            map.remove(&slide_id);
+        }
+    });
+}
+
+/// Mark a slide save as `Failed` (sticky until the next save attempt).
+fn finish_save_status_err(slide_id: String, save_status: SaveStatusMap, token: u64) {
+    save_status.update(|map| {
+        map.insert(slide_id, (SaveStatus::Failed, token));
+    });
+}
+
+/// Fire-and-forget save with indicator wiring. Used by the three textarea
+/// blur handlers where no refetch is needed.
 fn save_with_status(
     pres_id: String,
     slide_id: String,
@@ -145,15 +181,9 @@ fn save_with_status(
     translation: String,
     stage: String,
     group: Option<String>,
-    save_status: RwSignal<std::collections::HashMap<String, (SaveStatus, u64)>>,
+    save_status: SaveStatusMap,
 ) {
-    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
-    let key_saving = slide_id.clone();
-    save_status.update(|map| {
-        map.insert(key_saving, (SaveStatus::Saving, token));
-    });
-
-    let key_done = slide_id.clone();
+    let token = start_save_status(&slide_id, save_status);
     leptos::task::spawn_local(async move {
         let result = api::presentations::update_slide_with_group(
             &pres_id,
@@ -166,23 +196,8 @@ fn save_with_status(
         .await;
 
         match result {
-            Ok(_) => {
-                let key_for_saved = key_done.clone();
-                save_status.update(|map| {
-                    map.insert(key_for_saved, (SaveStatus::Saved, token));
-                });
-                TimeoutFuture::new(2_000).await;
-                save_status.update(|map| {
-                    if map.get(&key_done).map(|(_, t)| *t) == Some(token) {
-                        map.remove(&key_done);
-                    }
-                });
-            }
-            Err(_) => {
-                save_status.update(|map| {
-                    map.insert(key_done.clone(), (SaveStatus::Failed, token));
-                });
-            }
+            Ok(_) => finish_save_status_ok(slide_id, save_status, token).await,
+            Err(_) => finish_save_status_err(slide_id, save_status, token),
         }
     });
 }
@@ -654,43 +669,46 @@ pub fn SlideList() -> impl IntoView {
                                         }
                                     })}
                                     {
-                                        let sid_for_when = slide_id_for_badge.clone();
-                                        let sid_for_render = slide_id_for_badge.clone();
+                                        // Memo: derives this slide's status from the shared map.
+                                        // The body runs whenever any slide saves, but the Memo
+                                        // only NOTIFIES subscribers when THIS slide's value
+                                        // changes — so `<Show>` and its render closure only
+                                        // re-evaluate when our own status changes.
+                                        let sid_for_memo = slide_id_for_badge.clone();
                                         let save_status = op.save_status;
+                                        let badge_status = Memo::new(move |_| {
+                                            save_status.get().get(&sid_for_memo).map(|(s, _)| *s)
+                                        });
                                         view! {
-                                            <Show when=move || save_status.get().contains_key(&sid_for_when)>
-                                                {
-                                                    let sid_for_render = sid_for_render.clone();
-                                                    move || {
-                                                        let map = save_status.get();
-                                                        let Some((status, _)) = map.get(&sid_for_render).copied() else {
-                                                            return view! { <span></span> }.into_any();
-                                                        };
-                                                        match status {
-                                                            SaveStatus::Saving => view! {
-                                                                <span
-                                                                    class="operator__slide-save-indicator"
-                                                                    data-role="slide-save-indicator"
-                                                                    data-status="saving"
-                                                                >"Saving…"</span>
-                                                            }.into_any(),
-                                                            SaveStatus::Saved => view! {
-                                                                <span
-                                                                    class="operator__slide-save-indicator"
-                                                                    data-role="slide-save-indicator"
-                                                                    data-status="saved"
-                                                                >"Saved ✓"</span>
-                                                            }.into_any(),
-                                                            SaveStatus::Failed => view! {
-                                                                <span
-                                                                    class="operator__slide-save-indicator"
-                                                                    data-role="slide-save-indicator"
-                                                                    data-status="failed"
-                                                                >"Save failed"</span>
-                                                            }.into_any(),
-                                                        }
+                                            <Show when=move || badge_status.get().is_some()>
+                                                {move || {
+                                                    let Some(status) = badge_status.get() else {
+                                                        return view! { <span></span> }.into_any();
+                                                    };
+                                                    match status {
+                                                        SaveStatus::Saving => view! {
+                                                            <span
+                                                                class="operator__slide-save-indicator"
+                                                                data-role="slide-save-indicator"
+                                                                data-status="saving"
+                                                            >"Saving…"</span>
+                                                        }.into_any(),
+                                                        SaveStatus::Saved => view! {
+                                                            <span
+                                                                class="operator__slide-save-indicator"
+                                                                data-role="slide-save-indicator"
+                                                                data-status="saved"
+                                                            >"Saved ✓"</span>
+                                                        }.into_any(),
+                                                        SaveStatus::Failed => view! {
+                                                            <span
+                                                                class="operator__slide-save-indicator"
+                                                                data-role="slide-save-indicator"
+                                                                data-status="failed"
+                                                            >"Save failed"</span>
+                                                        }.into_any(),
                                                     }
-                                                }
+                                                }}
                                             </Show>
                                         }
                                     }
@@ -945,24 +963,37 @@ pub fn SlideList() -> impl IntoView {
                                                                     Some(group_val.trim().to_string())
                                                                 };
 
-                                                                save_with_status(
-                                                                    pres_id.clone(),
-                                                                    sid.clone(),
-                                                                    main,
-                                                                    translation,
-                                                                    stage,
-                                                                    group,
-                                                                    op.save_status,
-                                                                );
-
-                                                                // Refetch for group inheritance display, then restore focus.
-                                                                let pres_id_for_refetch = pres_id.clone();
+                                                                // PATCH first, refetch after save succeeds (avoids the
+                                                                // race where a refetch lands before the save), then mark
+                                                                // the indicator Saved. Indicator state is consistent with
+                                                                // what the operator actually sees on the next snapshot.
+                                                                let save_status = op.save_status;
+                                                                let token = start_save_status(&sid, save_status);
+                                                                let pres_id_for_save = pres_id.clone();
+                                                                let sid_for_save = sid.clone();
                                                                 let op_for_restore = op.clone();
                                                                 leptos::task::spawn_local(async move {
-                                                                    if let Ok(detail) = api::presentations::get_presentation(&pres_id_for_refetch).await {
-                                                                        selected_pres.set(Some(detail.presentation));
+                                                                    let result = api::presentations::update_slide_with_group(
+                                                                        &pres_id_for_save,
+                                                                        &sid_for_save,
+                                                                        &main,
+                                                                        &translation,
+                                                                        &stage,
+                                                                        group,
+                                                                    )
+                                                                    .await;
+                                                                    match result {
+                                                                        Ok(_) => {
+                                                                            if let Ok(detail) = api::presentations::get_presentation(&pres_id_for_save).await {
+                                                                                selected_pres.set(Some(detail.presentation));
+                                                                            }
+                                                                            restore_pending_focus(&op_for_restore);
+                                                                            finish_save_status_ok(sid_for_save, save_status, token).await;
+                                                                        }
+                                                                        Err(_) => {
+                                                                            finish_save_status_err(sid_for_save, save_status, token);
+                                                                        }
                                                                     }
-                                                                    restore_pending_focus(&op_for_restore);
                                                                 });
                                                             }
                                                         }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 
-use gloo_timers::future::TimeoutFuture;
 use leptos::prelude::*;
 use presenter_core::{resolve_sequence, ResolvedSlide};
 use wasm_bindgen::JsCast;
@@ -16,11 +14,9 @@ use super::slide_list_utils::{
     apply_focused_class, field_has_warning, format_multiline, reorder_slide_ids,
     slide_has_any_warning,
 };
-
-/// Monotonic token used to invalidate stale fade timers (#313).
-/// Each save increments this and stamps the per-slide save_status entry;
-/// the 2s fade timer only removes the entry if the token still matches.
-static SAVE_TOKEN: AtomicU64 = AtomicU64::new(0);
+use super::slide_save::{
+    finish_save_status_err, finish_save_status_ok, save_with_status, start_save_status,
+};
 
 /// Get a textarea/input value from the DOM by slide_id and field name.
 fn get_field_value(doc: &web_sys::Document, slide_id: &str, field: &str) -> String {
@@ -132,74 +128,6 @@ fn save_all_fields_from_dom(
         group,
         op.save_status,
     );
-}
-
-/// Status-map signal alias used by the save-status helpers (#313).
-type SaveStatusMap = RwSignal<std::collections::HashMap<String, (SaveStatus, u64)>>;
-
-/// Mark a slide as `Saving` and return its monotonic token. Callers pass the
-/// token to `finish_save_status_ok` / `finish_save_status_err` to ensure a
-/// stale completion can't overwrite a newer save's entry (#313).
-fn start_save_status(slide_id: &str, save_status: SaveStatusMap) -> u64 {
-    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
-    let key = slide_id.to_string();
-    save_status.update(|map| {
-        map.insert(key, (SaveStatus::Saving, token));
-    });
-    token
-}
-
-/// Mark a slide save as `Saved` and schedule the 2s fade-removal. The fade
-/// only clears the entry when the token still matches — guards against an
-/// older fade timer clearing a newer save's badge.
-async fn finish_save_status_ok(slide_id: String, save_status: SaveStatusMap, token: u64) {
-    let key_for_saved = slide_id.clone();
-    save_status.update(|map| {
-        map.insert(key_for_saved, (SaveStatus::Saved, token));
-    });
-    TimeoutFuture::new(2_000).await;
-    save_status.update(|map| {
-        if map.get(&slide_id).map(|(_, t)| *t) == Some(token) {
-            map.remove(&slide_id);
-        }
-    });
-}
-
-/// Mark a slide save as `Failed` (sticky until the next save attempt).
-fn finish_save_status_err(slide_id: String, save_status: SaveStatusMap, token: u64) {
-    save_status.update(|map| {
-        map.insert(slide_id, (SaveStatus::Failed, token));
-    });
-}
-
-/// Fire-and-forget save with indicator wiring. Used by the three textarea
-/// blur handlers where no refetch is needed.
-fn save_with_status(
-    pres_id: String,
-    slide_id: String,
-    main: String,
-    translation: String,
-    stage: String,
-    group: Option<String>,
-    save_status: SaveStatusMap,
-) {
-    let token = start_save_status(&slide_id, save_status);
-    leptos::task::spawn_local(async move {
-        let result = api::presentations::update_slide_with_group(
-            &pres_id,
-            &slide_id,
-            &main,
-            &translation,
-            &stage,
-            group,
-        )
-        .await;
-
-        match result {
-            Ok(_) => finish_save_status_ok(slide_id, save_status, token).await,
-            Err(_) => finish_save_status_err(slide_id, save_status, token),
-        }
-    });
 }
 
 /// Capture current selection range from a textarea event.

--- a/crates/presenter-ui/src/components/slide_save.rs
+++ b/crates/presenter-ui/src/components/slide_save.rs
@@ -1,0 +1,92 @@
+//! Per-slide save-status state machine for the worship slide editor (#313).
+//!
+//! The operator's worship slide editor saves on blur and shows a transient
+//! "Saved ✓ / Saving… / Save failed" badge per slide. This module owns the
+//! state machine for that badge:
+//!
+//! - `start_save_status` marks the slide as `Saving` and returns a token
+//! - `finish_save_status_ok` marks `Saved` and schedules the 2s fade
+//! - `finish_save_status_err` marks `Failed` (sticky)
+//! - `save_with_status` is the fire-and-forget wrapper used by textarea blur
+//!
+//! The monotonic `SAVE_TOKEN` guards against a stale fade timer clearing a
+//! newer save's entry — the fade only removes the entry when the token still
+//! matches the one captured at save start.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use gloo_timers::future::TimeoutFuture;
+use leptos::prelude::*;
+
+use crate::api;
+use crate::state::operator::SaveStatus;
+
+/// Monotonic token used to invalidate stale fade timers.
+static SAVE_TOKEN: AtomicU64 = AtomicU64::new(0);
+
+/// Status-map signal alias used by the save-status helpers.
+pub(super) type SaveStatusMap = RwSignal<HashMap<String, (SaveStatus, u64)>>;
+
+/// Mark a slide as `Saving` and return its monotonic token. Callers pass the
+/// token to `finish_save_status_ok` / `finish_save_status_err` so a stale
+/// completion can't overwrite a newer save's entry.
+pub(super) fn start_save_status(slide_id: &str, save_status: SaveStatusMap) -> u64 {
+    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
+    let key = slide_id.to_string();
+    save_status.update(|map| {
+        map.insert(key, (SaveStatus::Saving, token));
+    });
+    token
+}
+
+/// Mark a slide save as `Saved` and schedule the 2s fade-removal. The fade
+/// only clears the entry when the token still matches.
+pub(super) async fn finish_save_status_ok(
+    slide_id: String,
+    save_status: SaveStatusMap,
+    token: u64,
+) {
+    let key_for_saved = slide_id.clone();
+    save_status.update(|map| {
+        map.insert(key_for_saved, (SaveStatus::Saved, token));
+    });
+    TimeoutFuture::new(2_000).await;
+    save_status.update(|map| {
+        if map.get(&slide_id).map(|(_, t)| *t) == Some(token) {
+            map.remove(&slide_id);
+        }
+    });
+}
+
+/// Mark a slide save as `Failed` (sticky until the next save attempt).
+pub(super) fn finish_save_status_err(slide_id: String, save_status: SaveStatusMap, token: u64) {
+    save_status.update(|map| {
+        map.insert(slide_id, (SaveStatus::Failed, token));
+    });
+}
+
+/// Fire-and-forget save with indicator wiring. Used by the textarea blur
+/// handlers where no refetch is needed.
+pub(super) fn save_with_status(
+    pres_id: String,
+    slide_id: String,
+    main: String,
+    translation: String,
+    stage: String,
+    group: Option<String>,
+    save_status: SaveStatusMap,
+) {
+    let token = start_save_status(&slide_id, save_status);
+    leptos::task::spawn_local(async move {
+        let result = api::presentations::update_slide_with_group(
+            &pres_id, &slide_id, &main, &translation, &stage, group,
+        )
+        .await;
+
+        match result {
+            Ok(_) => finish_save_status_ok(slide_id, save_status, token).await,
+            Err(_) => finish_save_status_err(slide_id, save_status, token),
+        }
+    });
+}

--- a/crates/presenter-ui/src/state/operator.rs
+++ b/crates/presenter-ui/src/state/operator.rs
@@ -1,4 +1,13 @@
 use leptos::prelude::*;
+use std::collections::HashMap;
+
+/// Per-slide save status for the worship slide editor's "Saved" indicator (#313).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveStatus {
+    Saving,
+    Saved,
+    Failed,
+}
 
 /// Focus restoration data: (slide_id, field_name, selection_start, selection_end)
 pub type PendingFocus = (String, String, u32, u32);
@@ -50,6 +59,9 @@ pub struct OperatorState {
     pub stage_layout_loading: RwSignal<bool>,
     /// Slide ID currently being triggered (for is-loading class)
     pub triggering_slide_id: RwSignal<Option<String>>,
+    /// Per-slide save status keyed by slide_id, with a monotonic token to
+    /// prevent stale fade timers from clearing a newer save's entry (#313).
+    pub save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>,
 }
 
 impl OperatorState {
@@ -94,6 +106,7 @@ impl OperatorState {
             playlist_edit_initial: RwSignal::new(None),
             stage_layout_loading: RwSignal::new(false),
             triggering_slide_id: RwSignal::new(None),
+            save_status: RwSignal::new(HashMap::new()),
         }
     }
 }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2852,3 +2852,24 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     pointer-events: none;
     bottom: -2px;
 }
+
+/* ===== Worship slide save indicator (#313) ===== */
+.operator__slide-save-indicator {
+    margin-left: 0.5rem;
+    font-size: 0.85em;
+    font-weight: 500;
+    transition: opacity 200ms ease-out;
+}
+
+.operator__slide-save-indicator[data-status="saved"] {
+    color: #16a34a;
+}
+
+.operator__slide-save-indicator[data-status="saving"] {
+    color: #6b7280;
+}
+
+.operator__slide-save-indicator[data-status="failed"] {
+    color: #dc2626;
+    font-weight: 600;
+}

--- a/docs/superpowers/plans/2026-05-11-worship-slide-saved-indicator.md
+++ b/docs/superpowers/plans/2026-05-11-worship-slide-saved-indicator.md
@@ -1,0 +1,819 @@
+# Worship Slide Editor: Drop Save Button + "Saved ✓" Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the misleading Save button on the worship slide editor; add a transient per-slide "Saved ✓" indicator so the operator sees that blur-time persistence happened.
+
+**Architecture:** Add a per-slide save-status map to `OperatorState`. Wire the existing blur-time save path to update that map (Saving → Saved → fade, or Failed). Render the badge in the slide header. Remove the Save button from `operator__slide-controls`. A monotonic token prevents an earlier fade-timer from clearing a later save's entry.
+
+**Tech Stack:** Rust + Leptos (WASM), CSS, Playwright (TypeScript).
+
+**Spec:** `docs/superpowers/specs/2026-05-11-worship-slide-saved-indicator-design.md` (commit f7f65b4)
+
+---
+
+## Context
+
+Issue #313: the operator thinks they must click a Save button on the worship slide editor to persist edits. In reality, the `on:blur` handler on each textarea already saves via `save_all_fields_from_dom(...)`. The fix is to (a) remove the misleading button and (b) add a visible badge confirming each save.
+
+**Key existing code:**
+
+- `crates/presenter-ui/src/state/operator.rs` — `OperatorState` struct (53 fields incl. focused_slide_id, pending_focus, etc.). New `SaveStatus` enum + `save_status` HashMap field go here.
+- `crates/presenter-ui/src/components/slide_list.rs:82-142` — `save_all_fields_from_dom` function. Spawns async PUT, ignores result. Must be rewired to update `save_status`.
+- `crates/presenter-ui/src/components/slide_list.rs:614-635` — the `<button data-action="save">` to remove.
+- `crates/presenter-ui/src/components/slide_list.rs:583-606` — slide-header markup where the badge `<Show>` block is inserted.
+- `crates/presenter-ui/src/components/slide_list.rs:856+` — Group `<input>` blur handler that also calls `update_slide_with_group` inline. Must use the same status helper.
+- No existing tests reference `data-action="save"` outside the component file itself (verified by grep). No tests to delete.
+
+---
+
+## File Structure
+
+### Created files
+
+| File | Responsibility |
+|------|----------------|
+| `tests/e2e/operator-slide-save-indicator.spec.ts` | 3-scenario E2E covering: Saved ✓ appears+fades on success, no Save button in controls, "Save failed" sticky on 500. |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace) | bump `[workspace.package].version` 0.4.73 → 0.4.74 |
+| `crates/presenter-ui/src/state/operator.rs` | add `SaveStatus` enum + `save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>` field + constructor init |
+| `crates/presenter-ui/src/components/slide_list.rs` | extract `save_with_status` helper, rewire `save_all_fields_from_dom` + Group blur to use it; remove the Save button; add badge `<Show>` to slide header |
+| `crates/presenter-ui/styles/operator.css` | add `.operator__slide-save-indicator` rules with status-attribute color variants |
+
+---
+
+## Task 1: Version bump 0.4.73 → 0.4.74
+
+**Files:**
+- Modify: `Cargo.toml` (workspace `[workspace.package].version`)
+
+- [ ] **Step 1: Edit version**
+
+In `/home/newlevel/devel/presenter/presenter-dev2/Cargo.toml`, change:
+
+```toml
+version = "0.4.73"
+```
+
+to:
+
+```toml
+version = "0.4.74"
+```
+
+- [ ] **Step 2: Refresh Cargo.lock**
+
+Run: `cargo update -w`
+
+Expected: lines for each workspace member updating from `v0.4.73` → `v0.4.74`. No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.4.74"
+```
+
+---
+
+## Task 2: Write the regression-test-first Playwright E2E
+
+This task lands BEFORE the implementation, so scenario 2 fails RED (button still present) on this commit and turns GREEN once Task 5 removes it. Scenarios 1 and 3 also start RED (no indicator element exists yet) and turn GREEN after Tasks 3-6 ship the indicator. The plan-check + completion-report `✅ Regression test:` line cites scenario 2 by file:line and the RED + GREEN SHAs.
+
+**Files:**
+- Create: `tests/e2e/operator-slide-save-indicator.spec.ts`
+
+- [ ] **Step 1: Pick the closest reference test**
+
+Read `tests/e2e/operator-slide-edit.spec.ts` if it exists. If not, use `tests/e2e/stage-api-ndi.spec.ts` for the `beforeAll`/`afterAll` server bootstrap pattern (already used successfully in the prior NFC PR). Either way the spec needs the same `deriveTestConfig`/`startTestServer`/`stopServer` plumbing from `tests/e2e/support`.
+
+- [ ] **Step 2: Create the test file**
+
+Create `/home/newlevel/devel/presenter/presenter-dev2/tests/e2e/operator-slide-save-indicator.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(
+  page: import("@playwright/test").Page,
+  extraAllowed: RegExp[] = [],
+): string[] {
+  const messages: string[] = [];
+  const allowed = [...ALLOWED_CONSOLE_NOISE, ...extraAllowed];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!allowed.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+/**
+ * Helper: open the operator, select the first available presentation, put its
+ * first slide into edit mode. Returns the slide_id of the slide we're editing.
+ */
+async function openOperatorWithEditingSlide(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  // First library, first presentation
+  await page.locator('[data-role="library-list"] li').first().click();
+  await page.locator('[data-role="presentation-list"] li').first().click();
+  // Enter edit mode on the first slide
+  const slideCard = page.locator('[data-role="slide-card"]').first();
+  await slideCard.locator('[data-action="edit"]').click();
+  // Wait for the editor to materialize
+  await expect(slideCard.locator('textarea[data-field="main"]')).toBeVisible({
+    timeout: 5_000,
+  });
+  return (await slideCard.getAttribute("data-slide-id")) ?? "";
+}
+
+test('Saved indicator appears and fades after blur', async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-role="slide-card"][data-slide-id="${slideId}"]`);
+
+  // Type into the main textarea
+  const main = slideCard.locator('textarea[data-field="main"]');
+  await main.click();
+  await main.press("End");
+  await main.type(" autosave probe", { delay: 20 });
+
+  // Blur by clicking outside any editable region
+  await page.locator("body").click({ position: { x: 5, y: 5 } });
+
+  // Indicator must appear within 3s
+  const indicator = slideCard.locator('[data-role="slide-save-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 3_000 });
+  await expect(indicator).toHaveAttribute("data-status", "saved");
+  await expect(indicator).toHaveText(/Saved/);
+
+  // Indicator must fade (disappear) within 5s after that
+  await expect(indicator).toHaveCount(0, { timeout: 5_000 });
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test('Save button is absent from slide controls (regression #313)', async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-role="slide-card"][data-slide-id="${slideId}"]`);
+
+  // The Save button used to live in operator__slide-controls. After #313 it must be gone.
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="save"]'),
+  ).toHaveCount(0);
+
+  // Duplicate and Delete must remain.
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="duplicate"]'),
+  ).toBeVisible();
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="delete"]'),
+  ).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test('Save failed sticks when server returns 500', async ({ page }) => {
+  // 500 on the slide-update PUT will produce a console error; allow it for this test.
+  const consoleMessages = collectConsoleErrors(page, [
+    /Failed to load resource.*500/i,
+  ]);
+
+  await page.route("**/presentations/*/slides/*", (route) => {
+    if (route.request().method() === "PUT") {
+      route.fulfill({ status: 500, body: "boom" });
+    } else {
+      route.continue();
+    }
+  });
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-role="slide-card"][data-slide-id="${slideId}"]`);
+
+  const main = slideCard.locator('textarea[data-field="main"]');
+  await main.click();
+  await main.press("End");
+  await main.type(" will fail", { delay: 20 });
+  await page.locator("body").click({ position: { x: 5, y: 5 } });
+
+  const indicator = slideCard.locator('[data-role="slide-save-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 3_000 });
+  await expect(indicator).toHaveAttribute("data-status", "failed");
+  await expect(indicator).toHaveText(/failed/i);
+
+  // Must NOT fade within 5s
+  await page.waitForTimeout(5_000);
+  await expect(indicator).toBeVisible();
+  await expect(indicator).toHaveAttribute("data-status", "failed");
+
+  expect(consoleMessages).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run the test — expect it to FAIL (RED)**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npm run test:playwright -- operator-slide-save-indicator
+```
+
+Expected: AT LEAST scenario "Save button is absent from slide controls (regression #313)" FAILS — the button still exists. Scenarios 1 and 3 likely also fail because the indicator element doesn't exist yet. This RED state is the regression-test-first baseline. **Note the test commit SHA after the next step — this is the `RED` SHA you cite in the completion report.**
+
+- [ ] **Step 4: Commit (RED)**
+
+```bash
+git add tests/e2e/operator-slide-save-indicator.spec.ts
+git commit -m "test(e2e): regression test for #313 — Save button removed + Saved indicator (RED)"
+```
+
+Record this commit SHA — it's the RED reference.
+
+---
+
+## Task 3: Add `SaveStatus` enum + `save_status` field to `OperatorState`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/state/operator.rs`
+
+- [ ] **Step 1: Add the import and enum at the top of the file**
+
+Open `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/state/operator.rs`. After `use leptos::prelude::*;` (line 1), add:
+
+```rust
+use std::collections::HashMap;
+
+/// Per-slide save status for the worship slide editor's "Saved" indicator (#313).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveStatus {
+    Saving,
+    Saved,
+    Failed,
+}
+```
+
+- [ ] **Step 2: Add the field to `OperatorState`**
+
+Inside the existing `pub struct OperatorState { ... }` block, after the last field `pub triggering_slide_id: RwSignal<Option<String>>,` (line 52), add:
+
+```rust
+    /// Per-slide save status keyed by slide_id, with a monotonic token to
+    /// prevent stale fade timers from clearing a newer save's entry (#313).
+    pub save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>,
+```
+
+- [ ] **Step 3: Initialise it in the constructor**
+
+In `OperatorState::new()`, after `triggering_slide_id: RwSignal::new(None),` (line 96), add a trailing line so the struct literal ends with:
+
+```rust
+            triggering_slide_id: RwSignal::new(None),
+            save_status: RwSignal::new(HashMap::new()),
+```
+
+- [ ] **Step 4: Run WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: `Finished` with zero warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+git add crates/presenter-ui/src/state/operator.rs
+git commit -m "feat(operator): add SaveStatus + save_status map for indicator (#313)"
+```
+
+---
+
+## Task 4: Extract `save_with_status` helper + rewire blur saves
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs` (the `save_all_fields_from_dom` function and the Group `<input>` blur handler)
+
+- [ ] **Step 1: Add the imports**
+
+At the top of `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`, add (or extend existing `use` lines):
+
+```rust
+use crate::state::operator::SaveStatus;
+use gloo_timers::future::TimeoutFuture;
+use std::sync::atomic::{AtomicU64, Ordering};
+```
+
+If `gloo_timers` isn't already a dependency, check `crates/presenter-ui/Cargo.toml`. The crate is widely used in the codebase (search for `TimeoutFuture` elsewhere). If absent, add `gloo-timers = "0.3"` to `[dependencies]` in that Cargo.toml — but verify with grep first; do not add a dep that already exists.
+
+- [ ] **Step 2: Add the token counter near the top of the file**
+
+After the imports, add:
+
+```rust
+/// Monotonic token used to invalidate stale fade timers (#313).
+/// Each save increments this and stamps the per-slide entry; the fade
+/// only removes the entry if the token still matches at fade time.
+static SAVE_TOKEN: AtomicU64 = AtomicU64::new(0);
+```
+
+- [ ] **Step 3: Replace `save_all_fields_from_dom`**
+
+Find the existing function (around line 82-142). Replace its body with the version that uses `save_with_status`:
+
+```rust
+fn save_all_fields_from_dom(
+    pres_id: &str,
+    slide_id: &str,
+    _current_field: &str,
+    _sel_start: u32,
+    _sel_end: u32,
+    selected_pres: RwSignal<Option<presenter_core::Presentation>>,
+    op: &OperatorState,
+) {
+    let doc = crate::utils::window::document();
+
+    let main = get_field_value(&doc, slide_id, "main");
+    let translation = get_field_value(&doc, slide_id, "translation");
+    let stage = get_field_value(&doc, slide_id, "stage");
+    let group_val = get_field_value(&doc, slide_id, "group");
+    let group = if group_val.trim().is_empty() {
+        None
+    } else {
+        Some(group_val.trim().to_string())
+    };
+
+    // Skip no-op saves.
+    let pres = selected_pres.get_untracked();
+    if let Some(p) = &pres {
+        if let Some(slide) = p.slides.iter().find(|s| s.id.to_string() == slide_id) {
+            let orig = &slide.content;
+            let orig_group = orig.group.as_ref().map(|g| g.name().to_string());
+            if orig.main.value() == main
+                && orig.translation.value() == translation
+                && orig.stage.value() == stage
+                && orig_group == group
+            {
+                return;
+            }
+        }
+    }
+
+    save_with_status(
+        pres_id.to_string(),
+        slide_id.to_string(),
+        main,
+        translation,
+        stage,
+        group,
+        op.save_status,
+    );
+}
+```
+
+- [ ] **Step 4: Add the new `save_with_status` helper directly below `save_all_fields_from_dom`**
+
+```rust
+/// Wraps the slide-update PUT with save_status updates for the per-slide
+/// "Saved" indicator (#313). Sets `Saving` immediately, then `Saved`
+/// (auto-fades after 2s) on success or `Failed` (sticky) on error. Uses
+/// a monotonic token so an older fade timer can't clear a newer save.
+fn save_with_status(
+    pres_id: String,
+    slide_id: String,
+    main: String,
+    translation: String,
+    stage: String,
+    group: Option<String>,
+    save_status: RwSignal<std::collections::HashMap<String, (SaveStatus, u64)>>,
+) {
+    let token = SAVE_TOKEN.fetch_add(1, Ordering::Relaxed) + 1;
+    let key_saving = slide_id.clone();
+    save_status.update(|map| {
+        map.insert(key_saving, (SaveStatus::Saving, token));
+    });
+
+    let key_done = slide_id.clone();
+    leptos::task::spawn_local(async move {
+        let result = api::presentations::update_slide_with_group(
+            &pres_id,
+            &slide_id,
+            &main,
+            &translation,
+            &stage,
+            group,
+        )
+        .await;
+
+        match result {
+            Ok(_) => {
+                let key_for_saved = key_done.clone();
+                save_status.update(|map| {
+                    map.insert(key_for_saved, (SaveStatus::Saved, token));
+                });
+                TimeoutFuture::new(2_000).await;
+                save_status.update(|map| {
+                    if map.get(&key_done).map(|(_, t)| *t) == Some(token) {
+                        map.remove(&key_done);
+                    }
+                });
+            }
+            Err(_) => {
+                save_status.update(|map| {
+                    map.insert(key_done.clone(), (SaveStatus::Failed, token));
+                });
+            }
+        }
+    });
+}
+```
+
+- [ ] **Step 5: Update `save_all_fields_from_dom` call sites to pass `&op`**
+
+The three textarea `on:blur` handlers around lines 760-840 each call `save_all_fields_from_dom(&pres_id, &sid, "main", sel_start, sel_end, ctx.selected_presentation, &op);`. The signature is unchanged (still `op: &OperatorState`), so call sites work as-is. **Verify the existing 3 call sites** still compile and pass `&op`.
+
+- [ ] **Step 6: Update the Group `<input>` blur handler**
+
+Find the Group input's `on:blur` (around line 856+). It currently spawns its own async task that calls `update_slide_with_group` directly. Replace that async block with a call to `save_with_status` so the Group save also updates the indicator. Pseudocode:
+
+```rust
+on:blur={
+    let pres_id = pres_id_edit.clone();
+    let sid = slide_id_edit.clone();
+    let op = op.clone();
+    let selected_pres = ctx.selected_presentation;
+    move |ev| {
+        let (sel_start, sel_end) = capture_selection(&ev);
+        op.pending_focus.set(Some((sid.clone(), "group".to_string(), sel_start, sel_end)));
+
+        let doc = crate::utils::window::document();
+        let main = get_field_value(&doc, &sid, "main");
+        let translation = get_field_value(&doc, &sid, "translation");
+        let stage = get_field_value(&doc, &sid, "stage");
+        let group_val = get_field_value(&doc, &sid, "group");
+        let group = if group_val.trim().is_empty() {
+            None
+        } else {
+            Some(group_val.trim().to_string())
+        };
+
+        // Use the same helper so the indicator wires up on Group edits too.
+        save_with_status(
+            pres_id.clone(),
+            sid.clone(),
+            main,
+            translation,
+            stage,
+            group,
+            op.save_status,
+        );
+
+        // Refetch for group inheritance display, then restore focus.
+        let pres_id_for_refetch = pres_id.clone();
+        let op_for_restore = op.clone();
+        leptos::task::spawn_local(async move {
+            if let Ok(detail) = api::presentations::get_presentation(&pres_id_for_refetch).await {
+                selected_pres.set(Some(detail.presentation));
+            }
+            restore_pending_focus(&op_for_restore);
+        });
+    }
+}
+```
+
+(The refetch + focus restore retains the existing behavior; `save_with_status` runs concurrently. If race conditions surface in QA they can be addressed in a follow-up; the existing inline path was already racey.)
+
+- [ ] **Step 7: Run WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: `Finished` with zero warnings. Fix any `unused_imports` or signature mismatches and re-run.
+
+- [ ] **Step 8: Workspace clippy from root**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: `Finished` with zero warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/slide_list.rs crates/presenter-ui/Cargo.toml
+git commit -m "feat(operator): wire save-status updates into blur saves (#313)"
+```
+
+(If `Cargo.toml` wasn't touched in step 1, omit it from the `git add`.)
+
+---
+
+## Task 5: Render the badge in the slide header + remove the Save button
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/slide_list.rs` (slide-header block + slide-controls block)
+
+- [ ] **Step 1: Add the badge `<Show>` block in the slide header**
+
+Open `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/src/components/slide_list.rs`. Find the existing slide-header block (around line 583-606). Immediately after the existing `{group_badge_text.clone().map(|g| { ... })}` block (around line 593-606), insert:
+
+```rust
+                                    {
+                                        let sid_for_badge = slide_id.clone();
+                                        let save_status = op.save_status;
+                                        view! {
+                                            <Show when=move || save_status.get().contains_key(&sid_for_badge)>
+                                                {
+                                                    let sid_for_render = sid_for_badge.clone();
+                                                    move || {
+                                                        let map = save_status.get();
+                                                        let Some((status, _)) = map.get(&sid_for_render).copied() else {
+                                                            return view! { <span></span> }.into_any();
+                                                        };
+                                                        match status {
+                                                            SaveStatus::Saving => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="saving"
+                                                                >"Saving…"</span>
+                                                            }.into_any(),
+                                                            SaveStatus::Saved => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="saved"
+                                                                >"Saved ✓"</span>
+                                                            }.into_any(),
+                                                            SaveStatus::Failed => view! {
+                                                                <span
+                                                                    class="operator__slide-save-indicator"
+                                                                    data-role="slide-save-indicator"
+                                                                    data-status="failed"
+                                                                >"Save failed"</span>
+                                                            }.into_any(),
+                                                        }
+                                                    }
+                                                }
+                                            </Show>
+                                        }
+                                    }
+```
+
+(If `slide_id` isn't already in scope at this point in the closure stack, look at the existing `slide_id_edit.clone()` bindings just above and re-clone from there.)
+
+- [ ] **Step 2: Remove the Save button**
+
+Find the `<div class="operator__slide-controls">` block (around line 614). Remove the entire `<button type="button" data-action="save" ...>...</button>` element including its `on:click=move |_| { ... }` closure. The block becomes:
+
+```rust
+                                            <div class="operator__slide-controls">
+                                                <button type="button" data-action="duplicate"
+                                                    on:click=move |_| { /* existing duplicate closure */ }
+                                                >"Duplicate"</button>
+                                                <button type="button" data-action="delete"
+                                                    on:click=move |_| { /* existing delete closure */ }
+                                                >"Delete"</button>
+                                            </div>
+```
+
+Also remove the now-dead `let pres_id_save = pres_id_edit.clone();`, `let slide_id_save = slide_id_edit.clone();`, and `let selected_pres_save = ctx.selected_presentation;` bindings at the start of the closure that built that view.
+
+- [ ] **Step 3: Add `data-slide-id` to the slide card root**
+
+The E2E test selects each slide card via `[data-role="slide-card"][data-slide-id="..."]`. Check whether the existing slide card root (the outer `<article>` or `<li>` that holds the slide) already exposes `data-slide-id`. If not, add `data-slide-id=slide_id.clone()` to it. (This is a one-line change that makes the test deterministic; if the attribute already exists, leave it.)
+
+- [ ] **Step 4: WASM clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 5: Workspace clippy**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2 && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/slide_list.rs
+git commit -m "feat(operator): render Saved indicator + remove Save button (#313)"
+```
+
+Record this SHA — it's the GREEN reference for the regression test.
+
+---
+
+## Task 6: CSS for the indicator
+
+**Files:**
+- Modify: `crates/presenter-ui/styles/operator.css`
+
+- [ ] **Step 1: Append the new rules**
+
+At the end of `/home/newlevel/devel/presenter/presenter-dev2/crates/presenter-ui/styles/operator.css`, append:
+
+```css
+/* ===== Worship slide save indicator (#313) ===== */
+.operator__slide-save-indicator {
+    margin-left: 0.5rem;
+    font-size: 0.85em;
+    font-weight: 500;
+    transition: opacity 200ms ease-out;
+}
+
+.operator__slide-save-indicator[data-status="saved"] {
+    color: #16a34a;
+}
+
+.operator__slide-save-indicator[data-status="saving"] {
+    color: #6b7280;
+}
+
+.operator__slide-save-indicator[data-status="failed"] {
+    color: #dc2626;
+    font-weight: 600;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/presenter-ui/styles/operator.css
+git commit -m "style(operator): saved-indicator color variants (#313)"
+```
+
+---
+
+## Task 7: Re-run the E2E suite — must turn GREEN
+
+- [ ] **Step 1: Run all three scenarios**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+npm run test:playwright -- operator-slide-save-indicator
+```
+
+Expected: 3 passed. If any fail:
+
+- Scenario 1 fails on "indicator visible within 3s" → check that the badge's `data-role` is exactly `slide-save-indicator` and that `op.save_status` is the SAME signal instance shared by the save path and the renderer.
+- Scenario 2 fails (still has Save button) → Task 5 step 2 was not applied.
+- Scenario 3 fails (no failed state) → the PUT-route interception may not match; check the actual PUT URL path in network logs.
+
+If a fix is needed, edit the implementation files (NOT the test) and commit as a follow-up.
+
+- [ ] **Step 2: Capture the GREEN SHA**
+
+The GREEN reference is the SHA at which all three E2E scenarios pass — by default this is the Task 5 commit. If a fix commit was needed between Tasks 5 and 7, the GREEN SHA is the latter.
+
+---
+
+## Task 8: Push, monitor CI, manual verify on dev, open PR (controller-handled)
+
+This task is performed by the orchestrator, not a subagent.
+
+- [ ] **Step 1: Final local checks**
+
+```bash
+cd /home/newlevel/devel/presenter/presenter-dev2
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..
+cargo test --workspace -- --nocapture
+```
+
+All must pass.
+
+- [ ] **Step 2: Sync with main if needed and push**
+
+```bash
+git fetch origin
+git merge origin/main --no-edit   # only if dev is behind
+git push origin dev
+```
+
+- [ ] **Step 3: Capture run id and monitor**
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId
+# In a single background bash:
+sleep 1500 && gh run view <run-id> --json status,conclusion,jobs
+```
+
+Wait until ALL jobs (including Mutation Testing) report `success`. If any fail, `gh run view <run-id> --log-failed`, fix in ONE commit, push once.
+
+- [ ] **Step 4: Verify on dev**
+
+After Deploy to Dev is green:
+
+```bash
+curl -s 'http://10.77.8.134:8080/healthz'
+# Expect: {"channel":"dev","status":"ok","version":"0.4.74"}
+```
+
+Optionally drive the same Playwright flow against the live dev server to confirm the indicator works end-to-end on the deployed binary (not just the test server).
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --base main --head dev --title "feat(operator): drop Save button + add Saved indicator on worship slides (#313)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #313: the operator thought they had to click a Save button to persist worship-slide edits. Edits already saved on blur — the button was misleading. Removed the button and added a transient per-slide "Saved ✓" badge so persistence is visible.
+
+## What changed
+
+- `OperatorState` gains `SaveStatus` enum + `save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>`. Token guards against stale fade timers.
+- `save_all_fields_from_dom` and the Group `<input>` blur handler both route through a new `save_with_status` helper that sets `Saving`, then `Saved` (auto-fades after 2s) or `Failed` (sticky).
+- Slide header renders the badge via a `<Show>` block reading the map.
+- Save button removed from `operator__slide-controls`; Duplicate + Delete remain.
+- CSS adds `.operator__slide-save-indicator` with status-attribute color variants.
+- Playwright E2E `operator-slide-save-indicator.spec.ts` covers all three states (saved fades, no Save button, failed sticks).
+- Version bump 0.4.73 → 0.4.74.
+
+## Regression test
+
+`tests/e2e/operator-slide-save-indicator.spec.ts` — scenario `Save button is absent from slide controls (regression #313)`.
+RED on test commit `<task-2-sha>`; GREEN on fix commit `<task-5-sha>`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Replace `<task-2-sha>` and `<task-5-sha>` with the actual SHAs from Tasks 2 and 5 (or the GREEN fix commit if a later one was needed).
+
+Wait for `mergeStateStatus: CLEAN` and `mergeable: MERGEABLE` before reporting. Do NOT merge until the user says "merge it".
+
+---
+
+## Verification summary
+
+| Check | How to verify |
+|-------|---------------|
+| Save button removed from slide controls | Playwright scenario 2 |
+| "Saved ✓" appears within 3s of blur | Playwright scenario 1 |
+| "Saved ✓" fades within ~5s of appearing | Playwright scenario 1 |
+| "Save failed" sticks on PUT failure | Playwright scenario 3 |
+| Browser console clean across all three | `expect(consoleMessages).toEqual([])` |
+| Workspace builds | `cargo build --workspace` green |
+| Native clippy clean | `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` |
+| WASM clippy clean | from `crates/presenter-ui`: `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` |
+| Version bump | `Cargo.toml` workspace version is `0.4.74` |
+| Dev deploy | `/healthz` shows v0.4.74 |
+| Regression test cited | Bug-fix PR includes `✅ Regression test:` line with test path, line, RED + GREEN SHAs |

--- a/docs/superpowers/specs/2026-05-11-worship-slide-saved-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-11-worship-slide-saved-indicator-design.md
@@ -1,0 +1,186 @@
+# Worship Slide Editor: Drop Save Button + "Saved ✓" Indicator (Design)
+
+> **Status:** Approved
+> **Issue:** #313
+> **Created:** 2026-05-11
+
+## Problem
+
+The worship slide editor has three textareas (Main / Translation / Stage) plus a Group input. All four already save on blur via `save_all_fields_from_dom(...)`. A redundant Save button sits in the slide controls, leading the operator to believe they MUST click it before edits persist. The user's literal request:
+
+> "when editing worship slides i need to save each one with the save button, IT NEEDS TO SAVE AUTOMATICALLY AS SOON AS I TYPE SOMETHING IN THERE"
+
+After clarification, the chosen behavior is: **keep the current save-on-blur path, drop the misleading Save button, add a transient per-slide "Saved ✓" badge in the slide header so the operator sees that persistence happened.**
+
+## Goal
+
+Remove operator confusion about when edits persist. After tabbing/clicking out of any editor field, the operator must see a visible badge in the slide header confirming the save (or surfacing failure).
+
+## Approach
+
+Three slice changes to the WASM operator UI:
+
+1. Add per-slide save status to `OperatorState`.
+2. Wire `save_all_fields_from_dom` to write that status (Saving → Saved → fade, or Failed).
+3. Render the badge in the slide header; remove the Save button from slide controls; add CSS for the fade.
+
+No server changes. No schema changes. No new API.
+
+## Components
+
+### `crates/presenter-ui/src/state/operator.rs`
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveStatus {
+    Saving,
+    Saved,
+    Failed,
+}
+```
+
+Add a field to `OperatorState`:
+
+```rust
+pub save_status: RwSignal<std::collections::HashMap<String, SaveStatus>>,
+```
+
+Initialise as `RwSignal::new(HashMap::new())` in the existing constructor.
+
+### `crates/presenter-ui/src/components/slide_list.rs`
+
+#### `save_all_fields_from_dom` — wire the status updates
+
+Currently the function:
+
+1. Reads DOM values
+2. Skips if unchanged
+3. Spawns an async task that PUTs and ignores the result
+
+Updated flow:
+
+1. Read DOM values
+2. If unchanged → return (no status change)
+3. Set status to `Saving` for this slide_id
+4. Spawn:
+   - PUT via `api::presentations::update_slide_with_group(...)`
+   - If `Ok`: set `Saved`, then `TimeoutFuture::new(2000).await`, then remove the entry from the map (fades the badge)
+   - If `Err`: set `Failed` (sticky; replaced on next save attempt)
+
+The map entry is keyed by `slide_id: String`. `HashMap::get(&slide_id)` is cheap; the `RwSignal<HashMap>` re-renders the slide header on change but Leptos only re-flows the affected `<Show>`, so cost is one row.
+
+#### Slide header — render the badge
+
+In the existing slide-header `<header>` block (around line 583-606), add a sibling element next to the slide group:
+
+```rust
+<Show when=move || op.save_status.get().contains_key(&slide_id_for_badge)>
+    {move || {
+        let status = op.save_status.get();
+        let s = status.get(&slide_id_for_badge);
+        match s {
+            Some(SaveStatus::Saving) => view! {
+                <span class="operator__slide-save-indicator" data-role="slide-save-indicator" data-status="saving">"Saving…"</span>
+            }.into_any(),
+            Some(SaveStatus::Saved) => view! {
+                <span class="operator__slide-save-indicator" data-role="slide-save-indicator" data-status="saved">"Saved ✓"</span>
+            }.into_any(),
+            Some(SaveStatus::Failed) => view! {
+                <span class="operator__slide-save-indicator" data-role="slide-save-indicator" data-status="failed">"Save failed"</span>
+            }.into_any(),
+            None => view! { <span></span> }.into_any(),
+        }
+    }}
+</Show>
+```
+
+(Exact closure plumbing chosen by the implementer to satisfy Leptos's borrow rules — the spec captures the data-role attributes and copy strings, which are the contract for tests.)
+
+#### Remove the Save button
+
+Lines 615-635 of `slide_list.rs` — the `<button data-action="save">"Save"</button>` block inside `operator__slide-controls`. Remove the whole `<button>` element including its closure. Keep the `Duplicate` and `Delete` siblings.
+
+#### Group field
+
+The Group `<input>` already saves on blur via `update_slide_with_group`. After this change, the group save path must also update `save_status` (same Saving → Saved → fade or Failed flow). Either: (a) inline the status updates at the Group input's `on:blur` site, or (b) extract a small helper `save_with_status(...)` that wraps the PUT + status updates. (b) is preferred for DRY.
+
+### `crates/presenter-ui/styles/operator.css`
+
+Add:
+
+```css
+.operator__slide-save-indicator {
+    margin-left: 0.5rem;
+    font-size: 0.85em;
+    opacity: 1;
+    transition: opacity 200ms ease-out;
+}
+
+.operator__slide-save-indicator[data-status="saved"] {
+    color: #16a34a; /* green */
+}
+
+.operator__slide-save-indicator[data-status="saving"] {
+    color: #6b7280; /* gray */
+}
+
+.operator__slide-save-indicator[data-status="failed"] {
+    color: #dc2626; /* red */
+    font-weight: 600;
+}
+```
+
+(The fade-out at 2s is driven by REMOVING the entry from the HashMap in `save_all_fields_from_dom`, not by a CSS animation. The 200ms opacity transition above is for the moment the `<Show>` removes the element from the DOM — Leptos can apply leaving classes if we want a smoother fade, but the simple version is fine.)
+
+## Tests
+
+### Playwright E2E
+
+New file `tests/e2e/operator-slide-save-indicator.spec.ts`. Three scenarios:
+
+1. **Edit + blur shows "Saved ✓"**. Open operator, select a presentation, click into a slide's Main textarea, type a character, blur the textarea (`page.locator('body').click()`). Within 3 seconds, `[data-role="slide-save-indicator"][data-status="saved"]` is visible with text "Saved ✓". Within an additional 3 seconds, it's gone.
+
+2. **No Save button in slide controls**. With a slide in edit mode, assert `button[data-action="save"]` has count 0 in the slide controls.
+
+3. **Failure shows "Save failed"**. Intercept the PUT to return 500. Trigger the same edit+blur. Assert `[data-role="slide-save-indicator"][data-status="failed"]` is visible with text "Save failed" and does NOT auto-fade within 5 seconds.
+
+All three end with `expect(consoleMessages).toEqual([])`.
+
+### Regression test (for the bug-fix line in the completion report)
+
+The bug is "operator must click Save". The regression test that proves the fix is the **no-button** assertion in test scenario 2. Cite this in the completion report:
+
+```
+✅ Regression test: tests/e2e/operator-slide-save-indicator.spec.ts:<line of scenario 2> — RED on <test_sha>, GREEN on <fix_sha>
+```
+
+## Out of scope
+
+- Bible slide editor (`crates/presenter-ui/src/pages/bible_slides.rs`). Different page, similar pattern. File a follow-up issue if the same friction shows up there.
+- Save-while-typing autosave. User explicitly chose blur-only behavior.
+- A persistent "Last saved HH:MM:SS" timestamp. Indicator is transient by design.
+- Localization. The strings are English-only in the existing UI; matching that for now.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| HashMap re-render thrash when many slides save in quick succession | The map is keyed by slide_id; Leptos diffing on a HashMap signal re-runs each subscriber but the body uses `.get()` lookup, which is O(1). At 50 slides × 1 save each that's <1ms WASM. Acceptable. |
+| Existing E2E tests targeting the Save button break | Removed in this PR. Adjust or remove those tests as part of this work. |
+| Fade timer races with rapid blur/refocus | Each save attempt overwrites the map entry before spawning its own fade timer. The earlier fade timer eventually fires and removes the (now-newer) entry — which is the wrong moment. **Need:** include a per-save token in the entry; the fade only clears if the token still matches. (Implementation detail; the spec calls this out as a known correctness concern to address in the plan.) |
+| Operator misses the badge | The badge is 0.85em next to the slide group label, in the operator's gaze when they finish typing. If it proves invisible during real services, we can grow it. |
+
+## Verification checklist
+
+| Check | Method |
+|---|---|
+| Save button removed | Playwright scenario 2 |
+| "Saved ✓" appears within 3s of blur | Playwright scenario 1 |
+| "Saved ✓" fades within ~2-5s of appearing | Playwright scenario 1 |
+| "Save failed" sticks on PUT failure | Playwright scenario 3 |
+| Browser console clean across all three scenarios | `expect(consoleMessages).toEqual([])` |
+| Version bump 0.4.73 → 0.4.74 | `Cargo.toml` workspace version |
+| WASM clippy clean | `cargo clippy --target wasm32-unknown-unknown -p presenter-ui` |
+| Workspace clippy clean | `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` |

--- a/tests/e2e/operator-slide-save-indicator.spec.ts
+++ b/tests/e2e/operator-slide-save-indicator.spec.ts
@@ -169,7 +169,8 @@ test("Save failed sticks when server returns 500", async ({ page }) => {
   ]);
 
   await page.route("**/presentations/*/slides/*", (route) => {
-    if (route.request().method() === "PUT") {
+    // The slide-update API uses PATCH (not PUT).
+    if (route.request().method() === "PATCH") {
       route.fulfill({ status: 500, body: "boom" });
     } else {
       route.continue();

--- a/tests/e2e/operator-slide-save-indicator.spec.ts
+++ b/tests/e2e/operator-slide-save-indicator.spec.ts
@@ -1,0 +1,199 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(
+  page: import("@playwright/test").Page,
+  extraAllowed: RegExp[] = [],
+): string[] {
+  const messages: string[] = [];
+  const allowed = [...ALLOWED_CONSOLE_NOISE, ...extraAllowed];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!allowed.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+/**
+ * Helper: open the operator in edit mode, select the first available
+ * presentation, and wait for slides to render.
+ * Returns the slide_id of the first slide.
+ *
+ * NOTE: Worship slide cards use `data-slide-id` on the article element;
+ * there is no `data-role="slide-card"`. Edit mode is a global mode toggle
+ * (`[data-role="mode-toggle"][data-mode="edit"]`), not a per-slide button.
+ */
+async function openOperatorWithEditingSlide(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  // First library, first presentation
+  await page.waitForSelector('[data-role="library-item"]', { timeout: 30_000 });
+  await page.locator('[data-role="library-item"]').first().click();
+
+  await page.waitForSelector('[data-role="presentation-item"]', {
+    timeout: 15_000,
+  });
+  await page.locator('[data-role="presentation-item"]').first().click();
+
+  // Wait for slides to appear
+  await page.waitForFunction(
+    () => {
+      const slides = document.querySelectorAll("[data-slide-id]");
+      return slides.length > 0;
+    },
+    { timeout: 15_000 },
+  );
+
+  // Allow async presentation detail fetch to complete
+  await page
+    .waitForResponse(
+      (resp) => resp.url().includes("/presentations/") && resp.status() === 200,
+      { timeout: 10_000 },
+    )
+    .catch(() => {}); // May have already completed
+
+  // Switch to edit mode
+  await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "edit",
+    { timeout: 5_000 },
+  );
+
+  // Wait for textarea to materialise in the first slide card
+  await page.waitForSelector('[data-slide-id] textarea[data-field="main"]', {
+    timeout: 5_000,
+  });
+
+  // Return the slide-id of the first slide
+  const slideId =
+    (await page.locator("[data-slide-id]").first().getAttribute("data-slide-id")) ?? "";
+  return slideId;
+}
+
+test("Saved indicator appears and fades after blur", async ({ page }) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-slide-id="${slideId}"]`);
+
+  // Type into the main textarea
+  const main = slideCard.locator('textarea[data-field="main"]');
+  await main.click();
+  await main.press("End");
+  await main.type(" autosave probe", { delay: 20 });
+
+  // Blur by clicking outside any editable region
+  await page.locator("body").click({ position: { x: 5, y: 5 } });
+
+  // Indicator must appear within 3s
+  const indicator = slideCard.locator('[data-role="slide-save-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 3_000 });
+  await expect(indicator).toHaveAttribute("data-status", "saved");
+  await expect(indicator).toHaveText(/Saved/);
+
+  // Indicator must fade (disappear) within 5s after that
+  await expect(indicator).toHaveCount(0, { timeout: 5_000 });
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("Save button is absent from slide controls (regression #313)", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-slide-id="${slideId}"]`);
+
+  // The Save button used to live in operator__slide-controls. After #313 it must be gone.
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="save"]'),
+  ).toHaveCount(0);
+
+  // Duplicate and Delete must remain.
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="duplicate"]'),
+  ).toBeVisible();
+  await expect(
+    slideCard.locator('.operator__slide-controls button[data-action="delete"]'),
+  ).toBeVisible();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("Save failed sticks when server returns 500", async ({ page }) => {
+  // 500 on the slide-update PUT will produce a console error; allow it for this test.
+  const consoleMessages = collectConsoleErrors(page, [
+    /Failed to load resource.*500/i,
+  ]);
+
+  await page.route("**/presentations/*/slides/*", (route) => {
+    if (route.request().method() === "PUT") {
+      route.fulfill({ status: 500, body: "boom" });
+    } else {
+      route.continue();
+    }
+  });
+
+  const slideId = await openOperatorWithEditingSlide(page);
+  const slideCard = page.locator(`[data-slide-id="${slideId}"]`);
+
+  const main = slideCard.locator('textarea[data-field="main"]');
+  await main.click();
+  await main.press("End");
+  await main.type(" will fail", { delay: 20 });
+  await page.locator("body").click({ position: { x: 5, y: 5 } });
+
+  const indicator = slideCard.locator('[data-role="slide-save-indicator"]');
+  await expect(indicator).toBeVisible({ timeout: 3_000 });
+  await expect(indicator).toHaveAttribute("data-status", "failed");
+  await expect(indicator).toHaveText(/failed/i);
+
+  // Must NOT fade within 5s
+  await page.waitForTimeout(5_000);
+  await expect(indicator).toBeVisible();
+  await expect(indicator).toHaveAttribute("data-status", "failed");
+
+  expect(consoleMessages).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Closes #313: operator believed they had to click a Save button to persist worship-slide edits. Blur already saved them — the button was misleading. Removed the button and added a transient per-slide "Saved ✓" badge so persistence is visible.

## What changed

- `OperatorState` gains `SaveStatus` enum + `save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>`. A monotonic token prevents stale fade timers from clearing a newer save's entry.
- New `save_with_status` helper wraps the slide-update PUT/PATCH. It sets `Saving`, then `Saved` (auto-fades after 2s) on success or `Failed` (sticky) on error.
- `save_all_fields_from_dom` (textareas) and the Group `<input>` blur handler both route through the helper.
- Slide header renders the badge via a `<Show>` block. Save button removed from `operator__slide-controls`; Duplicate + Delete remain.
- CSS adds `.operator__slide-save-indicator` with status-attribute color variants (gray Saving, green Saved, red Failed).
- Playwright E2E `operator-slide-save-indicator.spec.ts` covers all three states (saved fades, no Save button, failed sticks).
- Version bump 0.4.73 → 0.4.74.

## Regression test

`tests/e2e/operator-slide-save-indicator.spec.ts:114` — `Save button is absent from slide controls (regression #313)`.
- RED on test commit `d55025c`
- GREEN on fix commit `b9413ba`

🤖 Generated with [Claude Code](https://claude.com/claude-code)