### PR TITLE
fix(ci): install gstreamer/glib dev libs in deploy and release workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler cmake nasm
+        # libglib2.0-dev + libgstreamer1.0-dev are required to compile the
+        # `glib-sys`/`gstreamer-sys` crates that the NDI WebRTC pipeline
+        # pulled in via gst-plugins-rs. Pre-WebRTC the build only needed
+        # protobuf+cmake+nasm; after PR #330 (NDI WebRTC migration) the
+        # release build will fail at glib-sys with
+        #   "Package 'glib-2.0', required by 'virtual:world', not found"
+        # unless the GStreamer dev headers are installed. Same dependency
+        # set as the dev pipeline's Build job in pipeline.yml.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            protobuf-compiler cmake nasm \
+            libglib2.0-dev \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler cmake nasm
+        # libglib2.0-dev + libgstreamer1.0-dev are required to compile
+        # `glib-sys` / `gstreamer-sys` (pulled in via gst-plugins-rs by the
+        # NDI WebRTC pipeline). Without them the build fails with
+        #   "Package 'glib-2.0', required by 'virtual:world', not found"
+        # at the glib-sys build script.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            protobuf-compiler cmake nasm \
+            libglib2.0-dev \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "axum",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.92"
+version = "0.4.93"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary

- Main branch Deploy run (`26191078695`) failed at `glib-sys` build immediately after PR #330 merged — `deploy.yml` and `release.yml` only install `protobuf+cmake+nasm`, missing the GStreamer + glib dev headers that gst-plugins-rs requires.
- Adds `libglib2.0-dev`, `libgstreamer1.0-dev`, `libgstreamer-plugins-base1.0-dev`, `libgstreamer-plugins-bad1.0-dev` to both workflows — same dev-package set the dev `pipeline.yml` already uses.
- Bumps workspace `0.4.92 → 0.4.93` (the previous PR landed 0.4.92 on main; `version-check.yml` would block without a bump).

## Test plan

- [x] Dev pipeline `26208090672` green through Build / Test / Coverage / E2E / Deploy to Dev with the new install set
- [ ] After merge: main `Deploy` workflow `Build Release` job succeeds (no glib-sys failure) and Deploy to Production reaches terminal Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)