### PR TITLE
feat(stage): PATCH /stage/broadcast-live + ON-AIR E2E coverage (#320)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "axum",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.79"
+version = "0.4.80"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -157,7 +157,10 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route("/stage/state", post(stage::update_stage_state))
         .route("/stage/clear", post(stage::clear_stage_state))
-        .route("/stage/broadcast-live", get(stage::get_broadcast_live))
+        .route(
+            "/stage/broadcast-live",
+            get(stage::get_broadcast_live).patch(stage::set_broadcast_live),
+        )
         .route("/api/stage", put(api_stage::update_api_stage))
         .route(
             "/integrations/resolume/hosts",

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -162,6 +162,21 @@ pub(super) async fn get_broadcast_live(
     })
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BroadcastLiveRequest {
+    pub(super) enabled: bool,
+}
+
+#[instrument(skip_all)]
+pub(super) async fn set_broadcast_live(
+    State(state): State<AppState>,
+    Json(payload): Json<BroadcastLiveRequest>,
+) -> StatusCode {
+    state.set_broadcast_live(payload.enabled);
+    StatusCode::NO_CONTENT
+}
+
 #[cfg(test)]
 mod camera_snapshot_query_tests {
     use super::*;
@@ -182,5 +197,33 @@ mod camera_snapshot_query_tests {
             panic!("expected Ok with snapshot, got {result:?}");
         };
         assert_eq!(snapshot.layout.code, "camera-crew");
+    }
+}
+
+#[cfg(test)]
+mod broadcast_live_handler_tests {
+    use super::*;
+    use axum::extract::State;
+
+    #[tokio::test]
+    async fn set_broadcast_live_handler_toggles_state() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        assert!(!state.broadcast_live());
+
+        let status = set_broadcast_live(
+            State(state.clone()),
+            Json(BroadcastLiveRequest { enabled: true }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(state.broadcast_live());
+
+        let status = set_broadcast_live(
+            State(state.clone()),
+            Json(BroadcastLiveRequest { enabled: false }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(!state.broadcast_live());
     }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1252,7 +1252,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.79"
+version = "0.4.80"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tests/e2e/wasm-stage-camera-crew.spec.ts
+++ b/tests/e2e/wasm-stage-camera-crew.spec.ts
@@ -252,3 +252,54 @@ test("renders seeded current group label after slide-state set", async ({
   // ── Console must be clean ─────────────────────────────────────────────────
   expect(consoleErrors).toEqual([]);
 });
+
+// ─── Scenario 3: ON-AIR indicator reacts to broadcast_live toggle ────────────
+
+test("on-air indicator toggles is-on class when broadcast_live flips", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleErrors(page);
+
+  await page.goto(new URL("/ui/camera", baseURL).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  // Wait for the stage WebSocket so BroadcastLive events arrive in the page.
+  await page.waitForFunction(
+    () => window.__presenterStageConnectionState === "connected",
+    { timeout: 30_000 },
+  );
+
+  const indicator = page.locator(".stage__camera-crew__on-air-indicator");
+  await expect(indicator).toBeVisible();
+
+  // Reset baseline: broadcast_live starts false on a fresh test server.
+  // Ensure the indicator does NOT carry is-on.
+  await expect(indicator).not.toHaveClass(/\bis-on\b/, { timeout: 5_000 });
+
+  // ── Toggle broadcast_live ON via the REST endpoint ───────────────────────
+  const onResp = await page.request.patch(
+    new URL("/stage/broadcast-live", baseURL).toString(),
+    { data: { enabled: true } },
+  );
+  expect(onResp.status()).toBe(204);
+
+  // The indicator must pick up is-on via the BroadcastLive WS event.
+  await expect(indicator).toHaveClass(/\bis-on\b/, { timeout: 5_000 });
+
+  // ── Toggle broadcast_live OFF and confirm class is removed ───────────────
+  const offResp = await page.request.patch(
+    new URL("/stage/broadcast-live", baseURL).toString(),
+    { data: { enabled: false } },
+  );
+  expect(offResp.status()).toBe(204);
+
+  await expect(indicator).not.toHaveClass(/\bis-on\b/, { timeout: 5_000 });
+
+  // Console must be clean.
+  expect(consoleMessages).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- New `PATCH /stage/broadcast-live` handler on the existing route — JSON body `{ "enabled": bool }`, returns 204
- Playwright E2E scenario 3 in `wasm-stage-camera-crew.spec.ts` asserting `.stage__camera-crew__on-air-indicator` toggles `is-on` class when `broadcast_live` flips via the new endpoint
- Unit test covering the handler

Closes #320

## Why

PR #319's reviewer flagged that the camera-crew layout had no E2E coverage of the ON-AIR indicator reactivity. The original scenario was removed in commit `0cd724e` (PR #319) because it relied on the Companion WebSocket protocol and was deemed fragile. A stable REST mechanism was the recommended fix.

## Test plan

- [x] `cargo test --package presenter-server broadcast_live_handler_tests` — passes
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all` — clean
- [x] CI: Pipeline run 25970222860 — all jobs green (Test, Clippy, Coverage, Build, 3× Playwright shards, Mutation, Deploy to Dev, Deploy Companion)
- [x] Dev verification at http://10.77.8.134:8080/ui/camera — Playwright DOM read confirmed:
  - `version: "v0.4.80 (dev)"`, `layoutCode: "camera-crew"`, `wsState: connected`
  - PATCH enabled=true → 204 → `is-on` class added within 800ms
  - PATCH enabled=false → 204 → `is-on` class removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)