### PR TITLE
Bundle: fix #312 + #314 + #269 + #229 + #247 — song prefix, timer placeholder, diff hygiene, CI smoke, AI chat flake

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/superpowers/** linguist-generated=true
+docs/superpowers/** -diff

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -910,7 +910,6 @@ jobs:
 
       - name: Verify deployment
         run: |
-          sleep 5
           ssh deploy-target << 'REMOTE_SCRIPT'
           set -e
           if ! systemctl is-active --quiet presenter-dev; then
@@ -920,17 +919,30 @@ jobs:
           fi
           echo "Service is running"
 
-          HEALTH=$(curl -sf http://localhost:8080/healthz)
-          if [ $? -ne 0 ]; then
-            echo "::error::Post-deploy health check FAILED"
+          # Poll the health endpoint until the port is bound. systemd reports
+          # the service active before tokio finishes binding, so a fixed sleep
+          # races with cold start (DB migration + Bible/library load). 60s
+          # max — beyond that something is genuinely wrong.
+          HEALTH=""
+          for attempt in $(seq 1 30); do
+            if HEALTH=$(curl -sf http://localhost:8080/healthz 2>/dev/null); then
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$HEALTH" ]; then
+            echo "::error::Post-deploy health check FAILED — /healthz did not respond within 60s"
             sudo journalctl -u presenter-dev -n 50 --no-pager
             exit 1
           fi
           echo "Health check passed: $HEALTH"
 
-          LIBS=$(curl -sf http://localhost:8080/libraries/summary)
-          if [ $? -ne 0 ] || [ "$LIBS" = "[]" ]; then
-            echo "::error::Post-deploy data check FAILED — database appears empty or inaccessible"
+          if ! LIBS=$(curl -sf http://localhost:8080/libraries/summary); then
+            echo "::error::Post-deploy data check FAILED — /libraries/summary did not respond"
+            exit 1
+          fi
+          if [ "$LIBS" = "[]" ]; then
+            echo "::error::Post-deploy data check FAILED — database appears empty"
             exit 1
           fi
           DISK_COUNT=$(find /opt/presenter-dev/libraries -mindepth 1 -maxdepth 1 -type d ! -name 'LibraryData' | wc -l)

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -294,6 +294,9 @@ jobs:
         run: cargo test --lib
         working-directory: crates/presenter-ui
 
+      - name: Run CI shell tests
+        run: bash tests/ci/check-dev-libraries.test.sh
+
   # ============================================
   # Mutation Testing
   # ============================================
@@ -930,7 +933,13 @@ jobs:
             echo "::error::Post-deploy data check FAILED — database appears empty or inaccessible"
             exit 1
           fi
-          echo "Data check passed: libraries endpoint returned data"
+          DISK_COUNT=$(find /opt/presenter-dev/libraries -mindepth 1 -maxdepth 1 -type d ! -name 'LibraryData' | wc -l)
+          DB_COUNT=$(printf '%s' "$LIBS" | python3 -c "import json,sys; data=json.load(sys.stdin); print(len([l for l in data if l.get('name','').strip().lower()!='bible']))")
+          if [ "$DISK_COUNT" -ne "$DB_COUNT" ]; then
+            echo "::error::Library count mismatch: disk=$DISK_COUNT db=$DB_COUNT (DB may be seed-only or import failed) — see issue #229"
+            exit 1
+          fi
+          echo "Data check passed: $DB_COUNT libraries on disk match DB"
           REMOTE_SCRIPT
 
       - name: Post-deploy smoke test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.74"
+version = "0.4.75"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/state/broadcasting.rs
+++ b/crates/presenter-server/src/state/broadcasting.rs
@@ -184,14 +184,16 @@ impl AppState {
         if next_entry.entry_type != "presentation" {
             return None;
         }
-        // Look up the raw presentation name (with number prefix)
+        // Look up the presentation name and strip the number prefix so the
+        // stage display / Companion variable matches the sanitized current
+        // song_name (see #312, build_stage_snapshot fallback).
         let next_id = next_entry.presentation_id?;
         if let Ok(Some((_, _, presentation))) =
             self.repository.fetch_presentation_detail(next_id).await
         {
-            Some(presentation.name.clone())
+            Some(sanitize_song_title(&presentation.name))
         } else if !next_entry.name.is_empty() {
-            Some(next_entry.name.clone())
+            Some(sanitize_song_title(&next_entry.name))
         } else {
             None
         }

--- a/crates/presenter-server/src/state/stage.rs
+++ b/crates/presenter-server/src/state/stage.rs
@@ -225,7 +225,13 @@ pub(crate) fn build_stage_snapshot(
             .resolution
             .override_song_name
             .clone()
-            .or_else(|| context.resolution.presentation_name.clone()),
+            .or_else(|| {
+                context
+                    .resolution
+                    .presentation_name
+                    .as_deref()
+                    .map(sanitize_song_title)
+            }),
         context
             .resolution
             .override_song_name

--- a/crates/presenter-server/src/state/stage.rs
+++ b/crates/presenter-server/src/state/stage.rs
@@ -221,17 +221,13 @@ pub(crate) fn build_stage_snapshot(
         context.resolution.presentation_id,
         context.resolution.presentation_name.clone(),
         context.resolution.library_name.clone(),
-        context
-            .resolution
-            .override_song_name
-            .clone()
-            .or_else(|| {
-                context
-                    .resolution
-                    .presentation_name
-                    .as_deref()
-                    .map(sanitize_song_title)
-            }),
+        context.resolution.override_song_name.clone().or_else(|| {
+            context
+                .resolution
+                .presentation_name
+                .as_deref()
+                .map(sanitize_song_title)
+        }),
         context
             .resolution
             .override_song_name
@@ -374,7 +370,10 @@ mod tests {
         );
     }
 
-    fn make_context(presentation_name: Option<&str>, override_song_name: Option<&str>) -> StageContext {
+    fn make_context(
+        presentation_name: Option<&str>,
+        override_song_name: Option<&str>,
+    ) -> StageContext {
         StageContext {
             generated_at: Utc::now(),
             overview: TimersOverview::demo(Utc::now()),
@@ -409,7 +408,10 @@ mod tests {
         let snapshot = build_stage_snapshot(layout, &context);
         assert_eq!(snapshot.song_name.as_deref(), Some("Amazing Grace"));
         assert_eq!(snapshot.song_number.as_deref(), Some("042"));
-        assert_eq!(snapshot.presentation_name.as_deref(), Some("042 Amazing Grace"));
+        assert_eq!(
+            snapshot.presentation_name.as_deref(),
+            Some("042 Amazing Grace")
+        );
     }
 
     #[test]

--- a/crates/presenter-server/src/state/stage.rs
+++ b/crates/presenter-server/src/state/stage.rs
@@ -367,4 +367,67 @@ mod tests {
             "Song Without Number"
         );
     }
+
+    fn make_context(presentation_name: Option<&str>, override_song_name: Option<&str>) -> StageContext {
+        StageContext {
+            generated_at: Utc::now(),
+            overview: TimersOverview::demo(Utc::now()),
+            resolution: StageResolution {
+                presentation_id: None,
+                presentation_name: presentation_name.map(str::to_string),
+                library_name: None,
+                current_slide_id: None,
+                current: None,
+                next_slide_id: None,
+                next: None,
+                override_song_name: override_song_name.map(str::to_string),
+                next_song_name: None,
+                current_index: None,
+                total_slides: None,
+                playlist_id: None,
+                playlist_name: None,
+                playlist_entries: None,
+            },
+            latency_ms: None,
+        }
+    }
+
+    #[test]
+    fn build_stage_snapshot_strips_song_number_from_song_name_when_no_override() {
+        let layout = StageDisplayLayout {
+            code: "timer".to_string(),
+            name: "Timer".to_string(),
+            description: "Countdown".to_string(),
+        };
+        let context = make_context(Some("042 Amazing Grace"), None);
+        let snapshot = build_stage_snapshot(layout, &context);
+        assert_eq!(snapshot.song_name.as_deref(), Some("Amazing Grace"));
+        assert_eq!(snapshot.song_number.as_deref(), Some("042"));
+        assert_eq!(snapshot.presentation_name.as_deref(), Some("042 Amazing Grace"));
+    }
+
+    #[test]
+    fn build_stage_snapshot_keeps_unnumbered_song_name_unchanged() {
+        let layout = StageDisplayLayout {
+            code: "timer".to_string(),
+            name: "Timer".to_string(),
+            description: "Countdown".to_string(),
+        };
+        let context = make_context(Some("Pure Title"), None);
+        let snapshot = build_stage_snapshot(layout, &context);
+        assert_eq!(snapshot.song_name.as_deref(), Some("Pure Title"));
+        assert_eq!(snapshot.song_number, None);
+    }
+
+    #[test]
+    fn build_stage_snapshot_preserves_override_song_name_verbatim() {
+        let layout = StageDisplayLayout {
+            code: "timer".to_string(),
+            name: "Timer".to_string(),
+            description: "Countdown".to_string(),
+        };
+        let context = make_context(Some("042 Amazing Grace"), Some("Custom AbleSet Title"));
+        let snapshot = build_stage_snapshot(layout, &context);
+        assert_eq!(snapshot.song_name.as_deref(), Some("Custom AbleSet Title"));
+    }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1252,7 +1252,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/timer_panel.rs
+++ b/crates/presenter-ui/src/components/timer_panel.rs
@@ -239,7 +239,7 @@ pub fn TimerPanel() -> impl IntoView {
                     <input
                         type="text"
                         inputmode="numeric"
-                        placeholder="18:00"
+                        placeholder="HH:MM"
                         data-role="countdown-target-input"
                         aria-label="Countdown target time (HH:MM)"
                         on:focus=on_countdown_focus

--- a/scripts/ci/check-dev-libraries.sh
+++ b/scripts/ci/check-dev-libraries.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verify that the dev server's database contains a library row for every
+# library directory on disk. Fails the build when the counts disagree, so a
+# seed-only DB or a half-failed import can no longer pass the smoke test
+# (regression guard for issue #229).
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <libraries-disk-path> <summary-url-or-json-file>" >&2
+    exit 2
+fi
+
+LIB_PATH="$1"
+SUMMARY_SOURCE="$2"
+
+if [ ! -d "$LIB_PATH" ]; then
+    echo "::error::Libraries path does not exist: $LIB_PATH" >&2
+    exit 1
+fi
+
+DISK_COUNT=$(find "$LIB_PATH" -mindepth 1 -maxdepth 1 -type d ! -name 'LibraryData' | wc -l)
+
+if [ -f "$SUMMARY_SOURCE" ]; then
+    JSON=$(cat "$SUMMARY_SOURCE")
+else
+    JSON=$(curl -sf "$SUMMARY_SOURCE")
+fi
+
+DB_COUNT=$(printf '%s' "$JSON" | python3 -c "import json,sys; data=json.load(sys.stdin); print(len([l for l in data if l.get('name','').strip().lower()!='bible']))")
+
+if [ "$DISK_COUNT" -ne "$DB_COUNT" ]; then
+    echo "::error::Library count mismatch: disk=$DISK_COUNT db=$DB_COUNT (DB may be seed-only or import failed)" >&2
+    exit 1
+fi
+
+echo "Library count check passed: $DB_COUNT libraries match disk"

--- a/tests/ci/check-dev-libraries.test.sh
+++ b/tests/ci/check-dev-libraries.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/ci/check-dev-libraries.sh.
+# Exercises the count-mismatch detection that issue #229 reported missing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../../scripts/ci/check-dev-libraries.sh"
+WORK=$(mktemp -d)
+trap "rm -rf $WORK" EXIT
+
+fail=0
+
+# Case 1: disk count matches DB count → script exits 0
+mkdir -p "$WORK/case1/Library_A" "$WORK/case1/Library_B" "$WORK/case1/LibraryData"
+echo '[{"name":"Library_A"},{"name":"Library_B"},{"name":"Bible"}]' > "$WORK/case1.json"
+if ! "$SCRIPT" "$WORK/case1" "$WORK/case1.json" > /dev/null; then
+    echo "FAIL case1: matching counts should succeed" >&2
+    fail=1
+fi
+
+# Case 2 — THE BUG SCENARIO from #229: many on disk, only seed in DB → fail
+mkdir -p "$WORK/case2/Library_A" "$WORK/case2/Library_B" "$WORK/case2/Library_C" "$WORK/case2/Library_D"
+echo '[{"name":"Sample Library"},{"name":"Bible"}]' > "$WORK/case2.json"
+if "$SCRIPT" "$WORK/case2" "$WORK/case2.json" > /dev/null 2>&1; then
+    echo "FAIL case2: seed-only DB with 4 disk libs must fail (the #229 bug)" >&2
+    fail=1
+fi
+
+# Case 3: DB has more rows than disk → fail
+mkdir -p "$WORK/case3/Library_A"
+echo '[{"name":"Library_A"},{"name":"Library_B"},{"name":"Bible"}]' > "$WORK/case3.json"
+if "$SCRIPT" "$WORK/case3" "$WORK/case3.json" > /dev/null 2>&1; then
+    echo "FAIL case3: extra DB rows must fail" >&2
+    fail=1
+fi
+
+# Case 4: Bible is excluded from both sides → matching pure non-Bible counts pass
+mkdir -p "$WORK/case4/Library_A" "$WORK/case4/LibraryData"
+echo '[{"name":"Library_A"},{"name":"bible"},{"name":"BIBLE"}]' > "$WORK/case4.json"
+if ! "$SCRIPT" "$WORK/case4" "$WORK/case4.json" > /dev/null; then
+    echo "FAIL case4: Bible (any case) must be excluded from DB count" >&2
+    fail=1
+fi
+
+# Case 5: missing disk path → script exits non-zero with clear message
+if "$SCRIPT" "$WORK/does-not-exist" "$WORK/case1.json" > /dev/null 2>&1; then
+    echo "FAIL case5: missing disk path must fail" >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "Shell tests for scripts/ci/check-dev-libraries.sh: FAILED" >&2
+    exit 1
+fi
+
+echo "Shell tests for scripts/ci/check-dev-libraries.sh: all passed"

--- a/tests/e2e/stage-song-names.spec.ts
+++ b/tests/e2e/stage-song-names.spec.ts
@@ -81,13 +81,15 @@ test("worship-snv shows current song name in amber box", async ({
   });
 
   // Wait for the current song box to show the sanitized song name
+  // (number prefix stripped per #312 — see build_stage_snapshot)
   const currentSongBox = stagePage.locator(
     ".stage__current-song .stage__song-name-text",
   );
   await expect(currentSongBox).toBeVisible({ timeout: 10_000 });
-  await expect(currentSongBox).toContainText("042 Hodny Chvaly", {
+  await expect(currentSongBox).toContainText("Hodny Chvaly", {
     timeout: 10_000,
   });
+  await expect(currentSongBox).not.toContainText("042", { timeout: 5_000 });
 
   // Verify amber color
   const color = await currentSongBox.evaluate(
@@ -179,21 +181,23 @@ test("worship-snv shows next song from playlist", async ({
     }
   });
 
-  // Current song should show "First Song" (number prefix stripped, uppercased by CSS)
+  // Current song should show "First Song" (number prefix stripped per #312, uppercased by CSS)
   const currentSongBox = stagePage.locator(
     ".stage__current-song .stage__song-name-text",
   );
-  await expect(currentSongBox).toContainText("001 First Song", {
+  await expect(currentSongBox).toContainText("First Song", {
     timeout: 10_000,
   });
+  await expect(currentSongBox).not.toContainText("001", { timeout: 5_000 });
 
-  // Next song should show "002 Second Song" (from playlist, with number)
+  // Next song should show "Second Song" (from playlist, prefix stripped per #312)
   const nextSongBox = stagePage.locator(
     ".stage__next-song .stage__song-name-text",
   );
-  await expect(nextSongBox).toContainText("002 Second Song", {
+  await expect(nextSongBox).toContainText("Second Song", {
     timeout: 10_000,
   });
+  await expect(nextSongBox).not.toContainText("002", { timeout: 5_000 });
 
   await stagePage.close();
   expect(consoleMessages).toEqual([]);

--- a/tests/e2e/wasm-ai-chat.spec.ts
+++ b/tests/e2e/wasm-ai-chat.spec.ts
@@ -292,6 +292,10 @@ test.describe("AI Settings Panel", () => {
 
 test.describe("AI Conversation Management", () => {
   test("Clear button removes messages and errors", async ({ page }) => {
+    // Reset persisted conversation before the page loads so the on-mount
+    // restore in ai.rs cannot resurrect messages from a prior test (#247).
+    await page.request.post(`${baseURL}/ai/clear`, { data: {} });
+
     await navigateToAi(page);
 
     // Send a message (will produce an error in test environment)
@@ -299,10 +303,11 @@ test.describe("AI Conversation Management", () => {
     await textarea.fill("test clear");
     await page.locator('[data-role="ai-send"]').click();
 
-    // Wait for user message to appear
+    // Wait for exactly one user message to appear (sent message above).
     const userMsg = page.locator(
       '[data-role="ai-message"][data-message-role="user"]',
     );
+    await expect(userMsg).toHaveCount(1, { timeout: 5_000 });
     await expect(userMsg).toBeVisible({ timeout: 5_000 });
 
     // Click Clear


### PR DESCRIPTION
## Summary

Bundle of five small fixes selected via `/issue-planner` (`autonomous-batch-issue-development.md`).

- **Closes #312** — Companion `song_name` and stage display previously surfaced the leading track number ("042 Hodny Chvaly") because `build_stage_snapshot` fell back to `presentation_name` without sanitization. Both the current and next-song paths now pipe through `sanitize_song_title`, matching the existing Resolume behaviour.
- **Closes #314** — Countdown placeholder dropped from misleading `18:00` to neutral `HH:MM`.
- **Closes #269** — Added `.gitattributes` (`linguist-generated` + `-diff`) for `docs/superpowers/**` so plan/spec markdown no longer drowns out code in PR diffs.
- **Closes #229** — Post-deploy data check now compares library directories on disk against `/libraries/summary` (Bible excluded). Same logic lives in `scripts/ci/check-dev-libraries.sh` with a bash test harness (`tests/ci/check-dev-libraries.test.sh`) wired into the Test job.
- **Closes #247** — `Clear button removes messages` flake fixed: test now clears the persisted conversation via `POST /ai/clear` before navigating, and asserts `toHaveCount(1)` so future regressions of the same kind fail loudly.

Also lands two follow-on hardenings discovered during CI:
- `tests/e2e/stage-song-names.spec.ts` updated to expect the now-sanitized song names (comments already described that intent).
- Verify-deployment step replaced fixed `sleep 5` with a 30 × 2s poll on `/healthz` to remove the binding race that surfaced after the smoke check tightened.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
- [x] `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all` (presenter-ui)
- [x] `cargo test --workspace --all-features`
- [x] `cargo test --lib` (presenter-ui)
- [x] `bash tests/ci/check-dev-libraries.test.sh`
- [x] CI pipeline 25821424043 fully green (20/20 jobs including Deploy to Dev)
- [x] Playwright on dev: `v0.4.75 (dev)`, timer placeholder `HH:MM`, WASM ready, console clean (only pre-existing favicon 404)
- [x] Regression test for #312: `crates/presenter-server/src/state/stage.rs:399` RED on `fdece66`, GREEN on `585f460`
- [x] Regression test for #229: `tests/ci/check-dev-libraries.test.sh:22` RED on `18cf169`, GREEN on `b4058fd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)