### PR TITLE
fix(companion): batch setVariableValues per server broadcast (#265)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "axum",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.89"
+version = "0.4.90"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.89"
+version = "0.4.90"
 dependencies = [
  "anyhow",
  "chrono",

--- a/ops/companion/presenter/companion/manifest.json
+++ b/ops/companion/presenter/companion/manifest.json
@@ -3,7 +3,7 @@
   "name": "Presenter Companion WS",
   "shortname": "presenter",
   "description": "Control Presenter via the /companion/ws API",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "repository": "https://git.newleveltech/presenter",
   "bugs": "https://git.newleveltech/presenter/issues",

--- a/ops/companion/presenter/index.js
+++ b/ops/companion/presenter/index.js
@@ -6,7 +6,7 @@ const {
 const WebSocket = require("ws");
 const { version: MODULE_VERSION } = require("./package.json");
 const { normaliseCountdownTarget } = require("./lib/time");
-const { computeVariableBatch } = require("./lib/variable-batch");
+const { applyVariablesMessage } = require("./lib/variable-batch");
 
 const VARIABLE_DEFINITIONS = [
   "stage_layout_code",
@@ -249,21 +249,9 @@ class PresenterInstance extends InstanceBase {
       case "welcome":
         this.log("debug", "Received welcome from Presenter");
         break;
-      case "variables": {
-        const batch = computeVariableBatch(
-          msg.values,
-          VARIABLE_DEFINITIONS,
-          this.variables,
-        );
-        const names = Object.keys(batch);
-        if (names.length > 0) {
-          for (const name of names) {
-            this.variables.set(name, batch[name]);
-          }
-          this.setVariableValues(batch);
-        }
+      case "variables":
+        applyVariablesMessage(msg, VARIABLE_DEFINITIONS, this);
         break;
-      }
       case "ack":
         this.log("debug", `Ack from server: ${msg.command}`);
         break;
@@ -281,8 +269,8 @@ class PresenterInstance extends InstanceBase {
     }
     const previous = this.variables.get(name);
     if (previous !== value) {
-      this.variables.set(name, value);
       this.setVariableValues({ [name]: value });
+      this.variables.set(name, value);
     }
   }
 

--- a/ops/companion/presenter/index.js
+++ b/ops/companion/presenter/index.js
@@ -6,6 +6,7 @@ const {
 const WebSocket = require("ws");
 const { version: MODULE_VERSION } = require("./package.json");
 const { normaliseCountdownTarget } = require("./lib/time");
+const { computeVariableBatch } = require("./lib/variable-batch");
 
 const VARIABLE_DEFINITIONS = [
   "stage_layout_code",
@@ -248,13 +249,21 @@ class PresenterInstance extends InstanceBase {
       case "welcome":
         this.log("debug", "Received welcome from Presenter");
         break;
-      case "variables":
-        if (Array.isArray(msg.values)) {
-          msg.values.forEach(({ name, value }) => {
-            this._updateVariable(name, value ?? "");
-          });
+      case "variables": {
+        const batch = computeVariableBatch(
+          msg.values,
+          VARIABLE_DEFINITIONS,
+          this.variables,
+        );
+        const names = Object.keys(batch);
+        if (names.length > 0) {
+          for (const name of names) {
+            this.variables.set(name, batch[name]);
+          }
+          this.setVariableValues(batch);
         }
         break;
+      }
       case "ack":
         this.log("debug", `Ack from server: ${msg.command}`);
         break;

--- a/ops/companion/presenter/lib/variable-batch.js
+++ b/ops/companion/presenter/lib/variable-batch.js
@@ -1,0 +1,18 @@
+function computeVariableBatch(values, variableDefinitions, currentMap) {
+  const batch = {};
+  if (!Array.isArray(values)) return batch;
+
+  for (const entry of values) {
+    if (!entry || typeof entry.name !== "string") continue;
+    if (!variableDefinitions.includes(entry.name)) continue;
+
+    const next = entry.value ?? "";
+    if (currentMap.get(entry.name) !== next) {
+      batch[entry.name] = next;
+    }
+  }
+
+  return batch;
+}
+
+module.exports = { computeVariableBatch };

--- a/ops/companion/presenter/lib/variable-batch.js
+++ b/ops/companion/presenter/lib/variable-batch.js
@@ -1,3 +1,24 @@
+/**
+ * Compute a single batched update object from a server "variables" payload.
+ *
+ * Semantics:
+ *   - Entries with non-string `name` are skipped (defensive against malformed input).
+ *   - Entries whose `name` is not in `variableDefinitions` are skipped (unknown vars).
+ *   - `null` / `undefined` values are coerced to empty string to mirror what
+ *     Companion expects.
+ *   - Only CHANGED values (compared against `currentMap`) are included in the
+ *     returned object; unchanged values are filtered out.
+ *
+ * The function does not mutate `currentMap`. Caller is responsible for writing
+ * the batch back to the cache *after* the Companion `setVariableValues` call
+ * succeeds (so a thrown call leaves the cache clean for retry on the next
+ * message — see `applyVariablesMessage`).
+ *
+ * @param {unknown} values Server-side array of `{name, value}` entries.
+ * @param {string[]} variableDefinitions Whitelist of accepted variable names.
+ * @param {Map<string,string>} currentMap Current cached values per variable.
+ * @returns {Object<string,string>} Diff object suitable for setVariableValues.
+ */
 function computeVariableBatch(values, variableDefinitions, currentMap) {
   const batch = {};
   if (!Array.isArray(values)) return batch;
@@ -15,4 +36,38 @@ function computeVariableBatch(values, variableDefinitions, currentMap) {
   return batch;
 }
 
-module.exports = { computeVariableBatch };
+/**
+ * Apply a "variables" message to a Companion plugin instance.
+ *
+ * Calls `instance.setVariableValues(batch)` AT MOST ONCE per server broadcast
+ * (the fix for #265: previously the plugin made N separate calls — one per
+ * changed variable — which caused N rounds of Companion feedback re-evaluation
+ * per timer tick).
+ *
+ * Ordering: setVariableValues is called BEFORE the local cache is updated. If
+ * setVariableValues throws, the cache stays clean, so the next message will
+ * re-detect the change and retry.
+ *
+ * @param {{values?: unknown}} msg Parsed server "variables" message.
+ * @param {string[]} variableDefinitions Whitelist of accepted variable names.
+ * @param {{variables: Map<string,string>, setVariableValues: Function}} instance
+ *   Plugin instance (or stub) exposing the cache map + Companion setter.
+ * @returns {number} Number of setVariableValues calls actually made (0 or 1).
+ */
+function applyVariablesMessage(msg, variableDefinitions, instance) {
+  const batch = computeVariableBatch(
+    msg && msg.values,
+    variableDefinitions,
+    instance.variables,
+  );
+  const names = Object.keys(batch);
+  if (names.length === 0) return 0;
+
+  instance.setVariableValues(batch);
+  for (const name of names) {
+    instance.variables.set(name, batch[name]);
+  }
+  return 1;
+}
+
+module.exports = { computeVariableBatch, applyVariablesMessage };

--- a/ops/companion/presenter/lib/variable-batch.test.js
+++ b/ops/companion/presenter/lib/variable-batch.test.js
@@ -1,0 +1,136 @@
+const { test, describe } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const { computeVariableBatch } = require("./variable-batch");
+
+const indexSource = fs.readFileSync(
+  path.resolve(__dirname, "..", "index.js"),
+  "utf-8",
+);
+
+describe("computeVariableBatch", () => {
+  const VARS = [
+    "timer_countdown_state",
+    "timer_countdown_remaining_seconds",
+    "timer_countdown_remaining_hms",
+    "timer_countdown_remaining_mmss",
+    "timer_countdown_remaining_hhmm",
+    "timer_countdown_remaining_readable",
+    "song_name",
+  ];
+
+  test("returns only changed known variables", () => {
+    const current = new Map([
+      ["timer_countdown_state", "running"],
+      ["song_name", "Hymn"],
+    ]);
+    const values = [
+      { name: "timer_countdown_state", value: "running" },
+      { name: "timer_countdown_remaining_seconds", value: "12" },
+      { name: "song_name", value: "Doxology" },
+      { name: "unknown_variable", value: "drop" },
+    ];
+
+    const batch = computeVariableBatch(values, VARS, current);
+
+    assert.deepEqual(batch, {
+      timer_countdown_remaining_seconds: "12",
+      song_name: "Doxology",
+    });
+  });
+
+  test("collapses a full timer-tick payload into a single batch (#265)", () => {
+    const current = new Map();
+    const values = [
+      { name: "timer_countdown_state", value: "running" },
+      { name: "timer_countdown_remaining_seconds", value: "299" },
+      { name: "timer_countdown_remaining_hms", value: "00:04:59" },
+      { name: "timer_countdown_remaining_mmss", value: "04:59" },
+      { name: "timer_countdown_remaining_hhmm", value: "00:04" },
+      { name: "timer_countdown_remaining_readable", value: "4m 59s" },
+    ];
+
+    const batch = computeVariableBatch(values, VARS, current);
+
+    assert.equal(
+      Object.keys(batch).length,
+      6,
+      "all 6 changed timer variables must be in ONE batch object",
+    );
+  });
+
+  test("treats null/undefined value as empty string", () => {
+    const current = new Map([["song_name", "Hymn"]]);
+    const values = [
+      { name: "song_name", value: null },
+      { name: "timer_countdown_state", value: undefined },
+    ];
+
+    const batch = computeVariableBatch(values, VARS, current);
+
+    assert.equal(batch.song_name, "");
+    assert.equal(batch.timer_countdown_state, "");
+  });
+
+  test("skips entries with non-string names", () => {
+    const current = new Map();
+    const values = [
+      { name: null, value: "x" },
+      { value: "y" },
+      "not-an-object",
+      null,
+      { name: "song_name", value: "OK" },
+    ];
+
+    const batch = computeVariableBatch(values, VARS, current);
+
+    assert.deepEqual(batch, { song_name: "OK" });
+  });
+
+  test("returns empty object when nothing changes", () => {
+    const current = new Map([
+      ["song_name", "Hymn"],
+      ["timer_countdown_state", "paused"],
+    ]);
+    const values = [
+      { name: "song_name", value: "Hymn" },
+      { name: "timer_countdown_state", value: "paused" },
+    ];
+
+    const batch = computeVariableBatch(values, VARS, current);
+
+    assert.deepEqual(batch, {});
+  });
+});
+
+describe("index.js variables-case regression (#265)", () => {
+  test("must not call _updateVariable inside forEach in the variables case", () => {
+    const m = indexSource.match(/case "variables":\s*([\s\S]*?)\n\s+case "/);
+    assert.ok(m, "could not locate the 'variables' case body in index.js");
+    const body = m[1];
+
+    assert.ok(
+      !/forEach[\s\S]*_updateVariable/.test(body),
+      "values.forEach calling _updateVariable produces N setVariableValues calls — must batch instead (regression for #265)",
+    );
+  });
+
+  test("variables case must use computeVariableBatch + single setVariableValues call", () => {
+    const m = indexSource.match(/case "variables":\s*([\s\S]*?)\n\s+case "/);
+    assert.ok(m, "could not locate the 'variables' case body in index.js");
+    const body = m[1];
+
+    assert.ok(
+      /computeVariableBatch/.test(body),
+      "variables case must use computeVariableBatch helper from lib/variable-batch",
+    );
+
+    const calls = body.match(/setVariableValues/g) || [];
+    assert.ok(
+      calls.length <= 1,
+      `variables case must call setVariableValues at most once per message (found ${calls.length})`,
+    );
+  });
+});

--- a/ops/companion/presenter/lib/variable-batch.test.js
+++ b/ops/companion/presenter/lib/variable-batch.test.js
@@ -3,24 +3,38 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
 
-const { computeVariableBatch } = require("./variable-batch");
+const {
+  computeVariableBatch,
+  applyVariablesMessage,
+} = require("./variable-batch");
 
 const indexSource = fs.readFileSync(
   path.resolve(__dirname, "..", "index.js"),
   "utf-8",
 );
 
-describe("computeVariableBatch", () => {
-  const VARS = [
-    "timer_countdown_state",
-    "timer_countdown_remaining_seconds",
-    "timer_countdown_remaining_hms",
-    "timer_countdown_remaining_mmss",
-    "timer_countdown_remaining_hhmm",
-    "timer_countdown_remaining_readable",
-    "song_name",
-  ];
+const VARS = [
+  "timer_countdown_state",
+  "timer_countdown_remaining_seconds",
+  "timer_countdown_remaining_hms",
+  "timer_countdown_remaining_mmss",
+  "timer_countdown_remaining_hhmm",
+  "timer_countdown_remaining_readable",
+  "song_name",
+];
 
+function makeStub() {
+  const stub = {
+    variables: new Map(),
+    setVariableValuesCalls: [],
+    setVariableValues(batch) {
+      this.setVariableValuesCalls.push({ ...batch });
+    },
+  };
+  return stub;
+}
+
+describe("computeVariableBatch", () => {
   test("returns only changed known variables", () => {
     const current = new Map([
       ["timer_countdown_state", "running"],
@@ -41,24 +55,19 @@ describe("computeVariableBatch", () => {
     });
   });
 
-  test("collapses a full timer-tick payload into a single batch (#265)", () => {
+  test("includes first-seen variables (undefined → value transition)", () => {
     const current = new Map();
     const values = [
-      { name: "timer_countdown_state", value: "running" },
-      { name: "timer_countdown_remaining_seconds", value: "299" },
-      { name: "timer_countdown_remaining_hms", value: "00:04:59" },
-      { name: "timer_countdown_remaining_mmss", value: "04:59" },
-      { name: "timer_countdown_remaining_hhmm", value: "00:04" },
-      { name: "timer_countdown_remaining_readable", value: "4m 59s" },
+      { name: "song_name", value: "Hymn" },
+      { name: "timer_countdown_state", value: "paused" },
     ];
 
     const batch = computeVariableBatch(values, VARS, current);
 
-    assert.equal(
-      Object.keys(batch).length,
-      6,
-      "all 6 changed timer variables must be in ONE batch object",
-    );
+    assert.deepEqual(batch, {
+      song_name: "Hymn",
+      timer_countdown_state: "paused",
+    });
   });
 
   test("treats null/undefined value as empty string", () => {
@@ -105,32 +114,140 @@ describe("computeVariableBatch", () => {
   });
 });
 
-describe("index.js variables-case regression (#265)", () => {
-  test("must not call _updateVariable inside forEach in the variables case", () => {
-    const m = indexSource.match(/case "variables":\s*([\s\S]*?)\n\s+case "/);
-    assert.ok(m, "could not locate the 'variables' case body in index.js");
-    const body = m[1];
+describe("applyVariablesMessage (behavior, #265)", () => {
+  test("collapses a full timer-tick payload into ONE setVariableValues call", () => {
+    const instance = makeStub();
+    const msg = {
+      type: "variables",
+      values: [
+        { name: "timer_countdown_state", value: "running" },
+        { name: "timer_countdown_remaining_seconds", value: "299" },
+        { name: "timer_countdown_remaining_hms", value: "00:04:59" },
+        { name: "timer_countdown_remaining_mmss", value: "04:59" },
+        { name: "timer_countdown_remaining_hhmm", value: "00:04" },
+        { name: "timer_countdown_remaining_readable", value: "4m 59s" },
+      ],
+    };
 
-    assert.ok(
-      !/forEach[\s\S]*_updateVariable/.test(body),
-      "values.forEach calling _updateVariable produces N setVariableValues calls — must batch instead (regression for #265)",
+    const calls = applyVariablesMessage(msg, VARS, instance);
+
+    assert.equal(calls, 1, "exactly one setVariableValues call");
+    assert.equal(instance.setVariableValuesCalls.length, 1);
+    assert.equal(
+      Object.keys(instance.setVariableValuesCalls[0]).length,
+      6,
+      "all 6 timer vars in the single call",
     );
   });
 
-  test("variables case must use computeVariableBatch + single setVariableValues call", () => {
-    const m = indexSource.match(/case "variables":\s*([\s\S]*?)\n\s+case "/);
+  test("skips setVariableValues entirely when nothing changed", () => {
+    const instance = makeStub();
+    instance.variables.set("song_name", "Hymn");
+
+    const calls = applyVariablesMessage(
+      { values: [{ name: "song_name", value: "Hymn" }] },
+      VARS,
+      instance,
+    );
+
+    assert.equal(calls, 0);
+    assert.equal(instance.setVariableValuesCalls.length, 0);
+  });
+
+  test("updates local cache for every batched variable", () => {
+    const instance = makeStub();
+    applyVariablesMessage(
+      {
+        values: [
+          { name: "song_name", value: "Doxology" },
+          { name: "timer_countdown_state", value: "running" },
+        ],
+      },
+      VARS,
+      instance,
+    );
+
+    assert.equal(instance.variables.get("song_name"), "Doxology");
+    assert.equal(instance.variables.get("timer_countdown_state"), "running");
+  });
+
+  test("on setVariableValues throw, cache stays clean for retry", () => {
+    const instance = {
+      variables: new Map(),
+      setVariableValues() {
+        throw new Error("simulated Companion failure");
+      },
+    };
+
+    assert.throws(() =>
+      applyVariablesMessage(
+        { values: [{ name: "song_name", value: "Hymn" }] },
+        VARS,
+        instance,
+      ),
+    );
+    assert.equal(
+      instance.variables.has("song_name"),
+      false,
+      "cache must NOT be written when setVariableValues throws",
+    );
+  });
+
+  test("tolerates malformed messages (no values, wrong shape)", () => {
+    const instance = makeStub();
+    assert.equal(applyVariablesMessage({}, VARS, instance), 0);
+    assert.equal(applyVariablesMessage({ values: null }, VARS, instance), 0);
+    assert.equal(
+      applyVariablesMessage({ values: "not-array" }, VARS, instance),
+      0,
+    );
+    assert.equal(instance.setVariableValuesCalls.length, 0);
+  });
+
+  test("filters unknown variables before counting changes", () => {
+    const instance = makeStub();
+    const calls = applyVariablesMessage(
+      {
+        values: [
+          { name: "unknown_extra", value: "x" },
+          { name: "song_name", value: "Hymn" },
+        ],
+      },
+      VARS,
+      instance,
+    );
+
+    assert.equal(calls, 1);
+    assert.deepEqual(instance.setVariableValuesCalls[0], {
+      song_name: "Hymn",
+    });
+    assert.equal(instance.variables.has("unknown_extra"), false);
+  });
+});
+
+describe("index.js wires applyVariablesMessage (regression for #265)", () => {
+  test("variables case delegates to applyVariablesMessage and contains NO inline setVariableValues call", () => {
+    const m = indexSource.match(
+      /case "variables":\s*([\s\S]*?)\n\s+(?:case "|default:|\})/,
+    );
     assert.ok(m, "could not locate the 'variables' case body in index.js");
     const body = m[1];
 
     assert.ok(
-      /computeVariableBatch/.test(body),
-      "variables case must use computeVariableBatch helper from lib/variable-batch",
+      /applyVariablesMessage\s*\(/.test(body),
+      "variables case must call applyVariablesMessage(...)",
     );
 
-    const calls = body.match(/setVariableValues/g) || [];
+    const inlineCalls = body.match(/this\.setVariableValues\s*\(/g) || [];
+    assert.equal(
+      inlineCalls.length,
+      0,
+      `variables case must not call this.setVariableValues directly (found ${inlineCalls.length}); use applyVariablesMessage instead (#265)`,
+    );
+
     assert.ok(
-      calls.length <= 1,
-      `variables case must call setVariableValues at most once per message (found ${calls.length})`,
+      !/forEach[\s\S]*_updateVariable/.test(body),
+      "values.forEach calling _updateVariable produces N setVariableValues calls — must batch via applyVariablesMessage (regression for #265)",
     );
   });
 });

--- a/ops/companion/presenter/package.json
+++ b/ops/companion/presenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-module/presenter",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "description": "Control Presenter via /companion/ws",
   "main": "index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:companion && npm run test:playwright",
     "test:playwright": "playwright test",
     "test:playwright:headed": "playwright test --headed",
-    "test:companion": "node --test ops/companion/presenter/lib/time.test.js ops/companion/presenter/lib/commands.test.js"
+    "test:companion": "node --test ops/companion/presenter/lib/time.test.js ops/companion/presenter/lib/commands.test.js ops/companion/presenter/lib/variable-batch.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fix #265 — Companion plugin slowness when co-located with Presenter server.

- Root cause: the plugin's `case "variables":` handler iterated `msg.values` and called `setVariableValues({[name]: value})` once per changed variable. With timers ticking 1 Hz the server broadcasts a full 39-variable snapshot, of which ~6 timer variables change. The plugin therefore made ~6 separate `setVariableValues` calls per second — each triggering a full Companion state propagation and re-evaluation of every advanced `text_*` feedback. Same-machine co-location made it worse because the WS roundtrip is sub-millisecond so there is no network-level coalescing to mask the per-variable churn.
- Fix: extract `computeVariableBatch` + `applyVariablesMessage` helpers in `ops/companion/presenter/lib/variable-batch.js`. The `variables` case is now a one-liner that emits ONE `setVariableValues(batch)` call per server message. `setVariableValues` is called BEFORE the local cache is updated so a thrown call leaves the cache clean for retry.
- Tests: 12 new tests in `ops/companion/presenter/lib/variable-batch.test.js` covering pure-function semantics, behavior on a stub instance (call count, batch contents, cache updates, throw-recovery, malformed messages), and a regression assertion against `index.js` source.
- Version: plugin `package.json` 0.7.0 → 0.8.1 and `manifest.json` 0.8.0 → 0.8.1 (drift aligned).

## Test plan

- [x] `npm run test:companion` — 25/25 green
- [x] CI Pipeline 26054553754 — Companion Tests / Format / Clippy / Test / Coverage / Build / E2E (×3) / Deploy to Dev / Deploy Companion Plugin all ✅ (Mutation Testing still running, last gate)
- [x] Deploy Companion Plugin job rsynced new plugin to companion-snv:/home/companion/.config/companion-nodejs/modules/presenter (v0.8.1) and restarted the companion service — verified live on host

🤖 Generated with [Claude Code](https://claude.com/claude-code)