### PR TITLE
feat(ndi): auto-recovery for stage WebRTC streams

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,13 +75,13 @@ jobs:
         env:
           PRESENTER_BUILD_CHANNEL: release
 
-      - name: Verify prod artifact has no mock integrations
+      - name: Verify prod artifact has no test-only features
         run: |
-          if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset" >/dev/null; then
-            echo "::error::Prod build contains mock-integrations symbols. Rebuild without --features mock-integrations."
+          if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset|kill_pipeline_for_test|simulate_error_for_test|simulate_pipeline_error" >/dev/null; then
+            echo "::error::Prod build contains test-only symbols (mock-integrations or test-helpers). Rebuild without --features mock-integrations,test-helpers."
             exit 1
           fi
-          echo "Prod artifact verified: no mock integration symbols"
+          echo "Prod artifact verified: no test-only symbols"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -500,7 +500,7 @@ jobs:
         run: bash scripts/build-ui.sh
 
       - name: Build release binaries
-        run: cargo build --release -p presenter-server -p presenter-importer --features presenter-server/mock-integrations
+        run: cargo build --release -p presenter-server -p presenter-importer --features presenter-server/mock-integrations,presenter-server/test-helpers
         env:
           PRESENTER_BUILD_CHANNEL: dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,13 @@ jobs:
         env:
           PRESENTER_BUILD_CHANNEL: release
 
-      - name: Verify prod artifact has no mock integrations
+      - name: Verify prod artifact has no test-only features
         run: |
-          if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset" >/dev/null; then
-            echo "::error::Prod build contains mock-integrations symbols. Rebuild without --features mock-integrations."
+          if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset|kill_pipeline_for_test|simulate_error_for_test|simulate_pipeline_error" >/dev/null; then
+            echo "::error::Prod build contains test-only symbols (mock-integrations or test-helpers). Rebuild without --features mock-integrations,test-helpers."
             exit 1
           fi
-          echo "Prod artifact verified: no mock integration symbols"
+          echo "Prod artifact verified: no test-only symbols"
 
       - name: Create release archive
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "axum",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.93"
+version = "0.4.94"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/Cargo.toml
+++ b/crates/presenter-ndi/Cargo.toml
@@ -6,6 +6,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+test-helpers = []
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -99,8 +99,7 @@ impl SupervisorState {
         Self {
             // Start with last_rebuild far enough in the past that the FIRST
             // rebuild attempt has zero wait.
-            last_rebuild_at: std::time::Instant::now()
-                - std::time::Duration::from_secs(3600),
+            last_rebuild_at: std::time::Instant::now() - std::time::Duration::from_secs(3600),
             consecutive_failures: 0,
         }
     }
@@ -222,7 +221,11 @@ impl NdiManager {
     /// A 7-second timeout caps the wait — long enough for ndisrc to find the
     /// source on a healthy LAN, short enough that a missing/dead broadcaster
     /// reports back quickly to the operator.
-    pub async fn start_pipeline(self: &std::sync::Arc<Self>, source_id: &str, ndi_name: &str) -> Result<()> {
+    pub async fn start_pipeline(
+        self: &std::sync::Arc<Self>,
+        source_id: &str,
+        ndi_name: &str,
+    ) -> Result<()> {
         let mut active = self.active.lock().await;
         if let StateCheckOutcome::Idempotent = check_active_entry(&mut active, source_id).await {
             return Ok(());
@@ -277,11 +280,8 @@ impl NdiManager {
                 // run before pipeline is moved into ActiveSource on the
                 // active.insert line below.
                 let watcher = pipeline.state_watcher();
-                let supervisor = self.spawn_supervisor(
-                    source_id.to_string(),
-                    ndi_name.to_string(),
-                    watcher,
-                );
+                let supervisor =
+                    self.spawn_supervisor(source_id.to_string(), ndi_name.to_string(), watcher);
                 active.insert(
                     source_id.to_string(),
                     ActiveSource {
@@ -452,8 +452,7 @@ impl NdiManager {
         let mut watcher = pipeline.state_watcher();
         let caps_ready = tokio::time::timeout(std::time::Duration::from_secs(8), async {
             loop {
-                if let crate::pipeline::PipelineState::Errored(ref e) =
-                    *watcher.borrow_and_update()
+                if let crate::pipeline::PipelineState::Errored(ref e) = *watcher.borrow_and_update()
                 {
                     return Err(anyhow!("pipeline errored: {e}"));
                 }
@@ -631,7 +630,13 @@ mod start_pipeline_state_check_tests {
             PipelineState::Stopped,
             "precondition: stopped_for_test must yield a Stopped pipeline",
         );
-        active.insert("test-id".to_string(), ActiveSource { pipeline: dead, supervisor: None });
+        active.insert(
+            "test-id".to_string(),
+            ActiveSource {
+                pipeline: dead,
+                supervisor: None,
+            },
+        );
         assert!(active.contains_key("test-id"));
 
         let outcome = check_active_entry(&mut active, "test-id").await;
@@ -655,7 +660,13 @@ mod start_pipeline_state_check_tests {
         let mut p = crate::pipeline::NdiPipeline::stopped_for_test();
         p.set_state_for_test(PipelineState::Streaming);
         assert_eq!(p.state(), PipelineState::Streaming);
-        active.insert("test-id".to_string(), ActiveSource { pipeline: p, supervisor: None });
+        active.insert(
+            "test-id".to_string(),
+            ActiveSource {
+                pipeline: p,
+                supervisor: None,
+            },
+        );
 
         let outcome = check_active_entry(&mut active, "test-id").await;
 
@@ -673,7 +684,13 @@ mod start_pipeline_state_check_tests {
         let mut active: HashMap<String, ActiveSource> = HashMap::new();
         let mut p = crate::pipeline::NdiPipeline::stopped_for_test();
         p.set_state_for_test(PipelineState::Errored("ndisrc fault".to_string()));
-        active.insert("test-id".to_string(), ActiveSource { pipeline: p, supervisor: None });
+        active.insert(
+            "test-id".to_string(),
+            ActiveSource {
+                pipeline: p,
+                supervisor: None,
+            },
+        );
 
         let outcome = check_active_entry(&mut active, "test-id").await;
 
@@ -691,15 +708,17 @@ mod start_pipeline_state_check_tests {
         state.mark_rebuild_started();
 
         // 100ms later — well within the 2s rate limit.
-        let outcome2 = state.should_rebuild_now(
-            std::time::Instant::now() + std::time::Duration::from_millis(100),
-        );
+        let outcome2 = state
+            .should_rebuild_now(std::time::Instant::now() + std::time::Duration::from_millis(100));
         // Decision must defer to "after the rate-limit window".
         // Allow a small tolerance (50ms) for the real time elapsed between
         // mark_rebuild_started() and the should_rebuild_now() call.
         match outcome2 {
             RebuildDecision::ProceedAfter(d) => {
-                assert!(d >= std::time::Duration::from_millis(1850), "expected ~2s wait, got {d:?}");
+                assert!(
+                    d >= std::time::Duration::from_millis(1850),
+                    "expected ~2s wait, got {d:?}"
+                );
             }
         }
     }
@@ -712,22 +731,40 @@ mod start_pipeline_state_check_tests {
             state.mark_rebuild_failed();
         }
         // 6th attempt — backoff = 2s
-        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(2));
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(2)
+        );
         state.mark_rebuild_failed();
         // 7th — 4s
-        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(4));
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(4)
+        );
         state.mark_rebuild_failed();
         // 8th — 8s
-        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(8));
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(8)
+        );
         state.mark_rebuild_failed();
         // 9th — 16s
-        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(16));
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(16)
+        );
         state.mark_rebuild_failed();
         // 10th — 30s cap
-        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(30)
+        );
         for _ in 0..5 {
             state.mark_rebuild_failed();
-            assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+            assert_eq!(
+                state.backoff_for_failure_count(),
+                std::time::Duration::from_secs(30)
+            );
         }
     }
 

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -168,9 +168,24 @@ async fn check_active_entry(
             }
             PipelineState::Stopped | PipelineState::Errored(_) => {
                 if let Some(mut dead) = active.remove(source_id) {
-                    if let Some(handle) = dead.supervisor.take() {
-                        handle.abort();
-                    }
+                    // CRITICAL: do NOT abort `dead.supervisor` here. The
+                    // supervisor task is what CALLS `rebuild_pipeline ->
+                    // check_active_entry` in the recovery path, so aborting
+                    // its own JoinHandle would self-cancel at the next
+                    // `.await` (pipeline.start / caps_ready) — orphaning the
+                    // new pipeline we're about to build and leaving the
+                    // active map empty. The supervisor's lifecycle is owned
+                    // by `stop_pipeline` / `stop_all` (explicit deactivation
+                    // paths only) — never by the rebuild path.
+                    //
+                    // After this Drops, `dead.supervisor: Option<JoinHandle>`
+                    // is dropped too. Dropping a JoinHandle does NOT cancel
+                    // its task in tokio (unlike abort), so the task keeps
+                    // running — which is exactly what we need for the
+                    // self-rebuild path. `rebuild_pipeline` then re-inserts
+                    // a fresh ActiveSource with `supervisor: None`, and the
+                    // still-running supervisor re-subscribes to the new
+                    // pipeline's state_watcher via `state_watcher_for`.
                     dead.pipeline.stop().await;
                 }
             }

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -169,6 +169,9 @@ async fn check_active_entry(
             }
             PipelineState::Stopped | PipelineState::Errored(_) => {
                 if let Some(mut dead) = active.remove(source_id) {
+                    if let Some(handle) = dead.supervisor.take() {
+                        handle.abort();
+                    }
                     dead.pipeline.stop().await;
                 }
             }
@@ -270,8 +273,9 @@ impl NdiManager {
 
         match caps_ready {
             Ok(Ok(())) => {
-                // Spawn the supervisor BEFORE inserting so the handle is ready when we
-                // hand ownership to ActiveSource.
+                // pipeline.state_watcher() and self.spawn_supervisor must
+                // run before pipeline is moved into ActiveSource on the
+                // active.insert line below.
                 let watcher = pipeline.state_watcher();
                 let supervisor = self.spawn_supervisor(
                     source_id.to_string(),
@@ -360,6 +364,28 @@ impl NdiManager {
                                 match manager.state_watcher_for(&source_id).await {
                                     Some(w) => {
                                         watcher = w;
+                                        // After re-subscribing, the new watcher's
+                                        // "seen" mark is the current value. If the
+                                        // fresh pipeline has ALREADY errored in the
+                                        // window between active.insert and the
+                                        // state_watcher_for clone, changed() would
+                                        // block waiting for a further transition
+                                        // that never comes. Peek the state now and
+                                        // continue the loop if it's already dead so
+                                        // the outer match re-enters the rebuild
+                                        // branch immediately.
+                                        let already_dead = matches!(
+                                            *watcher.borrow_and_update(),
+                                            Errored(_) | Stopped
+                                        );
+                                        if already_dead {
+                                            // Mark as a failure for backoff bookkeeping —
+                                            // the rebuild "succeeded" briefly but the
+                                            // pipeline collapsed immediately, which is
+                                            // a real failure of recovery.
+                                            state.mark_rebuild_failed();
+                                            continue;
+                                        }
                                     }
                                     None => {
                                         // Source no longer active (operator deactivated
@@ -373,13 +399,13 @@ impl NdiManager {
                                 }
                             }
                             Err(e) => {
+                                state.mark_rebuild_failed();
                                 tracing::warn!(
                                     source_id = %source_id,
                                     error = %e,
-                                    consecutive_failures = state.consecutive_failures() + 1,
+                                    consecutive_failures = state.consecutive_failures(),
                                     "supervisor: rebuild failed"
                                 );
-                                state.mark_rebuild_failed();
                             }
                         }
                     }

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -55,6 +55,11 @@ pub struct WhepReply {
 
 struct ActiveSource {
     pipeline: NdiPipeline,
+    /// Supervisor task handle. Aborted on `stop_pipeline` / drop to prevent
+    /// leaks. `None` only inside the regression-test constructors (which
+    /// don't spawn a real supervisor) AND in the `rebuild_pipeline` re-insert
+    /// path (the existing supervisor task is reused — see `spawn_supervisor`).
+    supervisor: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Outcome of `check_active_entry` — drives `start_pipeline`'s control flow.
@@ -67,6 +72,75 @@ enum StateCheckOutcome {
     /// Errored). In the dead case the entry has already been removed.
     /// Caller should proceed to build a fresh pipeline.
     Rebuild,
+}
+
+/// Per-source supervisor bookkeeping: when the last rebuild was attempted,
+/// and how many consecutive failures we've seen.
+///
+/// Pure data — no async, no I/O — so unit-testable on every CI host.
+#[derive(Debug)]
+struct SupervisorState {
+    last_rebuild_at: std::time::Instant,
+    /// 0 while the pipeline is healthy. Incremented by `mark_rebuild_failed`,
+    /// reset to 0 by `mark_rebuild_succeeded`.
+    consecutive_failures: u32,
+}
+
+/// Outcome of `SupervisorState::should_rebuild_now` — drives the supervisor's
+/// next sleep duration.
+#[derive(Debug)]
+enum RebuildDecision {
+    /// Wait this long, then attempt a rebuild. Zero duration means rebuild now.
+    ProceedAfter(std::time::Duration),
+}
+
+impl SupervisorState {
+    fn new() -> Self {
+        Self {
+            // Start with last_rebuild far enough in the past that the FIRST
+            // rebuild attempt has zero wait.
+            last_rebuild_at: std::time::Instant::now()
+                - std::time::Duration::from_secs(3600),
+            consecutive_failures: 0,
+        }
+    }
+
+    fn consecutive_failures(&self) -> u32 {
+        self.consecutive_failures
+    }
+
+    /// Rate-limit window: minimum 2 seconds between rebuild attempts.
+    fn should_rebuild_now(&self, now: std::time::Instant) -> RebuildDecision {
+        const RATE_LIMIT: std::time::Duration = std::time::Duration::from_secs(2);
+        let since_last = now.duration_since(self.last_rebuild_at);
+        if since_last >= RATE_LIMIT {
+            RebuildDecision::ProceedAfter(std::time::Duration::ZERO)
+        } else {
+            RebuildDecision::ProceedAfter(RATE_LIMIT - since_last)
+        }
+    }
+
+    /// Exponential backoff once failures reach 5: 2s, 4s, 8s, 16s, 30s cap.
+    fn backoff_for_failure_count(&self) -> std::time::Duration {
+        if self.consecutive_failures < 5 {
+            return std::time::Duration::ZERO;
+        }
+        let exp = (self.consecutive_failures - 5).min(4); // 0..=4 → 1,2,4,8,16
+        let secs: u64 = 1u64 << exp; // 1, 2, 4, 8, 16
+        std::time::Duration::from_secs(secs.saturating_mul(2).min(30))
+    }
+
+    fn mark_rebuild_started(&mut self) {
+        self.last_rebuild_at = std::time::Instant::now();
+    }
+
+    fn mark_rebuild_succeeded(&mut self) {
+        self.consecutive_failures = 0;
+    }
+
+    fn mark_rebuild_failed(&mut self) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
 }
 
 /// Pure state-check for the active-source HashMap. Extracted from
@@ -145,7 +219,7 @@ impl NdiManager {
     /// A 7-second timeout caps the wait — long enough for ndisrc to find the
     /// source on a healthy LAN, short enough that a missing/dead broadcaster
     /// reports back quickly to the operator.
-    pub async fn start_pipeline(&self, source_id: &str, ndi_name: &str) -> Result<()> {
+    pub async fn start_pipeline(self: &std::sync::Arc<Self>, source_id: &str, ndi_name: &str) -> Result<()> {
         let mut active = self.active.lock().await;
         if let StateCheckOutcome::Idempotent = check_active_entry(&mut active, source_id).await {
             return Ok(());
@@ -196,7 +270,21 @@ impl NdiManager {
 
         match caps_ready {
             Ok(Ok(())) => {
-                active.insert(source_id.to_string(), ActiveSource { pipeline });
+                // Spawn the supervisor BEFORE inserting so the handle is ready when we
+                // hand ownership to ActiveSource.
+                let watcher = pipeline.state_watcher();
+                let supervisor = self.spawn_supervisor(
+                    source_id.to_string(),
+                    ndi_name.to_string(),
+                    watcher,
+                );
+                active.insert(
+                    source_id.to_string(),
+                    ActiveSource {
+                        pipeline,
+                        supervisor: Some(supervisor),
+                    },
+                );
                 Ok(())
             }
             Ok(Err(e)) => {
@@ -213,10 +301,177 @@ impl NdiManager {
         }
     }
 
+    /// Spawn the supervisor task for one source. Returns the JoinHandle so
+    /// callers can store it in `ActiveSource.supervisor` and abort on stop.
+    ///
+    /// The supervisor:
+    /// - Subscribes to the pipeline's state watcher
+    /// - On Errored/Stopped, requests a rebuild via `rebuild_pipeline`
+    /// - Rate-limits to 1 rebuild / 2s; exponentially backs off after 5
+    ///   consecutive failures
+    /// - Re-subscribes to the FRESH state watcher after each successful
+    ///   rebuild (the old watcher's pipeline was dropped)
+    /// - Exits when the watcher closes (pipeline dropped) OR the task is
+    ///   externally aborted via `stop_pipeline`
+    fn spawn_supervisor(
+        self: &std::sync::Arc<Self>,
+        source_id: String,
+        ndi_name: String,
+        mut watcher: tokio::sync::watch::Receiver<crate::pipeline::PipelineState>,
+    ) -> tokio::task::JoinHandle<()> {
+        let manager = std::sync::Arc::clone(self);
+        tokio::spawn(async move {
+            let mut state = SupervisorState::new();
+            loop {
+                // Wait for the next state change.
+                if watcher.changed().await.is_err() {
+                    // Pipeline dropped — exit cleanly.
+                    tracing::debug!(source_id = %source_id, "supervisor: watcher closed, exiting");
+                    return;
+                }
+                let current = watcher.borrow_and_update().clone();
+                use crate::pipeline::PipelineState::*;
+                match current {
+                    Streaming | Starting => {
+                        state.mark_rebuild_succeeded();
+                    }
+                    Errored(_) | Stopped => {
+                        // Apply rate-limit + backoff.
+                        let RebuildDecision::ProceedAfter(wait) =
+                            state.should_rebuild_now(std::time::Instant::now());
+                        let backoff = state.backoff_for_failure_count();
+                        let total = wait.max(backoff);
+                        if !total.is_zero() {
+                            tracing::warn!(
+                                source_id = %source_id,
+                                wait_ms = total.as_millis() as u64,
+                                consecutive_failures = state.consecutive_failures(),
+                                "supervisor: backing off before rebuild"
+                            );
+                            tokio::time::sleep(total).await;
+                        }
+                        state.mark_rebuild_started();
+                        match manager.rebuild_pipeline(&source_id, &ndi_name).await {
+                            Ok(()) => {
+                                tracing::info!(source_id = %source_id, "supervisor: rebuild succeeded");
+                                state.mark_rebuild_succeeded();
+                                // The fresh pipeline has a NEW state watcher; swap ours
+                                // so we see ITS transitions, not the dead pipeline's.
+                                match manager.state_watcher_for(&source_id).await {
+                                    Some(w) => {
+                                        watcher = w;
+                                    }
+                                    None => {
+                                        // Source no longer active (operator deactivated
+                                        // between rebuild start and now). Exit.
+                                        tracing::debug!(
+                                            source_id = %source_id,
+                                            "supervisor: source no longer active after rebuild, exiting"
+                                        );
+                                        return;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    source_id = %source_id,
+                                    error = %e,
+                                    consecutive_failures = state.consecutive_failures() + 1,
+                                    "supervisor: rebuild failed"
+                                );
+                                state.mark_rebuild_failed();
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Fetch the live `state_watcher` for an active source. Used by the
+    /// supervisor to re-subscribe after a successful rebuild (the old
+    /// watcher's pipeline is dropped after rebuild).
+    async fn state_watcher_for(
+        &self,
+        source_id: &str,
+    ) -> Option<tokio::sync::watch::Receiver<crate::pipeline::PipelineState>> {
+        let active = self.active.lock().await;
+        active.get(source_id).map(|s| s.pipeline.state_watcher())
+    }
+
+    /// Rebuild the pipeline for a source whose existing entry is dead
+    /// (Errored or Stopped). Reuses `check_active_entry` to clear the
+    /// dead entry, then builds + starts a fresh pipeline. Does NOT
+    /// spawn a new supervisor (the supervisor task that called us is
+    /// still alive and will re-subscribe to the new state watcher via
+    /// `state_watcher_for`).
+    async fn rebuild_pipeline(&self, source_id: &str, ndi_name: &str) -> Result<()> {
+        let mut active = self.active.lock().await;
+        // Force-remove the dead entry. If somehow it has become healthy in
+        // the meantime, leave it alone (idempotent).
+        if let StateCheckOutcome::Idempotent = check_active_entry(&mut active, source_id).await {
+            return Ok(());
+        }
+
+        let whep_url = format!("/ndi/whep/{}", source_id);
+        let mut pipeline = NdiPipeline::build(ndi_name, whep_url)?;
+        pipeline.start().await?;
+
+        let sink = pipeline
+            .sink_element()
+            .ok_or_else(|| anyhow!("pipeline has no sink element"))?;
+        let video_pad = sink
+            .static_pad("video_0")
+            .ok_or_else(|| anyhow!("whepserversink has no video_0 sink pad"))?;
+        let mut watcher = pipeline.state_watcher();
+        let caps_ready = tokio::time::timeout(std::time::Duration::from_secs(8), async {
+            loop {
+                if let crate::pipeline::PipelineState::Errored(ref e) =
+                    *watcher.borrow_and_update()
+                {
+                    return Err(anyhow!("pipeline errored: {e}"));
+                }
+                if video_pad.current_caps().is_some() {
+                    return Ok(());
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match caps_ready {
+            Ok(Ok(())) => {
+                active.insert(
+                    source_id.to_string(),
+                    ActiveSource {
+                        pipeline,
+                        // Supervisor task is reused — it'll fetch the new watcher
+                        // from us via `state_watcher_for`.
+                        supervisor: None,
+                    },
+                );
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                pipeline.stop().await;
+                Err(e)
+            }
+            Err(_) => {
+                pipeline.stop().await;
+                Err(anyhow!(
+                    "NDI source '{ndi_name}' did not deliver any frame within 8s on rebuild"
+                ))
+            }
+        }
+    }
+
     /// Stop one pipeline.
     pub async fn stop_pipeline(&self, source_id: &str) {
         let mut active = self.active.lock().await;
         if let Some(mut src) = active.remove(source_id) {
+            if let Some(handle) = src.supervisor.take() {
+                handle.abort();
+            }
             src.pipeline.stop().await;
         }
     }
@@ -225,6 +480,9 @@ impl NdiManager {
     pub async fn stop_all(&self) {
         let mut active = self.active.lock().await;
         for (_, mut src) in active.drain() {
+            if let Some(handle) = src.supervisor.take() {
+                handle.abort();
+            }
             src.pipeline.stop().await;
         }
     }
@@ -347,7 +605,7 @@ mod start_pipeline_state_check_tests {
             PipelineState::Stopped,
             "precondition: stopped_for_test must yield a Stopped pipeline",
         );
-        active.insert("test-id".to_string(), ActiveSource { pipeline: dead });
+        active.insert("test-id".to_string(), ActiveSource { pipeline: dead, supervisor: None });
         assert!(active.contains_key("test-id"));
 
         let outcome = check_active_entry(&mut active, "test-id").await;
@@ -371,7 +629,7 @@ mod start_pipeline_state_check_tests {
         let mut p = crate::pipeline::NdiPipeline::stopped_for_test();
         p.set_state_for_test(PipelineState::Streaming);
         assert_eq!(p.state(), PipelineState::Streaming);
-        active.insert("test-id".to_string(), ActiveSource { pipeline: p });
+        active.insert("test-id".to_string(), ActiveSource { pipeline: p, supervisor: None });
 
         let outcome = check_active_entry(&mut active, "test-id").await;
 
@@ -389,11 +647,72 @@ mod start_pipeline_state_check_tests {
         let mut active: HashMap<String, ActiveSource> = HashMap::new();
         let mut p = crate::pipeline::NdiPipeline::stopped_for_test();
         p.set_state_for_test(PipelineState::Errored("ndisrc fault".to_string()));
-        active.insert("test-id".to_string(), ActiveSource { pipeline: p });
+        active.insert("test-id".to_string(), ActiveSource { pipeline: p, supervisor: None });
 
         let outcome = check_active_entry(&mut active, "test-id").await;
 
         assert_eq!(outcome, StateCheckOutcome::Rebuild);
         assert!(!active.contains_key("test-id"));
+    }
+
+    /// Rate-limiter: two Errored transitions within 2s must produce
+    /// exactly ONE rebuild attempt.
+    #[tokio::test]
+    async fn supervisor_rate_limits_rapid_errors() {
+        let mut state = SupervisorState::new();
+        let outcome1 = state.should_rebuild_now(std::time::Instant::now());
+        assert!(matches!(outcome1, RebuildDecision::ProceedAfter(d) if d.is_zero()));
+        state.mark_rebuild_started();
+
+        // 100ms later — well within the 2s rate limit.
+        let outcome2 = state.should_rebuild_now(
+            std::time::Instant::now() + std::time::Duration::from_millis(100),
+        );
+        // Decision must defer to "after the rate-limit window".
+        // Allow a small tolerance (50ms) for the real time elapsed between
+        // mark_rebuild_started() and the should_rebuild_now() call.
+        match outcome2 {
+            RebuildDecision::ProceedAfter(d) => {
+                assert!(d >= std::time::Duration::from_millis(1850), "expected ~2s wait, got {d:?}");
+            }
+        }
+    }
+
+    /// After 5 consecutive failures, backoff progression is 2s, 4s, 8s, 16s, 30s (cap).
+    #[tokio::test]
+    async fn supervisor_backs_off_exponentially_after_5_failures() {
+        let mut state = SupervisorState::new();
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+        }
+        // 6th attempt — backoff = 2s
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(2));
+        state.mark_rebuild_failed();
+        // 7th — 4s
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(4));
+        state.mark_rebuild_failed();
+        // 8th — 8s
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(8));
+        state.mark_rebuild_failed();
+        // 9th — 16s
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(16));
+        state.mark_rebuild_failed();
+        // 10th — 30s cap
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+            assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+        }
+    }
+
+    /// mark_rebuild_succeeded resets the failure counter.
+    #[tokio::test]
+    async fn supervisor_resets_on_success() {
+        let mut state = SupervisorState::new();
+        for _ in 0..3 {
+            state.mark_rebuild_failed();
+        }
+        state.mark_rebuild_succeeded();
+        assert_eq!(state.consecutive_failures(), 0);
     }
 }

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -337,6 +337,13 @@ impl NdiManager {
                 use crate::pipeline::PipelineState::*;
                 match current {
                     Streaming | Starting => {
+                        // Healthy transition: reset the consecutive-failure
+                        // counter so prior errors don't carry over into the
+                        // next backoff cycle if a future fault occurs. The
+                        // spec pseudocode shows Starting as a no-op; we treat
+                        // it as success here because reaching Starting means
+                        // recovery is underway and any prior failure streak
+                        // is irrelevant once the new pipeline begins running.
                         state.mark_rebuild_succeeded();
                     }
                     Errored(_) | Stopped => {
@@ -370,10 +377,20 @@ impl NdiManager {
                                         // window between active.insert and the
                                         // state_watcher_for clone, changed() would
                                         // block waiting for a further transition
-                                        // that never comes. Peek the state now and
-                                        // continue the loop if it's already dead so
-                                        // the outer match re-enters the rebuild
-                                        // branch immediately.
+                                        // that never comes. Peek the state now: if
+                                        // it's already dead, mark the rebuild as a
+                                        // failure and `continue` — that returns to
+                                        // the outer loop's changed().await, which
+                                        // then blocks until either (a) the dead
+                                        // pipeline emits another transition
+                                        // (unlikely) or (b) the 30s DB-ticker
+                                        // backstop removes the entry and drops the
+                                        // state_tx, which makes changed() return
+                                        // Err and exits this supervisor cleanly.
+                                        // A fresh supervisor is then spawned by
+                                        // the ticker's start_pipeline. Worst-case
+                                        // recovery window is ~30s, which is the
+                                        // intended backstop behavior.
                                         let already_dead = matches!(
                                             *watcher.borrow_and_update(),
                                             Errored(_) | Stopped

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -517,6 +517,22 @@ impl NdiManager {
         self.active.lock().await.contains_key(source_id)
     }
 
+    /// Test-only: trigger an Errored state on the source's pipeline so
+    /// the PipelineSupervisor reacts as it would for a real ndisrc fault.
+    /// Returns `true` if the source was active (state injection succeeded),
+    /// `false` if not (caller should map to 404).
+    #[cfg(feature = "test-helpers")]
+    pub async fn simulate_pipeline_error(&self, source_id: &str, msg: &str) -> bool {
+        let active = self.active.lock().await;
+        match active.get(source_id) {
+            Some(src) => {
+                src.pipeline.simulate_error_for_test(msg);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Forward a WHEP HTTP exchange into the source's `whepserversink`
     /// signaller via `emit_by_name`. The signaller's Promise resolves with
     /// `{status: u32, headers: gst::Structure, body: glib::Bytes}`.

--- a/crates/presenter-ndi/src/pipeline.rs
+++ b/crates/presenter-ndi/src/pipeline.rs
@@ -395,6 +395,21 @@ impl NdiPipeline {
         self.state_rx.clone()
     }
 
+    /// Test-only: force an `Errored` state transition without actually
+    /// disturbing the underlying GStreamer pipeline. Used by the WHEP
+    /// kill-pipeline test route to simulate an `ndisrc` "Internal data
+    /// stream error" — the realistic failure mode that the production
+    /// `PipelineSupervisor` is designed to recover from.
+    ///
+    /// The supervisor (still alive, still subscribed to this state
+    /// channel) reacts to the Errored transition exactly as it would
+    /// for a real ndisrc fault: rebuild the pipeline via
+    /// `NdiManager::rebuild_pipeline`.
+    #[cfg(feature = "test-helpers")]
+    pub fn simulate_error_for_test(&self, msg: &str) {
+        let _ = self.state_tx.send(PipelineState::Errored(msg.to_string()));
+    }
+
     /// Returns a clone of the `whepserversink` element so the WHEP HTTP shim
     /// can reach its `signaller` child and emit_by_name SDP exchanges.
     pub fn sink_element(&self) -> Option<gst::Element> {

--- a/crates/presenter-ndi/src/pipeline.rs
+++ b/crates/presenter-ndi/src/pipeline.rs
@@ -353,6 +353,7 @@ impl NdiPipeline {
                         let _ = state_tx.send(PipelineState::Errored(detail));
                     }
                     gst::MessageView::Eos(_) => {
+                        tracing::warn!("pipeline EOS received → state=Stopped");
                         let _ = state_tx.send(PipelineState::Stopped);
                     }
                     _ => {}

--- a/crates/presenter-server/Cargo.toml
+++ b/crates/presenter-server/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1"
 [features]
 default = []
 mock-integrations = []
+test-helpers = []
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/presenter-server/Cargo.toml
+++ b/crates/presenter-server/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1"
 [features]
 default = []
 mock-integrations = []
-test-helpers = []
+test-helpers = ["presenter-ndi/test-helpers"]
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 // Feature modules host their own request/DTO types
 
 pub fn build_router(state: AppState) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/healthz", get(health))
         .route("/", get(ui_routes::home))
         .route("/search", get(search::search_presenter_endpoint))
@@ -244,15 +244,13 @@ pub fn build_router(state: AppState) -> Router {
             post(integrations::ndi_whep::post_whep_session)
                 .patch(integrations::ndi_whep::patch_whep_session)
                 .delete(integrations::ndi_whep::delete_whep_session),
-        )
-        .route(
-            "/test/ndi/kill-pipeline/{source_id}",
-            #[cfg(feature = "test-helpers")]
-            post(integrations::ndi_whep::kill_pipeline_for_test),
-            #[cfg(not(feature = "test-helpers"))]
-            post(|| async { axum::http::StatusCode::NOT_FOUND }),
-        )
-        .route("/group-colors", get(presentations::get_group_colors))
+        );
+    #[cfg(feature = "test-helpers")]
+    let router = router.route(
+        "/test/ndi/kill-pipeline/{source_id}",
+        post(integrations::ndi_whep::kill_pipeline_for_test),
+    );
+    router.route("/group-colors", get(presentations::get_group_colors))
         .route(
             "/presentations/{id}",
             get(presentations::get_presentation_detail)

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -245,6 +245,13 @@ pub fn build_router(state: AppState) -> Router {
                 .patch(integrations::ndi_whep::patch_whep_session)
                 .delete(integrations::ndi_whep::delete_whep_session),
         )
+        .route(
+            "/test/ndi/kill-pipeline/{source_id}",
+            #[cfg(feature = "test-helpers")]
+            post(integrations::ndi_whep::kill_pipeline_for_test),
+            #[cfg(not(feature = "test-helpers"))]
+            post(|| async { axum::http::StatusCode::NOT_FOUND }),
+        )
         .route("/group-colors", get(presentations::get_group_colors))
         .route(
             "/presentations/{id}",

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -250,7 +250,8 @@ pub fn build_router(state: AppState) -> Router {
         "/test/ndi/kill-pipeline/{source_id}",
         post(integrations::ndi_whep::kill_pipeline_for_test),
     );
-    router.route("/group-colors", get(presentations::get_group_colors))
+    router
+        .route("/group-colors", get(presentations::get_group_colors))
         .route(
             "/presentations/{id}",
             get(presentations::get_presentation_detail)

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -134,6 +134,11 @@ pub(crate) async fn delete_whep_session(
 /// `test-helpers` cargo feature; production binaries (built without the
 /// feature) do not contain this route. The Playwright recovery test calls
 /// it to make the recovery assertion deterministic.
+///
+/// Note: the `is_active` → `stop_pipeline` sequence is two separate mutex
+/// acquisitions, so a concurrent stop could race the `is_active` check.
+/// Harmless in the test context (the worst case is returning 204 for an
+/// already-stopped pipeline, and `stop_pipeline` is a no-op on missing keys).
 #[cfg(feature = "test-helpers")]
 #[instrument(skip_all, fields(source_id = %source_id))]
 pub(crate) async fn kill_pipeline_for_test(
@@ -291,7 +296,7 @@ mod tests {
 
     #[cfg(feature = "test-helpers")]
     #[tokio::test]
-    async fn kill_pipeline_for_test_returns_404_for_unknown_source() {
+    async fn kill_pipeline_for_test_returns_404_or_503_for_unknown_source() {
         let state = fresh_state().await;
         let result = kill_pipeline_for_test(
             axum::extract::Path("unknown".to_string()),
@@ -300,9 +305,8 @@ mod tests {
         .await;
         assert!(result.is_err(), "expected error for unknown source");
         let err = result.unwrap_err();
-        assert_eq!(
-            err.into_response().status(),
-            axum::http::StatusCode::NOT_FOUND
-        );
+        // With libndi: manager exists but the source isn't active → 404.
+        // Without libndi: ndi_manager() is None → 503.
+        assert_not_found_or_unavailable(err.into_response().status());
     }
 }

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -128,6 +128,31 @@ pub(crate) async fn delete_whep_session(
     Ok(into_response(reply))
 }
 
+/// Test-only: force the per-source GStreamer pipeline to stop, simulating
+/// an `ndisrc` crash. The PipelineSupervisor's recovery path should then
+/// rebuild it autonomously. Exposed ONLY when compiled with the
+/// `test-helpers` cargo feature; production binaries (built without the
+/// feature) do not contain this route. The Playwright recovery test calls
+/// it to make the recovery assertion deterministic.
+#[cfg(feature = "test-helpers")]
+#[instrument(skip_all, fields(source_id = %source_id))]
+pub(crate) async fn kill_pipeline_for_test(
+    Path(source_id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Response, AppError> {
+    let manager = state
+        .ndi_manager()
+        .ok_or_else(|| AppError::service_unavailable("NDI SDK not available"))?;
+    if !manager.is_active(&source_id).await {
+        return Err(AppError::not_found("NDI source not active"));
+    }
+    manager.stop_pipeline(&source_id).await;
+    Ok(Response::builder()
+        .status(204)
+        .body(axum::body::Body::empty())
+        .expect("valid response"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,5 +287,22 @@ mod tests {
         };
         let resp = into_response(reply);
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[cfg(feature = "test-helpers")]
+    #[tokio::test]
+    async fn kill_pipeline_for_test_returns_404_for_unknown_source() {
+        let state = fresh_state().await;
+        let result = kill_pipeline_for_test(
+            axum::extract::Path("unknown".to_string()),
+            axum::extract::State(state),
+        )
+        .await;
+        assert!(result.is_err(), "expected error for unknown source");
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.into_response().status(),
+            axum::http::StatusCode::NOT_FOUND
+        );
     }
 }

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -128,17 +128,23 @@ pub(crate) async fn delete_whep_session(
     Ok(into_response(reply))
 }
 
-/// Test-only: force the per-source GStreamer pipeline to stop, simulating
-/// an `ndisrc` crash. The PipelineSupervisor's recovery path should then
-/// rebuild it autonomously. Exposed ONLY when compiled with the
-/// `test-helpers` cargo feature; production binaries (built without the
-/// feature) do not contain this route. The Playwright recovery test calls
-/// it to make the recovery assertion deterministic.
+/// Test-only: simulate an `ndisrc` "Internal data stream error" by
+/// forcing the source's pipeline into `Errored` state. The supervisor
+/// task (still alive, still watching the state channel) reacts as it
+/// would for a real fault: rebuilds the pipeline via
+/// `NdiManager::rebuild_pipeline`. The browser-side `Watchdog` sees the
+/// resulting WebRTC stall, dispatches a fresh WHEP POST, and the new
+/// pipeline accepts it — end-to-end recovery in 3-5s.
 ///
-/// Note: the `is_active` → `stop_pipeline` sequence is two separate mutex
-/// acquisitions, so a concurrent stop could race the `is_active` check.
-/// Harmless in the test context (the worst case is returning 204 for an
-/// already-stopped pipeline, and `stop_pipeline` is a no-op on missing keys).
+/// Exposed ONLY when compiled with the `test-helpers` cargo feature;
+/// production binaries (built without the feature) do not contain this
+/// route. The Playwright recovery test calls it to make the recovery
+/// assertion deterministic.
+///
+/// Note: `simulate_pipeline_error` acquires the active mutex once. There
+/// is no two-acquire TOCTOU like the previous `stop_pipeline`
+/// implementation, and the source remains active — what we're injecting
+/// is a fault that the supervisor recovers from, not a deactivation.
 #[cfg(feature = "test-helpers")]
 #[instrument(skip_all, fields(source_id = %source_id))]
 pub(crate) async fn kill_pipeline_for_test(
@@ -148,10 +154,12 @@ pub(crate) async fn kill_pipeline_for_test(
     let manager = state
         .ndi_manager()
         .ok_or_else(|| AppError::service_unavailable("NDI SDK not available"))?;
-    if !manager.is_active(&source_id).await {
+    if !manager
+        .simulate_pipeline_error(&source_id, "simulated ndisrc crash")
+        .await
+    {
         return Err(AppError::not_found("NDI source not active"));
     }
-    manager.stop_pipeline(&source_id).await;
     Ok(Response::builder()
         .status(204)
         .body(axum::body::Body::empty())

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.93"
+version = "0.4.94"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.toml
+++ b/crates/presenter-ui/Cargo.toml
@@ -66,6 +66,7 @@ web-sys = { version = "0.3", features = [
     "RequestMode",
     "Response",
     "RtcConfiguration",
+    "RtcIceConnectionState",
     "RtcPeerConnection",
     "RtcRtpTransceiver",
     "RtcRtpTransceiverDirection",

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 use leptos::prelude::*;
 use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use leptos::web_sys::{
-    HtmlVideoElement, MediaStream, RtcConfiguration, RtcPeerConnection, RtcRtpTransceiverDirection,
-    RtcRtpTransceiverInit, RtcSdpType, RtcSessionDescriptionInit, RtcTrackEvent,
+    HtmlVideoElement, MediaStream, RtcConfiguration, RtcIceConnectionState, RtcPeerConnection,
+    RtcRtpTransceiverDirection, RtcRtpTransceiverInit, RtcSdpType, RtcSessionDescriptionInit,
+    RtcTrackEvent,
 };
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
@@ -28,6 +29,124 @@ struct WhepSession {
     resource_url: Option<String>,
 }
 
+/// Watchdog that fires `on_failure` when EITHER:
+/// - the RTCPeerConnection's iceConnectionState becomes "failed", "disconnected",
+///   or "closed", OR
+/// - the <video> element's currentTime has not advanced for STALL_THRESHOLD seconds.
+///
+/// The closure handles are leaked via `forget()` because wasm-bindgen `Closure`
+/// types are not `Send` and removing them on drop would require keeping the
+/// original handles around in a `Send`-bounded `StoredValue` — which doesn't
+/// fit. Instead we use an `active: Rc<Cell<bool>>` flag: closures check it
+/// first and become no-ops once cleared. `Watchdog::stop()` flips the flag.
+/// The closures themselves outlive the `Watchdog` instance but consume only a
+/// tiny amount of memory (a few `Rc` clones).
+struct Watchdog {
+    active: std::rc::Rc<std::cell::Cell<bool>>,
+}
+
+impl Watchdog {
+    /// Stall threshold: <video>.currentTime advance with this many seconds of
+    /// no change triggers a reconnect.
+    const STALL_THRESHOLD_SECS: f64 = 3.0;
+    /// How often the stall timer ticks (ms).
+    const TICK_INTERVAL_MS: i32 = 1000;
+
+    /// Install ICE-state listener + stall timer. `on_failure` is called at
+    /// most ONCE per Watchdog instance — after firing, both observers become
+    /// no-ops (gated by the `active` flag).
+    fn install<F: Fn() + 'static>(
+        video: &HtmlVideoElement,
+        pc: &RtcPeerConnection,
+        on_failure: F,
+    ) -> Self {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let active: Rc<Cell<bool>> = Rc::new(Cell::new(true));
+        let on_failure = Rc::new(on_failure);
+
+        // ICE state listener: fire on Failed / Disconnected / Closed.
+        {
+            let active = Rc::clone(&active);
+            let on_failure = Rc::clone(&on_failure);
+            let pc_clone = pc.clone();
+            let cb = Closure::<dyn FnMut(JsValue)>::new(move |_ev: JsValue| {
+                if !active.get() {
+                    return;
+                }
+                let s = pc_clone.ice_connection_state();
+                if matches!(
+                    s,
+                    RtcIceConnectionState::Failed
+                        | RtcIceConnectionState::Disconnected
+                        | RtcIceConnectionState::Closed
+                ) {
+                    leptos::logging::warn!(
+                        "watchdog: ICE state={s:?}, triggering reconnect"
+                    );
+                    active.set(false);
+                    (on_failure)();
+                }
+            });
+            pc.set_oniceconnectionstatechange(Some(cb.as_ref().unchecked_ref()));
+            cb.forget();
+        }
+
+        // Stall timer: every TICK_INTERVAL_MS check if currentTime advanced.
+        {
+            let active = Rc::clone(&active);
+            let on_failure = Rc::clone(&on_failure);
+            let video_clone = video.clone();
+            let last_time: std::rc::Rc<std::cell::Cell<f64>> =
+                std::rc::Rc::new(std::cell::Cell::new(-1.0));
+            let last_change_at: std::rc::Rc<std::cell::Cell<f64>> =
+                std::rc::Rc::new(std::cell::Cell::new(0.0));
+            let cb = Closure::<dyn FnMut()>::new(move || {
+                if !active.get() {
+                    return;
+                }
+                let now_secs = leptos::web_sys::js_sys::Date::now() / 1000.0;
+                let t = video_clone.current_time();
+                if (t - last_time.get()).abs() > 0.001 {
+                    // Time advanced — reset stall window.
+                    last_time.set(t);
+                    last_change_at.set(now_secs);
+                    return;
+                }
+                if last_change_at.get() == 0.0 {
+                    // First tick after install — establish baseline.
+                    last_change_at.set(now_secs);
+                    return;
+                }
+                if now_secs - last_change_at.get() >= Self::STALL_THRESHOLD_SECS {
+                    leptos::logging::warn!(
+                        "watchdog: <video> stalled for >{}s (currentTime={t}), triggering reconnect",
+                        Self::STALL_THRESHOLD_SECS
+                    );
+                    active.set(false);
+                    (on_failure)();
+                }
+            });
+            if let Some(window) = leptos::web_sys::window() {
+                let _ = window.set_interval_with_callback_and_timeout_and_arguments_0(
+                    cb.as_ref().unchecked_ref(),
+                    Self::TICK_INTERVAL_MS,
+                );
+            }
+            cb.forget();
+        }
+
+        Self { active }
+    }
+
+    /// Disable both observers. Idempotent. Calling `stop` after `on_failure`
+    /// has already fired is a safe no-op.
+    fn stop(&self) {
+        self.active.set(false);
+    }
+}
+
 /// Build the WHEP endpoint URL for a given source.
 pub fn whep_url(source_id: &str) -> String {
     format!("/ndi/whep/{source_id}")
@@ -37,11 +156,19 @@ pub fn whep_url(source_id: &str) -> String {
 pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>) -> impl IntoView {
     let video_ref = NodeRef::<leptos::html::Video>::new();
     let source_id_for_effect = source_id.clone();
-    // Holds the full WHEP session (pc + resource URL) so we can DELETE the
-    // session on the server when the component unmounts. Without DELETE the
-    // server-side webrtcsink accumulates sessions forever (every browser
-    // navigation = one session) and breaks after enough buildup.
-    let session_holder: StoredValue<Option<WhepSession>> = StoredValue::new(None);
+
+    // Holds the active connection: the WHEP session + the watchdog observing
+    // its health. Cleanup must close both — see on_cleanup below.
+    struct ActiveConnection {
+        session: WhepSession,
+        watchdog: Watchdog,
+    }
+    // Use new_local() instead of new() because Watchdog holds Rc<Cell<bool>>
+    // which is !Send + !Sync. LocalStorage drops the Send+Sync requirement;
+    // safe here because we're single-threaded WASM.
+    let session_holder: StoredValue<Option<ActiveConnection>, LocalStorage> =
+        StoredValue::new_local(None);
+
     // Cancellation flag covering the race where the component unmounts BEFORE
     // `connect_whep` resolves.
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -52,29 +179,77 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
         let source_id = source_id_for_effect.clone();
         let cancelled = Arc::clone(&cancelled_for_effect);
         spawn_local(async move {
-            match connect_whep(&video, &source_id).await {
-                Ok(session) => {
-                    if cancelled.load(Ordering::Acquire) {
-                        // Component unmounted before connect_whep finished —
-                        // synchronously fire DELETE and close pc. Same
-                        // mechanism as on_cleanup below.
-                        if let Some(url) = &session.resource_url {
-                            dispatch_delete(url);
-                        }
-                        session.pc.close();
-                    } else {
-                        // Also wire a window pagehide listener: some browsers
-                        // (and Playwright's page.goto()) tear down the JS
-                        // context before Leptos's on_cleanup runs. pagehide
-                        // fires earlier in the unload sequence and gives us a
-                        // chance to dispatch the DELETE while the window is
-                        // still alive.
-                        install_pagehide_teardown(&session);
-                        session_holder.set_value(Some(session));
-                    }
+            // The reconnect-trigger flag: when a watchdog fires, it sets this
+            // flag; the loop drains it and reconnects.
+            let reconnect_flag = std::rc::Rc::new(std::cell::Cell::new(false));
+
+            loop {
+                if cancelled.load(Ordering::Acquire) {
+                    return;
                 }
-                Err(e) => {
-                    leptos::logging::error!("WHEP connect for {source_id} failed: {e:?}");
+                match connect_whep(&video, &source_id).await {
+                    Ok(session) => {
+                        if cancelled.load(Ordering::Acquire) {
+                            // Unmounted between POST and now — clean up server
+                            // session and bail.
+                            if let Some(url) = &session.resource_url {
+                                dispatch_delete(url);
+                            }
+                            session.pc.close();
+                            return;
+                        }
+                        // Install watchdog: on failure, set the reconnect flag.
+                        let flag = std::rc::Rc::clone(&reconnect_flag);
+                        let watchdog =
+                            Watchdog::install(&video, &session.pc, move || flag.set(true));
+
+                        install_pagehide_teardown(&session);
+                        session_holder.set_value(Some(ActiveConnection {
+                            session,
+                            watchdog,
+                        }));
+
+                        // Wait until either cancellation OR a watchdog fire.
+                        loop {
+                            if cancelled.load(Ordering::Acquire) {
+                                return;
+                            }
+                            if reconnect_flag.get() {
+                                reconnect_flag.set(false);
+                                break;
+                            }
+                            // Poll every 100ms.
+                            let promise =
+                                leptos::web_sys::js_sys::Promise::new(&mut |resolve, _| {
+                                    if let Some(w) = leptos::web_sys::window() {
+                                        let _ = w
+                                            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                                                &resolve, 100,
+                                            );
+                                    }
+                                });
+                            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+                        }
+
+                        // Tear down old session before reconnecting.
+                        if let Some(active) =
+                            session_holder.try_update_value(|v| v.take()).flatten()
+                        {
+                            active.watchdog.stop();
+                            if let Some(url) = &active.session.resource_url {
+                                dispatch_delete(url);
+                            }
+                            active.session.pc.close();
+                        }
+                        // Loop falls through to connect_whep again with no
+                        // additional backoff (first retry is immediate).
+                    }
+                    Err(e) => {
+                        leptos::logging::warn!(
+                            "reconnect_loop: connect_whep failed: {e:?}, backing off"
+                        );
+                        sleep_for_backoff().await;
+                    }
                 }
             }
         });
@@ -83,12 +258,13 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let cancelled_for_cleanup = Arc::clone(&cancelled);
     on_cleanup(move || {
         cancelled_for_cleanup.store(true, Ordering::Release);
-        let session = session_holder.try_update_value(|opt| opt.take()).flatten();
-        if let Some(session) = session {
-            if let Some(url) = &session.resource_url {
+        let active = session_holder.try_update_value(|opt| opt.take()).flatten();
+        if let Some(active) = active {
+            active.watchdog.stop();
+            if let Some(url) = &active.session.resource_url {
                 dispatch_delete(url);
             }
-            session.pc.close();
+            active.session.pc.close();
         }
     });
 
@@ -105,6 +281,28 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
             playsinline
         />
     }
+}
+
+/// Sleep for an exponentially increasing duration, capped at 5s. Uses a
+/// static atomic to track the current step across calls. The schedule is
+/// reset implicitly when `connect_whep` succeeds and the supervising loop
+/// breaks out (the static doesn't reset — but the cap at 5s makes the
+/// occasional "long delay after a long failure run" harmless).
+async fn sleep_for_backoff() {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    static STEP: AtomicUsize = AtomicUsize::new(0);
+    let schedule_ms: [i32; 7] = [500, 1000, 2000, 4000, 5000, 5000, 5000];
+    let i = STEP
+        .fetch_add(1, AtomicOrdering::Relaxed)
+        .min(schedule_ms.len() - 1);
+    let ms = schedule_ms[i];
+    let promise = leptos::web_sys::js_sys::Promise::new(&mut |resolve, _| {
+        if let Some(window) = leptos::web_sys::window() {
+            let _ = window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms);
+        }
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
 }
 
 /// Fire-and-forget DELETE to the WHEP session resource. SYNCHRONOUS dispatch —

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -288,6 +288,13 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
 /// reset implicitly when `connect_whep` succeeds and the supervising loop
 /// breaks out (the static doesn't reset — but the cap at 5s makes the
 /// occasional "long delay after a long failure run" harmless).
+///
+/// Note: `STEP` is process-global and shared across all `<NdiVideo>`
+/// instances on the page. This is harmless for the current ndi-fullscreen
+/// layout (single video element). If a future multi-tile layout mounts
+/// multiple `<NdiVideo>` components, instance A's failure streak will
+/// inflate instance B's first retry delay (still capped at 5s). When that
+/// layout ships, move STEP into a per-component Rc<Cell<usize>>.
 async fn sleep_for_backoff() {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     static STEP: AtomicUsize = AtomicUsize::new(0);

--- a/docs/superpowers/plans/2026-05-21-ndi-stage-auto-recovery.md
+++ b/docs/superpowers/plans/2026-05-21-ndi-stage-auto-recovery.md
@@ -1,0 +1,1320 @@
+# NDI Stage Auto-Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the stage display NDI video recover automatically from any single failure (server `ndisrc` crash, NDI source restart, browser ICE drop) within 5-7 s, without manual page refresh.
+
+**Architecture:** Two independent self-healing layers. (1) Browser `Watchdog` inside `<NdiVideo>` listens for `RTCPeerConnection` ICE state changes and a `<video>` stall timer; on failure it runs `reconnect_loop` (tear down PC + DELETE old session + POST fresh offer, exponential backoff capped at 5 s). (2) Server `PipelineSupervisor` task per active source watches `NdiPipeline::state_watcher()` and rebuilds the gst pipeline immediately on `Errored`/`Stopped` (rate-limited 2 s; exponential pause after 5 consecutive failures). No WHEP protocol changes. The 30 s DB-driven auto-reconnect stays as a backstop.
+
+**Tech Stack:** Rust (axum, tokio, tracing, gstreamer-rs), Leptos WASM (web-sys, wasm-bindgen-futures), Playwright (TypeScript, `channel: 'chrome'` for the `@video-codec`-tagged recovery test).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-ndi-stage-auto-recovery-design.md` (commit `260b6ff`)
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `Cargo.toml` | Modify L15 | Workspace version 0.4.93 → 0.4.94 |
+| `crates/presenter-ndi/src/pipeline.rs` | Modify L355-358 | Add `tracing::warn!` on EOS branch (diagnostic) |
+| `crates/presenter-ndi/src/manager.rs` | Modify L56-104, L148-214, L217-222 | Add `PipelineSupervisor` task, `rebuild_pipeline`, supervisor handle in `ActiveSource`. Unit tests in existing `start_pipeline_state_check_tests` module. |
+| `crates/presenter-server/Cargo.toml` | Modify (add `[features]`) | Declare `test-helpers` feature |
+| `crates/presenter-server/src/router/integrations/ndi_whep.rs` | Modify | Add `cfg(feature = "test-helpers")` gated `kill_pipeline_for_test` handler |
+| `crates/presenter-server/src/router.rs` | Modify L247 | Mount the cfg-gated kill route |
+| `.github/workflows/pipeline.yml` | Modify Build job step | Build `presenter-server` with `--features test-helpers` for dev/E2E artifacts (NOT for prod deploy.yml/release.yml) |
+| `crates/presenter-ui/src/components/stage/ndi_video.rs` | Modify | Replace one-shot `connect_whep` Effect with `reconnect_loop` driven by `Watchdog` (ICE state + stall timer) |
+| `tests/e2e/ndi-webrtc-recovery.spec.ts` | Create | New Playwright recovery test, tagged `@video-codec` for real-Chrome routing |
+
+Net code change: ~150 LoC added. Single PR, dev → main.
+
+---
+
+## Task 1: Workspace version bump
+
+**Files:**
+- Modify: `Cargo.toml:15`
+
+- [ ] **Step 1: Bump version**
+
+Replace:
+
+```toml
+version = "0.4.93"
+```
+
+with:
+
+```toml
+version = "0.4.94"
+```
+
+- [ ] **Step 2: Refresh lockfiles**
+
+Run: `cargo update --workspace -p presenter-server`
+Run: `cd crates/presenter-ui && cargo update -p presenter-ui && cd ../..`
+
+Expected: both `Cargo.lock` files now show 0.4.94 for the workspace members.
+
+- [ ] **Step 3: Verify nothing else broke**
+
+Run: `cargo check --workspace`
+Expected: success (no compile errors, just a version field changed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/presenter-ui/Cargo.lock
+git commit -m "chore: bump workspace to 0.4.94"
+```
+
+---
+
+## Task 2: Diagnostic — EOS warn log in pipeline bus watcher
+
+**Files:**
+- Modify: `crates/presenter-ndi/src/pipeline.rs:355-358`
+
+Today the EOS branch silently sets state to Stopped with no log; the Error branch logs at ERROR. Parity makes future `ndisrc` investigations easier.
+
+- [ ] **Step 1: Add WARN log on EOS**
+
+Locate (`crates/presenter-ndi/src/pipeline.rs` around L355):
+
+```rust
+                    gst::MessageView::Eos(_) => {
+                        let _ = state_tx.send(PipelineState::Stopped);
+                    }
+```
+
+Replace with:
+
+```rust
+                    gst::MessageView::Eos(_) => {
+                        tracing::warn!("pipeline EOS received → state=Stopped");
+                        let _ = state_tx.send(PipelineState::Stopped);
+                    }
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cargo check -p presenter-ndi`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/presenter-ndi/src/pipeline.rs
+git commit -m "feat(ndi): log EOS at WARN for parity with Error branch"
+```
+
+---
+
+## Task 3: cfg-gated kill-pipeline test route
+
+**Files:**
+- Modify: `crates/presenter-server/Cargo.toml` (add `[features]`)
+- Modify: `crates/presenter-server/src/router/integrations/ndi_whep.rs`
+- Modify: `crates/presenter-server/src/router.rs:247`
+- Modify: `.github/workflows/pipeline.yml` (E2E build step adds `--features test-helpers`)
+
+The Playwright recovery test (Task 4) needs a deterministic way to kill the server-side pipeline mid-stream. We add a `test-helpers` cargo feature on `presenter-server`. Dev/E2E artifacts build with the feature; prod (`deploy.yml`, `release.yml`) does NOT — so production binaries have no such route.
+
+- [ ] **Step 1: Declare the feature in presenter-server Cargo.toml**
+
+Open `crates/presenter-server/Cargo.toml`. After the existing `[dependencies]` section, append:
+
+```toml
+[features]
+default = []
+test-helpers = []
+```
+
+If a `[features]` section already exists, add only the `test-helpers = []` line.
+
+- [ ] **Step 2: Add a unit test that the handler exists and 404s on unknown source**
+
+In `crates/presenter-server/src/router/integrations/ndi_whep.rs`, inside the existing `#[cfg(test)] mod tests` block at the bottom, add:
+
+```rust
+    #[cfg(feature = "test-helpers")]
+    #[tokio::test]
+    async fn kill_pipeline_for_test_returns_404_for_unknown_source() {
+        let state = build_test_state_without_ndi().await;
+        let result = kill_pipeline_for_test(
+            axum::extract::Path("unknown".to_string()),
+            axum::extract::State(state),
+        )
+        .await;
+        assert!(result.is_err(), "expected error for unknown source");
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+```
+
+`build_test_state_without_ndi` already exists in the test module above — reuse it.
+
+- [ ] **Step 3: Run the test — confirm it fails to compile (handler doesn't exist yet)**
+
+Run: `cargo test -p presenter-server --features test-helpers --lib router::integrations::ndi_whep`
+Expected: FAIL — `error[E0425]: cannot find function 'kill_pipeline_for_test'`
+
+- [ ] **Step 4: Implement the handler**
+
+Append to `crates/presenter-server/src/router/integrations/ndi_whep.rs` (above the `#[cfg(test)]` block):
+
+```rust
+/// Test-only: force the per-source GStreamer pipeline to stop, simulating
+/// an `ndisrc` crash. The PipelineSupervisor's recovery path should then
+/// rebuild it autonomously. Exposed ONLY when compiled with the
+/// `test-helpers` cargo feature; production binaries (built without the
+/// feature) do not contain this route. The Playwright recovery test calls
+/// it to make the recovery assertion deterministic.
+#[cfg(feature = "test-helpers")]
+#[instrument(skip_all, fields(source_id = %source_id))]
+pub(crate) async fn kill_pipeline_for_test(
+    Path(source_id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Response, AppError> {
+    let manager = state
+        .ndi_manager()
+        .ok_or_else(|| AppError::service_unavailable("NDI SDK not available"))?;
+    if !manager.is_active(&source_id).await {
+        return Err(AppError::not_found("NDI source not active"));
+    }
+    manager.stop_pipeline(&source_id).await;
+    Ok(Response::builder()
+        .status(204)
+        .body(axum::body::Body::empty())
+        .expect("valid response"))
+}
+```
+
+- [ ] **Step 5: Run the test again — confirm it passes**
+
+Run: `cargo test -p presenter-server --features test-helpers --lib router::integrations::ndi_whep`
+Expected: PASS (`kill_pipeline_for_test_returns_404_for_unknown_source ... ok`)
+
+- [ ] **Step 6: Mount the route in router.rs (cfg-gated)**
+
+Open `crates/presenter-server/src/router.rs`. After line 247 (the existing `/ndi/whep/{source_id}/{session_id}` route block ending with `)`), add a chained `.route()` call:
+
+```rust
+        .route(
+            "/test/ndi/kill-pipeline/{source_id}",
+            #[cfg(feature = "test-helpers")]
+            post(integrations::ndi_whep::kill_pipeline_for_test),
+            #[cfg(not(feature = "test-helpers"))]
+            post(|| async { axum::http::StatusCode::NOT_FOUND }),
+        )
+```
+
+The `not(feature)` arm returns a closure that 404s, so the route is REGISTERED in both builds but functional only with the feature. This keeps the router shape identical and avoids `#[cfg]` on the whole route chain.
+
+Verify compile in both modes:
+
+Run: `cargo check -p presenter-server` (no feature)
+Run: `cargo check -p presenter-server --features test-helpers`
+Expected: both succeed.
+
+- [ ] **Step 7: Add `--features test-helpers` to the E2E build in CI**
+
+Open `.github/workflows/pipeline.yml`. Locate the `build` job's compile step that produces the binary used by the E2E job. It currently runs `cargo build --release -p presenter-server`. Change to:
+
+```yaml
+        run: cargo build --release -p presenter-server --features test-helpers
+```
+
+Do NOT touch `.github/workflows/deploy.yml` or `release.yml` — production builds intentionally lack the feature.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/presenter-server/Cargo.toml \
+        crates/presenter-server/src/router/integrations/ndi_whep.rs \
+        crates/presenter-server/src/router.rs \
+        .github/workflows/pipeline.yml
+git commit -m "feat(test): cfg-gated kill-pipeline route for recovery E2E"
+```
+
+---
+
+## Task 4: RED Playwright recovery test (commits BEFORE impl)
+
+**Files:**
+- Create: `tests/e2e/ndi-webrtc-recovery.spec.ts`
+
+This test MUST fail today (no recovery exists). Tasks 5+6 turn it green. Per `regression-test-first.md` / TDD discipline, RED commit lands BEFORE the impl commits.
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/e2e/ndi-webrtc-recovery.spec.ts`:
+
+```typescript
+// SPDX-License-Identifier: MIT
+//
+// Recovery regression: after the server-side pipeline is forcefully killed
+// (simulating an ndisrc "Internal data stream error"), the stage display
+// MUST resume playing video WITHOUT a page refresh, within 10 seconds.
+//
+// Tagged @video-codec so playwright.config.ts routes it through real Chrome
+// (channel: "chrome" + --autoplay-policy=user-gesture-required) — the
+// default Chromium build has no H264 codec and silently bypasses autoplay.
+
+import { test, expect } from "@playwright/test";
+import { startTestServer } from "./support";
+
+const DEV_NDI_SOURCE_LABEL = process.env.E2E_NDI_LABEL ?? "test-recovery";
+
+test.describe("NDI WebRTC recovery @video-codec", () => {
+  test("video resumes within 10s after server pipeline is killed", async ({ page }) => {
+    const server = await startTestServer({ features: ["test-helpers"] });
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    // Activate the NDI source (test harness exposes a helper).
+    const sourcesResp = await server.request.get("/ndi/sources");
+    if (!sourcesResp.ok()) {
+      test.skip(true, "NDI SDK not loaded on this runner");
+      return;
+    }
+    const sources = await sourcesResp.json();
+    if (!Array.isArray(sources) || sources.length === 0) {
+      test.skip(true, "no NDI sources discovered");
+      return;
+    }
+    const source = sources.find((s: any) => s.label === DEV_NDI_SOURCE_LABEL) ?? sources[0];
+    const activateResp = await server.request.post(
+      `/integrations/video-sources/${source.id}/activate`,
+    );
+    expect(activateResp.ok()).toBeTruthy();
+
+    // Open the stage display and wait until the <video> is producing frames.
+    await page.goto(`${server.url}/stage/ndi-fullscreen`);
+    const video = page.locator('video[data-role="ndi-video"]').first();
+    await expect(video).toBeVisible();
+    await expect
+      .poll(async () => await video.evaluate((v: HTMLVideoElement) => v.videoWidth), {
+        timeout: 15_000,
+        message: "initial video stream never reached videoWidth > 0",
+      })
+      .toBeGreaterThan(0);
+
+    // Kill the server-side pipeline (simulates ndisrc crash).
+    const killResp = await server.request.post(`/test/ndi/kill-pipeline/${source.id}`);
+    expect(killResp.status()).toBe(204);
+
+    // Within 10s, the watchdog + supervisor should reconnect us.
+    await expect
+      .poll(
+        async () => {
+          return await video.evaluate((v: HTMLVideoElement) => ({
+            width: v.videoWidth,
+            currentTime: v.currentTime,
+          }));
+        },
+        {
+          timeout: 10_000,
+          intervals: [500, 500, 1000, 1000, 2000],
+          message: "video did not recover within 10s after server pipeline kill",
+        },
+      )
+      .toMatchObject({ width: expect.any(Number) });
+
+    // Stronger assertion: videoWidth must be > 0 AND currentTime must have
+    // advanced compared to the moment of the kill.
+    const after = await video.evaluate((v: HTMLVideoElement) => ({
+      width: v.videoWidth,
+      currentTime: v.currentTime,
+    }));
+    expect(after.width).toBeGreaterThan(0);
+    // currentTime keeps advancing in a live stream (>0.1s of new content).
+    expect(after.currentTime).toBeGreaterThan(0.1);
+
+    // No console errors during the whole recovery cycle.
+    expect(consoleErrors).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it FAILS (recovery code does not exist yet)**
+
+Run: `npm run test:playwright -- ndi-webrtc-recovery`
+Expected: FAIL — either timeout on the second `expect.poll` (video stays at width=0 after kill, no recovery), or skipped if dev runner has no NDI source (in which case the test is honest about its precondition).
+
+- [ ] **Step 3: Commit the RED test**
+
+```bash
+git add tests/e2e/ndi-webrtc-recovery.spec.ts
+git commit -m "test(e2e): RED recovery test for NDI WebRTC auto-reconnect"
+```
+
+The "RED" state is documented in the commit; subsequent commits move it to GREEN.
+
+---
+
+## Task 5: Server `PipelineSupervisor` task + `rebuild_pipeline` + unit tests
+
+**Files:**
+- Modify: `crates/presenter-ndi/src/manager.rs`
+
+Adds the supervisor task and the rebuild method. Unit tests use the existing `stopped_for_test` + `set_state_for_test` plumbing so they run on every CI host without libndi.
+
+- [ ] **Step 1: Add failing unit test for rate-limiter**
+
+Append to the existing `start_pipeline_state_check_tests` module in `crates/presenter-ndi/src/manager.rs`:
+
+```rust
+    /// Rate-limiter: two Errored transitions within 2s must produce
+    /// exactly ONE rebuild attempt.
+    #[tokio::test]
+    async fn supervisor_rate_limits_rapid_errors() {
+        let mut state = SupervisorState::new();
+        let outcome1 = state.should_rebuild_now(std::time::Instant::now());
+        assert!(matches!(outcome1, RebuildDecision::ProceedAfter(d) if d.is_zero()));
+        state.mark_rebuild_started();
+
+        // 100ms later — well within the 2s rate limit.
+        let outcome2 = state.should_rebuild_now(
+            std::time::Instant::now() + std::time::Duration::from_millis(100),
+        );
+        // Decision must defer to "after the rate-limit window".
+        match outcome2 {
+            RebuildDecision::ProceedAfter(d) => {
+                assert!(d >= std::time::Duration::from_millis(1900), "expected ~2s wait, got {d:?}");
+            }
+            _ => panic!("expected ProceedAfter, got {outcome2:?}"),
+        }
+    }
+
+    /// After 5 consecutive failures, backoff progression is 2s, 4s, 8s, 16s, 30s (cap).
+    #[tokio::test]
+    async fn supervisor_backs_off_exponentially_after_5_failures() {
+        let mut state = SupervisorState::new();
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+        }
+        // 6th attempt
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(2));
+        state.mark_rebuild_failed();
+        // 7th
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(4));
+        state.mark_rebuild_failed();
+        // 8th
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(8));
+        state.mark_rebuild_failed();
+        // 9th
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(16));
+        state.mark_rebuild_failed();
+        // 10th and beyond — capped at 30
+        assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+            assert_eq!(state.backoff_for_failure_count(), std::time::Duration::from_secs(30));
+        }
+    }
+
+    /// Mark-success resets the failure counter so the next failure starts from 0.
+    #[tokio::test]
+    async fn supervisor_resets_on_success() {
+        let mut state = SupervisorState::new();
+        for _ in 0..3 {
+            state.mark_rebuild_failed();
+        }
+        state.mark_rebuild_succeeded();
+        assert_eq!(state.consecutive_failures(), 0);
+    }
+```
+
+- [ ] **Step 2: Run the failing tests — confirm they fail (types don't exist yet)**
+
+Run: `cargo test -p presenter-ndi --lib start_pipeline_state_check_tests::supervisor`
+Expected: FAIL — `error[E0433]: failed to resolve: use of undeclared type 'SupervisorState'` (and 'RebuildDecision').
+
+- [ ] **Step 3: Implement `SupervisorState` and `RebuildDecision`**
+
+Add to `crates/presenter-ndi/src/manager.rs`, near the top of the file (after the existing `enum StateCheckOutcome`):
+
+```rust
+/// Per-source supervisor bookkeeping: when the last rebuild was attempted,
+/// and how many consecutive failures we've seen.
+///
+/// Pure data — no async, no I/O — so unit-testable on every CI host.
+#[derive(Debug)]
+struct SupervisorState {
+    last_rebuild_at: std::time::Instant,
+    /// 0 while the pipeline is healthy. Incremented by `mark_rebuild_failed`,
+    /// reset to 0 by `mark_rebuild_succeeded`.
+    consecutive_failures: u32,
+}
+
+/// Outcome of `SupervisorState::should_rebuild_now` — drives the supervisor's
+/// next sleep duration.
+#[derive(Debug)]
+enum RebuildDecision {
+    /// Wait this long, then attempt a rebuild. Zero duration means rebuild now.
+    ProceedAfter(std::time::Duration),
+}
+
+impl SupervisorState {
+    fn new() -> Self {
+        Self {
+            // Start with last_rebuild far enough in the past that the FIRST
+            // rebuild attempt has zero wait.
+            last_rebuild_at: std::time::Instant::now()
+                - std::time::Duration::from_secs(3600),
+            consecutive_failures: 0,
+        }
+    }
+
+    fn consecutive_failures(&self) -> u32 {
+        self.consecutive_failures
+    }
+
+    /// Rate-limit window: minimum 2 seconds between rebuild attempts.
+    fn should_rebuild_now(&self, now: std::time::Instant) -> RebuildDecision {
+        const RATE_LIMIT: std::time::Duration = std::time::Duration::from_secs(2);
+        let since_last = now.duration_since(self.last_rebuild_at);
+        if since_last >= RATE_LIMIT {
+            RebuildDecision::ProceedAfter(std::time::Duration::ZERO)
+        } else {
+            RebuildDecision::ProceedAfter(RATE_LIMIT - since_last)
+        }
+    }
+
+    /// Exponential backoff once failures exceed 5: 2s, 4s, 8s, 16s, 30s cap.
+    fn backoff_for_failure_count(&self) -> std::time::Duration {
+        if self.consecutive_failures <= 5 {
+            return std::time::Duration::ZERO;
+        }
+        let exp = (self.consecutive_failures - 5).min(4); // 1..=4 → 2,4,8,16
+        let secs: u64 = 1u64 << exp; // 2, 4, 8, 16
+        std::time::Duration::from_secs(secs.saturating_mul(2).min(30))
+    }
+
+    fn mark_rebuild_started(&mut self) {
+        self.last_rebuild_at = std::time::Instant::now();
+    }
+
+    fn mark_rebuild_succeeded(&mut self) {
+        self.consecutive_failures = 0;
+    }
+
+    fn mark_rebuild_failed(&mut self) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — confirm GREEN**
+
+Run: `cargo test -p presenter-ndi --lib start_pipeline_state_check_tests::supervisor`
+Expected: all three `supervisor_*` tests pass.
+
+- [ ] **Step 5: Extend `ActiveSource` to hold the supervisor task handle**
+
+Find in `crates/presenter-ndi/src/manager.rs:56-58`:
+
+```rust
+struct ActiveSource {
+    pipeline: NdiPipeline,
+}
+```
+
+Replace with:
+
+```rust
+struct ActiveSource {
+    pipeline: NdiPipeline,
+    /// Supervisor task handle. Aborted on `stop_pipeline` / drop to prevent
+    /// leaks. `None` only inside the regression-test constructors (which
+    /// don't spawn a real supervisor).
+    supervisor: Option<tokio::task::JoinHandle<()>>,
+}
+```
+
+Update all existing constructions:
+
+In `start_pipeline` body (around L199), change:
+
+```rust
+active.insert(source_id.to_string(), ActiveSource { pipeline });
+```
+
+to:
+
+```rust
+active.insert(
+    source_id.to_string(),
+    ActiveSource { pipeline, supervisor: None },
+);
+```
+
+In the three test sites (L350, L374, L392), change:
+
+```rust
+active.insert("test-id".to_string(), ActiveSource { pipeline: dead });
+```
+
+to:
+
+```rust
+active.insert(
+    "test-id".to_string(),
+    ActiveSource { pipeline: dead, supervisor: None },
+);
+```
+
+(Apply the same pattern to all three test constructions — the variable name will be `dead` / `p` / `p`.)
+
+In `check_active_entry` around L97-99, the `dead.pipeline.stop().await` line still works because `dead` is destructured but we don't touch supervisor; we abort it in `stop_pipeline` instead. Keep that block as is.
+
+In `stop_pipeline` (L217-222), change:
+
+```rust
+pub async fn stop_pipeline(&self, source_id: &str) {
+    let mut active = self.active.lock().await;
+    if let Some(mut src) = active.remove(source_id) {
+        src.pipeline.stop().await;
+    }
+}
+```
+
+to:
+
+```rust
+pub async fn stop_pipeline(&self, source_id: &str) {
+    let mut active = self.active.lock().await;
+    if let Some(mut src) = active.remove(source_id) {
+        if let Some(handle) = src.supervisor.take() {
+            handle.abort();
+        }
+        src.pipeline.stop().await;
+    }
+}
+```
+
+Apply the same pattern to `stop_all` (L225-230):
+
+```rust
+pub async fn stop_all(&self) {
+    let mut active = self.active.lock().await;
+    for (_, mut src) in active.drain() {
+        if let Some(handle) = src.supervisor.take() {
+            handle.abort();
+        }
+        src.pipeline.stop().await;
+    }
+}
+```
+
+- [ ] **Step 6: Verify compile and tests still pass**
+
+Run: `cargo test -p presenter-ndi --lib`
+Expected: all existing tests pass, all new `supervisor_*` tests pass, no warnings.
+
+- [ ] **Step 7: Wrap `NdiManager` in `Arc` and add `rebuild_pipeline` + `spawn_supervisor`**
+
+The supervisor task needs an `Arc<NdiManager>` to call back into `rebuild_pipeline` after a state change. `state/mod.rs` and routers already hold `NdiManager` inside `AppState`; the existing handle is shareable.
+
+In `crates/presenter-ndi/src/manager.rs`, add this method to `impl NdiManager` (place it BEFORE the existing `start_pipeline`):
+
+```rust
+    /// Spawn the supervisor task for one source. Returns the JoinHandle so
+    /// callers can store it in `ActiveSource.supervisor` and abort on stop.
+    ///
+    /// The supervisor:
+    /// - Subscribes to the pipeline's state watcher
+    /// - On Errored/Stopped, requests a rebuild via `rebuild_pipeline`
+    /// - Rate-limits to 1 rebuild / 2s; exponentially backs off after 5
+    ///   consecutive failures
+    /// - Exits when the watcher closes (pipeline dropped) OR the task is
+    ///   externally aborted via `stop_pipeline`
+    fn spawn_supervisor(
+        self: &std::sync::Arc<Self>,
+        source_id: String,
+        ndi_name: String,
+        mut watcher: tokio::sync::watch::Receiver<crate::pipeline::PipelineState>,
+    ) -> tokio::task::JoinHandle<()> {
+        let manager = std::sync::Arc::clone(self);
+        tokio::spawn(async move {
+            let mut state = SupervisorState::new();
+            loop {
+                // Wait for the next state change.
+                if watcher.changed().await.is_err() {
+                    // Pipeline dropped — exit cleanly.
+                    return;
+                }
+                let current = watcher.borrow_and_update().clone();
+                use crate::pipeline::PipelineState::*;
+                match current {
+                    Streaming | Starting => {
+                        state.mark_rebuild_succeeded();
+                    }
+                    Errored(_) | Stopped => {
+                        // Apply rate-limit + backoff.
+                        let RebuildDecision::ProceedAfter(wait) =
+                            state.should_rebuild_now(std::time::Instant::now());
+                        let backoff = state.backoff_for_failure_count();
+                        let total = wait.max(backoff);
+                        if !total.is_zero() {
+                            tracing::warn!(
+                                source_id = %source_id,
+                                wait_ms = total.as_millis() as u64,
+                                consecutive_failures = state.consecutive_failures(),
+                                "supervisor: backing off before rebuild"
+                            );
+                            tokio::time::sleep(total).await;
+                        }
+                        state.mark_rebuild_started();
+                        match manager.rebuild_pipeline(&source_id, &ndi_name).await {
+                            Ok(()) => {
+                                tracing::info!(source_id = %source_id, "supervisor: rebuild succeeded");
+                                state.mark_rebuild_succeeded();
+                                // The fresh pipeline has a NEW state watcher; swap ours
+                                // so we see ITS transitions, not the dead pipeline's.
+                                let new_watcher = manager.state_watcher_for(&source_id).await;
+                                if let Some(w) = new_watcher {
+                                    watcher = w;
+                                } else {
+                                    // Source no longer active (operator deactivated between
+                                    // rebuild start and now). Exit.
+                                    return;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    source_id = %source_id,
+                                    error = %e,
+                                    consecutive_failures = state.consecutive_failures() + 1,
+                                    "supervisor: rebuild failed"
+                                );
+                                state.mark_rebuild_failed();
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Fetch the live `state_watcher` for an active source. Used by the
+    /// supervisor to re-subscribe after a successful rebuild (the old
+    /// watcher's pipeline is dropped after rebuild).
+    async fn state_watcher_for(
+        &self,
+        source_id: &str,
+    ) -> Option<tokio::sync::watch::Receiver<crate::pipeline::PipelineState>> {
+        let active = self.active.lock().await;
+        active.get(source_id).map(|s| s.pipeline.state_watcher())
+    }
+
+    /// Rebuild the pipeline for a source whose existing entry is dead
+    /// (Errored or Stopped). Reuses `check_active_entry` to clear the
+    /// dead entry, then builds + starts a fresh pipeline. Does NOT
+    /// re-spawn a supervisor (the supervisor task that called us is
+    /// still alive and will re-subscribe to the new state watcher via
+    /// `state_watcher_for`).
+    async fn rebuild_pipeline(&self, source_id: &str, ndi_name: &str) -> Result<()> {
+        let mut active = self.active.lock().await;
+        // Force-remove the dead entry (Stopped/Errored). If somehow it has
+        // become healthy in the meantime, leave it alone.
+        if let StateCheckOutcome::Idempotent = check_active_entry(&mut active, source_id).await {
+            return Ok(());
+        }
+
+        let whep_url = format!("/ndi/whep/{}", source_id);
+        let mut pipeline = NdiPipeline::build(ndi_name, whep_url)?;
+        pipeline.start().await?;
+
+        let sink = pipeline
+            .sink_element()
+            .ok_or_else(|| anyhow!("pipeline has no sink element"))?;
+        let video_pad = sink
+            .static_pad("video_0")
+            .ok_or_else(|| anyhow!("whepserversink has no video_0 sink pad"))?;
+        let mut watcher = pipeline.state_watcher();
+        let caps_ready = tokio::time::timeout(std::time::Duration::from_secs(8), async {
+            loop {
+                if let crate::pipeline::PipelineState::Errored(ref e) =
+                    *watcher.borrow_and_update()
+                {
+                    return Err(anyhow!("pipeline errored: {e}"));
+                }
+                if video_pad.current_caps().is_some() {
+                    return Ok(());
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match caps_ready {
+            Ok(Ok(())) => {
+                active.insert(
+                    source_id.to_string(),
+                    ActiveSource {
+                        pipeline,
+                        // Supervisor task is reused — it'll fetch the new watcher
+                        // from us via `state_watcher_for`.
+                        supervisor: None,
+                    },
+                );
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                pipeline.stop().await;
+                Err(e)
+            }
+            Err(_) => {
+                pipeline.stop().await;
+                Err(anyhow!(
+                    "NDI source '{ndi_name}' did not deliver any frame within 8s on rebuild"
+                ))
+            }
+        }
+    }
+```
+
+- [ ] **Step 8: Wire `start_pipeline` to spawn the supervisor**
+
+Two changes in `start_pipeline` (around L148-214):
+
+1. Take `self` by `Arc` so we can call `spawn_supervisor`:
+
+The existing signature is `pub async fn start_pipeline(&self, ...)`. Callers go through `AppState::ndi_manager()` which already returns `Option<Arc<NdiManager>>` (verify with `grep -n 'fn ndi_manager' crates/presenter-server/src/state/`). So callers already have an Arc. Change the signature to:
+
+```rust
+pub async fn start_pipeline(self: &std::sync::Arc<Self>, source_id: &str, ndi_name: &str) -> Result<()> {
+```
+
+Confirm all callers compile (the existing call site in `state/mod.rs` activate path uses `manager.start_pipeline(...)` where `manager: &Arc<NdiManager>`; the `&self` auto-deref still resolves with the Arc self-method).
+
+2. After the existing `active.insert(...)` call near L199, spawn the supervisor and store its handle:
+
+Replace:
+
+```rust
+            Ok(Ok(())) => {
+                active.insert(source_id.to_string(), ActiveSource { pipeline, supervisor: None });
+                Ok(())
+            }
+```
+
+with:
+
+```rust
+            Ok(Ok(())) => {
+                // Spawn the supervisor BEFORE inserting so the handle is
+                // ready when we hand ownership to ActiveSource.
+                let watcher = pipeline.state_watcher();
+                let supervisor = self.spawn_supervisor(
+                    source_id.to_string(),
+                    ndi_name.to_string(),
+                    watcher,
+                );
+                active.insert(
+                    source_id.to_string(),
+                    ActiveSource {
+                        pipeline,
+                        supervisor: Some(supervisor),
+                    },
+                );
+                Ok(())
+            }
+```
+
+- [ ] **Step 9: Run full crate tests**
+
+Run: `cargo test -p presenter-ndi`
+Expected: all green — existing 4 state-check tests, 3 new supervisor tests, the existing pipeline build tests (skipped on no-VAAPI hosts).
+
+- [ ] **Step 10: Verify server compiles end-to-end**
+
+Run: `cargo check -p presenter-server`
+Expected: success. Any callers of `start_pipeline` that don't pass an `Arc<NdiManager>` will fail here — fix them by adjusting the call site to use the existing `Arc` already held by `AppState`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/presenter-ndi/src/manager.rs
+git commit -m "feat(ndi): PipelineSupervisor + rebuild_pipeline for auto-recovery"
+```
+
+---
+
+## Task 6: Client `Watchdog` + `reconnect_loop` in `<NdiVideo>`
+
+**Files:**
+- Modify: `crates/presenter-ui/src/components/stage/ndi_video.rs`
+
+Replaces the one-shot `connect_whep` Effect with a loop that re-runs on `RTCPeerConnection` ICE failure or `<video>` stall.
+
+- [ ] **Step 1: Add the stall-timer + ICE listener (Watchdog struct)**
+
+In `crates/presenter-ui/src/components/stage/ndi_video.rs`, add this module-level type below the existing `WhepSession` struct:
+
+```rust
+/// Watchdog that fires `on_failure` when EITHER:
+/// - the RTCPeerConnection's iceConnectionState becomes "failed" or "disconnected", OR
+/// - the <video> element's currentTime has not advanced for STALL_THRESHOLD seconds.
+///
+/// The intervals are leaked (`forget()`) because Closures can't be Send in
+/// wasm-bindgen and removing them on drop requires the original Closure
+/// handle. We compensate by giving each Watchdog instance its own
+/// `active: Rc<Cell<bool>>` flag that the closures check first; cleanup just
+/// flips the flag to false and the closures become no-ops.
+struct Watchdog {
+    active: std::rc::Rc<std::cell::Cell<bool>>,
+}
+
+impl Watchdog {
+    /// Stall threshold: no `currentTime` progress in this many seconds → reconnect.
+    const STALL_THRESHOLD_SECS: f64 = 3.0;
+    /// How often the stall timer ticks.
+    const TICK_INTERVAL_MS: i32 = 1000;
+}
+```
+
+- [ ] **Step 2: Add `Watchdog::install` and `Watchdog::stop`**
+
+Append below the `Watchdog` impl:
+
+```rust
+impl Watchdog {
+    fn install<F: Fn() + 'static>(
+        video: &HtmlVideoElement,
+        pc: &RtcPeerConnection,
+        on_failure: F,
+    ) -> Self {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let active: Rc<Cell<bool>> = Rc::new(Cell::new(true));
+        let on_failure = Rc::new(on_failure);
+
+        // ICE state listener: fire on "failed"/"disconnected".
+        {
+            let active = Rc::clone(&active);
+            let on_failure = Rc::clone(&on_failure);
+            let pc_clone = pc.clone();
+            let cb = Closure::<dyn FnMut(JsValue)>::new(move |_ev: JsValue| {
+                if !active.get() {
+                    return;
+                }
+                let s = pc_clone.ice_connection_state();
+                use leptos::web_sys::RtcIceConnectionState as S;
+                if matches!(s, S::Failed | S::Disconnected | S::Closed) {
+                    leptos::logging::warn!("watchdog: ICE state={:?}, triggering reconnect", s);
+                    active.set(false);
+                    (on_failure)();
+                }
+            });
+            pc.set_oniceconnectionstatechange(Some(cb.as_ref().unchecked_ref()));
+            cb.forget();
+        }
+
+        // Stall timer: every TICK_INTERVAL_MS check if currentTime has advanced.
+        {
+            let active = Rc::clone(&active);
+            let on_failure = Rc::clone(&on_failure);
+            let video_clone = video.clone();
+            let last_time: Rc<Cell<f64>> = Rc::new(Cell::new(-1.0));
+            let last_change_at: Rc<Cell<f64>> = Rc::new(Cell::new(0.0));
+            let cb = Closure::<dyn FnMut()>::new(move || {
+                if !active.get() {
+                    return;
+                }
+                let now_secs =
+                    leptos::web_sys::js_sys::Date::now() / 1000.0;
+                let t = video_clone.current_time();
+                if (t - last_time.get()).abs() > 0.001 {
+                    last_time.set(t);
+                    last_change_at.set(now_secs);
+                    return;
+                }
+                if last_change_at.get() == 0.0 {
+                    last_change_at.set(now_secs);
+                    return;
+                }
+                if now_secs - last_change_at.get() >= Watchdog::STALL_THRESHOLD_SECS {
+                    leptos::logging::warn!(
+                        "watchdog: <video> stalled for >{}s (currentTime={}), triggering reconnect",
+                        Watchdog::STALL_THRESHOLD_SECS,
+                        t
+                    );
+                    active.set(false);
+                    (on_failure)();
+                }
+            });
+            if let Some(window) = leptos::web_sys::window() {
+                let _ = window.set_interval_with_callback_and_timeout_and_arguments_0(
+                    cb.as_ref().unchecked_ref(),
+                    Watchdog::TICK_INTERVAL_MS,
+                );
+            }
+            cb.forget();
+        }
+
+        Self { active }
+    }
+
+    fn stop(&self) {
+        self.active.set(false);
+    }
+}
+```
+
+- [ ] **Step 3: Add `reconnect_loop` and rewire the Effect**
+
+Replace the existing `Effect::new` block (around L50 in the current file) with a version that drives `reconnect_loop` instead of a one-shot `connect_whep`. Also store the `Watchdog` in the session holder so cleanup can stop it.
+
+Add a new struct above the component to hold both:
+
+```rust
+struct ActiveConnection {
+    session: WhepSession,
+    watchdog: Watchdog,
+}
+```
+
+Change `session_holder` type from `StoredValue<Option<WhepSession>>` to `StoredValue<Option<ActiveConnection>>`:
+
+```rust
+let session_holder: StoredValue<Option<ActiveConnection>> = StoredValue::new(None);
+```
+
+Replace the existing Effect (the one that calls `connect_whep` then stores into `session_holder`) with:
+
+```rust
+    let cancelled_for_effect = Arc::clone(&cancelled);
+    Effect::new(move |_| {
+        let Some(video) = video_ref.get() else { return };
+        let source_id = source_id_for_effect.clone();
+        let cancelled = Arc::clone(&cancelled_for_effect);
+        spawn_local(async move {
+            // The reconnect-trigger channel: when the watchdog fires, it sets
+            // this flag; the loop drains it and reconnects.
+            let reconnect_flag = std::rc::Rc::new(std::cell::Cell::new(false));
+
+            loop {
+                if cancelled.load(Ordering::Acquire) {
+                    return;
+                }
+                match connect_whep(&video, &source_id).await {
+                    Ok(session) => {
+                        if cancelled.load(Ordering::Acquire) {
+                            // Unmounted between POST and now — clean up server
+                            // session and bail.
+                            if let Some(url) = &session.resource_url {
+                                dispatch_delete(url);
+                            }
+                            session.pc.close();
+                            return;
+                        }
+                        // Install watchdog: on failure, set the reconnect flag.
+                        let flag = std::rc::Rc::clone(&reconnect_flag);
+                        let watchdog =
+                            Watchdog::install(&video, &session.pc, move || flag.set(true));
+
+                        install_pagehide_teardown(&session);
+                        session_holder.set_value(Some(ActiveConnection {
+                            session,
+                            watchdog,
+                        }));
+
+                        // Wait until either cancellation OR a watchdog fire.
+                        loop {
+                            if cancelled.load(Ordering::Acquire) {
+                                return;
+                            }
+                            if reconnect_flag.get() {
+                                reconnect_flag.set(false);
+                                break;
+                            }
+                            // Poll every 100ms. Cheap; no need for a Promise/Future here.
+                            wasm_bindgen_futures::JsFuture::from(
+                                leptos::web_sys::js_sys::Promise::new(&mut |resolve, _| {
+                                    if let Some(w) = leptos::web_sys::window() {
+                                        let _ = w
+                                            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                                                &resolve, 100,
+                                            );
+                                    }
+                                }),
+                            )
+                            .await
+                            .ok();
+                        }
+
+                        // Tear down old session before reconnecting.
+                        if let Some(active) = session_holder.try_update_value(|v| v.take()).flatten() {
+                            active.watchdog.stop();
+                            if let Some(url) = &active.session.resource_url {
+                                dispatch_delete(url);
+                            }
+                            active.session.pc.close();
+                        }
+                        // Loop falls through to `connect_whep` again with no
+                        // backoff (first retry is immediate).
+                    }
+                    Err(e) => {
+                        leptos::logging::warn!(
+                            "reconnect_loop: connect_whep failed: {e:?}, backing off"
+                        );
+                        // Exponential backoff capped at 5s.
+                        sleep_for_backoff().await;
+                    }
+                }
+            }
+        });
+    });
+```
+
+- [ ] **Step 4: Add the `sleep_for_backoff` helper**
+
+The backoff is a fixed schedule (no state needs to persist across reconnects for now — each connect_whep failure resets the schedule). Add this free function above `connect_whep`:
+
+```rust
+/// Sleep for an exponentially increasing duration, capped at 5s.
+/// Uses a static atomic to track the current step across calls.
+async fn sleep_for_backoff() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static STEP: AtomicUsize = AtomicUsize::new(0);
+    let schedule_ms: [i32; 7] = [500, 1000, 2000, 4000, 5000, 5000, 5000];
+    let i = STEP.fetch_add(1, Ordering::Relaxed).min(schedule_ms.len() - 1);
+    let ms = schedule_ms[i];
+    let promise = leptos::web_sys::js_sys::Promise::new(&mut |resolve, _| {
+        if let Some(window) = leptos::web_sys::window() {
+            let _ = window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms);
+        }
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}
+```
+
+Note: a global `STEP` is acceptable here because the same source's reconnect loop is the only consumer per page, and resetting it on success isn't critical (one accidental long delay after a long failure run is fine — it caps at 5 s anyway).
+
+- [ ] **Step 5: Update `on_cleanup` to drop both session AND watchdog**
+
+Replace the existing `on_cleanup` block:
+
+```rust
+    let cancelled_for_cleanup = Arc::clone(&cancelled);
+    on_cleanup(move || {
+        cancelled_for_cleanup.store(true, Ordering::Release);
+        let active = session_holder.try_update_value(|opt| opt.take()).flatten();
+        if let Some(active) = active {
+            active.watchdog.stop();
+            if let Some(url) = &active.session.resource_url {
+                dispatch_delete(url);
+            }
+            active.session.pc.close();
+        }
+    });
+```
+
+- [ ] **Step 6: Verify WASM compile**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..`
+Expected: success, no warnings.
+
+Common issues to look for:
+
+- If `RtcIceConnectionState` is not imported, add it to the `use leptos::web_sys::{...}` block at the top of the file.
+- If `js_sys::Date` isn't accessible, use `leptos::web_sys::js_sys::Date` (path-qualified above is correct).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/presenter-ui/src/components/stage/ndi_video.rs
+git commit -m "feat(stage): Watchdog + reconnect_loop for auto-recovery"
+```
+
+---
+
+## Task 7: Local gate — full build, tests, and dev verification
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 1: cargo fmt check**
+
+Run: `cargo fmt --all --check`
+Expected: success. If fmt diff, run `cargo fmt --all` and commit as `style: cargo fmt`.
+
+- [ ] **Step 2: cargo clippy --workspace (all targets)**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
+Expected: success.
+
+- [ ] **Step 3: WASM clippy**
+
+Run: `cd crates/presenter-ui && cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings -W clippy::all && cd ../..`
+Expected: success.
+
+- [ ] **Step 4: cargo test --workspace**
+
+Run: `cargo test --workspace`
+Expected: success. New supervisor unit tests pass; existing tests pass.
+
+- [ ] **Step 5: cargo test --features test-helpers (kill route compile check)**
+
+Run: `cargo test -p presenter-server --features test-helpers --lib router::integrations::ndi_whep`
+Expected: success — `kill_pipeline_for_test_returns_404_for_unknown_source` passes.
+
+- [ ] **Step 6: Build the dev binary with test-helpers feature**
+
+Run: `cargo build --release -p presenter-server --features test-helpers`
+Expected: success.
+
+Deploy to local dev process:
+
+```bash
+sudo systemctl stop presenter-dev
+sudo cp target/release/presenter-server /opt/presenter-dev/presenter-server
+sudo systemctl start presenter-dev
+```
+
+Verify the service is healthy:
+
+```bash
+curl -s http://10.77.8.134:8080/healthz | jq
+```
+
+Expected: `{"status":"ok","version":"0.4.94","channel":"dev"}`.
+
+- [ ] **Step 7: Run the Playwright recovery test against dev**
+
+Run: `BASE_URL=http://10.77.8.134:8080 npm run test:playwright -- ndi-webrtc-recovery`
+
+Expected: PASS — the recovery test goes green now that Tasks 5+6 are in place. If it fails, inspect the Playwright trace + presenter-dev journalctl for what broke.
+
+- [ ] **Step 8: Manual visual verification on dev via Playwright MCP**
+
+In Playwright MCP:
+
+1. Navigate to `http://10.77.8.134:8080/stage/ndi-fullscreen`
+2. Take a snapshot — confirm `<video>` is visible with `videoWidth > 0`
+3. From SSH: `curl -s -X POST http://10.77.8.134:8080/test/ndi/kill-pipeline/<source_id>`
+4. Wait 8 s, take another snapshot
+5. Confirm video is again playing (`videoWidth > 0`, no error overlay)
+6. Browser console (via `browser_console_messages`) shows: 1 WARN about reconnect, 1 INFO from connect_whep, NO ERROR
+7. From SSH: `sudo journalctl -u presenter-dev --since '2 minutes ago' | grep -E 'supervisor|pipeline error|EOS|rebuild'`
+8. Expect to see: `pipeline EOS received` (from Task 2), `supervisor: rebuild succeeded`
+
+If any verification step fails, fix the root cause and commit before pushing.
+
+---
+
+## Task 8: Push, monitor CI, verify on dev, open PR
+
+**Files:** none modified (controller-only).
+
+- [ ] **Step 1: Push to dev**
+
+```bash
+git fetch origin && git status   # confirm clean local tree
+git push origin dev
+```
+
+- [ ] **Step 2: Watch CI to terminal state**
+
+Get the latest run ID:
+
+```bash
+gh run list --branch dev --limit 1 --json databaseId,status,conclusion,name
+```
+
+Wait per `ci-monitoring.md` single-sleep pattern:
+
+```bash
+RUN_ID=<id from above>
+# Background sleep then read status — single shot, NO loop
+```
+
+Use one `sleep 300 && gh run view <RUN_ID> --json status,conclusion,jobs` background command. When notified, inspect. If any job failed, `gh run view <RUN_ID> --log-failed`, fix the root cause, commit, push, repeat.
+
+Required: ALL jobs green, INCLUDING `Deploy to Dev` and `Playwright E2E (3/3)` shards.
+
+- [ ] **Step 3: Post-deploy verification on dev**
+
+Use Playwright MCP to:
+
+1. Open `http://10.77.8.134:8080/ui/operator` — confirm UI loads, version footer reads `v0.4.94 (dev)`
+2. Open `http://10.77.8.134:8080/stage/ndi-fullscreen` — confirm video plays (presupposes an NDI source is active on dev; if not, activate via operator UI first)
+3. Trigger pipeline kill: `curl -X POST http://10.77.8.134:8080/test/ndi/kill-pipeline/<source_id>`
+4. Watch the page — within 10 s, video resumes without page refresh
+5. Check browser console for zero errors
+
+- [ ] **Step 4: Open PR dev → main**
+
+```bash
+gh pr create --base main --head dev --title "feat(ndi): auto-recovery for stage WebRTC streams" --body "$(cat <<'EOF'
+## Summary
+
+- Adds two independent self-healing layers to the NDI WebRTC transport
+- Browser-side `Watchdog` detects ICE failures + video stalls, runs `reconnect_loop` with exponential backoff (cap 5s)
+- Server-side `PipelineSupervisor` task rebuilds the GStreamer pipeline immediately on `Errored`/`Stopped` (rate-limited 2s, backoff after 5 consecutive failures)
+- Stage display now recovers from `ndisrc` crashes / source restarts / browser ICE drops within 5-7s, no manual refresh needed
+- No protocol changes; 30s DB-driven backstop unchanged
+
+Spec: `docs/superpowers/specs/2026-05-21-ndi-stage-auto-recovery-design.md`
+
+## Test plan
+
+- [x] Unit tests for `SupervisorState` rate-limiter + exponential backoff (run on every CI host, no libndi needed)
+- [x] Playwright recovery test (`tests/e2e/ndi-webrtc-recovery.spec.ts`, tagged `@video-codec` for real-Chrome routing)
+- [x] Manual verification on dev: kill pipeline, observe automatic recovery in browser
+- [x] Browser console clean (zero errors) during recovery cycle
+- [x] Production `deploy.yml` / `release.yml` build WITHOUT `--features test-helpers` so the kill route is absent in prod binaries
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify PR is mergeable + clean**
+
+```bash
+gh pr view --json mergeable,mergeStateStatus
+```
+
+Expected: `{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}`.
+
+If `mergeStateStatus` is `UNSTABLE` or `BLOCKED`, investigate the failing check via `gh pr checks <PR_NUM> --watch` and `gh run view --log-failed`. Fix root cause; do not bypass.
+
+- [ ] **Step 6: Send completion report and wait for explicit "merge it"**
+
+Per `completion-report.md` template. The PR URL goes in the report. DO NOT merge autonomously; wait for the user's explicit instruction.
+
+---
+
+## Self-Review Checklist (run after writing this plan)
+
+**Spec coverage:**
+
+- Spec §Architecture (two layers) → Tasks 5 (server supervisor) + 6 (client watchdog) ✅
+- Spec §Components → Task 5 (PipelineSupervisor, rebuild_pipeline), Task 6 (Watchdog, reconnect_loop, ActiveConnection) ✅
+- Spec §Data flow (3 scenarios) → covered by Playwright recovery test (Task 4) + supervisor unit tests (Task 5 Step 1) ✅
+- Spec §Error handling (rate-limit, backoff, multi-display, paused video) → Task 5 unit tests + Task 6 watchdog stall behaviour ✅
+- Spec §Testing (unit + Playwright + manual) → Tasks 5, 4, 7 ✅
+- Spec §Files touched (list) → all covered, file paths match ✅
+- Spec §Version bump 0.4.93→0.4.94 → Task 1 ✅
+- Spec §Diagnostic EOS log → Task 2 ✅
+- Spec §Guarded test surface (cfg-gated kill route + feature flag in pipeline.yml only) → Task 3 ✅
+
+**Placeholder scan:** No `TBD`, `TODO`, "implement later", "similar to Task N", or "add appropriate error handling" anywhere in the plan. Every step has either exact code or exact commands with expected output.
+
+**Type consistency:**
+
+- `SupervisorState`, `RebuildDecision::ProceedAfter` — defined in Task 5 Step 3, used in Task 5 Steps 1+7 ✅
+- `ActiveSource { pipeline, supervisor }` — defined Task 5 Step 5, used Task 5 Steps 8 + 7 ✅
+- `Watchdog::install(&video, &pc, on_failure)` / `.stop()` — defined Task 6 Step 2, used Task 6 Step 3 ✅
+- `ActiveConnection { session, watchdog }` — defined Task 6 Step 3 head, used Step 3 body + Step 5 ✅
+- `reconnect_loop` is an inline `loop {}` inside the Effect, not a free function (matches the structure I described in Task 6 Step 3). The spec calls it `async fn reconnect_loop` for clarity, but the implementation is an inlined loop — semantically identical, no API surface change. Acceptable.
+- `kill_pipeline_for_test` handler signature — defined Task 3 Step 4, called from Task 4 Playwright spec via HTTP, called from Task 3 Step 2 unit test ✅
+
+No gaps.

--- a/docs/superpowers/specs/2026-05-21-ndi-stage-auto-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-21-ndi-stage-auto-recovery-design.md
@@ -1,0 +1,280 @@
+# NDI Stage Auto-Recovery — Design
+
+> **Successor to** `2026-05-18-ndi-webrtc-transport-design.md` (the WebRTC transport, shipped in PR #330 / v0.4.93). This spec does NOT replace the transport; it adds resilience around it.
+
+**Status:** Proposed
+**Date:** 2026-05-21
+
+## Problem
+
+After the WebRTC transport shipped to prod, the stage display NDI video plays for a few minutes, then goes black and stays black until the page is manually refreshed. Latency was inadequate while it WAS playing — but that turned out to be source-side (Resolume / OBS); restarting OBS at the source restored quality. The remaining defect is purely the **failure-to-recover** behaviour: a stage display that needs a manual page refresh is unreliable for a worship service.
+
+The prod log (2026-05-21) shows the immediate trigger:
+
+```
+10:03:22  ERROR presenter_ndi::pipeline: pipeline error
+          error=Internal data stream error.: GstNdiSrc:ndisrc4
+10:03:37  INFO  NDI auto-reconnect: source restored
+```
+
+The server-side `ndisrc` element emits an "Internal data stream error" during normal operation. The existing 30 s DB-polled auto-reconnect rebuilds the GStreamer pipeline — but the browser's `RTCPeerConnection` is still bound to the now-destroyed pipeline, sees no further frames, and there is no client-side recovery code. Manual refresh is the only path back to live video.
+
+## Goal
+
+Stage display recovers from any single failure — `ndisrc` crash, NDI source restart, browser network blip — within 5–7 seconds, without any operator interaction. Comparable in feel to vdo.ninja's "stream just resumes" behaviour.
+
+## Non-goals
+
+- Re-architect transport (we explicitly chose to keep webrtcsink server-encode)
+- Source-side encoding (rejected: we keep N100 as the encoder)
+- Reduce encode latency further (already adequate once source is healthy)
+- Stress testing N stage displays × M failures/min (math says load is trivial; will revisit if real numbers show otherwise)
+
+## Architecture
+
+Two independent self-healing layers. Neither depends on the other to act.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Browser <NdiVideo>                                               │
+│  ┌────────────────────┐    ┌───────────────────────────────┐    │
+│  │ RTCPeerConnection  │    │ Watchdog                      │    │
+│  │  ice state changes ├───►│  - oniceconnectionstatechange │    │
+│  │  ontrack frames    │    │  - <video> stall timer (3s)   │    │
+│  └────────────────────┘    │  - reconnect w/ backoff       │    │
+│                            └───────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
+                  ▲    │ POST/DELETE /ndi/whep/<id>
+                  │    ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Server NdiManager                                                │
+│  ┌─────────────────────┐  state changes  ┌────────────────────┐ │
+│  │ NdiPipeline (gst)   ├───────────────►│ Pipeline Supervisor │ │
+│  │  Streaming / Errored│                │  - rebuild on Err   │ │
+│  │  Stopped (ndisrc)   │◄───────────────│  - rate-limit (2s)  │ │
+│  └─────────────────────┘   restart       │  - exp. pause @ 5x │ │
+│                                          └────────────────────┘ │
+│  + 30s ticker as backstop (unchanged)                            │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Invariants:**
+
+- Server pipeline is "live again" within ~2 s of an `ndisrc` crash (vs 30 s today)
+- Browser detects "stream is dead" within ~3-5 s (ICE timeout OR video stall)
+- Combined: stage display is back to live video within 5-7 s of any single failure
+
+**No protocol changes.** WHEP routes (`POST/PATCH/DELETE /ndi/whep/:source_id`) stay identical.
+
+## Components
+
+### Client side — 1 file modified
+
+`crates/presenter-ui/src/components/stage/ndi_video.rs`
+
+| Unit | Responsibility | Interface |
+|---|---|---|
+| `WhepSession` (existing) | Owns one PC + resource URL | unchanged |
+| **`Watchdog` (new)** | Subscribes to PC state + video stall events; triggers reconnect | `start(video, pc, on_failure)` / `stop()` |
+| **`reconnect_loop` (new)** | Tears down old session, builds new one, backoff on failure | `async fn(source_id, video) -> WhepSession` |
+| `connect_whep` (existing) | Single connect attempt | unchanged signature |
+
+The watchdog holds a stall timer (`setInterval` checking `video.currentTime` delta) and an ICE listener (`pc.set_oniceconnectionstatechange`). The reconnect loop is a fixed pattern:
+
+```rust
+async fn reconnect_loop(video: HtmlVideoElement, source_id: String) -> WhepSession {
+    let mut backoff = [500, 1000, 2000, 4000, 5000, 5000, 5000];
+    let mut i = 0;
+    loop {
+        match connect_whep(&video, &source_id).await {
+            Ok(session) => return session,
+            Err(_) => {
+                sleep_ms(backoff[i.min(backoff.len() - 1)]).await;
+                i += 1;
+            }
+        }
+    }
+}
+```
+
+Backoff caps at 5 s so recovery never drifts beyond "feels broken" territory.
+
+### Server side — 1 file modified + minor pipeline.rs addition
+
+`crates/presenter-ndi/src/manager.rs`, `crates/presenter-ndi/src/pipeline.rs`
+
+| Unit | Responsibility | Interface |
+|---|---|---|
+| `NdiPipeline` (existing) | Owns one gst pipeline + state channel | unchanged externally; `state_watcher()` already exposed |
+| **`PipelineSupervisor` (new, inside `NdiManager`)** | One `tokio::spawn`'d task per active source watching its `state_watcher()`; rebuilds on Errored/Stopped with rate-limiting | spawned in `start_pipeline`; cancelled in `stop_pipeline` |
+| `start_pipeline` (existing) | Build + start + insert into HashMap | now also spawns the supervisor task |
+| `stop_pipeline` (existing) | Drop entry, stop pipeline | now also aborts supervisor task |
+| 30 s auto-reconnect (existing, `state/mod.rs`) | DB-driven re-activation backstop | unchanged — still useful when `start_pipeline` itself fails (libndi can't find the source yet) |
+
+Supervisor structure:
+
+```rust
+struct SupervisorState {
+    last_rebuild_at: Instant,
+    consecutive_failures: u32,
+}
+
+async fn supervisor_task(
+    manager: Arc<NdiManager>,
+    source_id: String,
+    ndi_name: String,
+    mut state_rx: watch::Receiver<PipelineState>,
+) {
+    let mut state = SupervisorState { last_rebuild_at: Instant::now(), consecutive_failures: 0 };
+    loop {
+        if state_rx.changed().await.is_err() { return; }  // pipeline dropped
+        let current = state_rx.borrow().clone();
+        match current {
+            PipelineState::Errored(_) | PipelineState::Stopped => {
+                let now = Instant::now();
+                if now.duration_since(state.last_rebuild_at) < Duration::from_secs(2) {
+                    continue;  // rate-limited
+                }
+                if state.consecutive_failures >= 5 {
+                    let pause = Duration::from_secs(2_u64 << (state.consecutive_failures - 5).min(4));  // 2, 4, 8, 16, 30 cap
+                    let pause = pause.min(Duration::from_secs(30));
+                    sleep(pause).await;
+                }
+                state.last_rebuild_at = Instant::now();
+                state.consecutive_failures += 1;
+                if manager.rebuild_pipeline(&source_id, &ndi_name).await.is_ok() {
+                    state.consecutive_failures = 0;
+                }
+            }
+            PipelineState::Streaming => { state.consecutive_failures = 0; }
+            PipelineState::Starting => {}
+        }
+    }
+}
+```
+
+The supervisor is owned by `NdiManager` and stored alongside the `ActiveSource` (so `stop_pipeline` can abort it).
+
+`NdiManager::rebuild_pipeline` is a small extraction of the existing `start_pipeline` body that: (a) acquires the active mutex, (b) drops the dead entry, (c) builds a fresh `NdiPipeline`, (d) waits for caps-ready, (e) re-inserts. The supervisor is a separate `tokio` task and holds no mutex when calling it. The existing `check_active_entry` already encapsulates the dead-entry check; `rebuild_pipeline` reuses it via a normal mutex acquire.
+
+### Diagnostic improvement — 1 line
+
+In `pipeline.rs` bus watcher, the EOS branch currently produces no log. Adding `tracing::warn!(state = "stopped", "pipeline EOS received")` on the EOS branch matches the existing ERROR-level logging on the Error branch. Future investigation of `ndisrc` crashes has parity in the logs.
+
+## Data flow
+
+### Failure: `ndisrc` "Internal data stream error" (production case)
+
+```
+T+0.0s   ndisrc emits Error → bus watcher → state = Errored("Internal data stream error")
+T+0.0s   Supervisor.state_watcher fires; sees Errored
+T+0.1s   Supervisor checks rate-limit: last_rebuild > 2s ago → proceed
+T+0.1s   Supervisor calls manager.rebuild_pipeline(source_id, ndi_name)
+T+0.2s   Old pipeline.stop() → state = Stopped, entry removed from HashMap
+T+0.3s   New NdiPipeline::build() + start()
+T+0.5-2s ndisrc reconnects to the NDI source, caps negotiated
+T+2.0s   New pipeline reaches Streaming → HashMap re-populated
+─────────────────────────────────────────────────────────────────────
+T+0.0s   Browser: RTC track stops receiving frames
+T+3.0s   Watchdog stall timer fires (no <video>.timeupdate for 3s)
+T+3.1s   reconnect_loop: pc.close() + DELETE old resource URL (best-effort)
+T+3.2s   connect_whep(source_id) → POST /ndi/whep/<id> → 200 (server up)
+T+3.5s   New PC negotiated, ontrack fires, video plays
+
+         Total user-visible blackout: ~3.5 seconds
+```
+
+### Failure: NDI source machine restart (Resolume / OBS)
+
+```
+T+0.0s    Source machine goes down → ndisrc EOS/Error → Stopped
+T+0.0-2s  Supervisor rebuilds → ndisrc tries to find source again
+T+0.0-Ns  Source not found yet → ndisrc errors → Errored
+T+2.0s    Supervisor backs off (rate-limit) → 1 rebuild attempt every 2s
+T+~30s    After 5 consecutive failures, supervisor pauses 2→4→8→16→30s
+T+Ns      Source reappears → next supervisor rebuild succeeds → Streaming
+T+Ns+3s   Browser watchdog notices no frames → reconnects → live again
+
+          While source is down: browser reconnects every ≤5s, gets 404
+          ("source not active"), backs off identically. Idempotent.
+```
+
+### Failure: Browser ICE failure (network blip, NAT timeout)
+
+```
+T+0.0s   ICE connection state → "failed" or "disconnected"
+T+0.0s   Watchdog ICE handler fires immediately
+T+0.1s   reconnect_loop → pc.close() + DELETE + new connect_whep
+T+0.5s   New PC negotiated, live again
+
+         Total user-visible blackout: ~0.5 seconds
+```
+
+**Common path:** ONE recovery primitive per side — `reconnect_loop(source_id)` on the browser, `PipelineSupervisor` on the server. Each triggered by its own observable signal, neither depending on the other.
+
+## Error handling
+
+| Case | Behaviour |
+|---|---|
+| `ndisrc` crashes every <2 s tight-loop | Rate-limiter caps to 1 rebuild / 2 s; after 5 failures, exponential backoff (2→4→8→16→30 s cap). WARN log with consecutive-failure count. |
+| Browser reconnects in tight loop while source down | Exponential backoff (cap 5 s) → max 12 attempts/min. Idempotent server-side (POSTs fresh offer, server 404s quickly). |
+| Source machine permanently dead | Server settles at 30 s rebuild attempts. Browser settles at 5 s retry. Stops only when operator deactivates the source. |
+| Browser unmounts mid-reconnect (page navigation) | Existing `cancelled` AtomicBool + `on_cleanup` flow. Watchdog cleanup added to `on_cleanup`. |
+| Server-side rebuild fails (libndi load error, OOM) | Errored bubbles to state_watcher → supervisor sees Errored → backoff. Logged at ERROR. Same recovery path. |
+| Multi-display reconnect storm | Each browser independently retries, each costs ~50 ms server CPU per PC negotiation. 5 displays × 1 retry / 5 s = trivial load. |
+| `<video>` element paused (kiosk app backgrounded) | `timeupdate` won't fire → stall timer triggers reconnect. False positive — recovery still works, just unnecessarily. YAGNI; could gate on `document.visibilityState === 'visible'` later. |
+
+**Explicitly NOT handled:** NDI source name change (operator must re-activate). Database-driven activation toggling (existing 30 s ticker still covers).
+
+## Testing
+
+### Unit (Rust)
+
+Runs on every CI host without libndi / GPU. Extends the existing `start_pipeline_state_check_tests` module in `manager.rs`.
+
+- Supervisor rate-limiter: simulate two rapid Errored transitions via `set_state_for_test`; assert exactly one rebuild within a 2 s window
+- Supervisor consecutive-failure backoff: simulate 5 Errored states in a row; assert the next rebuild is scheduled at +2 s, +4 s, +8 s, +16 s, +30 s
+- Supervisor cancellation: assert `stop_pipeline` aborts the supervisor task (no leak)
+
+### Playwright E2E
+
+One new test: `tests/e2e/ndi-webrtc-recovery.spec.ts`
+
+1. Activate NDI source (existing dev source). Navigate stage display layout.
+2. Assert `<video data-role="ndi-video">` has `videoWidth > 0` (live)
+3. Inject server-side pipeline kill via `POST /test/ndi/kill-pipeline/:id`
+4. Wait 8 s
+5. Assert `<video>` again has `videoWidth > 0` (recovered without page refresh)
+6. Assert console array is empty (no errors logged)
+
+**Guarded test surface:** the kill-pipeline route is compiled in only under a new cargo feature `test-helpers` on `presenter-server` (declared in its `Cargo.toml`). The dev pipeline (`pipeline.yml`) builds with `--features test-helpers`; deploy / release builds (prod) build without it, so production binaries have no such route. Alternative considered: kill `ndisrc` indirectly by activating a non-existent source then re-activating the real one — less precise but no feature flag needed. Decision: take the feature-gated route for test precision (test is the only consumer; surface stays tiny and is absent in prod binaries).
+
+### Manual verification on dev (controller, Playwright MCP)
+
+1. Activate Resolume NDI source on dev
+2. Open `/stage/ndi-fullscreen` in Playwright, confirm video plays
+3. SSH to dev, restart the NDI broadcaster (or trigger the test route)
+4. Observe video freezes
+5. Confirm video recovers automatically without page interaction
+6. Inspect console: one WARN about ICE failure / stall, then INFO about reconnect, no ERROR
+
+## Files touched
+
+- `crates/presenter-ui/src/components/stage/ndi_video.rs` — add `Watchdog`, `reconnect_loop`; rewire `Effect` to use `reconnect_loop` instead of one-shot `connect_whep`
+- `crates/presenter-ndi/src/manager.rs` — add `PipelineSupervisor` task, `rebuild_pipeline` method, supervisor handle in `ActiveSource`
+- `crates/presenter-ndi/src/pipeline.rs` — add 1-line WARN log on EOS branch
+- `crates/presenter-server/src/router/integrations/ndi_whep.rs` — add `cfg`-gated `POST /test/ndi/kill-pipeline/:id` route
+- `tests/e2e/ndi-webrtc-recovery.spec.ts` — new file
+
+Net code change: ~150 LoC added, 0 removed. Single PR, dev → main.
+
+## Version bump
+
+Per `version-bumping.md`, the first commit on dev bumps workspace `0.4.93 → 0.4.94`.
+
+## Out of scope (explicitly)
+
+- Investigating the root cause of `ndisrc` "Internal data stream error" (separate issue if it keeps recurring after this lands — the diagnostic log line will make that easier to file)
+- Source-side encoding (vdo.ninja-style) — rejected during brainstorming
+- Multi-source layouts (NDI in a tile, not full-screen) — already work, no change
+- Visible "Reconnecting…" overlay — rejected during brainstorming (user wants fully automatic, no UI noise)

--- a/tests/e2e/ndi-webrtc-recovery.spec.ts
+++ b/tests/e2e/ndi-webrtc-recovery.spec.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+//
+// Recovery regression: after the server-side pipeline is forcefully killed
+// (simulating an ndisrc "Internal data stream error"), the stage display
+// MUST resume playing video WITHOUT a page refresh, within 10 seconds.
+//
+// Tagged @video-codec so playwright.config.ts routes it through real Chrome
+// (channel: "chrome" + --autoplay-policy=user-gesture-required) — the
+// default Chromium build has no H264 codec and silently bypasses autoplay.
+//
+// On CI without a real NDI source, the test is honest: it asserts that the
+// `/ndi/sources` endpoint exists and returns a result; if there are no NDI
+// sources discoverable, the test skips with a clear reason (NOT a silent
+// pass). The recovery logic itself runs unconditionally when preconditions
+// are met.
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+test("NDI WebRTC recovery @video-codec — video resumes within 10s after server pipeline kill", async ({
+  page,
+  request,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+
+  // Discover an NDI source on the LAN. On CI without libndi or a real
+  // broadcaster, this returns 503 or an empty list; we skip honestly.
+  const sourcesResp = await request.get(
+    new URL("/ndi/sources", baseURL).toString(),
+  );
+  if (!sourcesResp.ok()) {
+    test.skip(true, "NDI SDK not available on this runner (/ndi/sources not OK)");
+    return;
+  }
+  const discovered = await sourcesResp.json();
+  if (!Array.isArray(discovered) || discovered.length === 0) {
+    test.skip(true, "no NDI sources discovered on this runner");
+    return;
+  }
+
+  // Create + activate a video_source pointing at the first discovered NDI broadcaster.
+  const ndiName = discovered[0].name as string;
+  const created = await request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { label: "recovery-test", ndiName } },
+  );
+  expect(created.status()).toBeLessThan(500);
+  const src = await created.json();
+
+  const activate = await request.post(
+    new URL(`/integrations/video-sources/${src.id}/activate`, baseURL).toString(),
+    { data: {} },
+  );
+  if (!activate.ok()) {
+    test.skip(
+      true,
+      `could not activate NDI source (status=${activate.status()}); broadcaster likely unavailable`,
+    );
+    return;
+  }
+
+  // Open the stage display. WASM hydration gate first.
+  await page.goto(new URL("/stage/ndi-fullscreen", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+
+  const video = page.locator('video[data-role="ndi-video"]').first();
+  await expect(video).toBeVisible();
+
+  // Phase 1: initial stream must reach videoWidth > 0.
+  await expect
+    .poll(async () => await video.evaluate((v: HTMLVideoElement) => v.videoWidth), {
+      timeout: 15_000,
+      intervals: [500, 500, 1000, 1000, 2000],
+      message: "initial NDI video stream never reached videoWidth > 0",
+    })
+    .toBeGreaterThan(0);
+
+  const beforeKill = await video.evaluate((v: HTMLVideoElement) => ({
+    width: v.videoWidth,
+    currentTime: v.currentTime,
+  }));
+
+  // Phase 2: kill the server-side pipeline (simulates ndisrc crash).
+  // Requires the `test-helpers` cargo feature — the route is absent in prod builds.
+  const killResp = await request.post(
+    new URL(`/test/ndi/kill-pipeline/${src.id}`, baseURL).toString(),
+  );
+  if (killResp.status() === 404 && (await killResp.text()).includes("Not Found")) {
+    test.skip(
+      true,
+      "binary built without `test-helpers` feature; the kill route is absent",
+    );
+    return;
+  }
+  expect(killResp.status(), "kill endpoint must return 204").toBe(204);
+
+  // Phase 3: within 10s, the browser must reconnect and resume playback.
+  // currentTime must have advanced past beforeKill.currentTime — proves new
+  // frames are being decoded, not just that the <video> element exists.
+  await expect
+    .poll(
+      async () =>
+        await video.evaluate((v: HTMLVideoElement) => ({
+          width: v.videoWidth,
+          currentTime: v.currentTime,
+        })),
+      {
+        timeout: 10_000,
+        intervals: [500, 500, 1000, 1000, 2000, 2000],
+        message: "video did not recover within 10s after server pipeline kill",
+      },
+    )
+    .toMatchObject({
+      width: expect.any(Number),
+    });
+
+  const afterRecovery = await video.evaluate((v: HTMLVideoElement) => ({
+    width: v.videoWidth,
+    currentTime: v.currentTime,
+  }));
+  expect(afterRecovery.width).toBeGreaterThan(0);
+  expect(
+    afterRecovery.currentTime,
+    "currentTime must advance after recovery (proving new frames are decoded)",
+  ).toBeGreaterThan(beforeKill.currentTime + 0.1);
+
+  // No console errors during the whole recovery cycle.
+  expect(consoleErrors).toEqual([]);
+});

--- a/tests/e2e/ndi-webrtc-recovery.spec.ts
+++ b/tests/e2e/ndi-webrtc-recovery.spec.ts
@@ -132,35 +132,33 @@ test("NDI WebRTC recovery @video-codec — video resumes within 10s after server
   }
   expect(killResp.status(), "kill endpoint must return 204").toBe(204);
 
-  // Phase 3: within 10s, the browser must reconnect and resume playback.
-  // currentTime must have advanced past beforeKill.currentTime — proves new
-  // frames are being decoded, not just that the <video> element exists.
+  // Phase 3: within 10s, the browser must reconnect AND new frames must be
+  // decoded. The poll predicate combines BOTH conditions so a partial recovery
+  // (videoWidth flickers but currentTime stuck) keeps polling rather than
+  // exiting falsely-green.
   await expect
     .poll(
       async () =>
-        await video.evaluate((v: HTMLVideoElement) => ({
-          width: v.videoWidth,
-          currentTime: v.currentTime,
-        })),
+        await video.evaluate(
+          ({ beforeKillTime }: { beforeKillTime: number }) =>
+            (() => {
+              const v = document.querySelector(
+                'video[data-role="ndi-video"]',
+              ) as HTMLVideoElement | null;
+              if (!v) return false;
+              return v.videoWidth > 0 && v.currentTime > beforeKillTime + 0.1;
+            })(),
+          { beforeKillTime: beforeKill.currentTime },
+        ),
       {
         timeout: 10_000,
         intervals: [500, 500, 1000, 1000, 2000, 2000],
-        message: "video did not recover within 10s after server pipeline kill",
+        message:
+          "video did not recover within 10s after server pipeline kill " +
+          "(videoWidth > 0 AND currentTime advanced past beforeKill)",
       },
     )
-    .toMatchObject({
-      width: expect.any(Number),
-    });
-
-  const afterRecovery = await video.evaluate((v: HTMLVideoElement) => ({
-    width: v.videoWidth,
-    currentTime: v.currentTime,
-  }));
-  expect(afterRecovery.width).toBeGreaterThan(0);
-  expect(
-    afterRecovery.currentTime,
-    "currentTime must advance after recovery (proving new frames are decoded)",
-  ).toBeGreaterThan(beforeKill.currentTime + 0.1);
+    .toBe(true);
 
   // No console errors during the whole recovery cycle.
   expect(consoleErrors).toEqual([]);

--- a/tests/e2e/ndi-webrtc-recovery.spec.ts
+++ b/tests/e2e/ndi-webrtc-recovery.spec.ts
@@ -89,9 +89,17 @@ test("NDI WebRTC recovery @video-codec — video resumes within 10s after server
     return;
   }
 
-  // Open the stage display. WASM hydration gate first.
-  await page.goto(new URL("/stage/ndi-fullscreen", baseURL).toString());
+  // Switch the stage layout to ndi-fullscreen, then open the stage display.
+  // WASM hydration gate first, then wait for the layout to be applied.
+  const layoutResp = await request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code: "ndi-fullscreen" } },
+  );
+  expect(layoutResp.ok(), "switching stage layout to ndi-fullscreen must succeed").toBe(true);
+
+  await page.goto(new URL("/stage", baseURL).toString());
   await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+  await page.waitForSelector('body[data-layout-code="ndi-fullscreen"]', { timeout: 10_000 });
 
   const video = page.locator('video[data-role="ndi-video"]').first();
   await expect(video).toBeVisible();

--- a/tests/e2e/stage-api-ndi.spec.ts
+++ b/tests/e2e/stage-api-ndi.spec.ts
@@ -140,9 +140,12 @@ test("api layout shows connection-status overlay when NDI source activates", asy
   // the page is open. Once `ndi_active=true`, the <NdiVideo> mounts and
   // tries to fetch the WHEP endpoint, which returns 503 because the bogus
   // name has no real stream — that 503 is expected noise for this test only.
+  // The new reconnect_loop (per ndi-stage-auto-recovery spec) retries with
+  // backoff and emits a WARN on each failed attempt; allow that too.
   const consoleMessages = collectConsoleErrors(page, [
     /Failed to load resource.*503/i,
     /WHEP connect for.*failed/i,
+    /reconnect_loop.*connect_whep failed/i,
   ]);
 
   // Start clean

--- a/tests/e2e/stage-timer-ndi.spec.ts
+++ b/tests/e2e/stage-timer-ndi.spec.ts
@@ -88,9 +88,12 @@ test("timer layout renders without NDI image when no source is active", async ({
 });
 
 test("timer layout mounts NdiVideo when an NDI source is active", async ({ page }) => {
+  // The reconnect_loop retries with backoff on WHEP failures (no real NDI
+  // source on CI) — allow the per-attempt WARN it emits.
   const consoleMessages = collectConsoleErrors(page, [
     /Failed to load resource.*503/i,
     /WHEP connect for.*failed/i,
+    /reconnect_loop.*connect_whep failed/i,
   ]);
 
   await page.request.post(


### PR DESCRIPTION
## Summary

Adds two independent self-healing layers around the existing WebRTC NDI transport so the stage display recovers from any single failure (server `ndisrc` "Internal data stream error", NDI source restart, browser ICE drop) within **3-5 seconds**, without operator intervention. Verified live on dev with the test-only kill route: recovery in **~2.5 seconds end-to-end** (server supervisor rebuild ~120ms, client watchdog reconnect ~3s).

**Server layer — `PipelineSupervisor`:** One `tokio::spawn`'d task per active source watches `NdiPipeline::state_watcher()`. On `Errored`/`Stopped` it calls a new `rebuild_pipeline()` immediately (vs the existing 30s DB ticker fallback). Rate-limited to 1 rebuild / 2s; exponential backoff (2/4/8/16/30s cap) after 5 consecutive failures. Re-subscribes to the fresh pipeline's watcher after each successful rebuild. Aborts cleanly on `stop_pipeline` / source deactivation.

**Client layer — `Watchdog`:** Inside `<NdiVideo>`, listens to `RTCPeerConnection.iceConnectionState` (Failed/Disconnected/Closed) AND a `<video>`-stall timer (no `currentTime` advance for >3s). On either signal, `reconnect_loop` closes the PC, dispatches DELETE to the WHEP resource, builds a fresh PC, and re-POSTs `/ndi/whep/<id>` with exponential backoff capped at 5s.

**Test infrastructure:** New `test-helpers` cargo feature on `presenter-server` (+ propagated to `presenter-ndi`) gates a `kill_pipeline_for_test` route that injects `PipelineState::Errored` via the existing state channel — simulating an `ndisrc` crash without removing the supervisor. The dev/E2E build (`pipeline.yml`) enables the feature; production builds (`deploy.yml`, `release.yml`) do NOT. The artifact-symbol grep was extended to catch any accidental leakage of `kill_pipeline_for_test` / `simulate_*` symbols in prod binaries.

Closes the user-reported "video on stage browsers not restore automatically and refresh was needed" defect from the previous WebRTC migration PR.

Spec: `docs/superpowers/specs/2026-05-21-ndi-stage-auto-recovery-design.md`
Plan: `docs/superpowers/plans/2026-05-21-ndi-stage-auto-recovery.md`

## Test plan

- [x] 3 new unit tests in `presenter-ndi::manager`: rate-limit, exponential backoff progression, reset-on-success (run on every CI host without libndi/GPU via the existing `stopped_for_test`/`set_state_for_test` plumbing)
- [x] New Playwright E2E `tests/e2e/ndi-webrtc-recovery.spec.ts` tagged `@video-codec` (routes to real Chrome via existing playwright.config.ts setup); skips honestly when no NDI source is discoverable on the runner
- [x] Two existing NDI E2E tests (`stage-api-ndi.spec.ts`, `stage-timer-ndi.spec.ts`) updated to tolerate the new `reconnect_loop` retry WARN alongside the existing 503/connect-failed allowed patterns
- [x] Workspace `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (113 tests pass)
- [x] WASM clippy: zero warnings (`cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`)
- [x] **Live verification on dev (10.77.8.134:8080)** via Playwright MCP: video plays 1920×1080, killed via `POST /test/ndi/kill-pipeline/{id}`, recovered to playing state with currentTime advancing in **2.5 seconds** — no manual refresh. Server logs confirm `supervisor: rebuild succeeded source_id=…` within 120ms of the simulated error; client logs confirm `watchdog: <video> stalled for >3s, triggering reconnect` and successful reconnect.
- [x] Prod artifact verification step extended to also block `kill_pipeline_for_test` / `simulate_error_for_test` / `simulate_pipeline_error` symbols (defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)