### PR TITLE
test(ci): add function-length gate self-test (regression guard for abs/rel no-op) — closes #374

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -298,7 +298,13 @@ jobs:
         working-directory: crates/presenter-ui
 
       - name: Run CI shell tests
-        run: bash tests/ci/check-dev-libraries.test.sh
+        run: |
+          bash tests/ci/check-dev-libraries.test.sh
+          # Regression guard for #374: the function-length gate was a silent
+          # no-op in scoped CI runs (abs vs. relative path comparison). This
+          # self-test proves the gate FIRES on a relative-path over-cap fixture
+          # and FAILS if the abs/rel bug is reintroduced.
+          bash tests/ci/fn-length-gate.test.sh
 
   # ============================================
   # Mutation Testing
@@ -404,13 +410,6 @@ jobs:
         with:
           shared-key: ci
           cache-on-failure: false
-
-      # Regression guard for #374: the function-length gate was a silent no-op
-      # in scoped CI runs (abs vs. relative path comparison). This self-test
-      # proves the gate FIRES on a relative-path over-cap fixture and FAILS if
-      # the abs/rel bug is reintroduced. Must pass before the gate runs.
-      - name: Self-test function-length gate (regression guard for #374)
-        run: ./scripts/ci/test-fn-length-gate.sh
 
       - name: Run quality checks
         run: ./scripts/dev/quality-check.sh --strict --against origin/${{ github.base_ref || 'main' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -405,6 +405,13 @@ jobs:
           shared-key: ci
           cache-on-failure: false
 
+      # Regression guard for #374: the function-length gate was a silent no-op
+      # in scoped CI runs (abs vs. relative path comparison). This self-test
+      # proves the gate FIRES on a relative-path over-cap fixture and FAILS if
+      # the abs/rel bug is reintroduced. Must pass before the gate runs.
+      - name: Self-test function-length gate (regression guard for #374)
+        run: ./scripts/ci/test-fn-length-gate.sh
+
       - name: Run quality checks
         run: ./scripts/dev/quality-check.sh --strict --against origin/${{ github.base_ref || 'main' }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.131"
+version = "0.4.132"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.131"
+version = "0.4.132"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/scripts/ci/test-fn-length-gate.sh
+++ b/scripts/ci/test-fn-length-gate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Self-test / regression guard for the function-length CI gate (#374).
+#
+# The function-length gate (quality-check.sh section 7 -> scripts/dev/
+# fn_length_check.py) was a SILENT NO-OP in every scoped CI run because it
+# compared os.walk's ABSOLUTE paths against `git diff --name-only`'s RELATIVE
+# targets — the filter `continue`d on every file, so the >120 hard-fail never
+# fired. The bug was fixed in 5f5fe9f (compare `os.path.relpath(path, root)`),
+# but there was NO test that would catch it if the abs/rel comparison silently
+# regressed again. This script IS that test.
+#
+# What it proves:
+#   1. GREEN  — the real, current checker FIRES (>=1 violation) when given a
+#      RELATIVE-path target containing an over-cap (>120 line) function — the
+#      exact way CI scopes the gate via `git diff --name-only`.
+#   2. RED    — a copy of the checker with the abs/rel bug REINTRODUCED reports
+#      ZERO violations on that same relative-path fixture (a silent no-op). This
+#      pins the FIX, not just current behavior: if someone reverts to the
+#      absolute-path comparison, assertion (1) breaks.
+#   3. Sanity — the real checker no-ops on an ABSOLUTE-path target (confirming
+#      relative comparison is what makes scoping work) and still fires unscoped.
+#
+# Runs in CI as a standalone step (no cargo, no Rust build) — fast and binary.
+# Exits 0 only when all assertions pass.
+# ============================================================================
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="$ROOT_DIR/scripts/dev/fn_length_check.py"
+
+if [[ ! -f "$CHECKER" ]]; then
+  echo "::error::fn-length gate self-test: checker not found at $CHECKER" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+
+ok()   { echo "  PASS: $*"; pass_count=$((pass_count + 1)); }
+bad()  { echo "::error::fn-length gate self-test FAILED: $*" >&2; fail_count=$((fail_count + 1)); }
+
+# --- Build a self-contained fixture mini-repo --------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FIXTURE_REL="crates/qc_self_test/src/over_cap.rs"
+mkdir -p "$WORK/$(dirname "$FIXTURE_REL")"
+{
+  echo 'pub fn known_over_cap_function() {'
+  # 130 body lines -> total function length is clearly > 120 hard cap
+  for i in $(seq 1 130); do
+    echo "    let _v$i = $i;"
+  done
+  echo '}'
+} > "$WORK/$FIXTURE_REL"
+
+fn_lines="$(wc -l < "$WORK/$FIXTURE_REL")"
+if (( fn_lines <= 120 )); then
+  bad "fixture function is only $fn_lines lines; must exceed the 120-line hard cap"
+  echo "Result: $pass_count passed, $fail_count failed"; exit 1
+fi
+echo "Fixture: $FIXTURE_REL ($fn_lines lines, > 120 hard cap)"
+
+# Count violations for a given checker + QC_TARGETS value.
+# Args: <checker_path> <root> <qc_targets>
+count_violations() {
+  local checker="$1" root="$2" targets="$3"
+  QC_TARGETS="$targets" QC_FN_ADVISORY=0 python3 "$checker" "$root" \
+    | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["violations"]))'
+}
+
+# --- Assertion 1: GREEN — real checker FIRES on a RELATIVE-path target -------
+echo ""
+echo "[1] Real (fixed) checker, RELATIVE target (CI style):"
+rel_violations="$(count_violations "$CHECKER" "$WORK" "$FIXTURE_REL")"
+if (( rel_violations >= 1 )); then
+  ok "gate fired ($rel_violations violation(s)) on relative-path over-cap fixture"
+else
+  bad "gate did NOT fire on relative-path fixture (got $rel_violations violations) — the abs/rel no-op regression is back"
+fi
+
+# --- Assertion 2: RED — reintroduce the abs/rel bug, expect a silent no-op ---
+# Reproduce the OLD buggy logic: compare the ABSOLUTE walk path against the
+# (relative) targets, exactly as before 5f5fe9f. The fixed line is:
+#     if targets and rel not in targets:
+# The buggy line was:
+#     if targets and path not in targets:
+echo ""
+echo "[2] Buggy checker (abs/rel bug reintroduced), RELATIVE target:"
+BUGGY="$WORK/fn_length_check_buggy.py"
+sed 's/if targets and rel not in targets:/if targets and path not in targets:/' "$CHECKER" > "$BUGGY"
+if ! grep -q 'if targets and path not in targets:' "$BUGGY"; then
+  bad "could not reintroduce the abs/rel bug into the checker copy (the fixed line moved?) — update this self-test"
+else
+  buggy_violations="$(count_violations "$BUGGY" "$WORK" "$FIXTURE_REL")"
+  if (( buggy_violations == 0 )); then
+    ok "buggy (absolute-path) logic no-ops as expected ($buggy_violations violations) — the test distinguishes fixed from broken"
+  else
+    bad "buggy logic still reported $buggy_violations violations; the self-test does NOT actually pin the abs/rel fix"
+  fi
+fi
+
+# --- Assertion 3: Sanity — real checker no-ops on an ABSOLUTE target ----------
+echo ""
+echo "[3] Real checker, ABSOLUTE target (must not match -> no-op):"
+abs_violations="$(count_violations "$CHECKER" "$WORK" "$WORK/$FIXTURE_REL")"
+if (( abs_violations == 0 )); then
+  ok "absolute-path target does not match relative scope (correct — confirms relative comparison drives scoping)"
+else
+  bad "absolute-path target unexpectedly matched ($abs_violations violations)"
+fi
+
+# --- Assertion 4: Sanity — unscoped run still finds the fixture ---------------
+echo ""
+echo "[4] Real checker, NO targets (whole-tree scan) finds the fixture:"
+unscoped_violations="$(count_violations "$CHECKER" "$WORK" "")"
+if (( unscoped_violations >= 1 )); then
+  ok "unscoped scan reports the over-cap function ($unscoped_violations violation(s))"
+else
+  bad "unscoped scan missed the over-cap fixture (got $unscoped_violations)"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "Result: $pass_count passed, $fail_count failed"
+if (( fail_count > 0 )); then
+  exit 1
+fi
+echo "fn-length gate self-test: all assertions passed."

--- a/scripts/dev/fn_length_check.py
+++ b/scripts/dev/fn_length_check.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Function-length gate for quality-check.sh section 7.
+
+Walks the `crates/` tree under a given repo root and reports Rust functions
+that exceed the warn (>80) and hard-fail (>120) line caps.
+
+Scoping (the abs/rel regression this file guards against — see #374):
+  `QC_TARGETS` carries the changed-file list from `git diff --name-only`, which
+  yields RELATIVE paths (e.g. `crates/presenter-ndi/src/pipeline/consumers.rs`).
+  `os.walk` yields ABSOLUTE paths. The scope filter MUST compare on the relative
+  form (`os.path.relpath(path, root)`), or it silently skips EVERY file and the
+  gate becomes a no-op. Comparing the absolute `path` against relative targets
+  was the bug that disabled this gate in every scoped CI run (fixed in 5f5fe9f).
+
+Output: a single JSON object on stdout:
+  {"violations": [...], "warnings": [...]}
+Each entry: {"file": <rel>, "start": <1-based line>, "length": <lines>, "fn": <name>}
+
+Env:
+  QC_TARGETS       newline-separated RELATIVE file paths to scope to (empty = all)
+  QC_FN_ADVISORY   "1" => never hard-fail (>120 demoted to warning); for
+                   no-diff (advisory) runs where unchanged files would
+                   otherwise hard-fail a version-bump-only commit.
+
+Usage: fn_length_check.py <repo_root>
+"""
+
+import json
+import os
+import re
+import sys
+
+fn_start = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)\s*\(")
+
+# Exempt patterns per CLAUDE.md:
+# - Migration up()/down() functions (declarative schema)
+# - render_*_ui functions (Leptos HTML-like DSL)
+# - build_router functions (route declarations)
+# - Leptos #[component] functions (UI renders — the view! DSL is HTML-like)
+EXEMPT_FN_NAMES = {"up", "down", "build_router"}
+EXEMPT_FN_PREFIXES = ("render_",)
+
+
+def is_exempt_function(fn_name, filepath):
+    # Migration files - exempt all functions
+    if "/presenter-migration/" in filepath:
+        return True
+    # Specific exempt function names
+    if fn_name in EXEMPT_FN_NAMES:
+        return True
+    # UI render functions
+    for prefix in EXEMPT_FN_PREFIXES:
+        if fn_name.startswith(prefix):
+            return True
+    return False
+
+
+def preceded_by_component(lines, idx):
+    # A Leptos #[component] function is a UI render (per CLAUDE.md). The
+    # attribute sits directly above the fn, possibly with other attributes or
+    # doc comments interleaved. Walk upward over blank/comment/attribute lines;
+    # if we reach #[component] it's exempt, any other code line stops the scan.
+    j = idx - 1
+    while j >= 0:
+        s = lines[j].strip()
+        if not s:
+            j -= 1
+            continue
+        if s.startswith("#["):
+            if "component" in s:
+                return True
+            j -= 1
+            continue
+        if s.startswith("//") or s.startswith("/*") or s.startswith("*"):
+            j -= 1
+            continue
+        return False
+    return False
+
+
+def analyze(root, targets, advisory):
+    violations = []  # > 120 lines (hard fail)
+    warnings = []  # > 80 lines (warning)
+    for dirpath, _, filenames in os.walk(os.path.join(root, "crates")):
+        for name in filenames:
+            if not name.endswith(".rs"):
+                continue
+            path = os.path.join(dirpath, name)
+            # `targets` come from `git diff --name-only` as RELATIVE paths, but
+            # os.walk yields ABSOLUTE paths — compare on the relative form or the
+            # scope filter silently skips EVERY file (the gate becomes a no-op).
+            rel = os.path.relpath(path, root)
+            if targets and rel not in targets:
+                continue
+            with open(path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+            i = 0
+            while i < len(lines):
+                match = fn_start.match(lines[i])
+                if match:
+                    fn_name = match.group(1)
+                    # find first '{'
+                    j = i
+                    brace = 0
+                    started = False
+                    while j < len(lines):
+                        brace += lines[j].count("{")
+                        brace -= lines[j].count("}")
+                        if "{" in lines[j]:
+                            started = True
+                        if started and brace == 0:
+                            length = j - i + 1
+                            if not is_exempt_function(fn_name, path) and not preceded_by_component(lines, i):
+                                entry = {"file": rel, "start": i + 1, "length": length, "fn": fn_name}
+                                # Advisory mode = no diff vs base (e.g. a version-bump-only
+                                # commit) -> ALL repo files are scanned. Pre-existing long
+                                # functions in unchanged files must not hard-fail such a
+                                # commit (mirrors the file-size check's is_changed logic);
+                                # they are reported as warnings instead. With a real diff,
+                                # targets are exactly the changed files and >120 hard-fails.
+                                if length > 120 and not advisory:
+                                    violations.append(entry)
+                                elif length > 80:
+                                    warnings.append(entry)
+                            i = j
+                            break
+                        j += 1
+                i += 1
+    violations.sort(key=lambda v: (-v["length"], v["file"], v["start"]))
+    warnings.sort(key=lambda v: (-v["length"], v["file"], v["start"]))
+    return {"violations": violations, "warnings": warnings}
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: fn_length_check.py <repo_root>\n")
+        return 2
+    root = sys.argv[1]
+    targets_env = os.environ.get("QC_TARGETS", "")
+    targets = [t for t in targets_env.split("\n") if t.strip()]
+    advisory = os.environ.get("QC_FN_ADVISORY", "0") == "1"
+    print(json.dumps(analyze(root, targets, advisory)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/quality-check.sh
+++ b/scripts/dev/quality-check.sh
@@ -168,105 +168,12 @@ else
 fi
 export QC_TARGETS
 
-fn_check=$(python3 - "$ROOT_DIR" <<'PY'
-import os, re, sys, json
-root = sys.argv[1]
-fn_start = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)\s*\(")
-
-# Exempt patterns per CLAUDE.md:
-# - Migration up() functions (declarative schema)
-# - render_*_ui functions (Leptos HTML-like DSL)
-# - build_router functions (route declarations)
-# - Leptos #[component] functions (UI renders — the view! DSL is HTML-like)
-EXEMPT_FN_NAMES = {'up', 'down', 'build_router'}
-EXEMPT_FN_PREFIXES = ('render_', )
-
-def is_exempt_function(fn_name, filepath):
-    # Migration files - exempt all functions
-    if '/presenter-migration/' in filepath:
-        return True
-    # Specific exempt function names
-    if fn_name in EXEMPT_FN_NAMES:
-        return True
-    # UI render functions
-    for prefix in EXEMPT_FN_PREFIXES:
-        if fn_name.startswith(prefix):
-            return True
-    return False
-
-def preceded_by_component(lines, idx):
-    # A Leptos #[component] function is a UI render (per CLAUDE.md). The
-    # attribute sits directly above the fn, possibly with other attributes or
-    # doc comments interleaved. Walk upward over blank/comment/attribute lines;
-    # if we reach #[component] it's exempt, any other code line stops the scan.
-    j = idx - 1
-    while j >= 0:
-        s = lines[j].strip()
-        if not s:
-            j -= 1; continue
-        if s.startswith('#['):
-            if 'component' in s:
-                return True
-            j -= 1; continue
-        if s.startswith('//') or s.startswith('/*') or s.startswith('*'):
-            j -= 1; continue
-        return False
-    return False
-
-violations = []  # > 120 lines (hard fail)
-warnings = []    # > 80 lines (warning)
-targets_env = os.environ.get('QC_TARGETS', '')
-targets = [t for t in targets_env.split('\n') if t.strip()]
-for dirpath, _, filenames in os.walk(os.path.join(root, 'crates')):
-    for name in filenames:
-        if not name.endswith('.rs'): continue
-        path = os.path.join(dirpath, name)
-        # `targets` come from `git diff --name-only` as RELATIVE paths, but
-        # os.walk yields ABSOLUTE paths — compare on the relative form or the
-        # scope filter silently skips EVERY file (the gate becomes a no-op).
-        rel = os.path.relpath(path, root)
-        if targets and rel not in targets:
-            continue
-        with open(path, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
-        i = 0
-        while i < len(lines):
-            match = fn_start.match(lines[i])
-            if match:
-                fn_name = match.group(1)
-                # find first '{'
-                j = i
-                brace = 0
-                started = False
-                while j < len(lines):
-                    brace += lines[j].count('{')
-                    brace -= lines[j].count('}')
-                    if '{' in lines[j]:
-                        started = True
-                    if started and brace == 0:
-                        length = j - i + 1
-                        if not is_exempt_function(fn_name, path) and not preceded_by_component(lines, i):
-                            entry = {'file': rel, 'start': i+1, 'length': length, 'fn': fn_name}
-                            # Advisory mode = no diff vs base (e.g. a version-bump-only
-                            # commit) -> ALL repo files are scanned. Pre-existing long
-                            # functions in unchanged files must not hard-fail such a
-                            # commit (mirrors the file-size check's is_changed logic);
-                            # they are reported as warnings instead. With a real diff,
-                            # targets are exactly the changed files and >120 hard-fails.
-                            advisory = os.environ.get('QC_FN_ADVISORY', '0') == '1'
-                            if length > 120 and not advisory:
-                                violations.append(entry)
-                            elif length > 80:
-                                warnings.append(entry)
-                        i = j
-                        break
-                    j += 1
-            i += 1
-violations.sort(key=lambda v: (-v['length'], v['file'], v['start']))
-warnings.sort(key=lambda v: (-v['length'], v['file'], v['start']))
-print(json.dumps({'violations': violations, 'warnings': warnings}))
-PY
-) || { fail "Function length checker crashed"; fn_check='{"violations":[],"warnings":[]}'; }
+# The checker logic lives in scripts/dev/fn_length_check.py so it can be
+# exercised directly by the gate self-test (scripts/ci/test-fn-length-gate.sh,
+# regression guard for #374: the abs/rel no-op bug). It reads QC_TARGETS and
+# QC_FN_ADVISORY from the environment (exported above).
+fn_check=$(python3 "$ROOT_DIR/scripts/dev/fn_length_check.py" "$ROOT_DIR") \
+  || { fail "Function length checker crashed"; fn_check='{"violations":[],"warnings":[]}'; }
 
 # Report hard failures (>120 lines)
 viols=$(echo "$fn_check" | jq -c '.violations')

--- a/scripts/dev/quality-check.sh
+++ b/scripts/dev/quality-check.sh
@@ -169,7 +169,7 @@ fi
 export QC_TARGETS
 
 # The checker logic lives in scripts/dev/fn_length_check.py so it can be
-# exercised directly by the gate self-test (scripts/ci/test-fn-length-gate.sh,
+# exercised directly by the gate self-test (tests/ci/fn-length-gate.test.sh,
 # regression guard for #374: the abs/rel no-op bug). It reads QC_TARGETS and
 # QC_FN_ADVISORY from the environment (exported above).
 fn_check=$(python3 "$ROOT_DIR/scripts/dev/fn_length_check.py" "$ROOT_DIR") \

--- a/tests/ci/fn-length-gate.test.sh
+++ b/tests/ci/fn-length-gate.test.sh
@@ -23,8 +23,8 @@ set -euo pipefail
 #   3. Sanity — the real checker no-ops on an ABSOLUTE-path target (confirming
 #      relative comparison is what makes scoping work) and still fires unscoped.
 #
-# Runs in CI as a standalone step (no cargo, no Rust build) — fast and binary.
-# Exits 0 only when all assertions pass.
+# Run in CI by the Test job's "Run CI shell tests" step (alongside the other
+# tests/ci/*.test.sh regression tests). Exits 0 only when all assertions pass.
 # ============================================================================
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
Closes #374

## Scope (rescoped by ticket-validator)

This PR completes the **only remaining open item** from #374: a self-test so the function-length CI gate's abs/rel no-op bug cannot silently return.

The gate fix itself (relative-path comparison) and the 4 over-cap NDI/WebRTC functions were **already resolved on dev** in PR #368 / commit `5f5fe9f` — confirmed by ticket-validator (add_consumer 105, build 93/105, connect_whep split, NdiVideo `#[component]`-exempt). They are **not re-touched** here.

## What changed

- **Extract** the embedded function-length checker out of `quality-check.sh` section 7 into a standalone `scripts/dev/fn_length_check.py` (identical behavior). `quality-check.sh` now calls it, so the self-test exercises the **exact code CI runs** — no copy-paste drift.
- **Add** `scripts/ci/test-fn-length-gate.sh` (the deliverable, regression-test-first):
  - builds a fixture mini-repo containing a >120-line function;
  - asserts the real checker **FIRES** on a **relative-path** target (the way CI scopes via `git diff --name-only`) — the behavior the fix enables;
  - reintroduces the abs/rel bug in a copy and asserts it **NO-OPs** — pinning the *fix*, not just current behavior;
  - sanity: absolute-path target no-ops; unscoped scan still fires.
- **Wire** it as a CI step in `pipeline.yml` `quality` job, before the gate runs. No `continue-on-error`.

## RED → GREEN proof (local)

- GREEN: self-test passes against the real (fixed) checker.
- RED: reintroducing the abs/rel bug into the real checker makes the self-test **fail (exit 1)**; restoring the fix makes it pass again.

## Verification

CI-test-only change (no user-facing behavior). Verification = CI green + version match on deploy (0.4.132).