### PR TITLE
Bundle: arch-review #349 #350 #355 #358 #359 — AI arg validation, panic-safety, async I/O, visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,10 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
- "async-trait",
  "presenter-core",
  "regex",
  "reqwest",
@@ -3387,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3405,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3427,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
  "axum",
@@ -3463,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3484,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.97"
+version = "0.4.98"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.97"
+version = "0.4.98"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-bible/Cargo.toml
+++ b/crates/presenter-bible/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 presenter-core = { path = "../presenter-core" }
 reqwest.workspace = true
 tokio.workspace = true

--- a/crates/presenter-bible/src/lib.rs
+++ b/crates/presenter-bible/src/lib.rs
@@ -1,7 +1,6 @@
 mod parsers;
 
 use anyhow::{anyhow, Context, Result};
-use async_trait::async_trait;
 use presenter_core::bible::BibleIngestionBatch;
 use presenter_core::BibleTranslation;
 use std::collections::HashMap;
@@ -10,9 +9,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tracing::warn;
 
-#[async_trait]
 pub trait BibleContentProvider: Send + Sync {
-    async fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>>;
+    fn fetch_bytes(&self, url: &str) -> impl std::future::Future<Output = Result<Vec<u8>>> + Send;
 }
 
 #[derive(Clone, Debug)]
@@ -62,7 +60,6 @@ impl HttpBibleContentProvider {
     }
 }
 
-#[async_trait]
 impl BibleContentProvider for HttpBibleContentProvider {
     async fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>> {
         let cache_path = resolve_cache_path(url);
@@ -594,7 +591,6 @@ const SLOVAK_MILOST_BOOKS: [&str; 66] = [
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use rusqlite::Connection;
     use tempfile::NamedTempFile;
     use zip::write::FileOptions;
@@ -606,7 +602,6 @@ mod tests {
         payload: Vec<u8>,
     }
 
-    #[async_trait]
     impl BibleContentProvider for StubProvider {
         async fn fetch_bytes(&self, _url: &str) -> Result<Vec<u8>> {
             Ok(self.payload.clone())

--- a/crates/presenter-core/src/stage_display.rs
+++ b/crates/presenter-core/src/stage_display.rs
@@ -51,13 +51,20 @@ impl StageDisplayLayout {
                 "Full viewport NDI video stream",
             ),
             Self::new("bible", "BIBLE", "Full-screen Bible passage display"),
-            Self::new("api", "API", "External API-driven stage display"),
+            Self::api(),
             Self::new(
                 "camera-crew",
                 "CAMERA CREW",
                 "Group-focused director / camera-crew monitor",
             ),
         ]
+    }
+
+    /// The API-driven stage layout (`API_STAGE_LAYOUT_CODE`). Infallible
+    /// accessor so callers don't search `built_in()` and risk panicking on a
+    /// missing entry.
+    pub fn api() -> Self {
+        Self::new("api", "API", "External API-driven stage display")
     }
 
     fn new(code: &str, name: &str, description: &str) -> Self {

--- a/crates/presenter-importer/src/bible.rs
+++ b/crates/presenter-importer/src/bible.rs
@@ -68,7 +68,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use presenter_bible::{BibleSource, BibleSourceFormat};
     use presenter_core::{BibleReference, BibleTranslation};
     use presenter_persistence::Repository;
@@ -84,7 +83,6 @@ mod tests {
         url: String,
     }
 
-    #[async_trait]
     impl BibleContentProvider for SinglePayloadProvider {
         async fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>> {
             assert_eq!(url, self.url);
@@ -96,7 +94,6 @@ mod tests {
         payloads: HashMap<String, Vec<u8>>,
     }
 
-    #[async_trait]
     impl BibleContentProvider for MapProvider {
         async fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>> {
             self.payloads

--- a/crates/presenter-ndi/src/pipeline.rs
+++ b/crates/presenter-ndi/src/pipeline.rs
@@ -570,8 +570,8 @@ impl NdiPipeline {
                                 );
                             let our_state = WhepConnectionState::from(gst_state);
                             // std::sync::Mutex — safe to lock from any thread, no async runtime
-                            // required. Panic on poison is acceptable; the signal thread holds
-                            // the lock for a trivial enum write.
+                            // required. On poison we recover the guard via into_inner() rather
+                            // than panic; the signal thread only does a trivial enum write.
                             *connection_state_for_signal
                                 .lock()
                                 .unwrap_or_else(|p| p.into_inner()) = our_state;

--- a/crates/presenter-ndi/src/pipeline.rs
+++ b/crates/presenter-ndi/src/pipeline.rs
@@ -317,40 +317,41 @@ impl NdiPipeline {
         let bus = pipeline
             .bus()
             .ok_or_else(|| anyhow!("pipeline has no bus"))?;
-        *self.bus_watch.lock().unwrap() = Some(tokio::spawn(async move {
-            let mut stream = bus.stream();
-            use futures_util::StreamExt;
-            while let Some(msg) = stream.next().await {
-                match msg.view() {
-                    gst::MessageView::StateChanged(sc)
-                        if sc.src() == Some(&pipeline_obj)
-                            && sc.current() == gst::State::Playing =>
-                    {
-                        let _ = state_tx.send(PipelineState::Streaming);
+        *self.bus_watch.lock().unwrap_or_else(|p| p.into_inner()) =
+            Some(tokio::spawn(async move {
+                let mut stream = bus.stream();
+                use futures_util::StreamExt;
+                while let Some(msg) = stream.next().await {
+                    match msg.view() {
+                        gst::MessageView::StateChanged(sc)
+                            if sc.src() == Some(&pipeline_obj)
+                                && sc.current() == gst::State::Playing =>
+                        {
+                            let _ = state_tx.send(PipelineState::Streaming);
+                        }
+                        gst::MessageView::AsyncDone(_) => {
+                            // Harmless duplicate for live pipelines (the
+                            // StateChanged branch above already fired); load-bearing
+                            // for non-live test cases like videotestsrc.
+                            let _ = state_tx.send(PipelineState::Streaming);
+                        }
+                        gst::MessageView::Error(err) => {
+                            let detail = format!(
+                                "{}: {}",
+                                err.error(),
+                                err.debug().unwrap_or_default().as_str()
+                            );
+                            tracing::error!(error = %detail, "pipeline error");
+                            let _ = state_tx.send(PipelineState::Errored(detail));
+                        }
+                        gst::MessageView::Eos(_) => {
+                            tracing::warn!("pipeline EOS received → state=Stopped");
+                            let _ = state_tx.send(PipelineState::Stopped);
+                        }
+                        _ => {}
                     }
-                    gst::MessageView::AsyncDone(_) => {
-                        // Harmless duplicate for live pipelines (the
-                        // StateChanged branch above already fired); load-bearing
-                        // for non-live test cases like videotestsrc.
-                        let _ = state_tx.send(PipelineState::Streaming);
-                    }
-                    gst::MessageView::Error(err) => {
-                        let detail = format!(
-                            "{}: {}",
-                            err.error(),
-                            err.debug().unwrap_or_default().as_str()
-                        );
-                        tracing::error!(error = %detail, "pipeline error");
-                        let _ = state_tx.send(PipelineState::Errored(detail));
-                    }
-                    gst::MessageView::Eos(_) => {
-                        tracing::warn!("pipeline EOS received → state=Stopped");
-                        let _ = state_tx.send(PipelineState::Stopped);
-                    }
-                    _ => {}
                 }
-            }
-        }));
+            }));
 
         pipeline
             .set_state(gst::State::Playing)
@@ -391,7 +392,12 @@ impl NdiPipeline {
             );
         }
         let _ = self.pipeline.set_state(gst::State::Null);
-        if let Some(h) = self.bus_watch.lock().unwrap().take() {
+        if let Some(h) = self
+            .bus_watch
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+        {
             h.abort();
         }
     }
@@ -566,7 +572,9 @@ impl NdiPipeline {
                             // std::sync::Mutex — safe to lock from any thread, no async runtime
                             // required. Panic on poison is acceptable; the signal thread holds
                             // the lock for a trivial enum write.
-                            *connection_state_for_signal.lock().unwrap() = our_state;
+                            *connection_state_for_signal
+                                .lock()
+                                .unwrap_or_else(|p| p.into_inner()) = our_state;
                             tracing::debug!(
                                 session_id = %session_id_for_signal,
                                 state = ?our_state,
@@ -777,7 +785,10 @@ impl NdiPipeline {
             sessions
                 .iter()
                 .map(|(id, session)| {
-                    let connection_state = *session.connection_state.lock().unwrap();
+                    let connection_state = *session
+                        .connection_state
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
                     SessionSnapshot {
                         id: id.clone(),
                         connection_state,

--- a/crates/presenter-server/src/ai/bible_validator.rs
+++ b/crates/presenter-server/src/ai/bible_validator.rs
@@ -141,19 +141,16 @@ impl ValidationError {
 // - `( \([A-Z]+\))?` — optional translation code in parens.
 // - `$` — anchored.
 //
-// The `expect()` below can only trigger at first use of the static if
-// this literal regex is malformed — that is a programmer bug which the
-// unit tests in this module catch immediately. It is unreachable in
-// production because the pattern is a compile-time constant.
-static REFERENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[\p{L}0-9\. ]+ \d+:\d+[a-z]?(-\d+[a-z]?)?( \([A-Z]+\))?$")
-        .expect("REFERENCE_RE literal must compile")
-});
+// `Regex::new(...).ok()` yields `None` only if this literal regex is
+// malformed — a programmer bug which the unit tests in this module catch
+// immediately (callers fail closed on `None`). It is effectively
+// unreachable in production because the pattern is a compile-time constant.
+static REFERENCE_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"^[\p{L}0-9\. ]+ \d+:\d+[a-z]?(-\d+[a-z]?)?( \([A-Z]+\))?$").ok());
 
 // Rule 2 regex: multi-line mode, match any line starting with "N. ".
-// Same `expect()` rationale as `REFERENCE_RE` above.
-static VERSE_PREFIX_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^\d+\. ").expect("VERSE_PREFIX_RE literal must compile"));
+// Same fallible-init rationale as `REFERENCE_RE` above.
+static VERSE_PREFIX_RE: LazyLock<Option<Regex>> = LazyLock::new(|| Regex::new(r"(?m)^\d+\. ").ok());
 
 /// Validate a single bible slide's `main` and `main_reference` strings.
 ///
@@ -209,16 +206,20 @@ pub fn validate_bible_slide(
         return Ok(());
     }
 
-    // Verse slide — rule 1 (reference format).
-    if !REFERENCE_RE.is_match(main_reference) {
+    // Verse slide — rule 1 (reference format). If the regex literal failed to
+    // compile (programmer bug, caught by this module's tests), fail closed.
+    if !REFERENCE_RE
+        .as_ref()
+        .is_some_and(|re| re.is_match(main_reference))
+    {
         return Err(ValidationError::new(
             ValidationRule::ReferenceFormatRequiresParens,
             main_reference.to_string(),
         ));
     }
 
-    // Rule 2 (verse number prefix).
-    if !VERSE_PREFIX_RE.is_match(main) {
+    // Rule 2 (verse number prefix). Fail closed if the regex is unavailable.
+    if !VERSE_PREFIX_RE.as_ref().is_some_and(|re| re.is_match(main)) {
         return Err(ValidationError::new(
             ValidationRule::MissingVerseNumberPrefix,
             main.to_string(),

--- a/crates/presenter-server/src/ai/proxy.rs
+++ b/crates/presenter-server/src/ai/proxy.rs
@@ -84,7 +84,7 @@ impl ProxyManager {
         }
     }
 
-    fn binary_path(&self) -> Option<PathBuf> {
+    async fn binary_path(&self) -> Option<PathBuf> {
         let deploy_path = self.deploy_dir.join(PROXY_BINARY_NAME);
         if deploy_path.exists() {
             return Some(deploy_path);
@@ -95,10 +95,9 @@ impl ProxyManager {
             return Some(cwd_path);
         }
 
-        if let Ok(output) = std::process::Command::new("which")
-            .arg(PROXY_BINARY_NAME)
-            .output()
-        {
+        // `Command` is `tokio::process::Command` (see imports); `.output().await`
+        // offloads the `which` lookup instead of blocking the runtime thread.
+        if let Ok(output) = Command::new("which").arg(PROXY_BINARY_NAME).output().await {
             if output.status.success() {
                 let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 if !path.is_empty() {
@@ -119,21 +118,22 @@ impl ProxyManager {
     }
 
     /// Check if Claude credentials exist (either OAuth tokens or API key in config).
-    pub fn is_claude_authenticated(&self) -> bool {
-        if let Ok(content) = std::fs::read_to_string(self.config_path()) {
+    pub async fn is_claude_authenticated(&self) -> bool {
+        if let Ok(content) = tokio::fs::read_to_string(self.config_path()).await {
             if content.contains("claude-api-key:") {
                 return true;
             }
         }
         let auth_dir = self.auth_dir();
-        auth_dir.exists()
-            && std::fs::read_dir(&auth_dir)
-                .map(|entries| {
-                    entries
-                        .filter_map(|e| e.ok())
-                        .any(|e| e.file_name().to_string_lossy().contains("claude"))
-                })
-                .unwrap_or(false)
+        let Ok(mut entries) = tokio::fs::read_dir(&auth_dir).await else {
+            return false;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if entry.file_name().to_string_lossy().contains("claude") {
+                return true;
+            }
+        }
+        false
     }
 
     /// Write the config YAML file for CLIProxyAPI.
@@ -181,6 +181,7 @@ request-retry: 2
 
         let binary = self
             .binary_path()
+            .await
             .ok_or_else(|| anyhow::anyhow!("CLIProxyAPI binary not found"))?;
 
         let existing_key = self.read_existing_api_key().await;
@@ -247,8 +248,8 @@ request-retry: 2
             running: self.is_running().await,
             port,
             api_url: format!("http://127.0.0.1:{port}/v1"),
-            binary_found: self.binary_path().is_some(),
-            claude_authenticated: self.is_claude_authenticated(),
+            binary_found: self.binary_path().await.is_some(),
+            claude_authenticated: self.is_claude_authenticated().await,
         }
     }
 
@@ -289,6 +290,7 @@ request-retry: 2
 
         let binary = self
             .binary_path()
+            .await
             .ok_or_else(|| anyhow::anyhow!("CLIProxyAPI binary not found"))?;
 
         let existing_key = self.read_existing_api_key().await;
@@ -439,7 +441,7 @@ request-retry: 2
         let should_start = config.auto_start;
         drop(config);
 
-        if should_start && self.binary_path().is_some() {
+        if should_start && self.binary_path().await.is_some() {
             if let Err(e) = self.start().await {
                 warn!(?e, "failed to auto-start CLIProxyAPI");
             }

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -334,8 +334,8 @@ pub async fn execute_tool(
         "load_bible_verses" => {
             let translation = str_field(&args, "translation")?;
             let book = str_field(&args, "book")?;
-            let chapter = args["chapter"].as_u64().unwrap_or(1) as u16;
-            let verse_start = args["verse_start"].as_u64().unwrap_or(1) as u16;
+            let chapter = u64_field(&args, "chapter")? as u16;
+            let verse_start = u64_field(&args, "verse_start")? as u16;
             let verse_end = args["verse_end"].as_u64().unwrap_or(verse_start as u64) as u16;
 
             // Resolve the translation to get its short code for reference labels.
@@ -438,8 +438,8 @@ pub async fn execute_tool(
         "resolve_bible_slides" => {
             let translation = str_field(&args, "translation")?;
             let book = str_field(&args, "book")?;
-            let chapter = args["chapter"].as_u64().unwrap_or(1) as u16;
-            let verse_start = args["verse_start"].as_u64().unwrap_or(1) as u16;
+            let chapter = u64_field(&args, "chapter")? as u16;
+            let verse_start = u64_field(&args, "verse_start")? as u16;
             let verse_end = args["verse_end"].as_u64().unwrap_or(verse_start as u64) as u16;
             let char_limit = args["character_limit"]
                 .as_u64()
@@ -501,8 +501,8 @@ pub async fn execute_tool(
         "trigger_bible_verse" => {
             let translation = str_field(&args, "translation")?;
             let book = str_field(&args, "book")?;
-            let chapter = args["chapter"].as_u64().unwrap_or(1) as u16;
-            let verse_start = args["verse_start"].as_u64().unwrap_or(1) as u16;
+            let chapter = u64_field(&args, "chapter")? as u16;
+            let verse_start = u64_field(&args, "verse_start")? as u16;
             let verse_end = args["verse_end"]
                 .as_u64()
                 .map(|v| v as u16)

--- a/crates/presenter-server/src/ai/tools.rs
+++ b/crates/presenter-server/src/ai/tools.rs
@@ -186,11 +186,13 @@ pub async fn execute_tool(
 
         "add_slide" => {
             let pres_id = PresentationId::from_uuid(uuid_field(&args, "presentation_id")?);
+            // Validate the required `main` field before mutating the
+            // presentation, so a malformed call doesn't leave a blank slide.
+            let main = str_field(&args, "main")?;
             let position = args["position"].as_u64().map(|p| p as u32);
             let slides = state.insert_blank_slide(pres_id, position).await?;
             // Update the last inserted slide with content
             if let Some(slide) = slides.last() {
-                let main = args["main"].as_str().unwrap_or("").to_string();
                 let translation = args["translation"].as_str().unwrap_or("").to_string();
                 let stage = args["stage"].as_str().unwrap_or("").to_string();
                 let group = args["group"].as_str().map(String::from);
@@ -208,7 +210,7 @@ pub async fn execute_tool(
         "update_slide" => {
             let pres_id = PresentationId::from_uuid(uuid_field(&args, "presentation_id")?);
             let slide_id = SlideId::from_uuid(uuid_field(&args, "slide_id")?);
-            let main = args["main"].as_str().unwrap_or("").to_string();
+            let main = str_field(&args, "main")?;
             let translation = args["translation"].as_str().unwrap_or("").to_string();
             let stage = args["stage"].as_str().unwrap_or("").to_string();
             let group = args["group"].as_str().map(String::from);
@@ -271,8 +273,8 @@ pub async fn execute_tool(
         "get_bible_passage" => {
             let translation = str_field(&args, "translation")?;
             let book = str_field(&args, "book")?;
-            let chapter = args["chapter"].as_u64().unwrap_or(1) as u16;
-            let verse_start = args["verse_start"].as_u64().unwrap_or(1) as u16;
+            let chapter = u64_field(&args, "chapter")? as u16;
+            let verse_start = u64_field(&args, "verse_start")? as u16;
             let verse_end = args["verse_end"]
                 .as_u64()
                 .map(|v| v as u16)
@@ -777,10 +779,41 @@ fn uuid_field(args: &Value, field: &str) -> anyhow::Result<Uuid> {
     Uuid::parse_str(&s).map_err(|_| anyhow::anyhow!("{field} must be a valid UUID"))
 }
 
+/// Extract a required integer field. Errors (rather than silently defaulting)
+/// when the field is absent or not an unsigned integer, so the model gets
+/// explicit feedback and can self-correct on retry.
+fn u64_field(args: &Value, field: &str) -> anyhow::Result<u64> {
+    args[field]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("missing or invalid required integer field: {field}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::state::AppState;
+
+    #[tokio::test]
+    async fn add_slide_rejects_missing_required_main() {
+        let state = AppState::in_memory().await.unwrap();
+        let args = json!({ "presentation_id": Uuid::new_v4().to_string() }).to_string();
+        let result = execute_tool("add_slide", &args, &state, 320).await;
+        assert!(
+            result.is_err(),
+            "add_slide without required 'main' must error, not silently default"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bible_passage_rejects_missing_required_chapter() {
+        let state = AppState::in_memory().await.unwrap();
+        let args = json!({ "translation": "slk-seb", "book": "Ján", "verse_start": 1 }).to_string();
+        let result = execute_tool("get_bible_passage", &args, &state, 320).await;
+        assert!(
+            result.is_err(),
+            "get_bible_passage without required 'chapter' must error, not default to 1"
+        );
+    }
 
     #[tokio::test]
     async fn create_presentation_in_non_bible_library_has_no_metadata() {

--- a/crates/presenter-server/src/router/network_mode.rs
+++ b/crates/presenter-server/src/router/network_mode.rs
@@ -15,7 +15,7 @@ use crate::state::AppState;
 ///   so client is on the church LAN just using the tunnel URL → `local`.
 /// - Otherwise, if `local_public_ip` is set → `remote`.
 /// - Otherwise (no configured IP) → fall back to `is_private_ip` on the client IP.
-pub fn detect_network_mode(headers: &HeaderMap, local_public_ip: Option<&str>) -> &'static str {
+fn detect_network_mode(headers: &HeaderMap, local_public_ip: Option<&str>) -> &'static str {
     let client_ip = headers
         .get("cf-connecting-ip")
         .or_else(|| headers.get("x-forwarded-for"))
@@ -33,7 +33,7 @@ pub fn detect_network_mode(headers: &HeaderMap, local_public_ip: Option<&str>) -
 }
 
 /// Return true for IPs in private/loopback/link-local ranges.
-pub fn is_private_ip(ip: &str) -> bool {
+fn is_private_ip(ip: &str) -> bool {
     ip.parse::<std::net::IpAddr>().is_ok_and(|addr| match addr {
         std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local(),
         std::net::IpAddr::V6(v6) => v6.is_loopback(),

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -827,10 +827,7 @@ impl AppState {
     }
 
     async fn build_api_stage_snapshot(&self, state: &ApiStageState) -> StageDisplaySnapshot {
-        let layout = StageDisplayLayout::built_in()
-            .into_iter()
-            .find(|l| l.code == "api")
-            .expect("api layout must exist in built_in");
+        let layout = StageDisplayLayout::api();
 
         let current = self
             .build_api_slide(&state.current_text, &state.current_group)


### PR DESCRIPTION
Bundles five verified findings from the `arch-review: opus-4.8 2026-05-31` milestone (`/architecture-check`). All are low-risk hardening/refactors; no user-facing behavior change except stricter validation of malformed AI tool calls.

## Changes

- **Closes #349** — `fix(ai)`: validate required AI tool-call arguments instead of silently defaulting. `add_slide`/`update_slide` `main` and `get_bible_passage` `chapter`/`verse_start` now error explicitly (so the model can self-correct) rather than defaulting to `""`/`1`. Adds a `u64_field` helper and 2 regression tests.
- **Closes #350** — `refactor(ndi,ai)`: remove banned `unwrap()`/`expect()` from production. NDI pipeline `std::sync::Mutex` access is poison-tolerant (`unwrap_or_else(|p| p.into_inner())`); bible-validator regexes are `LazyLock<Option<Regex>>` (fail-closed); the API stage layout uses a new infallible `StageDisplayLayout::api()` instead of `.expect()`.
- **Closes #355** — `refactor(network)`: make `detect_network_mode`/`is_private_ip` private (internal-only helpers).
- **Closes #358** — `refactor(ai)`: `binary_path`/`is_claude_authenticated` are now `async` using `tokio::process`/`tokio::fs`, so they no longer block the runtime thread.
- **Closes #359** — `refactor(bible)`: `BibleContentProvider` uses native `-> impl Future + Send` (RPITIT); `#[async_trait]` removed and the `async-trait` dep dropped from `presenter-bible`.

## Verification

- `cargo fmt` clean · `cargo clippy --workspace --all-targets --all-features -D warnings` rc=0
- `cargo test` — **248 passed, 0 failed** (incl. new `add_slide_rejects_missing_required_main`, `get_bible_passage_rejects_missing_required_chapter`)
- CI pipeline green end-to-end (build, coverage, mutation, E2E ×3, deploy-dev)
- Deploy verified: dev `/healthz` and operator UI footer both show `v0.4.98 (dev)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
