### PR TITLE
fix(ai): bible builder bugs — Roháček alias, cross-turn delete intent, validator visibility (#310)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.76"
+version = "0.4.77"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/bible/canonical.rs
+++ b/crates/presenter-core/src/bible/canonical.rs
@@ -412,6 +412,81 @@ const SLOVAK_ECUMENICKY_NAMES: [&str; 66] = [
     "Zjavenie",
 ];
 
+// Roháček (slk-roh) book names — the Protestant Slovak tradition that
+// uses Hebrew-style ordinal naming for the Pentateuch ("1. Mojžišova" =
+// "First Book of Moses" = Genesis). Sourced from the live slk-roh
+// translation in the project DB. Used as alias input for the
+// canonical-book resolver so AI tools accept any common Slovak name
+// regardless of which translation actually stores the row. See #310.
+const SLOVAK_ROHACEK_NAMES: [&str; 66] = [
+    "1. Mojžišova",
+    "2. Mojžišova",
+    "3. Mojžišova",
+    "4. Mojžišova",
+    "5. Mojžišova",
+    "Jozua",
+    "Sudcovia",
+    "Rút",
+    "1. Samuelova",
+    "2. Samuelova",
+    "1. Kráľov",
+    "2. Kráľov",
+    "1. Kronická",
+    "2. Kronická",
+    "Ezdráš",
+    "Nehemiáš",
+    "Ester",
+    "Jób",
+    "Žalmy",
+    "Príslovia",
+    "Kazateľ",
+    "Pieseň",
+    "Izaiáš",
+    "Jeremiáš",
+    "Plač",
+    "Ezechiel",
+    "Daniel",
+    "Hozeáš",
+    "Joel",
+    "Ámos",
+    "Abdiáš",
+    "Jonáš",
+    "Micheáš",
+    "Náhum",
+    "Abakuk",
+    "Sofoniáš",
+    "Haggeus",
+    "Zachariáš",
+    "Malachiáš",
+    "Matúš",
+    "Marek",
+    "Lukáš",
+    "Ján",
+    "Skutky",
+    "Rimanom",
+    "1. Korinťanom",
+    "2. Korinťanom",
+    "Galaťanom",
+    "Efezanom",
+    "Filipanom",
+    "Kolosenským",
+    "1. Tesaloničanom",
+    "2. Tesaloničanom",
+    "1. Timoteovi",
+    "2. Timoteovi",
+    "Títovi",
+    "Filemonovi",
+    "Židom",
+    "Jakobov",
+    "1. Petrov",
+    "2. Petrov",
+    "1. Jánov",
+    "2. Jánov",
+    "3. Jánov",
+    "Júdov",
+    "Zjavenie",
+];
+
 const SLOVAK_OBOHU_NAMES: [&str; 66] = [
     "Genesis",
     "Exodus",
@@ -565,6 +640,14 @@ static BOOK_NAME_ALIASES: LazyLock<HashMap<String, BibleBookCanonical>> = LazyLo
 
     #[allow(clippy::cast_possible_truncation)]
     for (index, alias) in SLOVAK_OBOHU_NAMES.iter().enumerate() {
+        // SAFETY: Array has fixed size < 100 elements, so index fits in u16
+        if let Some(meta) = canonical_book_by_number((index as u16) + 1) {
+            register_alias_variants(&mut map, alias, meta);
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    for (index, alias) in SLOVAK_ROHACEK_NAMES.iter().enumerate() {
         // SAFETY: Array has fixed size < 100 elements, so index fits in u16
         if let Some(meta) = canonical_book_by_number((index as u16) + 1) {
             register_alias_variants(&mut map, alias, meta);

--- a/crates/presenter-core/src/bible/canonical.rs
+++ b/crates/presenter-core/src/bible/canonical.rs
@@ -672,3 +672,36 @@ pub fn canonical_book_by_number(number: u16) -> Option<BibleBookCanonical> {
         .copied()
         .find(|meta| meta.number == number)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slovak_rohacek_first_mojzisova_resolves_to_genesis() {
+        // Regression #310: AI uses Roháček naming "1. Mojžišova" but the SEB
+        // translation stores it as "Genezis". The alias resolver must accept
+        // ANY Slovak naming and return the canonical code.
+        let meta = canonical_book_by_name("1. Mojžišova").expect("must resolve");
+        assert_eq!(meta.code, "GEN");
+    }
+
+    #[test]
+    fn slovak_rohacek_diacritic_insensitive() {
+        // Roháček name without diacritics still resolves (per normalise_book_key).
+        let meta = canonical_book_by_name("1. Mojzisova").expect("must resolve");
+        assert_eq!(meta.code, "GEN");
+    }
+
+    #[test]
+    fn slovak_rohacek_lukas_resolves() {
+        let meta = canonical_book_by_name("Lukáš").expect("must resolve");
+        assert_eq!(meta.code, "LUK");
+    }
+
+    #[test]
+    fn ecumenical_genezis_still_resolves() {
+        let meta = canonical_book_by_name("Genezis").expect("must resolve");
+        assert_eq!(meta.code, "GEN");
+    }
+}

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -5,6 +5,14 @@ use tracing::{info, warn};
 
 const MAX_ITERATIONS: usize = 100;
 
+/// Stub: cross-turn delete-intent gate. Will accept the current user message
+/// AND the conversation history so deferred intent ("delete X" → "confirm?"
+/// → "yes") is still granted. Filled in by the next commit; this is the RED
+/// scaffold so the regression tests compile.
+fn delete_intent_for_turn(_user_message: &str, _conversation: &[ChatMessage]) -> bool {
+    false
+}
+
 /// Returns `true` if the user's message contains an explicit intent to delete.
 /// Used as a gate on all `delete_*` tool calls to prevent model hallucinations
 /// from causing data loss. The model must see a keyword in the user's actual
@@ -702,6 +710,60 @@ mod tests {
         ));
         assert!(delete_intent_allowed(
             "please vymaž everything from yesterday"
+        ));
+    }
+
+    #[test]
+    fn turn_intent_grants_when_prior_user_message_asked_to_delete() {
+        // Regression #310: user said "vymaž to" in turn N, AI asked
+        // "potvrdzujete?" in its text response, user replied "ano" in turn
+        // N+1. Without conversation context the gate sees only "ano" which
+        // has no delete keyword and blocks. The cross-turn gate must walk
+        // back through prior user messages and grant intent when a recent
+        // one contained an explicit delete keyword AND the current message
+        // is affirmative.
+        let convo = vec![
+            user_msg("vymaž tie dve prezentácie"),
+            assistant_msg("Potvrdzujete, že chcete vymazať tie dve prezentácie?"),
+            user_msg("ano"),
+        ];
+        assert!(
+            delete_intent_for_turn("ano", &convo),
+            "deferred delete intent + affirmative reply must grant the gate"
+        );
+    }
+
+    #[test]
+    fn turn_intent_grants_when_current_message_has_keyword() {
+        // Direct path: gate must still grant when the current message itself
+        // contains a delete keyword, regardless of conversation history.
+        let convo = vec![user_msg("delete the slide")];
+        assert!(delete_intent_for_turn("delete the slide", &convo));
+    }
+
+    #[test]
+    fn turn_intent_blocks_when_no_user_message_ever_asked_to_delete() {
+        // No prior message had delete intent — affirmative alone is not
+        // enough. Prevents the AI from inventing a delete then asking
+        // "should I?" then proceeding on "yes" without the user ever
+        // having actually asked.
+        let convo = vec![
+            user_msg("create a new presentation"),
+            assistant_msg("Should I delete the old one first?"),
+            user_msg("yes"),
+        ];
+        assert!(
+            !delete_intent_for_turn("yes", &convo),
+            "affirmative without prior user delete intent must NOT grant the gate"
+        );
+    }
+
+    #[test]
+    fn turn_intent_blocks_when_neither_signal_present() {
+        let convo = vec![user_msg("make a song presentation about hope")];
+        assert!(!delete_intent_for_turn(
+            "make a song presentation about hope",
+            &convo
         ));
     }
 

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -838,6 +838,29 @@ mod tests {
     }
 
     #[test]
+    fn turn_intent_does_not_grant_on_stale_intent_far_back_in_history() {
+        // Reviewer concern: unbounded lookback means a "delete X" from 30
+        // turns ago can be unlocked by an affirmative reply to a totally
+        // unrelated current question. The deferred-intent window must be
+        // bounded — only the most recent few user turns count.
+        let mut convo = vec![user_msg("vymaž tie staré slajdy")];
+        // 5 unrelated turns after the original delete request.
+        for i in 0..5 {
+            convo.push(assistant_msg(&format!("Hotovo {i}")));
+            convo.push(user_msg(&format!("now make a new song presentation {i}")));
+        }
+        // AI now asks "delete the cover slide?" and user replies yes —
+        // the user's CURRENT yes refers to the AI's question, NOT the
+        // long-ago delete. Gate must block.
+        convo.push(assistant_msg("Should I delete the cover slide?"));
+        convo.push(user_msg("ano"));
+        assert!(
+            !delete_intent_for_turn("ano", &convo),
+            "stale delete intent from >3 turns ago must NOT grant on current affirmative"
+        );
+    }
+
+    #[test]
     fn turn_intent_blocks_when_neither_signal_present() {
         let convo = vec![user_msg("make a song presentation about hope")];
         assert!(!delete_intent_for_turn(

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -5,12 +5,87 @@ use tracing::{info, warn};
 
 const MAX_ITERATIONS: usize = 100;
 
-/// Stub: cross-turn delete-intent gate. Will accept the current user message
-/// AND the conversation history so deferred intent ("delete X" → "confirm?"
-/// → "yes") is still granted. Filled in by the next commit; this is the RED
-/// scaffold so the regression tests compile.
-fn delete_intent_for_turn(_user_message: &str, _conversation: &[ChatMessage]) -> bool {
-    false
+/// Affirmative replies recognised by the cross-turn gate. Used when the
+/// user types a short confirmation after the AI proposed a delete in the
+/// preceding text response.
+const AFFIRMATIVE_REPLIES: &[&str] = &[
+    // English
+    "yes",
+    "yeah",
+    "yep",
+    "y",
+    "ok",
+    "okay",
+    "sure",
+    "confirm",
+    "confirmed",
+    "go ahead",
+    "do it",
+    "do it.",
+    "please do",
+    // Slovak with diacritics
+    "áno",
+    "súhlasím",
+    "potvrdzujem",
+    "iste",
+    "určite",
+    // Slovak ASCII-folded variants
+    "ano",
+    "suhlasim",
+    "potvrdzujem.",
+    "iste.",
+    // Czech
+    "souhlasim",
+    "souhlasím",
+    "ano.",
+];
+
+fn is_affirmative(msg: &str) -> bool {
+    let trimmed = msg.trim().to_lowercase();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Exact match OR starts with an affirmative followed by space/comma/period.
+    AFFIRMATIVE_REPLIES.iter().any(|a| {
+        let a_lower = a.to_lowercase();
+        trimmed == a_lower
+            || trimmed.starts_with(&format!("{a_lower} "))
+            || trimmed.starts_with(&format!("{a_lower},"))
+            || trimmed.starts_with(&format!("{a_lower}."))
+            || trimmed.starts_with(&format!("{a_lower}!"))
+    })
+}
+
+/// Cross-turn delete-intent gate. Grants when:
+/// - the current user message itself contains a delete keyword, OR
+/// - some prior user message in the conversation contained a delete keyword
+///   AND the current message is affirmative (covers the "user asks to
+///   delete, AI defers for confirmation, user replies 'yes'" workflow).
+///
+/// Used in place of the single-message `delete_intent_allowed` check so the
+/// gate survives the conversational pattern where the AI splits a destructive
+/// operation across turns. Without this, deferred deletions never proceed
+/// because the affirmative reply has no keyword and is the only thing the
+/// AI sees on the next turn.
+fn delete_intent_for_turn(user_message: &str, conversation: &[ChatMessage]) -> bool {
+    // Direct: current message has a delete keyword.
+    if delete_intent_allowed(user_message) {
+        return true;
+    }
+
+    // Deferred: walk back through prior user messages. If any contained a
+    // delete keyword AND the current message is affirmative, grant. This
+    // narrow window prevents an unrelated affirmative ("yes" answering a
+    // totally different question) from unlocking a stale intent — both
+    // signals must be present.
+    if !is_affirmative(user_message) {
+        return false;
+    }
+    conversation
+        .iter()
+        .filter(|m| m.role == "user")
+        .filter_map(|m| m.content.as_deref())
+        .any(delete_intent_allowed)
 }
 
 /// Returns `true` if the user's message contains an explicit intent to delete.
@@ -323,12 +398,16 @@ pub async fn run_agent(
 
                 // Execute each tool call
                 for tc in tool_calls {
-                    // Delete-intent gate: block any delete_* tool unless the user's
-                    // original message contained an explicit delete keyword. Prevents
-                    // model hallucinations from causing data loss. See spec
+                    // Delete-intent gate: block any delete_* tool unless either the
+                    // current user message OR a deferred-intent pattern across prior
+                    // user messages signals an explicit delete request. Prevents
+                    // model hallucinations from causing data loss while still
+                    // allowing the "user asks to delete → AI defers for confirmation
+                    // → user replies 'yes'" workflow that the single-message gate
+                    // mistakenly blocked (#310). See spec
                     // docs/superpowers/specs/2026-04-11-ai-mode-cleanup-design.md
                     if tc.function.name.starts_with("delete_")
-                        && !delete_intent_allowed(&original_user_message)
+                        && !delete_intent_for_turn(&original_user_message, &conversation)
                     {
                         warn!(
                             tool = %tc.function.name,

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -58,34 +58,41 @@ fn is_affirmative(msg: &str) -> bool {
 
 /// Cross-turn delete-intent gate. Grants when:
 /// - the current user message itself contains a delete keyword, OR
-/// - some prior user message in the conversation contained a delete keyword
-///   AND the current message is affirmative (covers the "user asks to
-///   delete, AI defers for confirmation, user replies 'yes'" workflow).
+/// - the IMMEDIATELY PRECEDING user message contained a delete keyword AND
+///   the current message is affirmative (covers the "user asks to delete,
+///   AI defers for confirmation, user replies 'yes'" workflow).
 ///
-/// Used in place of the single-message `delete_intent_allowed` check so the
-/// gate survives the conversational pattern where the AI splits a destructive
-/// operation across turns. Without this, deferred deletions never proceed
-/// because the affirmative reply has no keyword and is the only thing the
-/// AI sees on the next turn.
+/// The deferred path looks back EXACTLY one user turn — the previous one —
+/// so an unrelated affirmative ("yes" to a different question turns later)
+/// cannot unlock stale intent from far back in the conversation. This bounds
+/// the gate window to the only pattern it needs to cover: a single defer.
 fn delete_intent_for_turn(user_message: &str, conversation: &[ChatMessage]) -> bool {
     // Direct: current message has a delete keyword.
     if delete_intent_allowed(user_message) {
         return true;
     }
 
-    // Deferred: walk back through prior user messages. If any contained a
-    // delete keyword AND the current message is affirmative, grant. This
-    // narrow window prevents an unrelated affirmative ("yes" answering a
-    // totally different question) from unlocking a stale intent — both
-    // signals must be present.
+    // Deferred: current message must be affirmative AND the previous user
+    // turn must have had explicit delete intent. Both signals required, and
+    // the lookback is bounded to ONE prior user turn — not the whole
+    // conversation — so stale intent decays naturally as the conversation
+    // moves on.
     if !is_affirmative(user_message) {
         return false;
     }
-    conversation
+
+    // The current user message is already at the END of conversation (the
+    // run_agent loop pushes it before calling this gate). Skip that one and
+    // grab the immediately preceding user message; if it had delete intent,
+    // grant.
+    let mut user_msgs = conversation
         .iter()
+        .rev()
         .filter(|m| m.role == "user")
-        .filter_map(|m| m.content.as_deref())
-        .any(delete_intent_allowed)
+        .filter_map(|m| m.content.as_deref());
+    let _current = user_msgs.next();
+    let previous = user_msgs.next();
+    previous.map(delete_intent_allowed).unwrap_or(false)
 }
 
 /// Returns `true` if the user's message contains an explicit intent to delete.

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -342,6 +342,15 @@ pub async fn execute_tool(
                 .unwrap_or(&main_trans.code)
                 .to_uppercase();
 
+            // Resolve the input book name to its canonical code so the
+            // query matches regardless of which Slovak naming tradition the
+            // AI used. Without this step the Roháček "1. Mojžišova" would
+            // miss SEB rows stored as "Genezis" and return 0 verses (#310).
+            // Falls back to raw book-name filter when the alias map has no
+            // entry — preserves behavior for languages without canonical
+            // coverage.
+            let resolved_code =
+                presenter_core::bible::canonical_book_by_name(&book).map(|m| m.code);
             // Single range query instead of per-verse round trips. The
             // repository returns only the verses that exist, so we walk
             // the requested range and fill gaps with explicit not-found
@@ -352,7 +361,7 @@ pub async fn execute_tool(
                 .bible_passage_range(
                     &main_trans.code,
                     &book,
-                    None,
+                    resolved_code,
                     chapter,
                     verse_start,
                     verse_end,

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -1307,6 +1307,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_bible_verses_resolves_rohacek_book_name_against_ecumenical_translation() {
+        // Regression #310: AI submitted load_bible_verses("1. Mojžišova", ...)
+        // against the SEB (ecumenical) translation, which stores the book as
+        // "Genezis". The lookup matched book.eq("1. Mojžišova") and returned
+        // 0/N verses. The fix: resolve the input book name to its canonical
+        // code via canonical_book_by_name() and query by book_code instead.
+        use presenter_core::bible::BibleIngestionBatch;
+        use presenter_core::{BiblePassage, BibleReference, BibleTranslation};
+
+        let state = AppState::in_memory().await.unwrap();
+        let translation = BibleTranslation::new("slk-seb", "Slovenský ekumenický", "sk");
+        let reference = BibleReference::new("Genezis", 20, 2, 2).unwrap();
+        let passage = BiblePassage::new(
+            reference,
+            translation.clone(),
+            "Abrahám vtedy o svojej manželke...".to_string(),
+        );
+        let batch = BibleIngestionBatch::new(translation, vec![passage]).unwrap();
+        state
+            .repository()
+            .replace_bible_translation_passages(&batch)
+            .await
+            .unwrap();
+
+        let args = json!({
+            "translation": "slk-seb",
+            "book": "1. Mojžišova",
+            "chapter": 20,
+            "verse_start": 2,
+            "verse_end": 2,
+        });
+        let (body, _preview) = execute_tool("load_bible_verses", &args.to_string(), &state, 320)
+            .await
+            .unwrap();
+        let verses: Vec<Value> =
+            serde_json::from_str(&body).expect("response body must be a verses array");
+        assert_eq!(verses.len(), 1, "expected 1 verse, got body: {body}");
+        assert!(
+            verses[0].get("text").is_some(),
+            "verse should have text (not error), got: {body}"
+        );
+        assert!(
+            !verses[0]["text"].as_str().unwrap_or("").is_empty(),
+            "verse text should be non-empty, got: {body}"
+        );
+    }
+
+    #[tokio::test]
     async fn load_bible_verses_handler_is_registered() {
         // The in-memory state seeds no bible translations, so we expect
         // "translation not found" error. This proves the tool is registered

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -43,7 +43,23 @@ fn make_slide(i: usize, s: &Value) -> Slide {
 /// The `preview` is short for UI badges; the full error JSON is sent back
 /// to the LLM as the tool result content so it can self-correct on retry.
 fn validation_error_response(err: ValidationError) -> (String, String) {
-    let preview = format!("Validation failed: {}", err.rule.as_str());
+    // Truncate the offending string so the AI conversation preview stays
+    // readable. The full string still goes back to the LLM via the JSON
+    // body and to the server log via tracing::warn!.
+    let truncated_got: String = err.got.chars().take(80).collect();
+    let preview = if err.got.chars().count() > 80 {
+        format!(
+            "Validation failed: {} (got: '{}...')",
+            err.rule.as_str(),
+            truncated_got
+        )
+    } else {
+        format!(
+            "Validation failed: {} (got: '{}')",
+            err.rule.as_str(),
+            truncated_got
+        )
+    };
     tracing::warn!(
         rule = %err.rule.as_str(),
         got = %err.got,

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1252,7 +1252,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.76"
+version = "0.4.77"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary

Closes #310. Three independent fixes in the AI bible-builder path:

1. **Roháček book-name resolution** — `load_bible_verses('1. Mojžišova', ..., 'SEB')` returned 0/N verses because the SEB translation stores the book as 'Genezis'. Added `SLOVAK_ROHACEK_NAMES` (66 entries) to the canonical alias map and switched the AI tool to resolve the input to a canonical code, querying by `book_code` instead of raw `book` string. AI can now use any common Slovak naming and the lookup works regardless of which translation the row lives in.

2. **Cross-turn delete-intent gate** — the gate looked only at the literal current user message. When the AI deferred a destructive op for confirmation ("delete and recreate?") and the user replied "ano" (yes), the gate blocked because "ano" has no delete keyword. New `delete_intent_for_turn` walks the conversation: grants when a prior user message contained delete intent AND the current message is affirmative ("yes", "ano", "súhlasím", etc.). Both signals must be present so an unrelated "yes" can't unlock a stale intent.

3. **Validator preview visibility** — the validation_error_response preview only showed the rule name (`Validation failed: reference_format_requires_parens`), making it impossible to see what string failed from the AI conversation log. Now includes the offending string truncated to 80 chars: `Validation failed: ... (got: '...')`. Server log + LLM-facing JSON unchanged.

## Test plan

- [x] `cargo test --workspace` — 475+ tests pass locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] CI all green: Format, Clippy, Test, Mutation, Coverage, E2E (3/3), Build, Deploy
- [x] Regression tests: canonical_book_by_name resolves '1. Mojžišova'/'1. Mojzisova'/'Lukáš'; load_bible_verses returns verses for Roháček name against SEB; cross-turn gate grants on deferred intent + affirmative
- [x] Dev deploy green: http://10.77.8.134:8080/healthz shows v0.4.77

🤖 Generated with [Claude Code](https://claude.com/claude-code)