### PR TITLE
feat(operator): surface-nav strip — jump to Stage/Camera/Tablet/Timer (#326)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.88"
+version = "0.4.89"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.84"
+version = "0.4.85"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.85"
+version = "0.4.86"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.86"
+version = "0.4.87"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.87"
+version = "0.4.88"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.88"
+version = "0.4.89"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.86"
+version = "0.4.87"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -147,12 +147,15 @@ pub fn Header() -> impl IntoView {
 
     view! {
         <header class="operator__header">
-            <div class="operator__header-left">
+            <div class="operator__header-top">
                 <div class="operator__header-brand">
                     <h1>"Presenter"</h1>
                     <span class="operator__version-badge">{move || version_text.get()}</span>
-                    <SurfaceNav />
                 </div>
+                <SurfaceNav />
+            </div>
+            <div class="operator__header-main">
+            <div class="operator__header-left">
                 <form class="operator__search" data-role="global-search-form" role="search" autocomplete="off"
                     on:submit=on_search_submit
                 >
@@ -262,6 +265,7 @@ pub fn Header() -> impl IntoView {
                 >
                     "\u{2630}"
                 </button>
+            </div>
             </div>
         </header>
     }

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use crate::api::bible as bible_api;
 use crate::components::stage_preview::StagePreview;
+use crate::components::surface_nav::SurfaceNav;
 use crate::state::operator::OperatorState;
 use crate::state::AppContext;
 
@@ -150,6 +151,7 @@ pub fn Header() -> impl IntoView {
                 <div class="operator__header-brand">
                     <h1>"Presenter"</h1>
                     <span class="operator__version-badge">{move || version_text.get()}</span>
+                    <SurfaceNav />
                 </div>
                 <form class="operator__search" data-role="global-search-form" role="search" autocomplete="off"
                     on:submit=on_search_submit

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -147,15 +147,12 @@ pub fn Header() -> impl IntoView {
 
     view! {
         <header class="operator__header">
-            <div class="operator__header-top">
+            <div class="operator__header-left">
                 <div class="operator__header-brand">
                     <h1>"Presenter"</h1>
                     <span class="operator__version-badge">{move || version_text.get()}</span>
+                    <SurfaceNav />
                 </div>
-                <SurfaceNav />
-            </div>
-            <div class="operator__header-main">
-            <div class="operator__header-left">
                 <form class="operator__search" data-role="global-search-form" role="search" autocomplete="off"
                     on:submit=on_search_submit
                 >
@@ -265,7 +262,6 @@ pub fn Header() -> impl IntoView {
                 >
                     "\u{2630}"
                 </button>
-            </div>
             </div>
         </header>
     }

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod header;
 pub mod info_popover;
+pub mod surface_nav;
 pub mod library_list;
 pub mod library_modal;
 pub mod modal;

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -1,6 +1,5 @@
 pub mod header;
 pub mod info_popover;
-pub mod surface_nav;
 pub mod library_list;
 pub mod library_modal;
 pub mod modal;
@@ -16,6 +15,7 @@ mod slide_list_utils;
 mod slide_save;
 pub mod stage;
 pub mod stage_preview;
+pub mod surface_nav;
 pub mod timer_panel;
 pub mod toast;
 pub mod version_label;

--- a/crates/presenter-ui/src/components/surface_nav.rs
+++ b/crates/presenter-ui/src/components/surface_nav.rs
@@ -1,0 +1,38 @@
+use leptos::prelude::*;
+
+/// Surface-nav strip: 4 pill links that open external surfaces in a new
+/// browser tab. Lives on the operator chrome only (rendered in
+/// `pages/operator.rs`). See spec
+/// `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md`.
+#[component]
+pub fn SurfaceNav() -> impl IntoView {
+    let targets = [
+        ("Stage", "/stage"),
+        ("Camera", "/ui/camera"),
+        ("Tablet", "/ui/tablet"),
+        ("Timer", "/overlays/timer"),
+    ];
+
+    view! {
+        <nav
+            class="operator__surface-nav"
+            data-role="surface-nav"
+            aria-label="Open other surfaces in a new tab"
+        >
+            <span class="operator__surface-nav-label">"Open in new tab:"</span>
+            {targets.into_iter().map(|(label, href)| view! {
+                <a
+                    class="operator__surface-nav-link"
+                    data-role="surface-nav-link"
+                    data-target=label
+                    href=href
+                    target="_blank"
+                    rel="noopener"
+                >
+                    {label}
+                    <span class="operator__surface-nav-icon" aria-hidden="true">"\u{2197}"</span>
+                </a>
+            }).collect_view()}
+        </nav>
+    }
+}

--- a/crates/presenter-ui/src/components/surface_nav.rs
+++ b/crates/presenter-ui/src/components/surface_nav.rs
@@ -1,10 +1,11 @@
 use leptos::prelude::*;
 
 /// Surface-nav pills: 4 inline links that open external surfaces in a new
-/// browser tab. Lives in the right side of the operator header's slim top
-/// row (rendered in `components/header.rs`'s `operator__header-top`).
-/// Separate from the main header row so the existing search / view-nav /
-/// stage-output controls keep their full width. See spec
+/// browser tab. Lives inside the operator header's brand row (rendered in
+/// `components/header.rs`'s `operator__header-brand`, immediately after the
+/// version badge). Header uses `align-items: flex-start` so brand+pills sit
+/// flush at the top border; the existing Worship/Bible/Timers/AI/Settings
+/// tabs and stage-output controls keep their original positions. See spec
 /// `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md`.
 #[component]
 pub fn SurfaceNav() -> impl IntoView {

--- a/crates/presenter-ui/src/components/surface_nav.rs
+++ b/crates/presenter-ui/src/components/surface_nav.rs
@@ -1,8 +1,8 @@
 use leptos::prelude::*;
 
-/// Surface-nav strip: 4 pill links that open external surfaces in a new
-/// browser tab. Lives on the operator chrome only (rendered in
-/// `pages/operator.rs`). See spec
+/// Surface-nav pills: 4 inline links that open external surfaces in a new
+/// browser tab. Lives inside the operator header's brand row (rendered in
+/// `components/header.rs`, next to the version badge). See spec
 /// `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md`.
 #[component]
 pub fn SurfaceNav() -> impl IntoView {
@@ -19,7 +19,6 @@ pub fn SurfaceNav() -> impl IntoView {
             data-role="surface-nav"
             aria-label="Open other surfaces in a new tab"
         >
-            <span class="operator__surface-nav-label">"Open in new tab:"</span>
             {targets.into_iter().map(|(label, href)| view! {
                 <a
                     class="operator__surface-nav-link"

--- a/crates/presenter-ui/src/components/surface_nav.rs
+++ b/crates/presenter-ui/src/components/surface_nav.rs
@@ -1,8 +1,10 @@
 use leptos::prelude::*;
 
 /// Surface-nav pills: 4 inline links that open external surfaces in a new
-/// browser tab. Lives inside the operator header's brand row (rendered in
-/// `components/header.rs`, next to the version badge). See spec
+/// browser tab. Lives in the right side of the operator header's slim top
+/// row (rendered in `components/header.rs`'s `operator__header-top`).
+/// Separate from the main header row so the existing search / view-nav /
+/// stage-output controls keep their full width. See spec
 /// `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md`.
 #[component]
 pub fn SurfaceNav() -> impl IntoView {

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -4,7 +4,6 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
 use crate::components::header::Header;
-use crate::components::surface_nav::SurfaceNav;
 use crate::components::library_list::LibraryList;
 use crate::components::library_modal::LibraryModals;
 use crate::components::playlist_list::PlaylistList;
@@ -13,6 +12,7 @@ use crate::components::presentation_list::PresentationList;
 use crate::components::presentation_modal::PresentationModals;
 use crate::components::search::SearchResults;
 use crate::components::slide_list::SlideList;
+use crate::components::surface_nav::SurfaceNav;
 use crate::components::timer_panel::TimerPanel;
 use crate::components::toast::Toast;
 use crate::components::version_label::VersionLabel;

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
 use crate::components::header::Header;
+use crate::components::surface_nav::SurfaceNav;
 use crate::components::library_list::LibraryList;
 use crate::components::library_modal::LibraryModals;
 use crate::components::playlist_list::PlaylistList;
@@ -161,6 +162,7 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
 
     view! {
         <Header />
+        <SurfaceNav />
         <SearchResults />
         <main class="operator__main">
             <section class="operator__worship" data-view-panel="worship">

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -12,7 +12,6 @@ use crate::components::presentation_list::PresentationList;
 use crate::components::presentation_modal::PresentationModals;
 use crate::components::search::SearchResults;
 use crate::components::slide_list::SlideList;
-use crate::components::surface_nav::SurfaceNav;
 use crate::components::timer_panel::TimerPanel;
 use crate::components::toast::Toast;
 use crate::components::version_label::VersionLabel;
@@ -162,7 +161,6 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
 
     view! {
         <Header />
-        <SurfaceNav />
         <SearchResults />
         <main class="operator__main">
             <section class="operator__worship" data-view-panel="worship">

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2873,3 +2873,52 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     color: #dc2626;
     font-weight: 600;
 }
+
+/* --- Surface-nav strip (#326) ------------------------------------------- */
+
+.operator__surface-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    background: var(--bg-secondary, #1a1a1a);
+    border-bottom: 1px solid var(--border-subtle, #2a2a2a);
+    font-size: 0.85rem;
+}
+
+.operator__surface-nav-label {
+    color: var(--text-muted, #888);
+    margin-right: 0.25rem;
+}
+
+.operator__surface-nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--border-subtle, #2a2a2a);
+    border-radius: 999px;
+    color: var(--text-primary, #e0e0e0);
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.operator__surface-nav-link:hover,
+.operator__surface-nav-link:focus-visible {
+    background: var(--bg-hover, #2a2a2a);
+    border-color: var(--border-strong, #444);
+    outline: none;
+}
+
+.operator__surface-nav-icon {
+    opacity: 0.7;
+    font-size: 0.9em;
+}
+
+@media (max-width: 800px) {
+    .operator__surface-nav {
+        flex-wrap: wrap;
+        padding: 0.3rem 0.5rem;
+        font-size: 0.8rem;
+    }
+}

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2874,33 +2874,27 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     font-weight: 600;
 }
 
-/* --- Surface-nav strip (#326) ------------------------------------------- */
+/* --- Surface-nav pills inline in brand row (#326) ----------------------- */
 
 .operator__surface-nav {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 1rem;
-    background: var(--bg-secondary, #1a1a1a);
-    border-bottom: 1px solid var(--border-subtle, #2a2a2a);
-    font-size: 0.85rem;
-}
-
-.operator__surface-nav-label {
-    color: var(--text-muted, #888);
-    margin-right: 0.25rem;
+    gap: 0.3rem;
+    margin-left: 0.75rem;
+    font-size: 0.8rem;
 }
 
 .operator__surface-nav-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.6rem;
+    gap: 0.2rem;
+    padding: 0.15rem 0.5rem;
     border: 1px solid var(--border-subtle, #2a2a2a);
     border-radius: 999px;
     color: var(--text-primary, #e0e0e0);
     text-decoration: none;
     transition: background 0.15s ease, border-color 0.15s ease;
+    line-height: 1.2;
 }
 
 .operator__surface-nav-link:hover {
@@ -2917,13 +2911,13 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
 
 .operator__surface-nav-icon {
     opacity: 0.7;
-    font-size: 0.9em;
+    font-size: 0.85em;
 }
 
 @media (max-width: 800px) {
     .operator__surface-nav {
-        flex-wrap: wrap;
-        padding: 0.3rem 0.5rem;
-        font-size: 0.8rem;
+        margin-left: 0.5rem;
+        gap: 0.2rem;
+        font-size: 0.75rem;
     }
 }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -40,29 +40,15 @@ body.operator {
 
 .operator__header {
   display: flex;
-  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.4rem 1rem;
   background: linear-gradient(90deg, #111827, #1f2937);
   color: #ffffff;
   box-shadow: var(--shadow-soft);
   position: sticky;
   top: 0;
   z-index: 10;
-}
-
-.operator__header-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.15rem 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.operator__header-main {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 1rem;
 }
 
 .operator__header h1 {
@@ -98,6 +84,11 @@ body.operator {
   gap: 0.75rem;
   margin-left: auto;
   flex-shrink: 0;
+  align-self: center;
+}
+
+.operator__view-nav {
+  align-self: center;
 }
 
 .operator__hamburger {
@@ -2888,12 +2879,13 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     font-weight: 600;
 }
 
-/* --- Surface-nav pills on right of slim top header row (#326) ----------- */
+/* --- Surface-nav pills inline right of brand+version (#326) ------------ */
 
 .operator__surface-nav {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
+    margin-left: 0.75rem;
     font-size: 0.8rem;
 }
 

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -40,15 +40,29 @@ body.operator {
 
 .operator__header {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 1rem;
+  flex-direction: column;
   background: linear-gradient(90deg, #111827, #1f2937);
   color: #ffffff;
   box-shadow: var(--shadow-soft);
   position: sticky;
   top: 0;
   z-index: 10;
+}
+
+.operator__header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.15rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.operator__header-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 1rem;
 }
 
 .operator__header h1 {
@@ -2874,13 +2888,12 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     font-weight: 600;
 }
 
-/* --- Surface-nav pills inline in brand row (#326) ----------------------- */
+/* --- Surface-nav pills on right of slim top header row (#326) ----------- */
 
 .operator__surface-nav {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    margin-left: 0.75rem;
     font-size: 0.8rem;
 }
 
@@ -2916,7 +2929,6 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
 
 @media (max-width: 800px) {
     .operator__surface-nav {
-        margin-left: 0.5rem;
         gap: 0.2rem;
         font-size: 0.75rem;
     }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -69,6 +69,7 @@ body.operator {
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
+  position: relative;
 }
 
 .operator__version-badge {
@@ -2879,14 +2880,19 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     font-weight: 600;
 }
 
-/* --- Surface-nav pills inline right of brand+version (#326) ------------ */
+/* --- Surface-nav pills right of brand+version (#326) ------------------- */
+/* Absolute-positioned to avoid widening `.operator__header-left`'s         */
+/* intrinsic width — otherwise the view-nav tabs wrap to 2 rows.            */
 
 .operator__surface-nav {
+    position: absolute;
+    left: calc(100% + 0.75rem);
+    top: 0;
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    margin-left: 0.75rem;
     font-size: 0.8rem;
+    white-space: nowrap;
 }
 
 .operator__surface-nav-link {

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2903,11 +2903,16 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     transition: background 0.15s ease, border-color 0.15s ease;
 }
 
-.operator__surface-nav-link:hover,
+.operator__surface-nav-link:hover {
+    background: var(--bg-hover, #2a2a2a);
+    border-color: var(--border-strong, #444);
+}
+
 .operator__surface-nav-link:focus-visible {
     background: var(--bg-hover, #2a2a2a);
     border-color: var(--border-strong, #444);
-    outline: none;
+    outline: 2px solid rgba(59, 124, 255, 0.6);
+    outline-offset: 2px;
 }
 
 .operator__surface-nav-icon {

--- a/docs/superpowers/plans/2026-05-18-operator-surface-nav.md
+++ b/docs/superpowers/plans/2026-05-18-operator-surface-nav.md
@@ -1,0 +1,615 @@
+# Operator Surface-Nav Strip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 4-pill jump-link strip below the operator header that opens Stage, Camera, Tablet, and Timer surfaces in new browser tabs.
+
+**Architecture:** New pure-static Leptos component `<SurfaceNav />` rendering 4 `<a target="_blank" rel="noopener">` links. Inserted once into the operator shell in `pages/operator.rs` between `<Header />` and `<SearchResults />`. CSS appended to `operator.css`. New Playwright spec asserts presence on operator routes, absence on tablet/camera, correct hrefs/target/rel attributes, and zero console errors.
+
+**Tech Stack:** Rust 1.x (workspace), Leptos 0.7 (CSR for `presenter-ui` WASM crate), CSS, Playwright (TypeScript).
+
+**Spec:** `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md` (commit `c6d4709`).
+
+**Closes:** #326.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+- `crates/presenter-ui/src/components/surface_nav.rs` — new pure-static component (~40 LoC).
+- `tests/e2e/operator-surface-nav.spec.ts` — Playwright E2E covering 3 test cases.
+
+**Files to modify:**
+
+- `Cargo.toml` (workspace `[workspace.package].version`) — version bump.
+- `Cargo.lock` — lockfile refresh.
+- `crates/presenter-ui/Cargo.lock` — WASM lockfile refresh.
+- `crates/presenter-ui/src/components/mod.rs` — register the new module.
+- `crates/presenter-ui/src/pages/operator.rs` — insert `<SurfaceNav />` in the view! block.
+- `crates/presenter-ui/styles/operator.css` — append `.operator__surface-nav` rules.
+
+`crates/presenter-ui/Cargo.toml` is NOT touched — its version is independent of the workspace version (last workspace bump did not touch it; verified in git log).
+
+---
+
+## Task 1: Workspace version bump
+
+**Files:**
+
+- Modify: `Cargo.toml:15`
+- Modify: `Cargo.lock` (regenerated)
+- Modify: `crates/presenter-ui/Cargo.lock` (regenerated)
+
+**Per `version-bumping.md` — bump BEFORE any feature code. Dev is at 0.4.85 (matches main after PR #327 merge), so the next commit MUST bump it.**
+
+- [ ] **Step 1: Bump workspace version**
+
+Edit `Cargo.toml:15` — change `version = "0.4.85"` to `version = "0.4.86"`.
+
+- [ ] **Step 2: Refresh workspace lockfile**
+
+Run: `cargo update --workspace`
+Expected: `Cargo.lock` rewrites; no errors.
+
+- [ ] **Step 3: Refresh WASM lockfile**
+
+Run: `cd crates/presenter-ui && cargo update && cd ../..`
+Expected: `crates/presenter-ui/Cargo.lock` rewrites; no errors.
+
+- [ ] **Step 4: Verify version pickup**
+
+Run: `cargo metadata --format-version=1 --no-deps | python3 -c "import json,sys; d=json.load(sys.stdin); print(set(p['version'] for p in d['packages']))"`
+Expected: output includes `'0.4.86'` (and `'0.1.39'` for presenter-ui, which is independent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump workspace version to 0.4.86 for #326
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: RED — Playwright E2E asserting the surface-nav
+
+**Files:**
+
+- Create: `tests/e2e/operator-surface-nav.spec.ts`
+
+Per `tdd-workflow.md`: write the failing test FIRST so we have proof it catches the bug class (no surface-nav present) before we add the component.
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/e2e/operator-surface-nav.spec.ts` with the following content:
+
+```typescript
+/**
+ * Operator Surface-Nav Strip E2E (#326).
+ *
+ * Asserts the 4-pill jump-link row appears on operator chrome
+ * (including the bible internal view), is absent on tablet and camera,
+ * and links open in a new tab (target=_blank rel=noopener).
+ *
+ * Also asserts zero browser console errors/warnings per
+ * ci/browser-console-zero-errors.md.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+});
+
+function collectConsole(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    const type = msg.type();
+    if (type === "error" || type === "warning") {
+      messages.push(`[${type}] ${msg.text()}`);
+    }
+  });
+  page.on("pageerror", (err) => {
+    messages.push(`[pageerror] ${err.message}`);
+  });
+  return messages;
+}
+
+const EXPECTED_TARGETS: ReadonlyArray<{ name: string; href: string }> = [
+  { name: "Stage", href: "/stage" },
+  { name: "Camera", href: "/ui/camera" },
+  { name: "Tablet", href: "/ui/tablet" },
+  { name: "Timer", href: "/overlays/timer" },
+];
+
+async function waitForOperatorReady(page: Page): Promise<void> {
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+}
+
+test("surface-nav strip is visible on /ui/operator with 4 correct anchors", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/operator`);
+  await waitForOperatorReady(page);
+
+  const nav = page.locator('[data-role="surface-nav"]');
+  await expect(nav).toBeVisible();
+
+  for (const target of EXPECTED_TARGETS) {
+    const link = nav.locator(`[data-role="surface-nav-link"][data-target="${target.name}"]`);
+    await expect(link, `link for ${target.name} should exist`).toHaveCount(1);
+    await expect(link).toHaveAttribute("href", target.href);
+    await expect(link).toHaveAttribute("target", "_blank");
+    const rel = await link.getAttribute("rel");
+    expect(rel ?? "", `rel for ${target.name} should contain noopener`).toContain("noopener");
+  }
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});
+
+test("surface-nav strip is visible on the bible internal view", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/operator/bible`);
+  await waitForOperatorReady(page);
+
+  const nav = page.locator('[data-role="surface-nav"]');
+  await expect(nav).toBeVisible();
+
+  for (const target of EXPECTED_TARGETS) {
+    await expect(
+      nav.locator(`[data-role="surface-nav-link"][data-target="${target.name}"]`),
+    ).toHaveCount(1);
+  }
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});
+
+test("surface-nav strip is absent on /ui/tablet and /ui/camera", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/tablet`);
+  await waitForOperatorReady(page);
+  await expect(page.locator('[data-role="surface-nav"]')).toHaveCount(0);
+
+  await page.goto(`${baseURL}/ui/camera`);
+  await waitForOperatorReady(page);
+  await expect(page.locator('[data-role="surface-nav"]')).toHaveCount(0);
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (RED)**
+
+Run: `npm run test:playwright -- operator-surface-nav`
+Expected: All 3 tests FAIL. The first two should fail with `[data-role="surface-nav"]` not visible / not found. The third should pass (the strip is genuinely absent everywhere right now).
+
+Record the failure output; the test commit SHA becomes the RED reference for the PR description.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/e2e/operator-surface-nav.spec.ts
+git commit -m "test(operator): add E2E for surface-nav strip [red] (#326)
+
+Asserts the 4-pill jump-link row appears on /ui/operator and
+/ui/operator/bible with correct hrefs, target=_blank, rel=noopener,
+and is absent on /ui/tablet and /ui/camera. Console must be clean.
+
+Test fails before the component lands. Locks the regression once it
+passes after the next commit.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Create the SurfaceNav component
+
+**Files:**
+
+- Create: `crates/presenter-ui/src/components/surface_nav.rs`
+- Modify: `crates/presenter-ui/src/components/mod.rs:2`
+
+- [ ] **Step 1: Create the component file**
+
+Create `crates/presenter-ui/src/components/surface_nav.rs` with the following content:
+
+```rust
+use leptos::prelude::*;
+
+/// Surface-nav strip: 4 pill links that open external surfaces in a new
+/// browser tab. Lives on the operator chrome only (rendered in
+/// `pages/operator.rs`). See spec
+/// `docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md`.
+#[component]
+pub fn SurfaceNav() -> impl IntoView {
+    let targets = [
+        ("Stage", "/stage"),
+        ("Camera", "/ui/camera"),
+        ("Tablet", "/ui/tablet"),
+        ("Timer", "/overlays/timer"),
+    ];
+
+    view! {
+        <nav
+            class="operator__surface-nav"
+            data-role="surface-nav"
+            aria-label="Open other surfaces in a new tab"
+        >
+            <span class="operator__surface-nav-label">"Open in new tab:"</span>
+            {targets.into_iter().map(|(label, href)| view! {
+                <a
+                    class="operator__surface-nav-link"
+                    data-role="surface-nav-link"
+                    data-target=label
+                    href=href
+                    target="_blank"
+                    rel="noopener"
+                >
+                    {label}
+                    <span class="operator__surface-nav-icon" aria-hidden="true">"\u{2197}"</span>
+                </a>
+            }).collect_view()}
+        </nav>
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+Modify `crates/presenter-ui/src/components/mod.rs`. The current line 2 reads:
+
+```rust
+pub mod info_popover;
+```
+
+Add a new line immediately after it:
+
+```rust
+pub mod info_popover;
+pub mod surface_nav;
+```
+
+Keep the rest of the file unchanged. Alphabetical-ish order is fine — `info_popover` before `surface_nav` is OK.
+
+- [ ] **Step 3: Verify WASM clippy passes**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..`
+Expected: success with zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/surface_nav.rs crates/presenter-ui/src/components/mod.rs
+git commit -m "feat(operator): add SurfaceNav component (#326)
+
+Pure-static Leptos component rendering 4 pill anchors to /stage,
+/ui/camera, /ui/tablet, /overlays/timer. target=_blank rel=noopener
+on every link. No state, no signals, no API calls.
+
+Not yet mounted — next commit wires it into the operator shell.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire SurfaceNav into the operator shell
+
+**Files:**
+
+- Modify: `crates/presenter-ui/src/pages/operator.rs:6` (import)
+- Modify: `crates/presenter-ui/src/pages/operator.rs:162-164` (view! insertion)
+
+- [ ] **Step 1: Add the import**
+
+Find line 6 in `crates/presenter-ui/src/pages/operator.rs`:
+
+```rust
+use crate::components::header::Header;
+```
+
+Add a new line immediately after it:
+
+```rust
+use crate::components::header::Header;
+use crate::components::surface_nav::SurfaceNav;
+```
+
+- [ ] **Step 2: Insert SurfaceNav in the view!**
+
+Find the view! block starting at line 162. The current opening looks like:
+
+```rust
+    view! {
+        <Header />
+        <SearchResults />
+```
+
+Change it to:
+
+```rust
+    view! {
+        <Header />
+        <SurfaceNav />
+        <SearchResults />
+```
+
+Keep everything else in the view! block unchanged.
+
+- [ ] **Step 3: Verify WASM clippy passes**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..`
+Expected: success with zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/presenter-ui/src/pages/operator.rs
+git commit -m "feat(operator): mount SurfaceNav in operator shell (#326)
+
+Strip is shell-level (one mount, not per-view-panel), so it appears
+on every /ui/operator/* route including /ui/operator/bible.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Surface-nav CSS
+
+**Files:**
+
+- Modify: `crates/presenter-ui/styles/operator.css` (append at end)
+
+- [ ] **Step 1: Append the CSS rules**
+
+Open `crates/presenter-ui/styles/operator.css`. At the end of the file (after the last existing rule, after any closing `}`), append a blank line, then the following block:
+
+```css
+/* --- Surface-nav strip (#326) ------------------------------------------- */
+
+.operator__surface-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    background: var(--bg-secondary, #1a1a1a);
+    border-bottom: 1px solid var(--border-subtle, #2a2a2a);
+    font-size: 0.85rem;
+}
+
+.operator__surface-nav-label {
+    color: var(--text-muted, #888);
+    margin-right: 0.25rem;
+}
+
+.operator__surface-nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--border-subtle, #2a2a2a);
+    border-radius: 999px;
+    color: var(--text-primary, #e0e0e0);
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.operator__surface-nav-link:hover,
+.operator__surface-nav-link:focus-visible {
+    background: var(--bg-hover, #2a2a2a);
+    border-color: var(--border-strong, #444);
+    outline: none;
+}
+
+.operator__surface-nav-icon {
+    opacity: 0.7;
+    font-size: 0.9em;
+}
+
+@media (max-width: 800px) {
+    .operator__surface-nav {
+        flex-wrap: wrap;
+        padding: 0.3rem 0.5rem;
+        font-size: 0.8rem;
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add crates/presenter-ui/styles/operator.css
+git commit -m "feat(operator): style surface-nav strip (#326)
+
+Pill row below operator header. Mobile breakpoint at 800px wraps pills.
+Mirrors existing operator__view-nav visual language via CSS variables.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: GREEN — final local gate
+
+This task runs the full local test/lint matrix and confirms the RED Playwright test from Task 2 is now GREEN.
+
+- [ ] **Step 1: Workspace formatting**
+
+Run: `cargo fmt --all --check`
+Expected: no output, exit 0. If it fails, run `cargo fmt --all` and amend… wait, no — never amend. Instead: run `cargo fmt --all`, then `git add -u` the formatting fixups and add them to a new commit `style: cargo fmt`.
+
+- [ ] **Step 2: Workspace clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
+Expected: success with zero warnings.
+
+- [ ] **Step 3: WASM clippy**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..`
+Expected: success with zero warnings.
+
+- [ ] **Step 4: Workspace tests**
+
+Run: `cargo test --workspace`
+Expected: all tests pass. The new feature touches no Rust unit-test territory; this is a regression check that the WASM/component additions didn't break anything else.
+
+- [ ] **Step 5: Playwright E2E — GREEN**
+
+Run: `npm run test:playwright -- operator-surface-nav`
+Expected: all 3 tests PASS. Record the commit SHA here as the GREEN reference for the PR body.
+
+If any test fails:
+
+- Inspect the failure with `npx playwright show-report`.
+- Most likely failure mode: trunk/WASM bundle stale. Run `cd crates/presenter-ui && trunk build --release && cd ../..` (the dev server rebuilds on its own, but `startTestServer` may use a cached bundle). Then rerun.
+- DO NOT change the test assertions to make it pass. The assertions reflect the spec.
+
+- [ ] **Step 6: If formatting fixups were needed, commit them**
+
+If Step 1 surfaced formatting changes:
+
+```bash
+git add -u
+git commit -m "style: cargo fmt fixups (#326)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+Skip this step if Step 1 was already clean.
+
+---
+
+## Task 7: Controller-handled — push, CI, deploy-verify, PR
+
+This task is NOT executed by the implementer subagent. The controller (parent agent) runs it after Tasks 1-6 are committed locally.
+
+- [ ] **Step 1: Final pre-push review**
+
+Run: `git log --oneline origin/dev..HEAD` — confirm the commit order:
+1. `chore: bump workspace version to 0.4.86 for #326`
+2. `test(operator): add E2E for surface-nav strip [red] (#326)`
+3. `feat(operator): add SurfaceNav component (#326)`
+4. `feat(operator): mount SurfaceNav in operator shell (#326)`
+5. `feat(operator): style surface-nav strip (#326)`
+6. (optional) `style: cargo fmt fixups (#326)`
+
+- [ ] **Step 2: Push**
+
+Run: `git push origin dev`
+Expected: clean push, no force, no hooks-skipped.
+
+- [ ] **Step 3: Monitor CI**
+
+Run in background: `sleep 300 && gh run view <run-id> --json status,conclusion,jobs`
+Per `ci-monitoring.md`: single sleep + `gh run view` call, NOT `gh run watch`, NOT `/loop`, NOT a custom bash script. Wait for ALL jobs (Branch Sync, Format, Clippy, Test, Quality, Coverage, Mutation Testing, Build, Playwright E2E 1-3/3, Deploy to Dev) to reach terminal state.
+
+If any job fails: `gh run view <run-id> --log-failed`, investigate root cause, fix locally, push fix as ONE commit. Do NOT blindly rerun.
+
+- [ ] **Step 4: Verify on dev**
+
+Once Deploy to Dev is green, verify deployment per `post-deploy-verification.md` and `autonomous-verification.md`:
+
+1. `curl -s http://10.77.8.134:8080/healthz` — confirm `version: 0.4.86`.
+2. Open `http://10.77.8.134:8080/ui/operator` in Playwright (NOT localhost):
+   - Read `[data-testid="version"]` — confirm `v0.4.86 (dev)`.
+   - Read `[data-role="surface-nav"]` — confirm visible, 4 anchors with correct hrefs/target/rel.
+   - Check browser console — must be clean.
+3. Navigate to `http://10.77.8.134:8080/ui/operator/bible` — confirm strip still visible.
+4. Navigate to `http://10.77.8.134:8080/ui/tablet` — confirm strip absent.
+5. Navigate to `http://10.77.8.134:8080/ui/camera` — confirm strip absent.
+
+Record the version from the live DOM for the completion-report `✅ Deploy:` line.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --head dev \
+  --title "feat(operator): surface-nav strip — jump to Stage/Camera/Tablet/Timer (#326)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds a 4-pill jump-link strip below the operator header. Each pill opens
+the corresponding surface in a new browser tab.
+
+Closes #326.
+
+## Surfaces and targets
+
+- Source: `/ui/operator` and all internal views (`/ui/operator/bible`, timers, AI, settings)
+- Targets (new tab): Stage `/stage`, Camera `/ui/camera`, Tablet `/ui/tablet`, Timer `/overlays/timer`
+- NOT on: `/ui/tablet`, `/ui/camera`, `/stage` (clean surfaces)
+- NOT a target: Worship (current view), Bible (internal operator tab)
+
+## Tests
+
+- New Playwright spec `tests/e2e/operator-surface-nav.spec.ts` with 3 cases:
+  - Strip visible on `/ui/operator` with correct hrefs/target/rel
+  - Strip visible on `/ui/operator/bible`
+  - Strip absent on `/ui/tablet` and `/ui/camera`
+- Every case also asserts zero console errors/warnings
+- RED before component, GREEN after — verified locally
+
+## Test plan
+
+- [x] Workspace fmt, clippy, test
+- [x] WASM clippy
+- [x] Playwright E2E green locally
+- [x] CI green
+- [x] Dev deploy verified at http://10.77.8.134:8080/ui/operator (v0.4.86)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Verify PR is mergeable + clean**
+
+Run: `gh pr view <number> --json mergeable,mergeStateStatus`
+Expected: `mergeable: true`, `mergeStateStatus: CLEAN`. If `UNSTABLE`/`BLOCKED`/`BEHIND`/`DIRTY` — investigate and fix per `autonomous-quality-discipline.md`. Do NOT report ready until clean.
+
+- [ ] **Step 7: Send completion report**
+
+Per `completion-report.md` template. MUST include the audit block (all 3 audit lines green) and both 🌐 Dev + 🌐 Prod URL lines once main deploys post-merge. Then WAIT for explicit "merge it" — never merge a PR without user instruction per `pr-merge-policy.md`.
+
+---
+
+## Spec coverage check
+
+| Spec section | Plan task |
+|--------------|-----------|
+| Mental model — operator-only source | Tasks 3, 4 (mount in operator shell only) |
+| 4 targets (Stage/Camera/Tablet/Timer) | Task 3 (`targets` array) |
+| Strip on all `/ui/operator/*` views | Task 4 (shell-level mount), Task 2 (test for `/ui/operator/bible`) |
+| Strip absent on tablet/camera | Task 2 (test #3) |
+| `target=_blank` + `rel=noopener` | Task 3 (component), Task 2 (assertions) |
+| Pure-static (no state/API) | Task 3 (no signals, no `use_ctx!`) |
+| New row below header, label "Open in new tab:" | Task 3 (component) |
+| Mobile wrap at 800px | Task 5 (CSS media query) |
+| Console-clean assertion in E2E | Task 2 (`collectConsole` + `expect(...).toEqual([])`) |
+| Workspace version bump first | Task 1 (BEFORE Task 2's failing test) |

--- a/docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md
+++ b/docs/superpowers/specs/2026-05-18-operator-surface-nav-design.md
@@ -1,0 +1,224 @@
+# Operator Surface-Nav Strip — Design
+
+> **Issue:** #326 — Operator page jump links to other surfaces (camera, tablet, bible, stage)
+> **Status:** Accepted (2026-05-18)
+
+## Problem
+
+Once a user enters the operator UI at `/ui/operator`, there is no quick way to open the sibling surfaces (`/ui/camera`, `/ui/tablet`, `/stage`, `/overlays/timer`) for verification. They have to back out to the landing page `/` and click through, or type the URL.
+
+## Mental model
+
+The user's framing:
+
+- **Operator app** = worship + bible + timers + AI + settings. One Leptos shell, multiple internal views switched via the top tab strip (`.operator__view-nav`). The route `/ui/bible` already redirects to `/ui/operator/bible`.
+- **Tablet** = preacher's view. Never needs to navigate to other surfaces.
+- **Camera, Stage** = clean output surfaces. Anything overlaid is undesirable (visible on the wall, or distracts the director).
+
+So the switcher appears only on operator chrome and only opens external surfaces (not internal tabs).
+
+## Scope
+
+**In scope:**
+
+- New row of 4 jump pills on operator chrome, opening in new browser tab.
+- Targets: Stage (`/stage`), Camera (`/ui/camera`), Tablet (`/ui/tablet`), Timer Overlay (`/overlays/timer`).
+- Covers every `/ui/operator/*` route (worship, bible, timers, AI, settings) — one component, single insertion point.
+- Playwright E2E asserting presence + correct hrefs + `target=_blank`, and absence on tablet/camera surfaces.
+
+**Out of scope:**
+
+- Switcher on `/ui/tablet`, `/ui/camera`, `/stage`.
+- Internal targets (Worship, Bible) — Worship is the current view; Bible is reachable via the existing `operator__view-nav` button.
+- Conditional / role-based visibility.
+- Keyboard shortcuts to jump between surfaces.
+- Active-state highlighting (operator is always the source; there is no "current external surface").
+
+## Visual layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Presenter v0.4.85  [search]   [Worship][Bible][Timers][AI][Settings]   [Stage Output ▾] [Live][Edit] ☰ │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  Open in new tab:   [ Stage ↗ ]  [ Camera ↗ ]  [ Tablet ↗ ]  [ Timer ↗ ]    │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  ... slide grid / controls ...                                               │
+```
+
+The strip is its own row directly below the existing `<header class="operator__header">`, before `<SearchResults />`. Left-aligned label "Open in new tab:" followed by 4 pill links. Each pill includes the surface name and a small ↗ icon (Unicode `\u{2197}`) to signal external-tab behavior.
+
+## Component design
+
+**New component:** `crates/presenter-ui/src/components/surface_nav.rs` (~40 LoC).
+
+```rust
+use leptos::prelude::*;
+
+#[component]
+pub fn SurfaceNav() -> impl IntoView {
+    let targets = [
+        ("Stage", "/stage"),
+        ("Camera", "/ui/camera"),
+        ("Tablet", "/ui/tablet"),
+        ("Timer", "/overlays/timer"),
+    ];
+
+    view! {
+        <nav
+            class="operator__surface-nav"
+            data-role="surface-nav"
+            aria-label="Open other surfaces in a new tab"
+        >
+            <span class="operator__surface-nav-label">"Open in new tab:"</span>
+            {targets.into_iter().map(|(label, href)| view! {
+                <a
+                    class="operator__surface-nav-link"
+                    data-role="surface-nav-link"
+                    data-target=label
+                    href=href
+                    target="_blank"
+                    rel="noopener"
+                >
+                    {label}
+                    <span class="operator__surface-nav-icon" aria-hidden="true">"\u{2197}"</span>
+                </a>
+            }).collect_view()}
+        </nav>
+    }
+}
+```
+
+Pure static. No state, no signals, no API calls. Read-only links.
+
+## Integration
+
+**File:** `crates/presenter-ui/src/pages/operator.rs:162` — view! block.
+
+```rust
+view! {
+    <Header />
+    <SurfaceNav />          // NEW
+    <SearchResults />
+    <main class="operator__main">
+        ...
+    </main>
+    ...
+}
+```
+
+**File:** `crates/presenter-ui/src/components/mod.rs` — add `pub mod surface_nav;`.
+
+The component renders unconditionally on operator chrome. Internal tab switching (`ctx.view`) does not affect it — the strip is always visible.
+
+## CSS
+
+**File:** `crates/presenter-ui/styles/operator.css` — append rules mirroring `.operator__view-nav` visual language.
+
+```css
+.operator__surface-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    background: var(--bg-secondary, #1a1a1a);
+    border-bottom: 1px solid var(--border-subtle, #2a2a2a);
+    font-size: 0.85rem;
+}
+
+.operator__surface-nav-label {
+    color: var(--text-muted, #888);
+    margin-right: 0.25rem;
+}
+
+.operator__surface-nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--border-subtle, #2a2a2a);
+    border-radius: 999px;
+    color: var(--text-primary, #e0e0e0);
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.operator__surface-nav-link:hover,
+.operator__surface-nav-link:focus-visible {
+    background: var(--bg-hover, #2a2a2a);
+    border-color: var(--border-strong, #444);
+    outline: none;
+}
+
+.operator__surface-nav-icon {
+    opacity: 0.7;
+    font-size: 0.9em;
+}
+
+@media (max-width: 800px) {
+    .operator__surface-nav {
+        flex-wrap: wrap;
+        padding: 0.3rem 0.5rem;
+        font-size: 0.8rem;
+    }
+}
+```
+
+Mobile: pills wrap onto a second line at ≤800px viewport. No hamburger collapse; the strip is short enough to fit when wrapped.
+
+## Test plan
+
+### Playwright E2E
+
+**New file:** `tests/e2e/operator-surface-nav.spec.ts` (~50 LoC).
+
+Three test cases, all started via `startTestServer()` helper consistent with neighbouring specs:
+
+1. **Strip visible on operator with 4 correct anchors:**
+   - Navigate to `/ui/operator`. Wait for `body[data-wasm-ready="true"]`.
+   - Assert `[data-role="surface-nav"]` is visible.
+   - For each of `Stage`, `Camera`, `Tablet`, `Timer`:
+     - Assert `[data-role="surface-nav-link"][data-target="<Name>"]` exists.
+     - Assert its `href` equals the expected URL.
+     - Assert its `target` attribute equals `_blank`.
+     - Assert its `rel` attribute contains `noopener`.
+
+2. **Strip visible on the bible internal view (operator chrome):**
+   - Navigate to `/ui/operator/bible`. Wait for WASM ready.
+   - Assert `[data-role="surface-nav"]` is visible.
+   - Assert all 4 anchors still present (the strip is shell-level, not per-view).
+
+3. **Strip absent on tablet and camera surfaces:**
+   - Navigate to `/ui/tablet`. Wait for WASM ready. Assert `[data-role="surface-nav"]` count is 0.
+   - Navigate to `/ui/camera`. Wait for WASM ready. Assert `[data-role="surface-nav"]` count is 0.
+
+Every test must also assert zero console errors / warnings (project convention from `browser-console-zero-errors.md`).
+
+### Manual verification (post-deploy on dev)
+
+- Open `http://10.77.8.134:8080/ui/operator` in Chromium.
+- Confirm strip visible with 4 pills under the header.
+- Click each pill — confirm new browser tab opens at the expected URL.
+- Switch operator tabs (Worship → Bible → Timers → AI → Settings) — confirm strip remains visible and unchanged.
+- Open `http://10.77.8.134:8080/ui/tablet` and `http://10.77.8.134:8080/ui/camera` — confirm strip absent.
+
+## Constraints
+
+- **No backend changes.** Pure frontend addition. No new HTTP endpoints, no schema, no migrations.
+- **No new dependencies.** Standard Leptos `view!` macro + static `<a>` tags.
+- **No state leakage.** SurfaceNav holds no signals, makes no network calls, does not depend on `AppContext`.
+- **Single PR per `autonomous-batch-issue-development.md`.** Component + integration + CSS + E2E ship together.
+- **Version bump first** per `version-bumping.md`. Workspace 0.4.85 → 0.4.86 before any other code change.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Strip crowds the operator at narrow widths | Mobile breakpoint at 800px wraps pills; no fixed minimum width. |
+| User confuses the new strip with the internal tab strip (Worship/Bible/...) | Visual distinction: `<a>` tags with rounded pill shape and ↗ icon, label "Open in new tab:" explicitly signals external-tab behavior. |
+| Future surface (e.g. new dashboard) requires updating multiple places | All 4 targets live in a single `targets` array at the top of `surface_nav.rs`. Adding one means one line. |
+
+## Non-goals
+
+- Active-state highlighting on the current source surface — the strip only appears on operator, and operator has no entry for itself.
+- Single-tab same-window navigation — explicit user requirement: open in new chrome tab.
+- Surface-switcher on tablet/camera/stage — explicit user requirement: tablet is preacher-only, camera/stage are clean output surfaces.

--- a/tests/e2e/operator-surface-nav.spec.ts
+++ b/tests/e2e/operator-surface-nav.spec.ts
@@ -41,8 +41,10 @@ test.afterAll(async () => {
 const BENIGN_WARNING_PATTERNS: RegExp[] = [
   // crbug.com/981419: Chromium logs this every time it sees `integrity` on a
   // `<link rel=preload>`. Trunk emits SRI on the WASM preload tag (valid per
-  // the SRI spec) but Chromium ignores it and warns. Not a project bug.
-  /preload destinations that do not support subresource integrity/i,
+  // the SRI spec) but Chromium ignores it and warns. Anchor on the crbug URL
+  // (more stable than the human-readable wording) to match the filter
+  // pattern already used in `tests/e2e/api-stage.spec.ts`.
+  /crbug\.com\/981419/i,
 ];
 
 function isBenignWarning(text: string): boolean {

--- a/tests/e2e/operator-surface-nav.spec.ts
+++ b/tests/e2e/operator-surface-nav.spec.ts
@@ -34,12 +34,31 @@ test.afterAll(async () => {
   await stopServer(serverHandle);
 });
 
+// Known-benign Chromium warnings to ignore. These are browser-side
+// informational notes about W3C-spec attributes Chromium does not yet act on;
+// they fire on every WASM-loaded page across the codebase and are not project
+// bugs. Filter narrowly so real warnings still surface.
+const BENIGN_WARNING_PATTERNS: RegExp[] = [
+  // crbug.com/981419: Chromium logs this every time it sees `integrity` on a
+  // `<link rel=preload>`. Trunk emits SRI on the WASM preload tag (valid per
+  // the SRI spec) but Chromium ignores it and warns. Not a project bug.
+  /preload destinations that do not support subresource integrity/i,
+];
+
+function isBenignWarning(text: string): boolean {
+  return BENIGN_WARNING_PATTERNS.some((re) => re.test(text));
+}
+
 function collectConsole(page: Page): string[] {
   const messages: string[] = [];
   page.on("console", (msg) => {
     const type = msg.type();
     if (type === "error" || type === "warning") {
-      messages.push(`[${type}] ${msg.text()}`);
+      const text = msg.text();
+      if (type === "warning" && isBenignWarning(text)) {
+        return;
+      }
+      messages.push(`[${type}] ${text}`);
     }
   });
   page.on("pageerror", (err) => {

--- a/tests/e2e/operator-surface-nav.spec.ts
+++ b/tests/e2e/operator-surface-nav.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Operator Surface-Nav Strip E2E (#326).
+ *
+ * Asserts the 4-pill jump-link row appears on operator chrome
+ * (including the bible internal view), is absent on tablet and camera,
+ * and links open in a new tab (target=_blank rel=noopener).
+ *
+ * Also asserts zero browser console errors/warnings per
+ * ci/browser-console-zero-errors.md.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+});
+
+function collectConsole(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    const type = msg.type();
+    if (type === "error" || type === "warning") {
+      messages.push(`[${type}] ${msg.text()}`);
+    }
+  });
+  page.on("pageerror", (err) => {
+    messages.push(`[pageerror] ${err.message}`);
+  });
+  return messages;
+}
+
+const EXPECTED_TARGETS: ReadonlyArray<{ name: string; href: string }> = [
+  { name: "Stage", href: "/stage" },
+  { name: "Camera", href: "/ui/camera" },
+  { name: "Tablet", href: "/ui/tablet" },
+  { name: "Timer", href: "/overlays/timer" },
+];
+
+async function waitForOperatorReady(page: Page): Promise<void> {
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+}
+
+test("surface-nav strip is visible on /ui/operator with 4 correct anchors", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/operator`);
+  await waitForOperatorReady(page);
+
+  const nav = page.locator('[data-role="surface-nav"]');
+  await expect(nav).toBeVisible();
+
+  for (const target of EXPECTED_TARGETS) {
+    const link = nav.locator(`[data-role="surface-nav-link"][data-target="${target.name}"]`);
+    await expect(link, `link for ${target.name} should exist`).toHaveCount(1);
+    await expect(link).toHaveAttribute("href", target.href);
+    await expect(link).toHaveAttribute("target", "_blank");
+    const rel = await link.getAttribute("rel");
+    expect(rel ?? "", `rel for ${target.name} should contain noopener`).toContain("noopener");
+  }
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});
+
+test("surface-nav strip is visible on the bible internal view", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/operator/bible`);
+  await waitForOperatorReady(page);
+
+  const nav = page.locator('[data-role="surface-nav"]');
+  await expect(nav).toBeVisible();
+
+  for (const target of EXPECTED_TARGETS) {
+    await expect(
+      nav.locator(`[data-role="surface-nav-link"][data-target="${target.name}"]`),
+    ).toHaveCount(1);
+  }
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});
+
+test("surface-nav strip is absent on /ui/tablet and /ui/camera", async ({ page }) => {
+  const consoleMessages = collectConsole(page);
+
+  await page.goto(`${baseURL}/ui/tablet`);
+  await waitForOperatorReady(page);
+  await expect(page.locator('[data-role="surface-nav"]')).toHaveCount(0);
+
+  await page.goto(`${baseURL}/ui/camera`);
+  await waitForOperatorReady(page);
+  await expect(page.locator('[data-role="surface-nav"]')).toHaveCount(0);
+
+  expect(consoleMessages, "browser console must be clean").toEqual([]);
+});


### PR DESCRIPTION
## Summary

Adds a 4-pill jump-link strip below the operator header. Each pill opens
the corresponding surface in a new browser tab.

Closes #326.

## Surfaces and targets

- Source: `/ui/operator` and all internal views (`/ui/operator/bible`, timers, AI, settings)
- Targets (new tab): Stage `/stage`, Camera `/ui/camera`, Tablet `/ui/tablet`, Timer `/overlays/timer`
- NOT on: `/ui/tablet`, `/ui/camera`, `/stage` (clean surfaces)
- NOT a target: Worship (current view), Bible (internal operator tab)

## Tests

- New Playwright spec `tests/e2e/operator-surface-nav.spec.ts` with 3 cases:
  - Strip visible on `/ui/operator` with correct hrefs/target/rel
  - Strip visible on `/ui/operator/bible`
  - Strip absent on `/ui/tablet` and `/ui/camera`
- Every case asserts zero console errors/warnings (with narrow filter for known-benign Chromium preload-integrity warning, see commit ddb6680)
- RED before component, GREEN after — verified locally

## Test plan

- [x] Workspace fmt, clippy, test
- [x] WASM clippy
- [x] Playwright E2E green locally
- [x] CI green
- [x] Dev deploy verified at http://10.77.8.134:8080/ui/operator (v0.4.86):
  - Strip visible on /ui/operator and /ui/operator/bible (4 links each, contract attributes match)
  - Strip absent on /ui/tablet and /ui/camera
  - Version label reads `v0.4.86 (dev)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)