### PR TITLE
Bundle: fix #335 + #337 + #339 — NDI hardening (resource limits, supervisor cool-off, boot-race fix)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -798,9 +798,19 @@ jobs:
           fi
           REMOTE_SCRIPT
 
-      - name: Stop service (if running)
+      - name: Stop service (and clear any failed state)
         run: |
-          ssh deploy-target "if systemctl is-active --quiet ${{ env.SERVICE_NAME }}; then sudo systemctl stop ${{ env.SERVICE_NAME }}; echo 'Service stopped'; else echo 'Service not running'; fi"
+          # is-active returns true ONLY for `active`/`reloading`. A unit
+          # caught mid-restart-loop reports `activating` (start-pre) or
+          # `failed`, both of which used to skip the stop step. The stale
+          # restart cycle then raced our `systemctl start` below — caught
+          # in dev deploy 2026-05-24 after the #339 ExecStartPre rolled
+          # out with a vah264enc probe that never resolved on dev2's
+          # Nvidia GPU. Always stop + reset-failed so the next start runs
+          # against a clean unit slate, regardless of prior state.
+          ssh deploy-target "sudo systemctl stop ${{ env.SERVICE_NAME }} 2>/dev/null || true; \
+                             sudo systemctl reset-failed ${{ env.SERVICE_NAME }} 2>/dev/null || true; \
+                             echo 'Service stopped + failed state cleared'"
 
       - name: Deploy binaries
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "axum",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.95"
+version = "0.4.96"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -108,6 +108,17 @@ impl SupervisorState {
         self.consecutive_failures
     }
 
+    /// #337: after `COOL_OFF_THRESHOLD` consecutive failures the supervisor
+    /// is "cooling off" — it should stop rebuilding and let an operator
+    /// re-activate manually (or auto-retry once per cool-off window).
+    ///
+    /// RED stub: always returns false. The GREEN fix in the next commit
+    /// makes this return `true` once consecutive_failures reaches the
+    /// threshold.
+    fn is_cooling_off(&self) -> bool {
+        false
+    }
+
     /// Rate-limit window: minimum 2 seconds between rebuild attempts.
     fn should_rebuild_now(&self, now: std::time::Instant) -> RebuildDecision {
         const RATE_LIMIT: std::time::Duration = std::time::Duration::from_secs(2);
@@ -857,6 +868,67 @@ mod start_pipeline_state_check_tests {
             state.mark_rebuild_failed();
         }
         state.mark_rebuild_succeeded();
+        assert_eq!(state.consecutive_failures(), 0);
+    }
+
+    /// #337 RED: after 5 consecutive failures, supervisor enters
+    /// CoolingOff state. Without an explicit cool-off ceiling, the
+    /// 30s-capped exponential backoff retries forever and produces
+    /// continuous log spam + repeated encoder-rebuild CPU churn for an
+    /// unrecoverable fault (e.g. encoder vanished). With cool-off, the
+    /// supervisor pauses for 5 min and lets the operator manually
+    /// reactivate to retry sooner.
+    ///
+    /// FAILS before the GREEN fix in the next commit (is_cooling_off
+    /// stub always returns false).
+    #[tokio::test]
+    async fn supervisor_enters_cool_off_at_5_consecutive_failures() {
+        let mut state = SupervisorState::new();
+        for _ in 0..4 {
+            state.mark_rebuild_failed();
+        }
+        assert!(
+            !state.is_cooling_off(),
+            "4 failures must NOT trigger cool-off (threshold is 5)"
+        );
+        state.mark_rebuild_failed();
+        assert!(
+            state.is_cooling_off(),
+            "5 consecutive failures must trigger cool-off (#337)"
+        );
+    }
+
+    /// #337 RED: while cooling off, the supervisor must wait 5 minutes
+    /// before its next rebuild attempt — NOT the 30s exp-backoff cap.
+    #[tokio::test]
+    async fn supervisor_cool_off_window_is_five_minutes() {
+        let mut state = SupervisorState::new();
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+        }
+        assert_eq!(
+            state.backoff_for_failure_count(),
+            std::time::Duration::from_secs(5 * 60),
+            "cool-off window must be 5 minutes (#337) — not the prior 2s exp-backoff entry"
+        );
+    }
+
+    /// #337 RED: mark_rebuild_succeeded clears cool-off. Without this,
+    /// a manual reactivation that succeeds once would still leave the
+    /// counter pinned, sending the next failure straight back into
+    /// cool-off.
+    #[tokio::test]
+    async fn supervisor_cool_off_clears_on_success() {
+        let mut state = SupervisorState::new();
+        for _ in 0..5 {
+            state.mark_rebuild_failed();
+        }
+        assert!(state.is_cooling_off());
+        state.mark_rebuild_succeeded();
+        assert!(
+            !state.is_cooling_off(),
+            "successful rebuild must clear the cool-off flag (#337)"
+        );
         assert_eq!(state.consecutive_failures(), 0);
     }
 }

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -109,15 +109,31 @@ impl SupervisorState {
     }
 
     /// #337: after `COOL_OFF_THRESHOLD` consecutive failures the supervisor
-    /// is "cooling off" — it should stop rebuilding and let an operator
-    /// re-activate manually (or auto-retry once per cool-off window).
-    ///
-    /// RED stub: always returns false. The GREEN fix in the next commit
-    /// makes this return `true` once consecutive_failures reaches the
-    /// threshold.
+    /// is "cooling off" — it sleeps `COOL_OFF_WINDOW` before each rebuild
+    /// attempt instead of the prior 30s exp-backoff cap. Manual reactivation
+    /// via the operator UI calls `start_pipeline`, which removes the dead
+    /// active-map entry, builds a fresh pipeline, and spawns a NEW
+    /// supervisor with a zero counter — so the old supervisor's cool-off
+    /// is implicitly cleared. mark_rebuild_succeeded also clears it (a
+    /// rebuild that succeeded inside the cool-off window means the fault
+    /// self-resolved).
     fn is_cooling_off(&self) -> bool {
-        false
+        self.consecutive_failures >= Self::COOL_OFF_THRESHOLD
     }
+
+    /// #337: number of consecutive failures before entering cool-off. Picked
+    /// from the issue body — small enough that an unrecoverable fault
+    /// stops thrashing within seconds, large enough that a flaky NDI
+    /// source (5-second LAN dropout) doesn't immediately cool off.
+    const COOL_OFF_THRESHOLD: u32 = 5;
+
+    /// #337: how long the supervisor waits between rebuild attempts once
+    /// the threshold is crossed. 5 minutes is the operator-comfortable
+    /// retry interval — long enough to stop log spam + CPU churn for
+    /// unrecoverable faults; short enough that a self-healing transient
+    /// fault (intermittent NDI broadcaster, GPU contention from another
+    /// process) recovers without operator intervention.
+    const COOL_OFF_WINDOW: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 
     /// Rate-limit window: minimum 2 seconds between rebuild attempts.
     fn should_rebuild_now(&self, now: std::time::Instant) -> RebuildDecision {
@@ -130,14 +146,17 @@ impl SupervisorState {
         }
     }
 
-    /// Exponential backoff once failures reach 5: 2s, 4s, 8s, 16s, 30s cap.
+    /// #337: once `COOL_OFF_THRESHOLD` consecutive failures hit, the
+    /// supervisor sleeps `COOL_OFF_WINDOW` (5 min) between attempts
+    /// instead of the prior 30s exp-backoff cap. This stops log-spam +
+    /// CPU churn for unrecoverable faults (encoder vanished, NDI source
+    /// removed). Manual reactivation via `start_pipeline` spawns a fresh
+    /// supervisor with a zero counter, which is the operator escape hatch.
     fn backoff_for_failure_count(&self) -> std::time::Duration {
-        if self.consecutive_failures < 5 {
+        if self.consecutive_failures < Self::COOL_OFF_THRESHOLD {
             return std::time::Duration::ZERO;
         }
-        let exp = (self.consecutive_failures - 5).min(4); // 0..=4 → 1,2,4,8,16
-        let secs: u64 = 1u64 << exp; // 1, 2, 4, 8, 16
-        std::time::Duration::from_secs(secs.saturating_mul(2).min(30))
+        Self::COOL_OFF_WINDOW
     }
 
     fn mark_rebuild_started(&mut self) {
@@ -815,47 +834,28 @@ mod start_pipeline_state_check_tests {
         }
     }
 
-    /// After 5 consecutive failures, backoff progression is 2s, 4s, 8s, 16s, 30s (cap).
+    /// #337: prior exp-backoff (2s/4s/8s/16s/30s cap) is replaced with a
+    /// flat 5-minute cool-off window once `COOL_OFF_THRESHOLD` failures
+    /// hit. The window stays at 5 min regardless of how many further
+    /// failures accumulate — no further growth, no risk of an
+    /// integer-overflow timer pathology.
     #[tokio::test]
-    async fn supervisor_backs_off_exponentially_after_5_failures() {
+    async fn supervisor_cool_off_window_stays_flat_after_threshold() {
         let mut state = SupervisorState::new();
         for _ in 0..5 {
             state.mark_rebuild_failed();
         }
-        // 6th attempt — backoff = 2s
         assert_eq!(
             state.backoff_for_failure_count(),
-            std::time::Duration::from_secs(2)
+            std::time::Duration::from_secs(5 * 60),
+            "at threshold (5 failures): cool-off = 5 min"
         );
-        state.mark_rebuild_failed();
-        // 7th — 4s
-        assert_eq!(
-            state.backoff_for_failure_count(),
-            std::time::Duration::from_secs(4)
-        );
-        state.mark_rebuild_failed();
-        // 8th — 8s
-        assert_eq!(
-            state.backoff_for_failure_count(),
-            std::time::Duration::from_secs(8)
-        );
-        state.mark_rebuild_failed();
-        // 9th — 16s
-        assert_eq!(
-            state.backoff_for_failure_count(),
-            std::time::Duration::from_secs(16)
-        );
-        state.mark_rebuild_failed();
-        // 10th — 30s cap
-        assert_eq!(
-            state.backoff_for_failure_count(),
-            std::time::Duration::from_secs(30)
-        );
-        for _ in 0..5 {
+        for _ in 0..50 {
             state.mark_rebuild_failed();
             assert_eq!(
                 state.backoff_for_failure_count(),
-                std::time::Duration::from_secs(30)
+                std::time::Duration::from_secs(5 * 60),
+                "many failures: cool-off STAYS at 5 min, doesn't grow further"
             );
         }
     }

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -272,8 +272,39 @@ impl NdiManager {
         ndi_name: &str,
     ) -> Result<()> {
         let mut active = self.active.lock().await;
+
+        // Operator-reactivation path: if the existing entry is dead, snapshot
+        // its supervisor handle BEFORE `check_active_entry` removes the entry,
+        // so we can abort the prior supervisor below. Without this, a
+        // cool-off-bound supervisor that's mid-5-min-sleep keeps running and
+        // ends up double-watching the new pipeline alongside the fresh
+        // supervisor we spawn below (deep-review 🔵 #3, 2026-05-24 PR #340).
+        // Safe to `.take()` here because we hold the lock: state observed by
+        // `check_active_entry` below cannot change between these two reads.
+        let prior_supervisor: Option<tokio::task::JoinHandle<()>> = active
+            .get_mut(source_id)
+            .filter(|entry| {
+                matches!(
+                    entry.pipeline.state(),
+                    PipelineState::Stopped | PipelineState::Errored(_)
+                )
+            })
+            .and_then(|entry| entry.supervisor.take());
+
         if let StateCheckOutcome::Idempotent = check_active_entry(&mut active, source_id).await {
+            // Pipeline turned out healthy — the dead-state filter above didn't
+            // match, so prior_supervisor is None. If somehow it leaked, drop
+            // the handle (does NOT cancel the task in tokio; the supervisor
+            // is still owned by its `ActiveSource.supervisor` slot if we
+            // didn't `.take()`).
+            debug_assert!(prior_supervisor.is_none());
             return Ok(());
+        }
+        // The entry was dead → check_active_entry removed it. Abort the prior
+        // supervisor (if any) so it doesn't double-watch the new pipeline we
+        // build below.
+        if let Some(handle) = prior_supervisor {
+            handle.abort();
         }
 
         let whep_url = format!("/ndi/whep/{}", source_id);
@@ -356,12 +387,15 @@ impl NdiManager {
     /// The supervisor:
     /// - Subscribes to the pipeline's state watcher
     /// - On Errored/Stopped, requests a rebuild via `rebuild_pipeline`
-    /// - Rate-limits to 1 rebuild / 2s; exponentially backs off after 5
-    ///   consecutive failures
+    /// - Rate-limits to 1 rebuild / 2s; enters a 5-minute cool-off after
+    ///   `COOL_OFF_THRESHOLD` (5) consecutive failures (#337). During
+    ///   cool-off the supervisor sleeps between rebuild attempts but does
+    ///   not exit — manual reactivation via `start_pipeline` aborts this
+    ///   supervisor and spawns a fresh one with a zero counter.
     /// - Re-subscribes to the FRESH state watcher after each successful
     ///   rebuild (the old watcher's pipeline was dropped)
     /// - Exits when the watcher closes (pipeline dropped) OR the task is
-    ///   externally aborted via `stop_pipeline`
+    ///   externally aborted via `stop_pipeline` / operator reactivate
     fn spawn_supervisor(
         self: &std::sync::Arc<Self>,
         source_id: String,
@@ -410,7 +444,15 @@ impl NdiManager {
                         match manager.rebuild_pipeline(&source_id, &ndi_name).await {
                             Ok(()) => {
                                 tracing::info!(source_id = %source_id, "supervisor: rebuild succeeded");
-                                state.mark_rebuild_succeeded();
+                                // NOTE: do NOT mark_rebuild_succeeded() yet. We only
+                                // know the pipeline build returned Ok — we don't yet
+                                // know it survived the immediate state-watcher peek
+                                // below. If we reset the counter here, the
+                                // already_dead branch below would mark_failed and
+                                // the counter would oscillate 0 → 1 → 0 → 1 forever,
+                                // never crossing the cool-off threshold (deep-review
+                                // 🟡 #1, 2026-05-24 PR #340). Reset only AFTER the
+                                // peek confirms the new pipeline is alive.
                                 // The fresh pipeline has a NEW state watcher; swap ours
                                 // so we see ITS transitions, not the dead pipeline's.
                                 match manager.state_watcher_for(&source_id).await {
@@ -458,6 +500,10 @@ impl NdiManager {
                                             }
                                             continue;
                                         }
+                                        // Pipeline confirmed alive on the new watcher
+                                        // → reset the failure streak now (deferred
+                                        // from above per deep-review 🟡 #1).
+                                        state.mark_rebuild_succeeded();
                                     }
                                     None => {
                                         // Source no longer active (operator deactivated

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -445,7 +445,17 @@ impl NdiManager {
                                             // the rebuild "succeeded" briefly but the
                                             // pipeline collapsed immediately, which is
                                             // a real failure of recovery.
+                                            let was_cooling_off = state.is_cooling_off();
                                             state.mark_rebuild_failed();
+                                            if !was_cooling_off && state.is_cooling_off() {
+                                                tracing::warn!(
+                                                    source_id = %source_id,
+                                                    consecutive_failures = state.consecutive_failures(),
+                                                    cool_off_minutes = 5,
+                                                    "supervisor: NDI source entered cool-off — pausing retries (#337); \
+                                                     manual reactivate via operator UI resumes immediately"
+                                                );
+                                            }
                                             continue;
                                         }
                                     }
@@ -461,6 +471,7 @@ impl NdiManager {
                                 }
                             }
                             Err(e) => {
+                                let was_cooling_off = state.is_cooling_off();
                                 state.mark_rebuild_failed();
                                 tracing::warn!(
                                     source_id = %source_id,
@@ -468,6 +479,15 @@ impl NdiManager {
                                     consecutive_failures = state.consecutive_failures(),
                                     "supervisor: rebuild failed"
                                 );
+                                if !was_cooling_off && state.is_cooling_off() {
+                                    tracing::warn!(
+                                        source_id = %source_id,
+                                        consecutive_failures = state.consecutive_failures(),
+                                        cool_off_minutes = 5,
+                                        "supervisor: NDI source entered cool-off — pausing retries (#337); \
+                                         manual reactivate via operator UI resumes immediately"
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -91,6 +91,42 @@ fn presenter_service_blocks_start_until_vah264enc_probeable() {
     }
 }
 
+/// Regression for #335: cap presenter.service resource usage so a runaway
+/// NDI pipeline cannot wedge the entire host. The 2026-05-24 prod incident
+/// showed that once `whepserversink` spawned multiple per-consumer
+/// encoders, the N100 saturated all 4 cores within 3 minutes — sshd and
+/// presenter both stopped responding to TCP handshakes; recovery required
+/// power-cycling. CPUQuota leaves at least one core for sshd. MemoryMax
+/// bounds growth so the kernel's per-service OOM kicks in before the
+/// host-wide OOM killer. TasksMax caps thread/process explosion if a
+/// pipeline rebuild leaks (e.g. a leaked tokio task per failed retry).
+///
+/// Without this test, a future deploy-script refactor could silently
+/// drop these directives — re-opening the wedge failure mode that took
+/// prod offline. Both unit files (prod + dev) are pinned.
+#[test]
+fn presenter_service_has_resource_limits() {
+    let prod = include_str!("../../../../scripts/deploy/presenter.service");
+    let dev = include_str!("../../../../scripts/deploy/presenter-dev.service");
+    for (name, src) in [("presenter.service", prod), ("presenter-dev.service", dev)] {
+        assert!(
+            src.contains("CPUQuota="),
+            "{name}: missing CPUQuota directive — runaway pipeline can saturate \
+             all cores and lock out sshd (see #335 + 2026-05-24 prod incident)"
+        );
+        assert!(
+            src.contains("MemoryMax="),
+            "{name}: missing MemoryMax directive — runaway pipeline can grow \
+             until host-wide OOM killer fires unpredictable victims (#335)"
+        );
+        assert!(
+            src.contains("TasksMax="),
+            "{name}: missing TasksMax directive — pipeline rebuilds that leak \
+             tasks can exhaust the kernel PID space (#335)"
+        );
+    }
+}
+
 #[tokio::test]
 async fn empty_state_does_not_auto_seed_library() {
     // Regression guard for issue #228: server startup must NOT auto-import any

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -69,32 +69,48 @@ fn presenter_service_blocks_start_until_h264_encoder_probeable() {
     let prod = include_str!("../../../../scripts/deploy/presenter.service");
     let dev = include_str!("../../../../scripts/deploy/presenter-dev.service");
     for (name, src) in [("presenter.service", prod), ("presenter-dev.service", dev)] {
+        // Tighten substring-only checks (deep-review 🔵 #4) by pinning all
+        // required tokens on the SAME line. A refactor that leaves comments
+        // mentioning the encoders but removes the actual probe would still
+        // have satisfied substring assertions across the whole file.
+        let exec_pre = src
+            .lines()
+            .find(|l| l.trim_start().starts_with("ExecStartPre="))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{name}: missing ExecStartPre directive — the binary can exec \
+                 before /dev/dri/renderD128 is fully usable for VA-API (see #339 \
+                 prod cold-reboot reproduction 2026-05-24 17:07 CEST)"
+                )
+            });
+        let exec_pre_trimmed = exec_pre.trim_start();
         assert!(
-            src.contains("ExecStartPre=-"),
-            "{name}: missing ExecStartPre with leading `-` (best-effort prefix). \
+            exec_pre_trimmed.starts_with("ExecStartPre=-"),
+            "{name}: ExecStartPre must use leading `-` (best-effort prefix). \
              Without `-`, a 30s timeout (no GPU at all) makes systemd fail the \
-             unit — blocking non-NDI features (lyrics, Bible, timers) from \
-             starting. The gate must be non-fatal so item 6's encoder gate can \
-             take over (#339)"
+             whole unit — blocking non-NDI features (lyrics, Bible, timers) \
+             from starting. Item 6's encoder gate must be allowed to take \
+             over instead (#339). Line: {exec_pre}"
         );
         assert!(
-            src.contains("vah264enc"),
+            exec_pre.contains("gst-inspect-1.0"),
+            "{name}: ExecStartPre must use `gst-inspect-1.0` — canonical \
+             GStreamer feature query that matches what `presenter_ndi::\
+             hw_h264_encoder()` sees at startup (#339). Line: {exec_pre}"
+        );
+        assert!(
+            exec_pre.contains("vah264enc"),
             "{name}: ExecStartPre must probe `vah264enc` (Intel/AMD VA-API — \
-             prod N100). The `va` plugin can register without features, so a \
-             generic plugin check is insufficient (#339)"
+             prod N100). The `va` plugin can register without features so a \
+             generic plugin check is insufficient (#339). Line: {exec_pre}"
         );
         assert!(
-            src.contains("nvh264enc"),
+            exec_pre.contains("nvh264enc"),
             "{name}: ExecStartPre must ALSO probe `nvh264enc` (Nvidia NVENC — \
              dev2 RTX). Without this branch the dev deploy unit-loops on a \
              machine with Nvidia GPU because vah264enc never registers there \
-             (caught 2026-05-24 in CI run 26367361768 — #339 hotfix)"
-        );
-        assert!(
-            src.contains("gst-inspect-1.0"),
-            "{name}: ExecStartPre must use `gst-inspect-1.0` — that's the \
-             canonical GStreamer feature query and matches what \
-             `presenter_ndi::hw_h264_encoder()` will see at startup (#339)"
+             (caught 2026-05-24 in CI run 26367361768 — #339 hotfix). \
+             Line: {exec_pre}"
         );
     }
 }

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -48,6 +48,49 @@ fn auto_restore_sites_invoke_encoder_gate_predicate() {
     );
 }
 
+/// Regression for #339: cold-reboot verification of PR #334 on prod
+/// (2026-05-24 17:07 CEST) reproduced the boot-time race. Item 1's forced
+/// registry rescan executed (log line emitted) but the resulting registry
+/// still showed the `va` plugin with zero features — `vah264enc` remained
+/// unregistered for ~50s after boot. Item 6's encoder gate correctly
+/// skipped the auto-restore (host stayed administrable), but the user
+/// still had to manually restart presenter to get streaming back.
+///
+/// Fix: add `ExecStartPre` that polls `gst-inspect-1.0 vah264enc` until
+/// the encoder is probeable (capped at 30s by `timeout`). systemd will
+/// not exec the presenter binary until the encoder is visible, closing
+/// the boot race without code-side polling.
+///
+/// This test pins the ExecStartPre line in BOTH unit files (prod +
+/// dev). Without both files, a partial revert would re-open the race
+/// on one environment.
+#[test]
+fn presenter_service_blocks_start_until_vah264enc_probeable() {
+    let prod = include_str!("../../../../scripts/deploy/presenter.service");
+    let dev = include_str!("../../../../scripts/deploy/presenter-dev.service");
+    for (name, src) in [("presenter.service", prod), ("presenter-dev.service", dev)] {
+        assert!(
+            src.contains("ExecStartPre="),
+            "{name}: missing ExecStartPre directive — without it the binary can \
+             exec before /dev/dri/renderD128 is fully usable for VA-API (see #339 \
+             prod cold-reboot reproduction 2026-05-24 17:07 CEST)"
+        );
+        assert!(
+            src.contains("vah264enc"),
+            "{name}: ExecStartPre must probe `vah264enc` specifically — that's \
+             the encoder the WHEP pipeline depends on. A generic `gst-inspect-1.0` \
+             call is insufficient because the `va` plugin can register without \
+             features (#339)"
+        );
+        assert!(
+            src.contains("gst-inspect-1.0"),
+            "{name}: ExecStartPre must use `gst-inspect-1.0` for the probe — that's \
+             the canonical GStreamer feature query and matches what `presenter_ndi::\
+             hw_h264_encoder()` will see at startup (#339)"
+        );
+    }
+}
+
 #[tokio::test]
 async fn empty_state_does_not_auto_seed_library() {
     // Regression guard for issue #228: server startup must NOT auto-import any

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -65,28 +65,36 @@ fn auto_restore_sites_invoke_encoder_gate_predicate() {
 /// dev). Without both files, a partial revert would re-open the race
 /// on one environment.
 #[test]
-fn presenter_service_blocks_start_until_vah264enc_probeable() {
+fn presenter_service_blocks_start_until_h264_encoder_probeable() {
     let prod = include_str!("../../../../scripts/deploy/presenter.service");
     let dev = include_str!("../../../../scripts/deploy/presenter-dev.service");
     for (name, src) in [("presenter.service", prod), ("presenter-dev.service", dev)] {
         assert!(
-            src.contains("ExecStartPre="),
-            "{name}: missing ExecStartPre directive — without it the binary can \
-             exec before /dev/dri/renderD128 is fully usable for VA-API (see #339 \
-             prod cold-reboot reproduction 2026-05-24 17:07 CEST)"
+            src.contains("ExecStartPre=-"),
+            "{name}: missing ExecStartPre with leading `-` (best-effort prefix). \
+             Without `-`, a 30s timeout (no GPU at all) makes systemd fail the \
+             unit — blocking non-NDI features (lyrics, Bible, timers) from \
+             starting. The gate must be non-fatal so item 6's encoder gate can \
+             take over (#339)"
         );
         assert!(
             src.contains("vah264enc"),
-            "{name}: ExecStartPre must probe `vah264enc` specifically — that's \
-             the encoder the WHEP pipeline depends on. A generic `gst-inspect-1.0` \
-             call is insufficient because the `va` plugin can register without \
-             features (#339)"
+            "{name}: ExecStartPre must probe `vah264enc` (Intel/AMD VA-API — \
+             prod N100). The `va` plugin can register without features, so a \
+             generic plugin check is insufficient (#339)"
+        );
+        assert!(
+            src.contains("nvh264enc"),
+            "{name}: ExecStartPre must ALSO probe `nvh264enc` (Nvidia NVENC — \
+             dev2 RTX). Without this branch the dev deploy unit-loops on a \
+             machine with Nvidia GPU because vah264enc never registers there \
+             (caught 2026-05-24 in CI run 26367361768 — #339 hotfix)"
         );
         assert!(
             src.contains("gst-inspect-1.0"),
-            "{name}: ExecStartPre must use `gst-inspect-1.0` for the probe — that's \
-             the canonical GStreamer feature query and matches what `presenter_ndi::\
-             hw_h264_encoder()` will see at startup (#339)"
+            "{name}: ExecStartPre must use `gst-inspect-1.0` — that's the \
+             canonical GStreamer feature query and matches what \
+             `presenter_ndi::hw_h264_encoder()` will see at startup (#339)"
         );
     }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -405,9 +405,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "either_of"
@@ -898,9 +898,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1650,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2198,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2211,18 +2211,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
 dependencies = [
  "async-trait",
  "cast",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"
@@ -2306,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -16,7 +16,7 @@ WorkingDirectory=/opt/presenter-dev
 # (dev2 RTX Nvidia). Leading `-` makes the gate non-fatal — if no
 # GPU is available at all, presenter still starts for non-NDI
 # features and item 6 skips NDI auto-restore.
-ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1 || gst-inspect-1.0 nvh264enc >/dev/null 2>&1; do sleep 1; done'
+ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 --exists vah264enc || gst-inspect-1.0 --exists nvh264enc; do sleep 1; done'
 ExecStart=/opt/presenter-dev/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -36,7 +36,10 @@ ProtectHome=read-only
 ReadWritePaths=/opt/presenter-dev
 PrivateTmp=true
 
-# Resource limits
+# Resource limits — #335 (mirror of prod; see presenter.service for context).
+CPUQuota=300%
+MemoryMax=4G
+TasksMax=512
 LimitNOFILE=65536
 
 [Install]

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -10,6 +10,12 @@ Type=simple
 User=newlevel
 Group=newlevel
 WorkingDirectory=/opt/presenter-dev
+# #339: block start until vah264enc is probeable. Mirrors prod
+# presenter.service; see that file for the full incident context.
+# `timeout 30` caps the wait — if VA-API never registers, the
+# binary still starts (presenter_ndi item 6 then skips auto-restore
+# rather than melting the host).
+ExecStartPre=/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1; do sleep 1; done'
 ExecStart=/opt/presenter-dev/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -10,12 +10,13 @@ Type=simple
 User=newlevel
 Group=newlevel
 WorkingDirectory=/opt/presenter-dev
-# #339: block start until vah264enc is probeable. Mirrors prod
-# presenter.service; see that file for the full incident context.
-# `timeout 30` caps the wait — if VA-API never registers, the
-# binary still starts (presenter_ndi item 6 then skips auto-restore
-# rather than melting the host).
-ExecStartPre=/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1; do sleep 1; done'
+# #339: gate start on hardware H264 encoder being probeable. Mirrors
+# prod presenter.service; see that file for the full incident
+# context. Probes EITHER vah264enc (prod N100 Intel) OR nvh264enc
+# (dev2 RTX Nvidia). Leading `-` makes the gate non-fatal — if no
+# GPU is available at all, presenter still starts for non-NDI
+# features and item 6 skips NDI auto-restore.
+ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1 || gst-inspect-1.0 nvh264enc >/dev/null 2>&1; do sleep 1; done'
 ExecStart=/opt/presenter-dev/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -17,6 +17,21 @@ Type=simple
 User=newlevel
 Group=newlevel
 WorkingDirectory=/opt/presenter
+# #339: block start until vah264enc is probeable. The race that took
+# prod down on 2026-05-24 and reproduced on cold-reboot of PR #334
+# (17:07 CEST) is: After=dev-dri-renderD128.device fires as soon as
+# udev creates the node, but i915/VA-API features can take 30-50s
+# longer to register. Without this gate, item 1's registry rescan
+# runs against an empty va plugin and item 6's encoder gate then
+# skips auto-restore (correct safety behaviour, but operator still
+# has to manually restart 50s later). Polling gst-inspect-1.0 in a
+# 1s loop capped at 30s by `timeout` closes the race: systemd will
+# not exec the presenter binary until the encoder is visible to the
+# same probe presenter_ndi::hw_h264_encoder() uses at startup. If
+# the probe never succeeds (no GPU at all), `timeout` exits non-zero,
+# systemd marks the start failed, Restart=always retries with the
+# same gate — eventually item 6 takes over once we time out.
+ExecStartPre=/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1; do sleep 1; done'
 ExecStart=/opt/presenter/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -17,21 +17,28 @@ Type=simple
 User=newlevel
 Group=newlevel
 WorkingDirectory=/opt/presenter
-# #339: block start until vah264enc is probeable. The race that took
-# prod down on 2026-05-24 and reproduced on cold-reboot of PR #334
-# (17:07 CEST) is: After=dev-dri-renderD128.device fires as soon as
-# udev creates the node, but i915/VA-API features can take 30-50s
-# longer to register. Without this gate, item 1's registry rescan
-# runs against an empty va plugin and item 6's encoder gate then
+# #339: gate start on hardware H264 encoder being probeable. The race
+# that took prod down on 2026-05-24 (and reproduced on cold-reboot of
+# PR #334, 17:07 CEST) is: After=dev-dri-renderD128.device fires as
+# soon as udev creates the node, but the i915/VA-API features can
+# take 30-50s longer to register. Without this gate, item 1's
+# registry rescan runs against an empty va plugin and item 6's gate
 # skips auto-restore (correct safety behaviour, but operator still
 # has to manually restart 50s later). Polling gst-inspect-1.0 in a
 # 1s loop capped at 30s by `timeout` closes the race: systemd will
 # not exec the presenter binary until the encoder is visible to the
-# same probe presenter_ndi::hw_h264_encoder() uses at startup. If
-# the probe never succeeds (no GPU at all), `timeout` exits non-zero,
-# systemd marks the start failed, Restart=always retries with the
-# same gate — eventually item 6 takes over once we time out.
-ExecStartPre=/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1; do sleep 1; done'
+# same probe presenter_ndi::hw_h264_encoder() uses at startup.
+#
+# Probe BOTH vah264enc (Intel/AMD VA-API — prod N100) AND nvh264enc
+# (Nvidia NVENC — dev2 RTX). The encoder probe inside presenter
+# returns the first one it finds; the gate matches that semantic.
+#
+# The leading `-` makes failures non-fatal: if the 30s timeout
+# expires (no GPU at all, BIOS disabled, kernel issue), systemd
+# still starts presenter so non-NDI features (lyrics, Bible,
+# timers, stage display) remain available. Item 6's encoder gate
+# then skips NDI auto-restore.
+ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1 || gst-inspect-1.0 nvh264enc >/dev/null 2>&1; do sleep 1; done'
 ExecStart=/opt/presenter/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -51,6 +51,19 @@ ReadWritePaths=/opt/presenter
 PrivateTmp=true
 
 # Resource limits
+# #335: cap presenter.service so a runaway NDI pipeline cannot wedge the
+# host. 2026-05-24 incident: whepserversink spawned a per-consumer encoder
+# per WHEP client, all 4 N100 cores saturated within 3 minutes, sshd
+# stopped responding, recovery required power-cycling. CPUQuota=300% leaves
+# one core for sshd + critical services. MemoryMax=4G triggers the
+# per-service OOM (presenter restarts via Restart=always) before the
+# host-wide OOM picks an unpredictable victim. TasksMax=512 caps
+# thread/process explosion if a pipeline rebuild leaks tasks. The 30-day
+# observation window after rollout will tell us whether these caps are
+# tight enough (see #335 acceptance criteria) — adjust then.
+CPUQuota=300%
+MemoryMax=4G
+TasksMax=512
 LimitNOFILE=65536
 
 [Install]

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -38,7 +38,7 @@ WorkingDirectory=/opt/presenter
 # still starts presenter so non-NDI features (lyrics, Bible,
 # timers, stage display) remain available. Item 6's encoder gate
 # then skips NDI auto-restore.
-ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 vah264enc >/dev/null 2>&1 || gst-inspect-1.0 nvh264enc >/dev/null 2>&1; do sleep 1; done'
+ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 --exists vah264enc || gst-inspect-1.0 --exists nvh264enc; do sleep 1; done'
 ExecStart=/opt/presenter/presenter-server
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary

Bundles three NDI-hardening follow-ups from PR #334's incident review:

- **#339** — Boot-race fix. Cold-reboot verification of #334 reproduced the 2026-05-24 incident first symptom: item 1's registry rescan executes, but the va plugin still probes empty for ~50s. Fix: ExecStartPre that polls `gst-inspect-1.0` for EITHER `vah264enc` (Intel/AMD VA-API — prod N100) OR `nvh264enc` (Nvidia NVENC — dev2 RTX) with a 30s timeout. Leading `-` prefix makes the gate best-effort so a no-GPU box still starts presenter for non-NDI features (lyrics, Bible, timers, stage display) and item 6 takes over the encoder-missing branch.
- **#335** — Resource fence. `CPUQuota=300%` + `MemoryMax=4G` + `TasksMax=512` on both `presenter.service` and `presenter-dev.service` so a runaway pipeline can't wedge the host (the failure mode that took prod down on 2026-05-24, requiring power-cycle).
- **#337** — Supervisor cool-off. Replaces the 30s exp-backoff ceiling with a flat 5-minute cool-off window once consecutive failures hit 5. Stops log spam + CPU churn for unrecoverable faults (encoder vanished, NDI source removed). `is_cooling_off()` predicate exposed; operator-initiated `Activate` spawns a fresh supervisor with zero counter.

## Test plan

- [x] Regression tests RED-then-GREEN per `regression-test-first.md`:
  - `presenter_service_blocks_start_until_h264_encoder_probeable` — RED on `ecebe89`, hotfixed test on `3893463`, GREEN on both `aec48d3` + `3893463`
  - `presenter_service_has_resource_limits` — RED on `96a5d00`, GREEN on `41ebb6c`
  - `supervisor_enters_cool_off_at_5_consecutive_failures` + `supervisor_cool_off_window_is_five_minutes` + `supervisor_cool_off_clears_on_success` — RED on `34c8a45`, GREEN on `ac49f97`
- [x] `cargo test --workspace` — 522/522 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] WASM clippy clean
- [x] CI run 26369729111 — all 20 jobs ✅ (Test, Build, Coverage, Mutation, E2E 1/3 + 2/3 + 3/3, Deploy to Dev, Deploy Companion Plugin)
- [x] Dev verified: `http://10.77.8.134:8080/healthz` returns `{"channel":"dev","ndi_pipelines":[],"status":"ok","version":"0.4.96"}`. Service active. Resource limits applied (`max: 4.0G`, `Tasks: limit 512`). Startup log: `NDI WebRTC encoder: nvh264enc` (correct for dev2 Nvidia).

## Incident discovered during CI

The original #339 design probed only `vah264enc`. Dev2 (the deploy target for "Deploy to Dev") has an Nvidia RTX 5060, not Intel — so `vah264enc` never registers there and the ExecStartPre always hit its 30s timeout. Two follow-up commits hotfixed this:

- `3893463` — added `nvh264enc` to the probe + `-` prefix so timeout doesn't fail the unit
- `e97d748` — workflow hardening: `systemctl stop` + `reset-failed` always run before `start` so a stuck restart-loop from a prior bad unit can't race a deploy

Closes #335
Closes #337
Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)