### PR TITLE
fix(ndi): post-merge review fixes — 30s reaper, drop diagnostic leftovers, stale docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.130"
+version = "0.4.131"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/manager/supervisor.rs
+++ b/crates/presenter-ndi/src/manager/supervisor.rs
@@ -13,10 +13,11 @@ use crate::pipeline::NdiPipeline;
 use super::{check_active_entry, NdiManager, StateCheckOutcome};
 
 /// #388 periodic RTCP-liveness sweep cadence: how often each source's
-/// supervisor reaps zombie sessions. 30s matches the issue spec — frequent
-/// enough that a freed slot is visible within half a minute, infrequent enough
-/// that the per-session get-stats reads cost nothing measurable.
-const PERIODIC_REAP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3600);
+/// supervisor reaps zombie sessions. ~30s matches the issue spec — frequent
+/// enough that a vanished consumer's slot is freed within half a minute,
+/// infrequent enough that the per-session get-stats reads cost nothing
+/// measurable.
+const PERIODIC_REAP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// #388 periodic stale window: a session whose webrtcbin transport has received
 /// no new bytes for longer than this is reaped by the periodic sweep. 60s — the

--- a/crates/presenter-server/src/router/integrations/ndi.rs
+++ b/crates/presenter-server/src/router/integrations/ndi.rs
@@ -38,11 +38,11 @@ pub(crate) async fn ndi_status(State(state): State<AppState>) -> Json<serde_json
 ///
 /// Returns JSON (camelCase) with `encoderCount`, `consumerCount`, and a
 /// per-session `sessions` array. Used by the Playwright fanout E2E test
-/// to assert `encoderCount=2` (one encoder per PROFILE — 720p default +
-/// 640×480 compat — never per consumer) + `consumerCount=2` when two
-/// browser tabs are connected to the same NDI source, and as an operator/
-/// incident-debugging tool for checking pipeline health without tailing
-/// logs.
+/// to assert `encoderCount=1` (one shared encoder — the single 720p H264
+/// stream every consumer shares, never one per consumer) + `consumerCount=2`
+/// when two browser tabs are connected to the same NDI source, and as an
+/// operator/incident-debugging tool for checking pipeline health without
+/// tailing logs.
 ///
 /// 404 — source is not currently active (no pipeline exists for this id).
 /// 503 — NDI SDK not available on this host.
@@ -70,12 +70,13 @@ pub(crate) struct NdiClientStatsBeacon {
     /// Persistent random per-display id (localStorage `ndiDisplayId`) — the
     /// attribution key that makes per-TV health traceable across sessions.
     pub display_id: Option<String>,
-    /// Negotiated video codec mimeType from getStats (now "video/H264" for
-    /// every consumer — both stream profiles are H264).
+    /// Negotiated video codec mimeType from getStats ("video/H264" for every
+    /// consumer — there is a single shared 720p H264 stream).
     pub codec: Option<String>,
-    /// Stream profile the display requested ("default"/"compat") — the
-    /// field that attributes weak-TV health to the 640×480 compat branch,
-    /// since `codec` no longer distinguishes the branches.
+    /// Stream profile the display requested ("default"/"compat"). The server
+    /// always serves the single shared 720p H264 stream regardless of this
+    /// value (see `StreamProfile::from_query`); it is logged only to record
+    /// which mode a display's WASM watchdog was in when it reported health.
     pub profile: Option<String>,
     /// Physical screen size as "WxH" — tells TV models apart in the logs.
     pub screen: Option<String>,

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -16,11 +16,9 @@ use tracing::instrument;
 use super::super::AppError;
 use crate::state::AppState;
 
-/// Query parameters on the WHEP POST. `?profile=compat` selects the 854×480
-/// realtime-VP8 compat encode branch (weak TVs whose H264 OMX decoder is
-/// vendor-broken; they software-decode token-partitioned VP8); absent or any
-/// other value selects the default 720p H264 branch — see
-/// `StreamProfile::from_query`.
+/// Query parameters on the WHEP POST. `?profile=` is parsed but always resolves
+/// to the single shared 720p H264 stream (see `StreamProfile::from_query`); the
+/// value is accepted for backward-compat and never changes the codec.
 #[derive(Debug, Default, serde::Deserialize)]
 pub(crate) struct WhepPostQuery {
     profile: Option<String>,
@@ -249,9 +247,9 @@ mod tests {
     }
 
     /// `?profile=compat` must not change the error contract for an inactive
-    /// source: the query is parsed (compat selects the realtime-VP8 854×480
-    /// branch once the source streams) but an inactive source still yields
-    /// the same 404/503 path as a default-profile POST.
+    /// source: the query is parsed but always resolves to the single shared
+    /// 720p H264 stream (see `StreamProfile::from_query`), so an inactive
+    /// source still yields the same 404/503 path as a bare-profile POST.
     #[tokio::test]
     async fn post_whep_endpoint_with_compat_profile_keeps_inactive_source_contract() {
         let state = fresh_state().await;

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -81,17 +81,7 @@ impl AppState {
     }
 
     pub(super) async fn sync_resolume_hosts(&self) -> anyhow::Result<()> {
-        // PRESENTER_DISABLE_RESOLUME: load ZERO hosts so no worker is spawned.
-        // The Resolume control integration is independent of NDI video; when its
-        // hosts are unreachable it hammers them (10s mapping refresh + per-command
-        // HTTP), flooding errors and spiking CPU — escape hatch to rule that out
-        // / run cleanly where Resolume is absent. Config in the DB is untouched.
-        let hosts = if std::env::var("PRESENTER_DISABLE_RESOLUME").is_ok() {
-            tracing::warn!("PRESENTER_DISABLE_RESOLUME=1 → Resolume integration disabled (no host workers spawned)");
-            Vec::new()
-        } else {
-            self.repository.list_resolume_hosts().await?
-        };
+        let hosts = self.repository.list_resolume_hosts().await?;
         self.resolume_registry.set_hosts(hosts).await;
         Ok(())
     }

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -32,10 +32,12 @@ struct WhepSession {
 }
 
 /// Build the WHEP endpoint URL for a given source. In compat mode the URL
-/// carries `?profile=compat`, asking the server for its 640×480 H264 branch
-/// (the stream the weak TVs' OMX decoder can play without the fatal port
-/// reconfig — spec addendum 2 pivot); default mode posts the bare URL and
-/// gets the 720p stream.
+/// carries `?profile=compat`; otherwise it posts the bare URL. NOTE: the
+/// server now serves ONE 720p H264 stream regardless of `?profile=` (see
+/// `StreamProfile::from_query`), so the profile value itself is a no-op
+/// server-side. The compat flip is retained ONLY because changing the URL
+/// triggers a reconnect, and that reconnect re-establishes a stuck session
+/// (see `ndi_watchdog`).
 pub fn whep_url(source_id: &str, compat: bool) -> String {
     if compat {
         format!("/ndi/whep/{source_id}?profile=compat")

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -15,11 +15,14 @@ use leptos::web_sys::{HtmlVideoElement, RtcIceConnectionState, RtcPeerConnection
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 /// localStorage key for the stream-profile fallback mode. Absent or
-/// `"default"` = default behavior (WHEP POST without a profile query → the
-/// server serves the 720p stream). `"compat"` = fallback (the WHEP POST URL
-/// carries `?profile=compat`, selecting the server's 640×480 H264 branch —
-/// spec addendum 2 pivot: the Vestel TVs' OMX decoder default-inits at
-/// 640×480 and dies on the port reconfig any other size forces).
+/// `"default"` = WHEP POST without a profile query; `"compat"` = the WHEP
+/// POST URL carries `?profile=compat`.
+///
+/// NOTE: the server now serves ONE 720p H264 stream regardless of
+/// `?profile=` (see `StreamProfile::from_query`), so the compat flip is a
+/// no-op server-side — it does NOT switch to any 640×480 / VP8 branch (that
+/// branch never shipped). The flip is retained ONLY because changing the URL
+/// forces a reconnect, and that reconnect re-establishes a stuck session.
 ///
 /// The KEY deliberately keeps its historical name ("ndiCodecMode") so
 /// deployed TVs don't grow a second orphaned entry; the retired "vp8" value
@@ -671,8 +674,10 @@ async fn post_client_stats(
         "displayId": display_id(),
         "codec": codec,
         // Which stream profile this display requested ("default"/"compat").
-        // codec now reads video/H264 everywhere, so this is the field that
-        // attributes weak-TV health to the 640×480 compat branch.
+        // The server serves ONE 720p H264 stream regardless of this value
+        // (see `StreamProfile::from_query`); it is reported only to record
+        // which watchdog mode the display was in when it sent this beacon —
+        // there is no 640×480 / VP8 branch.
         "profile": profile_mode_name(profile_mode_is_compat()),
         "screen": screen,
         "framesDecoded": frames_decoded.as_f64(),

--- a/crates/presenter-ui/src/utils/autofit.rs
+++ b/crates/presenter-ui/src/utils/autofit.rs
@@ -44,6 +44,12 @@ pub fn autofit_effect<T: 'static>(
 /// removes the per-second reflow while still re-fitting on real content changes
 /// (`CONNECTED`→`CONNECTING…`, a different-length song number). This must NOT be
 /// used for proportional text (lyrics) — there, same length ≠ same width.
+///
+/// COUPLING: the "equal char-length ⇒ equal width" optimization REQUIRES the
+/// status-bar texts to render in a tabular/monospace face. `stage.css` supplies
+/// `font-variant-numeric: tabular-nums` on `.stage__clock`, `.stage__song-number`
+/// and `.stage__connection`; dropping that CSS would silently break this autofit
+/// (proportional digits → unequal width at equal length → clipped text).
 pub fn autofit_effect_tabular(
     node_ref: NodeRef<leptos::html::Div>,
     max_font: f64,


### PR DESCRIPTION
Deep-review (PR #390) follow-up — all findings were in-diff, so fixed here:

- **🟡 Reaper regression** — `PERIODIC_REAP_INTERVAL` reverted 3600s → **30s**. A hitch-hunt experiment (84a8f68) had disabled the #388 RTCP-liveness sweep on a hypothesis that proved wrong (the 20s hitch was the system WebView); a vanished TV's consumer slot was held up to 1h instead of 30s.
- **🟡 Diagnostic leftover** — removed the `PRESENTER_DISABLE_RESOLUME` env flag (a29d701); restored unconditional Resolume host loading.
- **🟡 Stale server docs** — `ndi_whep.rs` + `ndi.rs` described a `?profile=compat → VP8 854×480` branch that no longer exists; now state `?profile=` is parsed but always resolves to the single shared 720p H264 stream (`encoderCount=1`).
- **🔵 Stale WASM docs** — `ndi_video.rs`/`ndi_watchdog.rs` referenced a "640×480 H264 compat branch" that never shipped; the compat flip is a server-side no-op, retained only for its reconnect side-effect.
- **🔵 autofit coupling note** — documented that `autofit_effect_tabular`'s length-gate depends on the `tabular-nums` CSS.

fmt/build/test/clippy green. `StreamProfile` single-variant forward-compat seam intentionally kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)