### PR TITLE
fix(favicon): serve /favicon.ico to stop 404 console error on every route (#361)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "axum",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.98"
+version = "0.4.99"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -138,6 +138,8 @@ pub fn build_router(state: AppState) -> Router {
             get(tablet_pwa::apple_touch_icon),
         )
         .route("/ui/tablet/sw.js", get(tablet_pwa::service_worker))
+        // App-wide favicon — browsers auto-request /favicon.ico on every route
+        .route("/favicon.ico", get(tablet_pwa::favicon))
         .route(
             "/ui/bible",
             get(|| async { axum::response::Redirect::permanent("/ui/operator/bible") }),

--- a/crates/presenter-server/src/router/tablet_pwa.rs
+++ b/crates/presenter-server/src/router/tablet_pwa.rs
@@ -46,3 +46,19 @@ pub async fn service_worker() -> impl IntoResponse {
         SERVICE_WORKER,
     )
 }
+
+/// Serve `/favicon.ico` for every route.
+///
+/// Browsers automatically request `/favicon.ico` regardless of any `<link rel="icon">`,
+/// so without this handler every page (operator, tablet, stage, bible…) logged a 404
+/// console error. We reuse the embedded 192px app icon (served as PNG, which all modern
+/// browsers accept for a favicon) rather than shipping a separate `.ico` binary.
+pub async fn favicon() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "image/png"),
+            (header::CACHE_CONTROL, "public, max-age=86400"),
+        ],
+        ICON_192,
+    )
+}

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -206,6 +206,46 @@ async fn home_route_links_match_live_routes() {
 }
 
 #[tokio::test]
+async fn favicon_is_served_so_no_404_console_error() {
+    // Regression for #361: browsers auto-request /favicon.ico on every route.
+    // Without a handler this returned 404, logging a console error on every page
+    // and masking real console errors. Assert a real image is served instead.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/favicon.ico")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/favicon.ico must return 200 (was {}) — a 404 logs a browser console error on every route",
+        response.status()
+    );
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.starts_with("image/"),
+        "/favicon.ico must be served as an image (was {content_type:?})"
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert!(
+        !bytes.is_empty(),
+        "/favicon.ico must return a non-empty icon body"
+    );
+}
+
+#[tokio::test]
 async fn settings_page_has_no_dead_links() {
     let app = build_router(AppState::in_memory().await.unwrap());
     let response = app

--- a/tests/e2e/favicon.spec.ts
+++ b/tests/e2e/favicon.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Favicon E2E (#361).
+ *
+ * Browsers automatically request `/favicon.ico` on every navigation. Before the
+ * fix this returned 404, logging a console error on every page (operator,
+ * tablet, stage, bible, landing) — which also masked any *real* console error a
+ * reviewer would otherwise notice.
+ *
+ * This test loads the plain landing page (no WASM, so no benign Chromium WASM
+ * warnings to filter) and asserts:
+ *   1. `/favicon.ico` responds 200 with an image content-type.
+ *   2. Zero browser console errors/warnings on the route — locking in the
+ *      "zero console errors" invariant per ci/browser-console-zero-errors.md.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  attachConsoleErrorCollector,
+  deriveTestConfig,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+});
+
+test("favicon.ico is served (no 404) and the landing page console is clean", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  attachConsoleErrorCollector(page, consoleErrors);
+
+  // The favicon request fires automatically as part of loading the document.
+  await page.goto(`${baseURL}/`, { waitUntil: "networkidle" });
+
+  // Directly assert the favicon route is healthy.
+  const faviconResponse = await page.request.get(`${baseURL}/favicon.ico`);
+  expect(faviconResponse.status()).toBe(200);
+  expect(faviconResponse.headers()["content-type"] ?? "").toMatch(/^image\//);
+
+  // No favicon 404 (or anything else) in the console.
+  expect(consoleErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Browsers automatically request `/favicon.ico` on every navigation. The server had no handler, so every page (operator, tablet, stage, bible, landing) logged a **404 console error** — violating the "zero console errors" standard and masking any real console error a reviewer would otherwise notice.

## Fix

- Add a top-level `/favicon.ico` route serving the embedded 192px app icon as PNG (all modern browsers accept a PNG favicon), with `Cache-Control: public, max-age=86400`.
- One route fixes **every** page since browsers default-request `/favicon.ico` regardless of any `<link rel="icon">`.
- Reuses the existing embedded icon — no new binary asset.

## Tests (RED → GREEN)

- `test(favicon)` commit `37bf3fd` — RED: route test returns 404 without the handler.
- `fix(favicon)` commit `df9dd22` — GREEN: route test passes.
- Rust: `router::tests::favicon_is_served_so_no_404_console_error` (200 + image content-type + non-empty body).
- Playwright: `tests/e2e/favicon.spec.ts` — asserts `/favicon.ico` 200 and a clean landing-page console.

## Verified on dev (v0.4.99)

- `/favicon.ico` → 200 image/png (648 bytes)
- Landing page console: 0 errors / 0 warnings
- Operator console: 0 errors; footer shows `v0.4.99 (dev)`

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)