### PR TITLE
feat(bible): keyboard chain + diacritic-insensitive book search

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -298,7 +298,6 @@ jobs:
 
       - name: Verify deployment
         run: |
-          sleep 5
           ssh deploy-target << 'REMOTE_SCRIPT'
           set -e
           if ! systemctl is-active --quiet presenter; then
@@ -308,17 +307,29 @@ jobs:
           fi
           echo "Service is running"
 
-          HEALTH=$(curl -sf http://localhost:80/healthz)
-          if [ $? -ne 0 ]; then
-            echo "::error::Post-deploy health check FAILED"
+          # Poll /healthz until the port is bound. systemd reports the service
+          # active before tokio finishes binding; a fixed sleep raced with
+          # cold start (DB migration + library/Bible load). 60s max.
+          HEALTH=""
+          for attempt in $(seq 1 30); do
+            if HEALTH=$(curl -sf http://localhost:80/healthz 2>/dev/null); then
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$HEALTH" ]; then
+            echo "::error::Post-deploy health check FAILED — /healthz did not respond within 60s"
             sudo journalctl -u presenter -n 50 --no-pager
             exit 1
           fi
           echo "Health check passed: $HEALTH"
 
-          LIBS=$(curl -sf http://localhost:80/libraries/summary)
-          if [ $? -ne 0 ] || [ "$LIBS" = "[]" ]; then
-            echo "::error::Post-deploy data check FAILED — database appears empty or inaccessible"
+          if ! LIBS=$(curl -sf http://localhost:80/libraries/summary); then
+            echo "::error::Post-deploy data check FAILED — /libraries/summary did not respond"
+            exit 1
+          fi
+          if [ "$LIBS" = "[]" ]; then
+            echo "::error::Post-deploy data check FAILED — database appears empty"
             exit 1
           fi
           echo "Data check passed: libraries endpoint returned data"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,6 @@ jobs:
 
       - name: Verify deployment
         run: |
-          sleep 5
           ssh deploy-target << 'REMOTE_SCRIPT'
           set -e
           if ! systemctl is-active --quiet presenter; then
@@ -300,17 +299,29 @@ jobs:
           fi
           echo "Service is running"
 
-          HEALTH=$(curl -sf http://localhost:80/healthz)
-          if [ $? -ne 0 ]; then
-            echo "::error::Post-deploy health check FAILED"
+          # Poll /healthz until the port is bound. systemd reports the service
+          # active before tokio finishes binding; a fixed sleep raced with
+          # cold start. 60s max.
+          HEALTH=""
+          for attempt in $(seq 1 30); do
+            if HEALTH=$(curl -sf http://localhost:80/healthz 2>/dev/null); then
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$HEALTH" ]; then
+            echo "::error::Post-deploy health check FAILED — /healthz did not respond within 60s"
             sudo journalctl -u presenter -n 50 --no-pager
             exit 1
           fi
           echo "Health check passed: $HEALTH"
 
-          LIBS=$(curl -sf http://localhost:80/libraries/summary)
-          if [ $? -ne 0 ] || [ "$LIBS" = "[]" ]; then
-            echo "::error::Post-deploy data check FAILED — database appears empty or inaccessible"
+          if ! LIBS=$(curl -sf http://localhost:80/libraries/summary); then
+            echo "::error::Post-deploy data check FAILED — /libraries/summary did not respond"
+            exit 1
+          fi
+          if [ "$LIBS" = "[]" ]; then
+            echo "::error::Post-deploy data check FAILED — database appears empty"
             exit 1
           fi
           echo "Data check passed: libraries endpoint returned data"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.75"
+version = "0.4.76"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/bible/mod.rs
+++ b/crates/presenter-core/src/bible/mod.rs
@@ -1,7 +1,7 @@
 mod canonical;
 mod presentation;
 mod reference;
-mod search;
+pub mod search;
 mod translation;
 
 pub use canonical::{
@@ -9,6 +9,7 @@ pub use canonical::{
 };
 pub use presentation::{BiblePresentation, BiblePresentationSlide, BiblePresentationSummary};
 pub use reference::{BibleReference, BibleReferenceError};
+pub use search::normalise_book_key;
 pub use translation::{
     BibleBookChapterSummary, BibleBroadcast, BibleIngestionBatch, BibleIngestionError,
     BiblePassage, BiblePreferences, BiblePreferencesDraft, BibleSlideOutput, BibleTranslation,

--- a/crates/presenter-core/src/bible/search.rs
+++ b/crates/presenter-core/src/bible/search.rs
@@ -1,6 +1,6 @@
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 
-pub(crate) fn normalise_book_key(input: &str) -> String {
+pub fn normalise_book_key(input: &str) -> String {
     let mut result = String::new();
     for ch in input.nfd().filter(|c| !is_combining_mark(*c)) {
         if ch.is_ascii_alphanumeric() {
@@ -21,5 +21,11 @@ mod tests {
             normalise_book_key("Acts (of the Apostles)"),
             "actsoftheapostles"
         );
+    }
+
+    #[test]
+    fn strips_slovak_diacritics() {
+        assert_eq!(normalise_book_key("Lukáš"), "lukas");
+        assert_eq!(normalise_book_key("1. Mojžišova"), "1mojzisova");
     }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1252,7 +1252,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.75"
+version = "0.4.76"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/pages/bible.rs
+++ b/crates/presenter-ui/src/pages/bible.rs
@@ -300,6 +300,7 @@ fn BibleTabNav() -> impl IntoView {
 #[component]
 fn BibleLiveTab() -> impl IntoView {
     let bs = use_ctx!(BibleState);
+    let ctx = use_ctx!(AppContext);
     let bible_tab = bs.bible_tab;
 
     // Shared focus chain for keyboard navigation (#257).
@@ -311,12 +312,24 @@ fn BibleLiveTab() -> impl IntoView {
     };
     provide_context(refs);
 
-    // Auto-focus the book-filter on first mount so the operator can start
-    // typing immediately without clicking. `NodeRef::on_load` runs once when
-    // the element first appears in the DOM.
-    refs.book_filter.on_load(|el| {
-        let _ = el.focus();
-    });
+    // Auto-focus the book-filter whenever the operator switches into the
+    // bible/live view. The Bible panel is rendered behind CSS even when
+    // inactive, so a one-shot `on_load` would fire while the input is
+    // hidden (focus() is a no-op on hidden elements). This effect tracks
+    // the view + tab signals so focus lands every time bible/live becomes
+    // active, including the initial navigation from worship.
+    {
+        let view_signal = ctx.view;
+        Effect::new(move || {
+            let v = view_signal.get();
+            let t = bible_tab.get();
+            if v == "bible" && t == "live" {
+                if let Some(el) = refs.book_filter.get() {
+                    let _ = el.focus();
+                }
+            }
+        });
+    }
 
     view! {
         <div

--- a/crates/presenter-ui/src/pages/bible.rs
+++ b/crates/presenter-ui/src/pages/bible.rs
@@ -9,6 +9,17 @@ use super::bible_controls::SelectionControls;
 use super::bible_prepared::{BiblePreparedTab, BiblePresentationModal, BibleSettingsTab};
 use super::bible_slides::BibleSlidesColumn;
 
+/// Shared `NodeRef` handles for the four inputs that participate in the
+/// keyboard-navigation chain on the Bible live tab. Provided via context so
+/// each input's `on:keydown` handler can step focus to the next input.
+#[derive(Copy, Clone)]
+struct BibleFocusRefs {
+    book_filter: NodeRef<leptos::html::Input>,
+    chapter: NodeRef<leptos::html::Input>,
+    verse_start: NodeRef<leptos::html::Input>,
+    verse_end: NodeRef<leptos::html::Input>,
+}
+
 /// Bible page — 2-column layout matching the legacy Bible UI.
 /// Rendered inside the operator shell's `<section data-view-panel="bible">`.
 #[component]
@@ -291,6 +302,22 @@ fn BibleLiveTab() -> impl IntoView {
     let bs = use_ctx!(BibleState);
     let bible_tab = bs.bible_tab;
 
+    // Shared focus chain for keyboard navigation (#257).
+    let refs = BibleFocusRefs {
+        book_filter: NodeRef::<leptos::html::Input>::new(),
+        chapter: NodeRef::<leptos::html::Input>::new(),
+        verse_start: NodeRef::<leptos::html::Input>::new(),
+        verse_end: NodeRef::<leptos::html::Input>::new(),
+    };
+    provide_context(refs);
+
+    // Auto-focus the book-filter on first mount so the operator can start
+    // typing immediately without clicking. `NodeRef::on_load` runs once when
+    // the element first appears in the DOM.
+    refs.book_filter.on_load(|el| {
+        let _ = el.focus();
+    });
+
     view! {
         <div
             class="bible__tab-panel"
@@ -386,6 +413,7 @@ fn TranslationSelectors() -> impl IntoView {
 #[component]
 fn BookFilter() -> impl IntoView {
     let bs = use_ctx!(BibleState);
+    let refs = expect_context::<BibleFocusRefs>();
     let book_filter = bs.book_filter;
 
     let on_input = move |ev: web_sys::Event| {
@@ -397,6 +425,53 @@ fn BookFilter() -> impl IntoView {
         }
     };
 
+    let on_keydown = {
+        let bs = bs.clone();
+        move |ev: web_sys::KeyboardEvent| {
+            if ev.key() != "Enter" {
+                return;
+            }
+            ev.prevent_default();
+            // Pick the first filtered book only when the filter is non-empty;
+            // an empty filter is the post-chain return to book-filter, where
+            // pressing Enter should not stomp the currently selected book.
+            let filter_text = book_filter.get_untracked();
+            if !filter_text.trim().is_empty() {
+                let books = bs.filtered_books();
+                if let Some(book) = books.first().cloned() {
+                    let chapter_count = book.chapters.len() as u16;
+                    let verse_counts: Vec<u16> =
+                        book.chapters.iter().map(|c| c.verse_count).collect();
+                    let current_chapter = bs.selected_chapter.get_untracked();
+                    let current_v_start = bs.verse_start.get_untracked();
+                    let current_v_end = bs.verse_end.get_untracked();
+                    let clamped = crate::state::bible::clamp_selection(
+                        chapter_count,
+                        &verse_counts,
+                        current_chapter,
+                        current_v_start,
+                        current_v_end,
+                    );
+                    bs.selected_book.set(Some(SelectedBook {
+                        book: book.book.clone(),
+                        code: book.code.clone(),
+                        number: book.number,
+                        chapter_count,
+                        verse_counts,
+                    }));
+                    bs.selected_chapter.set(clamped.chapter);
+                    bs.verse_start.set(clamped.verse_start);
+                    bs.verse_end.set(clamped.verse_end);
+                    book_filter.set(String::new());
+                }
+            }
+            if let Some(el) = refs.chapter.get() {
+                let _ = el.focus();
+                el.select();
+            }
+        }
+    };
+
     view! {
         <label class="operator__field">
             <span>"Find book"</span>
@@ -404,8 +479,10 @@ fn BookFilter() -> impl IntoView {
                 type="search"
                 data-role="book-filter"
                 placeholder="Start typing\u{2026}"
+                node_ref=refs.book_filter
                 prop:value=move || book_filter.get()
                 on:input=on_input
+                on:keydown=on_keydown
             />
         </label>
     }
@@ -525,6 +602,8 @@ fn BookList() -> impl IntoView {
 #[component]
 fn ReferenceInputs() -> impl IntoView {
     let bs = use_ctx!(BibleState);
+    let refs = expect_context::<BibleFocusRefs>();
+    let book_filter = bs.book_filter;
     let selected_chapter = bs.selected_chapter;
     let verse_start_signal = bs.verse_start;
     let verse_end_signal = bs.verse_end;
@@ -566,6 +645,67 @@ fn ReferenceInputs() -> impl IntoView {
         }
     };
 
+    // Enter on chapter → commit chapter value, jump to verse-start.
+    let on_chapter_keydown = move |ev: web_sys::KeyboardEvent| {
+        if ev.key() != "Enter" {
+            return;
+        }
+        ev.prevent_default();
+        if let Some(input) = refs.chapter.get() {
+            if let Ok(val) = input.value().parse::<u16>() {
+                selected_chapter.set(val.max(1));
+                verse_start_signal.set(1);
+                verse_end_signal.set(None);
+            }
+        }
+        if let Some(el) = refs.verse_start.get() {
+            let _ = el.focus();
+            el.select();
+        }
+    };
+
+    // Enter on verse-start → commit value, jump to verse-end.
+    let on_verse_start_keydown = move |ev: web_sys::KeyboardEvent| {
+        if ev.key() != "Enter" {
+            return;
+        }
+        ev.prevent_default();
+        if let Some(input) = refs.verse_start.get() {
+            if let Ok(val) = input.value().parse::<u16>() {
+                verse_start_signal.set(val.max(1));
+            }
+        }
+        if let Some(el) = refs.verse_end.get() {
+            let _ = el.focus();
+            el.select();
+        }
+    };
+
+    // Enter on verse-end → commit (or clear) value, return to book-filter.
+    // The debounced auto-load effect (`bible.rs` mount-time) already fires
+    // a passage fetch 300ms after the signal updates, so no explicit load
+    // click is needed here. Clearing the filter collapses the book list so
+    // the operator can immediately start typing the next book.
+    let on_verse_end_keydown = move |ev: web_sys::KeyboardEvent| {
+        if ev.key() != "Enter" {
+            return;
+        }
+        ev.prevent_default();
+        if let Some(input) = refs.verse_end.get() {
+            let val_str = input.value();
+            if val_str.is_empty() {
+                verse_end_signal.set(None);
+            } else if let Ok(val) = val_str.parse::<u16>() {
+                verse_end_signal.set(Some(val.max(1)));
+            }
+            let _ = input.blur();
+        }
+        book_filter.set(String::new());
+        if let Some(el) = refs.book_filter.get() {
+            let _ = el.focus();
+        }
+    };
+
     view! {
         <div class="operator__reference-grid">
             <label class="operator__field">
@@ -574,8 +714,10 @@ fn ReferenceInputs() -> impl IntoView {
                     type="number"
                     data-role="chapter-input"
                     min="1"
+                    node_ref=refs.chapter
                     prop:value=move || selected_chapter.get().to_string()
                     on:change=on_chapter
+                    on:keydown=on_chapter_keydown
                 />
             </label>
             <label class="operator__field">
@@ -584,8 +726,10 @@ fn ReferenceInputs() -> impl IntoView {
                     type="number"
                     data-role="verse-start"
                     min="1"
+                    node_ref=refs.verse_start
                     prop:value=move || verse_start_signal.get().to_string()
                     on:change=on_verse_start
+                    on:keydown=on_verse_start_keydown
                 />
             </label>
             <label class="operator__field">
@@ -594,9 +738,11 @@ fn ReferenceInputs() -> impl IntoView {
                     type="number"
                     data-role="verse-end"
                     min="1"
+                    node_ref=refs.verse_end
                     prop:value=move || verse_end_signal.get().map(|v| v.to_string()).unwrap_or_default()
                     placeholder="All"
                     on:change=on_verse_end
+                    on:keydown=on_verse_end_keydown
                 />
             </label>
         </div>

--- a/crates/presenter-ui/src/state/bible.rs
+++ b/crates/presenter-ui/src/state/bible.rs
@@ -106,14 +106,19 @@ impl BibleState {
     }
 
     /// Get filtered books based on the book_filter signal.
+    ///
+    /// Matching is case- AND diacritic-insensitive — a filter of "lukas"
+    /// surfaces "Lukáš"; "1moj" surfaces "1. Mojžišova". Uses the same
+    /// normalisation the server applies for canonical-name lookup.
     pub fn filtered_books(&self) -> Vec<BibleBookDto> {
-        let filter = self.book_filter.get().to_lowercase();
+        let filter_raw = self.book_filter.get();
+        let filter = presenter_core::bible::normalise_book_key(&filter_raw);
         let all = self.books.get();
         if filter.is_empty() {
             return all;
         }
         all.into_iter()
-            .filter(|b| b.book.to_lowercase().contains(&filter))
+            .filter(|b| presenter_core::bible::normalise_book_key(&b.book).contains(&filter))
             .collect()
     }
 }
@@ -237,6 +242,16 @@ mod tests {
                 verse_start: 1,
                 verse_end: None,
             }
+        );
+    }
+
+    #[test]
+    fn book_name_normalisation_folds_slovak_diacritics() {
+        let filter = presenter_core::bible::normalise_book_key("lukas");
+        let key = presenter_core::bible::normalise_book_key("Lukáš");
+        assert!(
+            key.contains(&filter),
+            "expected normalised key {key:?} to contain filter {filter:?}"
         );
     }
 }

--- a/crates/presenter-ui/src/state/bible.rs
+++ b/crates/presenter-ui/src/state/bible.rs
@@ -37,6 +37,10 @@ pub struct BibleState {
 
     // -- Book / chapter / verse selection --
     pub books: RwSignal<Vec<BibleBookDto>>,
+    /// Normalised key (case + diacritic + punctuation folded) for each book
+    /// in `books`, in the same order. Derived via Memo so the per-keystroke
+    /// filter avoids NFD-decomposing every book name on every render.
+    pub book_keys: Memo<Vec<String>>,
     pub book_filter: RwSignal<String>,
     pub selected_book: RwSignal<Option<SelectedBook>>,
     pub selected_chapter: RwSignal<u16>,
@@ -73,12 +77,21 @@ pub struct BibleState {
 
 impl BibleState {
     pub fn new() -> Self {
+        let books: RwSignal<Vec<BibleBookDto>> = RwSignal::new(Vec::new());
+        let book_keys: Memo<Vec<String>> = Memo::new(move |_| {
+            books
+                .get()
+                .iter()
+                .map(|b| presenter_core::bible::normalise_book_key(&b.book))
+                .collect()
+        });
         Self {
             translations: RwSignal::new(Vec::new()),
             selected_translation: RwSignal::new(None),
             secondary_translation: RwSignal::new(None),
 
-            books: RwSignal::new(Vec::new()),
+            books,
+            book_keys,
             book_filter: RwSignal::new(String::new()),
             selected_book: RwSignal::new(None),
             selected_chapter: RwSignal::new(1),
@@ -109,7 +122,10 @@ impl BibleState {
     ///
     /// Matching is case- AND diacritic-insensitive — a filter of "lukas"
     /// surfaces "Lukáš"; "1moj" surfaces "1. Mojžišova". Uses the same
-    /// normalisation the server applies for canonical-name lookup.
+    /// normalisation the server applies for canonical-name lookup, and
+    /// memoises per-book keys via [`Self::book_keys`] so each filter
+    /// keystroke walks pre-normalised strings instead of re-NFD'ing every
+    /// book name.
     pub fn filtered_books(&self) -> Vec<BibleBookDto> {
         let filter_raw = self.book_filter.get();
         let filter = presenter_core::bible::normalise_book_key(&filter_raw);
@@ -117,8 +133,15 @@ impl BibleState {
         if filter.is_empty() {
             return all;
         }
+        let keys = self.book_keys.get();
         all.into_iter()
-            .filter(|b| presenter_core::bible::normalise_book_key(&b.book).contains(&filter))
+            .enumerate()
+            .filter(|(idx, _)| {
+                keys.get(*idx)
+                    .map(|key| key.contains(&filter))
+                    .unwrap_or(false)
+            })
+            .map(|(_, book)| book)
             .collect()
     }
 }

--- a/docs/superpowers/plans/2026-05-14-bible-keyboard-nav-diacritic-search.md
+++ b/docs/superpowers/plans/2026-05-14-bible-keyboard-nav-diacritic-search.md
@@ -1,0 +1,352 @@
+# Bible keyboard-nav + diacritic search — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) — controller will run tasks in this session. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add keyboard-driven navigation chain and diacritic-insensitive book search to the bible live page. Closes #257.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-bible-keyboard-nav-diacritic-search-design.md`.
+
+**Architecture:** Promote `normalise_book_key` to public in `presenter-core`. Switch `BibleState::filtered_books` to use it. Add `NodeRef`s + `on:keydown` Enter handlers on the four inputs (`book-filter`, `chapter-input`, `verse-start`, `verse-end`) to step focus through the chain, returning to `book-filter` after verse-end.
+
+**Version status:** dev = 0.4.76, main = 0.4.75 → dev > main, no bump needed.
+
+---
+
+### Task 1: RED — Playwright E2E spec asserting full keyboard chain + diacritic match
+
+**Files:**
+- Create: `tests/e2e/wasm-bible-keyboard-nav.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Use existing `tests/e2e/wasm-bible.spec.ts` patterns for server start, navigation, and `data-role="book-item"` selectors. Two scenarios:
+1. Type `lukas` → assert at least one `[data-role="book-item"]` rendered AND its label contains `Lukáš`.
+2. Type `lukas`, press Enter → assert `document.activeElement` matches `[data-role="chapter-input"]`. Type `6`, press Enter → activeElement is `[data-role="verse-start"]`. Type `38`, press Enter → activeElement is `[data-role="verse-end"]`. Press Enter on empty verse-end → activeElement is `[data-role="book-filter"]`, value empty. Assert console clean.
+
+- [ ] **Step 2: Run test, see RED**
+
+```bash
+npm run test:playwright -- wasm-bible-keyboard-nav
+```
+
+Expected: BOTH scenarios fail (no normalisation, no Enter handlers).
+
+- [ ] **Step 3: Commit RED**
+
+```bash
+git add tests/e2e/wasm-bible-keyboard-nav.spec.ts
+git commit -m "test(e2e): assert bible keyboard chain + diacritic book search (#257)"
+```
+
+### Task 2: Promote `normalise_book_key` to `pub`
+
+**Files:**
+- Modify: `crates/presenter-core/src/bible/search.rs:3` — `pub(crate)` → `pub`
+- Modify: `crates/presenter-core/src/bible/mod.rs:4` — `mod search;` → `pub mod search;` + add `pub use search::normalise_book_key;` to the `pub use` block
+
+- [ ] **Step 1: Edit search.rs**
+
+```rust
+pub fn normalise_book_key(input: &str) -> String {
+```
+
+- [ ] **Step 2: Edit mod.rs — promote and re-export**
+
+```rust
+pub mod search;
+
+pub use search::normalise_book_key;
+```
+
+(Keep the existing `pub use bible::...` chain in `lib.rs` working — `normalise_book_key` will be reachable as `presenter_core::bible::normalise_book_key`.)
+
+- [ ] **Step 3: Add a diacritic test case**
+
+Append to the `#[cfg(test)] mod tests` block in `search.rs`:
+
+```rust
+    #[test]
+    fn strips_slovak_diacritics() {
+        assert_eq!(normalise_book_key("Lukáš"), "lukas");
+        assert_eq!(normalise_book_key("1. Mojžišova"), "1mojzisova");
+    }
+```
+
+- [ ] **Step 4: Run unit tests**
+
+```bash
+cargo test -p presenter-core bible::search
+```
+
+Expected: 2 tests pass (existing `strips_non_alphanumeric_characters` + new `strips_slovak_diacritics`).
+
+### Task 3: Switch `BibleState::filtered_books` to normalised matching
+
+**Files:**
+- Modify: `crates/presenter-ui/src/state/bible.rs:109-118`
+
+- [ ] **Step 1: Replace the body of `filtered_books`**
+
+```rust
+pub fn filtered_books(&self) -> Vec<BibleBookDto> {
+    let filter_raw = self.book_filter.get();
+    let filter = presenter_core::bible::normalise_book_key(&filter_raw);
+    let all = self.books.get();
+    if filter.is_empty() {
+        return all;
+    }
+    all.into_iter()
+        .filter(|b| presenter_core::bible::normalise_book_key(&b.book).contains(&filter))
+        .collect()
+}
+```
+
+- [ ] **Step 2: Add a module-public diacritic test**
+
+Append to the `#[cfg(test)] mod tests` block in `state/bible.rs`:
+
+```rust
+    #[test]
+    fn book_filter_matches_diacritic_insensitively() {
+        use crate::api::bible::BibleBookDto;
+        // Build a minimal BibleBookDto fixture for Lukáš
+        let book = BibleBookDto {
+            book: "Lukáš".into(),
+            code: "LUK".into(),
+            number: 42,
+            chapters: vec![],
+        };
+        // Substring match: ASCII "lukas" matches "Lukáš"
+        let filter = presenter_core::bible::normalise_book_key("lukas");
+        let key = presenter_core::bible::normalise_book_key(&book.book);
+        assert!(key.contains(&filter));
+    }
+```
+
+(The test exercises the same code path `filtered_books` uses — exhaustive end-to-end via state requires a Leptos runtime, which isn't worth setting up in a `#[cfg(test)]` block.)
+
+- [ ] **Step 3: Run UI crate tests**
+
+```bash
+cargo test -p presenter-ui state::bible
+```
+
+Expected: existing 6 clamp tests + new 1 pass.
+
+### Task 4: Add `NodeRef`s, `on:keydown` handlers, and mount auto-focus on `BibleLiveTab`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/pages/bible.rs` — `BookFilter`, `ReferenceInputs`, and `BibleLiveTab` components
+
+- [ ] **Step 1: Promote the four inputs to use shared `NodeRef`s**
+
+Replace `BookFilter` and `ReferenceInputs` so they accept `NodeRef<leptos::html::Input>` props for focus chaining. Or — simpler given Leptos 0.7 — make the four `NodeRef`s in `BibleLiveTab` and pass into the children as props.
+
+Working approach: keep the existing component structure. Define four `NodeRef`s in `BibleLiveTab`, store them in a small struct shared via `provide_context`, and have each child read them via `use_context`. The `KeyboardEvent` handler in `BookFilter` reads `chapter_ref.get()` and calls `.focus()` on it.
+
+Concrete shared-context type at top of `pages/bible.rs`:
+
+```rust
+#[derive(Copy, Clone)]
+struct BibleFocusRefs {
+    book_filter: NodeRef<leptos::html::Input>,
+    chapter: NodeRef<leptos::html::Input>,
+    verse_start: NodeRef<leptos::html::Input>,
+    verse_end: NodeRef<leptos::html::Input>,
+}
+```
+
+Provide via `provide_context(BibleFocusRefs { ... })` inside `BibleLiveTab` BEFORE rendering children. Each child does `let refs = use_context::<BibleFocusRefs>().expect("BibleFocusRefs provided");`.
+
+- [ ] **Step 2: Attach `node_ref` to each of the four `<input>`s and add `on:keydown`**
+
+`book-filter` (in `BookFilter`):
+
+```rust
+let refs = expect_context::<BibleFocusRefs>();
+let bs = use_ctx!(BibleState);
+let on_keydown = move |ev: web_sys::KeyboardEvent| {
+    if ev.key() == "Enter" {
+        ev.prevent_default();
+        // Pick the first filtered book — same path as click handler.
+        let books = bs.filtered_books();
+        if let Some(book) = books.first().cloned() {
+            let chapter_count = book.chapters.len() as u16;
+            let verse_counts: Vec<u16> = book.chapters.iter().map(|c| c.verse_count).collect();
+            let current_chapter = bs.selected_chapter.get_untracked();
+            let current_v_start = bs.verse_start.get_untracked();
+            let current_v_end = bs.verse_end.get_untracked();
+            let clamped = crate::state::bible::clamp_selection(
+                chapter_count,
+                &verse_counts,
+                current_chapter,
+                current_v_start,
+                current_v_end,
+            );
+            bs.selected_book.set(Some(SelectedBook {
+                book: book.book.clone(),
+                code: book.code.clone(),
+                number: book.number,
+                chapter_count,
+                verse_counts,
+            }));
+            bs.selected_chapter.set(clamped.chapter);
+            bs.verse_start.set(clamped.verse_start);
+            bs.verse_end.set(clamped.verse_end);
+            bs.book_filter.set(String::new());
+            if let Some(el) = refs.chapter.get() {
+                let _ = el.focus();
+            }
+        }
+    }
+};
+```
+
+Then on the `<input>`: `node_ref=refs.book_filter on:keydown=on_keydown`.
+
+`chapter-input` (in `ReferenceInputs`):
+
+```rust
+let refs = expect_context::<BibleFocusRefs>();
+let on_chapter_keydown = move |ev: web_sys::KeyboardEvent| {
+    if ev.key() == "Enter" {
+        ev.prevent_default();
+        // Commit current value via existing on_chapter logic
+        if let Some(input) = refs.chapter.get() {
+            if let Ok(val) = input.value().parse::<u16>() {
+                selected_chapter.set(val.max(1));
+                verse_start_signal.set(1);
+                verse_end_signal.set(None);
+            }
+            if let Some(el) = refs.verse_start.get() {
+                let _ = el.focus();
+                let _ = el.select();
+            }
+        }
+    }
+};
+```
+
+Same shape for `verse-start` (advance to `verse-end`).
+
+`verse-end` (chain terminator):
+
+```rust
+let on_verse_end_keydown = move |ev: web_sys::KeyboardEvent| {
+    if ev.key() == "Enter" {
+        ev.prevent_default();
+        if let Some(input) = refs.verse_end.get() {
+            let val_str = input.value();
+            if val_str.is_empty() {
+                verse_end_signal.set(None);
+            } else if let Ok(val) = val_str.parse::<u16>() {
+                verse_end_signal.set(Some(val.max(1)));
+            }
+            let _ = input.blur();
+        }
+        // Return focus to book-filter; book_filter signal is already empty
+        // because book-filter Enter cleared it. Defensive reset:
+        bs.book_filter.set(String::new());
+        if let Some(el) = refs.book_filter.get() {
+            let _ = el.focus();
+        }
+    }
+};
+```
+
+- [ ] **Step 3: Mount-time auto-focus**
+
+Inside `BibleLiveTab`, AFTER `provide_context(refs)`:
+
+```rust
+let refs = ...;
+Effect::new(move |prev: Option<()>| {
+    if prev.is_none() {
+        if let Some(el) = refs.book_filter.get() {
+            let _ = el.focus();
+        }
+    }
+});
+```
+
+- [ ] **Step 4: Local lint + check**
+
+```bash
+cargo fmt --all --check
+cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all
+cd - && cargo clippy --workspace --all-targets -- -D warnings -W clippy::all
+```
+
+Expected: no warnings.
+
+- [ ] **Step 5: Build WASM**
+
+```bash
+cd crates/presenter-ui && trunk build --release
+```
+
+Expected: success. (Pre-existing local-build policy allowed per CLAUDE.md.)
+
+### Task 5: GREEN — Run E2E again, expect pass
+
+- [ ] **Step 1: Run dev server locally**
+
+```bash
+sudo systemctl restart presenter-dev
+sleep 3
+curl -sf http://10.77.8.134:8080/healthz
+```
+
+- [ ] **Step 2: Run Playwright spec**
+
+```bash
+npm run test:playwright -- wasm-bible-keyboard-nav
+```
+
+Expected: BOTH scenarios PASS.
+
+- [ ] **Step 3: Run full Playwright suite (sanity, regressions)**
+
+Optional locally; CI runs the full suite in 3 shards anyway. Skip locally.
+
+- [ ] **Step 4: Commit GREEN**
+
+```bash
+git add crates/presenter-core/src/bible/search.rs \
+        crates/presenter-core/src/bible/mod.rs \
+        crates/presenter-ui/src/state/bible.rs \
+        crates/presenter-ui/src/pages/bible.rs
+git commit -m "$(cat <<'EOF'
+feat(bible): keyboard chain + diacritic-insensitive book search
+
+- Promote presenter_core::bible::search::normalise_book_key to pub and
+  re-export at presenter_core::bible::normalise_book_key.
+- BibleState::filtered_books matches via normalised keys so typing "lukas"
+  finds "Lukáš" and "1moj" finds "1. Mojžišova".
+- Add Enter-key handlers on book-filter, chapter, verse-start, verse-end
+  inputs that step focus through the chain. Verse-end terminator returns
+  focus to book-filter and clears the filter.
+- Auto-focus book-filter on /ui/operator/bible mount via NodeRef.
+
+Closes #257.
+EOF
+)"
+```
+
+### Task 6: Controller-handled push, monitor, PR, wait for merge
+
+- [ ] **Step 1: Push dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 2: Monitor pipeline to terminal green per `ci-monitoring.md`** — single background `sleep 300 && gh run view <id>`.
+
+- [ ] **Step 3: Open PR dev → main** with body listing `Closes #257`.
+
+- [ ] **Step 4: Verify mergeable: true AND mergeable_state: clean.**
+
+- [ ] **Step 5: Send completion report.** Wait for explicit user merge instruction.
+
+- [ ] **Step 6: Post-deploy verification on dev (10.77.8.134:8080)** — open `/ui/operator/bible` in Playwright, type `lukas`, verify Lukáš shown; press Enter chain manually; assert console clean.

--- a/docs/superpowers/specs/2026-05-14-bible-keyboard-nav-diacritic-search-design.md
+++ b/docs/superpowers/specs/2026-05-14-bible-keyboard-nav-diacritic-search-design.md
@@ -1,0 +1,49 @@
+# Bible page keyboard-nav + diacritic-insensitive book search
+
+> **Closes #257.** Two related improvements on `/ui/operator/bible` (live tab) so the operator can drive the page from the keyboard during a service without touching the mouse.
+
+## Goal
+
+1. **Keyboard chain.** Open the bible page, start typing the book name — Enter commits the top-of-list match and moves focus to the next field in the chain: `book-filter → chapter-input → verse-start → verse-end → book-filter (reset)`.
+2. **Diacritic-insensitive book search.** Typing `lukas` matches `Lukáš`. Typing `1moj` matches `1. Mojžišova`. Matching also ignores case, punctuation, and whitespace (same normalisation already used server-side by `normalise_book_key`).
+
+## Architecture
+
+- **Shared normalisation:** Promote `presenter_core::bible::search::normalise_book_key` from `pub(crate)` to `pub` and re-export it via `presenter_core::bible::normalise_book_key`. The WASM UI calls the same function the server uses for canonical name lookup — single source of truth.
+- **Filtering:** `BibleState::filtered_books()` in `crates/presenter-ui/src/state/bible.rs` switches from `book.book.to_lowercase().contains(&filter)` to `normalise_book_key(book.book).contains(&normalise_book_key(filter))`.
+- **Keyboard chain:** Each input in the bible live panel (`book-filter`, `chapter-input`, `verse-start`, `verse-end`) gets an `on:keydown` handler that intercepts `Enter`. The handler commits the current value into the underlying `RwSignal`, then calls `.focus()` on the next input via a `NodeRef`.
+- **Auto-focus:** A `NodeRef` on the `book-filter` input plus a `node_ref` mount-time `.focus()` call on `BibleLiveTab` covers the "just start typing" requirement on initial load. The verse-end → book-filter step in the chain reuses the same `NodeRef`.
+- **Filter reset after chain completes:** When the user presses Enter on `verse-end`, the chain ends: focus returns to `book-filter` AND `bs.book_filter` resets to empty so the list collapses to the loaded book (existing collapse behaviour at `bible.rs:431`) and the operator can immediately start typing the next book.
+
+## Decisions (from brainstorm)
+
+- **Enter target:** first book in the filtered list (top visible). Matches user wording "highest book".
+- **Verse-end Enter:** blur + focus returns to book-filter. The existing 300 ms debounced auto-load already triggers the passage fetch on signal change; no extra Load Passage click is needed.
+- **Auto-focus:** on mount AND after every chain completes.
+
+## Out of scope (deferred)
+
+- **Synonym book names** (e.g. Slovak `1. Mojžišova` ↔ canonical `Genezis`). Different from substring/diacritic-insensitive matching — synonym handling needs the server-side canonical alias table. That's #310's territory.
+- **Chapter / verse normalisation:** numeric inputs only, no normalisation needed.
+- **Diacritic handling in chapter/verse number parsing:** N/A — numeric.
+
+## Testing
+
+- **Unit:** `presenter_core::bible::search::normalise_book_key` already has unit coverage for diacritic stripping. Add one more case asserting Slovak `Lukáš` → `lukas`.
+- **Unit:** `BibleState::filtered_books` add a test case for diacritic-insensitive matching (requires lift to module-public if not already).
+- **E2E:** new Playwright spec `tests/e2e/wasm-bible-keyboard-nav.spec.ts` with two scenarios:
+  - **A. Diacritic search:** load `/ui/operator/bible`, type `lukas` in book-filter, assert filtered list shows `Lukáš` and that book is the top match.
+  - **B. Keyboard chain:** type `lukas`, Enter → assert chapter-input focused. Type `6`, Enter → assert verse-start focused. Type `38`, Enter → assert verse-end focused. Press Enter on empty verse-end → assert book-filter focused AND book_filter input value is empty.
+- Browser console must be clean (no errors/warnings) per `browser-console-zero-errors`.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `crates/presenter-core/src/bible/search.rs` | `normalise_book_key` → `pub`. Add one more test case. |
+| `crates/presenter-core/src/bible/mod.rs` | `pub mod search;` + `pub use search::normalise_book_key;`. |
+| `crates/presenter-ui/src/state/bible.rs` | `filtered_books()` uses `normalise_book_key`. Add module-public test for diacritic-insensitive match. |
+| `crates/presenter-ui/src/pages/bible.rs` | Add `NodeRef`s, `on:keydown` handlers on 4 inputs, mount-time `.focus()`. |
+| `tests/e2e/wasm-bible-keyboard-nav.spec.ts` | New file with two scenarios above. |
+
+No schema change. No API break. ≤200 LoC est. Bundle-safe.

--- a/tests/e2e/wasm-bible-keyboard-nav.spec.ts
+++ b/tests/e2e/wasm-bible-keyboard-nav.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Bible keyboard navigation + diacritic-insensitive book search (#257).
+ *
+ * Scenarios:
+ *   A. Typing ASCII "lukas" surfaces the Slovak "Lukáš" book.
+ *   B. Enter steps focus through book-filter → chapter → verse-start →
+ *      verse-end → book-filter (cleared) for a no-mouse passage workflow.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+});
+
+/** Open the operator, switch to bible view, ensure WASM is ready. */
+async function openBibleLive(page: import("@playwright/test").Page) {
+  await page.goto(`${baseURL}/ui/operator`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  const bibleToggle = page.locator(
+    '[data-role="view-toggle"][data-view="bible"]',
+  );
+  await bibleToggle.click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-view") === "bible",
+    { timeout: 5_000 },
+  );
+}
+
+/** Pick a translation that contains diacritics in book names (SEB / Slovak). */
+async function selectSlovakTranslation(
+  page: import("@playwright/test").Page,
+): Promise<boolean> {
+  const mainSelect = page.locator('[data-role="main-translation"]');
+  await expect(mainSelect).toBeVisible({ timeout: 10_000 });
+
+  // Find the option whose label looks Slovak (SEB / Roháček / Milost / SEVP).
+  const slovakValue = await mainSelect.evaluate((el) => {
+    const select = el as HTMLSelectElement;
+    for (const opt of Array.from(select.options)) {
+      const label = opt.textContent ?? "";
+      if (/SEB|Slovak|slovenský|Roh[áa]ček|Milost|SEVP/i.test(label)) {
+        return opt.value;
+      }
+    }
+    return null;
+  });
+  if (!slovakValue) {
+    return false;
+  }
+  await mainSelect.selectOption(slovakValue);
+
+  // Wait for the book list to repopulate against the new translation.
+  await page.waitForFunction(
+    () => document.querySelectorAll('[data-role="book-item"]').length > 0,
+    { timeout: 15_000 },
+  );
+  return true;
+}
+
+test.describe("Bible keyboard nav + diacritic search (#257)", () => {
+  test("ASCII filter 'lukas' surfaces 'Lukáš'", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleErrors.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+
+    await openBibleLive(page);
+    const haveSlovak = await selectSlovakTranslation(page);
+    test.skip(!haveSlovak, "No diacritic-bearing translation available");
+
+    const bookFilter = page.locator('[data-role="book-filter"]');
+    await bookFilter.fill("lukas");
+
+    // Top filtered item should be the Slovak Lukáš book.
+    const firstItem = page.locator('[data-role="book-item"]').first();
+    await expect(firstItem).toBeVisible({ timeout: 5_000 });
+    await expect(firstItem).toContainText("Luk", { timeout: 5_000 });
+    const label = (await firstItem.textContent()) ?? "";
+    expect(label).toMatch(/Luk[aá][sš]/);
+
+    expect(consoleErrors.filter((m) => !m.includes("favicon"))).toEqual([]);
+  });
+
+  test("Enter chain: book-filter → chapter → verse-start → verse-end → book-filter", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleErrors.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+
+    await openBibleLive(page);
+    const haveSlovak = await selectSlovakTranslation(page);
+    test.skip(!haveSlovak, "No diacritic-bearing translation available");
+
+    // Step 0 — on mount, book-filter should already be focused.
+    const activeRoleAtMount = await page.evaluate(
+      () => document.activeElement?.getAttribute("data-role") ?? null,
+    );
+    expect(activeRoleAtMount).toBe("book-filter");
+
+    // Step 1 — type "lukas" then Enter → focus moves to chapter.
+    const bookFilter = page.locator('[data-role="book-filter"]');
+    await bookFilter.fill("lukas");
+    await page.waitForFunction(
+      () => document.querySelectorAll('[data-role="book-item"]').length > 0,
+      { timeout: 5_000 },
+    );
+    await bookFilter.press("Enter");
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-role") ?? null,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe("chapter-input");
+
+    // Step 2 — type "6" then Enter → focus moves to verse-start.
+    const chapter = page.locator('[data-role="chapter-input"]');
+    await chapter.fill("6");
+    await chapter.press("Enter");
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-role") ?? null,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe("verse-start");
+
+    // Step 3 — type "38" then Enter → focus moves to verse-end.
+    const verseStart = page.locator('[data-role="verse-start"]');
+    await verseStart.fill("38");
+    await verseStart.press("Enter");
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-role") ?? null,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe("verse-end");
+
+    // Step 4 — Enter on empty verse-end → focus returns to book-filter,
+    // and book-filter value is cleared.
+    const verseEnd = page.locator('[data-role="verse-end"]');
+    await verseEnd.press("Enter");
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-role") ?? null,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe("book-filter");
+    await expect(bookFilter).toHaveValue("");
+
+    expect(consoleErrors.filter((m) => !m.includes("favicon"))).toEqual([]);
+  });
+});

--- a/tests/e2e/wasm-bible-keyboard-nav.spec.ts
+++ b/tests/e2e/wasm-bible-keyboard-nav.spec.ts
@@ -117,17 +117,26 @@ test.describe("Bible keyboard nav + diacritic search (#257)", () => {
     });
 
     await openBibleLive(page);
+
+    // Step 0 — book-filter auto-focuses on first mount BEFORE any other
+    // interaction. Run this check before changing translation, since
+    // `selectOption` moves focus to the <select> element.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-role") ?? null,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe("book-filter");
+
     const haveSlovak = await selectSlovakTranslation(page);
     test.skip(!haveSlovak, "No diacritic-bearing translation available");
 
-    // Step 0 — on mount, book-filter should already be focused.
-    const activeRoleAtMount = await page.evaluate(
-      () => document.activeElement?.getAttribute("data-role") ?? null,
-    );
-    expect(activeRoleAtMount).toBe("book-filter");
-
     // Step 1 — type "lukas" then Enter → focus moves to chapter.
     const bookFilter = page.locator('[data-role="book-filter"]');
+    await bookFilter.click(); // return focus from translation <select>
     await bookFilter.fill("lukas");
     await page.waitForFunction(
       () => document.querySelectorAll('[data-role="book-item"]').length > 0,

--- a/tests/e2e/wasm-bible.spec.ts
+++ b/tests/e2e/wasm-bible.spec.ts
@@ -2868,6 +2868,24 @@ test.describe("Bible workflow fixes (issue #256)", () => {
     });
     await navigateToBible(page);
 
+    // Reset main translation to the English option so the "Ge" filter has a
+    // match. Earlier tests in this spec change Main translation; preferences
+    // persist in the test DB, so navigateToBible alone does not reset it.
+    const mainSelect = page.locator('[data-role="main-translation"]');
+    await expect(mainSelect).toBeVisible({ timeout: 10_000 });
+    const englishValue = await mainSelect.evaluate((el) => {
+      const select = el as HTMLSelectElement;
+      for (const opt of Array.from(select.options)) {
+        if (/eng-|english|KJV|King James/i.test(opt.value + " " + (opt.textContent ?? ""))) {
+          return opt.value;
+        }
+      }
+      return null;
+    });
+    if (englishValue) {
+      await mainSelect.selectOption(englishValue);
+    }
+
     // Wait for books to load first
     await expect(
       page.locator('[data-role="book-item"]').first(),
@@ -3036,12 +3054,12 @@ test.describe("Bible workflow fixes (issue #256)", () => {
     });
     await navigateToBible(page);
 
-    // Select first book
+    // Select first book and capture its canonical CODE (not the localized
+    // label). Cross-translation preservation matches by book code; labels
+    // legitimately change between translations.
     const firstBook = page.locator('[data-role="book-item"]').first();
     await expect(firstBook).toBeVisible({ timeout: 10_000 });
-    const firstBookLabel = await firstBook
-      .locator(".operator__list-label")
-      .textContent();
+    const firstBookCode = await firstBook.getAttribute("data-book-code");
     await firstBook.click();
     await expect(
       page.locator('[data-role="book-item"][data-active="true"]'),
@@ -3060,17 +3078,24 @@ test.describe("Bible workflow fixes (issue #256)", () => {
           break;
         }
       }
-      // Either the book is still selected (preserved) or cleared.
-      // If preserved, the label must match.
-      const stillActive = page.locator(
-        '[data-role="book-item"][data-active="true"]',
-      );
-      if ((await stillActive.count()) > 0) {
-        const label = await stillActive
-          .locator(".operator__list-label")
-          .textContent();
-        expect(label).toBe(firstBookLabel);
-      }
+      // Either the book is preserved (same code, possibly new label) or
+      // cleared. Use poll-with-timeout so the assertion does not race the
+      // translation-switch effect that re-renders the book list.
+      await expect
+        .poll(
+          async () => {
+            const active = page.locator(
+              '[data-role="book-item"][data-active="true"]',
+            );
+            const count = await active.count();
+            if (count === 0) {
+              return "cleared";
+            }
+            return (await active.first().getAttribute("data-book-code")) ?? "";
+          },
+          { timeout: 10_000 },
+        )
+        .toMatch(new RegExp(`^(cleared|${firstBookCode})$`));
     }
 
     expect(consoleMessages).toEqual([]);


### PR DESCRIPTION
## Summary

- Operator can now drive the bible live page from the keyboard. Typing the book name and pressing Enter selects the top match and moves focus to chapter; Enter on chapter → verse-start; Enter on verse-start → verse-end; Enter on verse-end clears the filter and returns focus to book-filter for the next passage.
- Book search now ignores diacritics: typing `lukas` surfaces `Lukáš`; `1moj` surfaces `1. Mojžišova`. Same `normalise_book_key` the server uses for canonical name lookup — single source of truth.
- book-filter auto-focuses every time the operator enters bible/live view via an Effect on the view + tab signals (the panel renders behind CSS even when inactive, so a one-shot `on_load` fired on a hidden element and was a no-op).
- Bundled fixes for two pre-existing flakes in `wasm-bible.spec.ts` that retry-passed before but began both-attempts-failing under the reshuffled shard 2 timing introduced by the new spec:
  - `selecting a book clears the filter`: prior tests change Main translation; preferences persist in the test DB. Reset to the English translation before filtering "Ge" so there's at least one match.
  - `translation change preserves book when available`: cross-translation preservation matches by canonical book code, not localized label. Capture `data-book-code` instead of textContent, and replace the racing count + textContent check with `expect.poll`.

Closes #257.

## Test plan

- [x] Unit: `cargo test -p presenter-core bible::search` (2 tests, includes new `strips_slovak_diacritics`).
- [x] Unit: `cargo test -p presenter-ui --lib state::bible` (7 tests, includes new `book_name_normalisation_folds_slovak_diacritics`).
- [x] Lint: `cargo fmt --all --check`, workspace + wasm clippy clean.
- [x] E2E: new `tests/e2e/wasm-bible-keyboard-nav.spec.ts` — 2 scenarios (RED on `65d4f07`, GREEN on `b441759`).
- [x] CI: pipeline `25856962027` — all jobs green (Branch Sync, Format, Clippy, Cargo Deny x2, Cargo Audit, Companion, Validate Version, npm Audit, Test, Quality, Code Coverage, Build, Mutation Testing, Playwright 1/3 + 2/3 + 3/3, Merge E2E Reports, Deploy to Dev, Deploy Companion Plugin).
- [x] Deploy verified on dev `10.77.8.134:8080`: `v0.4.76 (dev)` (matches `/healthz`), bible page auto-focuses book-filter, "lukas" → Lukáš, full Enter chain steps focus through chapter → verse-start → verse-end → book-filter (cleared). Console clean apart from pre-existing favicon 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)