### PR TITLE
Bundle: fix #375 (audit-log spam) + #410 (#401 reload loop while source offline)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.137"
+version = "0.4.138"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -799,6 +799,21 @@ impl Repository {
             .all(&txn)
             .await?;
 
+        // #375: idempotency guard. When the target is ALREADY active and there
+        // is no sibling to deactivate, this activation changes nothing (before
+        // == after). Returning early — without bumping `updated_at` and without
+        // writing an audit row — keeps the settings_audit log a record of real
+        // CHANGES, not no-ops. The NDI 30s auto-reconnect loop re-calls this
+        // every tick while an active source is unreachable (its pipeline start
+        // fails but the DB row stays `is_active=true`); without this guard that
+        // wrote one audit row every ~30s forever. A genuine activate (the row
+        // was inactive) or switch (a sibling is active) still falls through and
+        // writes exactly the audit rows it always did.
+        if target_before.is_active && siblings.is_empty() {
+            txn.commit().await?;
+            return Ok(target_before);
+        }
+
         // Deactivate each sibling individually so we can record per-row
         // before/after JSON for the audit log. Using `update_many` would
         // erase the per-row identity we need to log.

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -1285,7 +1285,10 @@ async fn reactivating_already_active_source_writes_no_audit_row() {
             .activate_video_source(a.id, SettingsAuditSource::StartupDefault, "system")
             .await
             .unwrap();
-        assert!(returned.is_active, "re-activation still returns the active row");
+        assert!(
+            returned.is_active,
+            "re-activation still returns the active row"
+        );
         assert_eq!(returned.id, a.id);
     }
 

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -1216,6 +1216,122 @@ async fn activate_video_source_audits_each_deactivated_sibling() {
     assert_eq!(c_row.after_json["isActive"], true);
 }
 
+/// #375: re-activating the SAME source that is already active (and the only
+/// active row) must be a no-op — it must NOT write a settings_audit row, and a
+/// genuine switch must still write its audit rows. The 30s NDI auto-reconnect
+/// loop re-calls `activate_video_source` every tick while an active source is
+/// unreachable (pipeline start fails but the DB row stays `is_active=true`);
+/// before this fix each tick wrote a fresh audit row, spamming the forensic log
+/// with one no-op row every ~30s forever.
+#[tokio::test]
+async fn reactivating_already_active_source_writes_no_audit_row() {
+    use crate::audit::SettingsAuditSource;
+    let repo = Repository::connect_in_memory().await.unwrap();
+
+    let a = repo
+        .create_video_source(
+            &VideoSourceDraft::new("Cam A", "CAM_A"),
+            SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+    let b = repo
+        .create_video_source(
+            &VideoSourceDraft::new("Cam B", "CAM_B"),
+            SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+
+    // Baseline: creating A+B already wrote one audit row each. Measure all
+    // subsequent assertions as deltas against this baseline.
+    let baseline = repo
+        .list_settings_audit(Some("video_source"), None, None, 1000)
+        .await
+        .unwrap()
+        .len();
+
+    // Genuine activation of A: writes exactly one audit row (A activated, no
+    // siblings active yet).
+    repo.activate_video_source(a.id, SettingsAuditSource::StartupDefault, "system")
+        .await
+        .unwrap();
+    let after_first = repo
+        .list_settings_audit(Some("video_source"), None, None, 1000)
+        .await
+        .unwrap();
+    assert_eq!(
+        after_first.len(),
+        baseline + 1,
+        "first (genuine) activation must write exactly one audit row, got {after_first:?}"
+    );
+
+    // Capture the activated row's updated_at so we can assert it is NOT bumped
+    // by the no-op re-activation.
+    let updated_at_before = repo
+        .get_active_video_source()
+        .await
+        .unwrap()
+        .expect("A is active")
+        .updated_at;
+
+    // Re-activate A three times (simulating three 30s auto-reconnect ticks
+    // against an unreachable-but-active source). Each is a no-op: A is already
+    // active and is the only active row, so nothing changes.
+    for _ in 0..3 {
+        let returned = repo
+            .activate_video_source(a.id, SettingsAuditSource::StartupDefault, "system")
+            .await
+            .unwrap();
+        assert!(returned.is_active, "re-activation still returns the active row");
+        assert_eq!(returned.id, a.id);
+    }
+
+    let after_noops = repo
+        .list_settings_audit(Some("video_source"), None, None, 1000)
+        .await
+        .unwrap();
+    assert_eq!(
+        after_noops.len(),
+        baseline + 1,
+        "re-activating an already-active source must add NO audit rows, got {after_noops:?}"
+    );
+
+    let updated_at_after = repo
+        .get_active_video_source()
+        .await
+        .unwrap()
+        .expect("A still active")
+        .updated_at;
+    assert_eq!(
+        updated_at_before, updated_at_after,
+        "no-op re-activation must NOT bump updated_at"
+    );
+
+    // A genuine switch A -> B must STILL write audit rows (B activated + A
+    // deactivated): the idempotency guard must not break the real audit trail.
+    repo.activate_video_source(b.id, SettingsAuditSource::HttpSetter, "ip-9.9.9.9")
+        .await
+        .unwrap();
+    let switch_rows = repo
+        .list_settings_audit(Some("video_source"), None, None, 1000)
+        .await
+        .unwrap();
+    // Delta = +2 over (baseline + 1): B activation + A deactivation.
+    assert_eq!(
+        switch_rows.len(),
+        baseline + 3,
+        "a genuine A->B switch must still write its audit rows, got {switch_rows:?}"
+    );
+    let b_row = switch_rows
+        .iter()
+        .find(|r| r.setting_id == b.id.to_string())
+        .expect("audit row for newly-activated B");
+    assert_eq!(b_row.after_json["isActive"], true);
+}
+
 /// Assert that `rows` contains the audit row for a sibling video source that
 /// was deactivated by an activation: actor/source match and the row records the
 /// is_active=true → is_active=false transition.

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.137"
+version = "0.4.138"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/mod.rs
+++ b/crates/presenter-ui/src/components/stage/mod.rs
@@ -3,6 +3,7 @@ pub mod bible_layout;
 pub mod bible_overlay;
 pub mod camera_crew;
 pub mod ndi_fullscreen;
+mod ndi_reload_guard;
 pub mod ndi_video;
 mod ndi_watchdog;
 pub mod preach_layout;

--- a/crates/presenter-ui/src/components/stage/ndi_reload_guard.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_reload_guard.rs
@@ -1,0 +1,156 @@
+//! #410 server-liveness gate for the #401 last-resort stage-page reload.
+//!
+//! The #401 watchdog (`ndi_watchdog.rs`) reloads the whole stage page as a
+//! last resort when no frame has decoded across reconnect attempts for the
+//! no-frames horizon. That assumed reloading could recover ANY stuck stream.
+//! But when the active NDI source is legitimately offline (Resolume silent),
+//! the server has NO streaming pipeline (`/healthz` `ndi_pipelines` empty) and
+//! no consumer can ever decode a frame — so the page reloaded every ~60s
+//! forever (benign but wasteful).
+//!
+//! This module decides, given the server's pipeline state, whether the reload
+//! can even help. The decision is split into small pure functions
+//! (`should_reload_given_pipeline_state`, `healthz_body_has_streaming_pipeline`)
+//! so the gate is unit-testable on host without a browser or a running server;
+//! `fetch_healthz_has_streaming_pipeline` is the browser-only wiring. Split
+//! into its own file to keep `ndi_watchdog.rs` under the size cap.
+
+use leptos::wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+/// LAST-RESORT reload gate (#410): given whether the SERVER currently has an
+/// actively-streaming NDI pipeline, should the stuck stage page reload?
+///
+/// - `true` (server is streaming, but this consumer decoded nothing) → reload:
+///   the page/consumer is stuck and a fresh WHEP negotiation + DOM can recover
+///   it (the #401 case).
+/// - `false` (no streaming pipeline) → DON'T reload: the source itself is down
+///   (Resolume silent / `ndi_pipelines` empty), so reloading cannot produce
+///   frames — it would just loop every ~60s. Keep waiting instead.
+///
+/// Pure + side-effect-free so the gate is unit-testable on host without a
+/// browser or a running server. The fetch-failure case is handled by the
+/// caller (it defaults to reloading), NOT here.
+pub(crate) fn should_reload_given_pipeline_state(server_has_streaming_pipeline: bool) -> bool {
+    server_has_streaming_pipeline
+}
+
+/// Parse a `/healthz` JSON body and decide whether the server has at least one
+/// actively-streaming NDI pipeline. An entry counts as "streaming" when its
+/// `state` is `"streaming"` or `"starting"` (about to deliver frames) — a
+/// `"stopped"` / `"errored"` pipeline, or an empty/absent `ndi_pipelines`
+/// array, means the source is NOT delivering media.
+///
+/// Pure over the response text so it is unit-testable on host. A body that
+/// fails to parse returns `false` here — but callers treat a FAILED fetch
+/// (network error, non-2xx) as "reload anyway", so a parse-of-garbage that
+/// only happens on a successful-but-malformed response stays conservative
+/// (no reload) rather than masking a real stuck consumer.
+pub(crate) fn healthz_body_has_streaming_pipeline(body: &str) -> bool {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(pipelines) = json.get("ndi_pipelines").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    pipelines.iter().any(|p| {
+        matches!(
+            p.get("state").and_then(|s| s.as_str()),
+            Some("streaming") | Some("starting")
+        )
+    })
+}
+
+/// Fetch `/healthz` and report whether the server has an actively-streaming NDI
+/// pipeline. Returns `true` on ANY fetch/response failure so a transient
+/// `/healthz` outage never SUPPRESSES a genuinely-needed last-resort reload
+/// (#410 — additive guard, must not break #401 recovery).
+pub(crate) async fn fetch_healthz_has_streaming_pipeline() -> bool {
+    async fn try_fetch() -> Option<bool> {
+        let window = leptos::web_sys::window()?;
+        let resp_val = JsFuture::from(window.fetch_with_str("/healthz"))
+            .await
+            .ok()?;
+        let resp: leptos::web_sys::Response = resp_val.dyn_into().ok()?;
+        if !resp.ok() {
+            return None;
+        }
+        let text = JsFuture::from(resp.text().ok()?).await.ok()?;
+        let body = text.as_string()?;
+        Some(healthz_body_has_streaming_pipeline(&body))
+    }
+    // Fetch/parse failure → default to TRUE (reload), preserving #401 behavior.
+    try_fetch().await.unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{healthz_body_has_streaming_pipeline, should_reload_given_pipeline_state};
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #410 server-liveness reload gate.
+    //
+    // The #401 last-resort reload assumed reloading could recover any stuck
+    // stream. But when the SOURCE itself is legitimately offline (Resolume
+    // silent → the server has NO streaming pipeline, /healthz ndi_pipelines is
+    // empty), no consumer can ever decode a frame, so the page reloaded every
+    // ~60s forever — benign but wasteful. The gate distinguishes
+    // "source legitimately down" (don't reload, keep waiting) from
+    // "my page/consumer is stuck while the server IS streaming" (reload, the
+    // #401 recovery). A failed /healthz fetch must NOT suppress a needed
+    // reload, so the caller defaults to reloading on fetch error.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn reload_when_server_has_a_streaming_pipeline_but_consumer_is_stuck() {
+        // Server is streaming, but THIS page decoded nothing for the whole
+        // window → the consumer/page is stuck → reload (the #401 recovery).
+        assert!(should_reload_given_pipeline_state(true));
+    }
+
+    #[test]
+    fn suppress_reload_when_server_has_no_streaming_pipeline() {
+        // No streaming pipeline → the source itself is down → reloading cannot
+        // help → DON'T reload, keep waiting.
+        assert!(!should_reload_given_pipeline_state(false));
+    }
+
+    #[test]
+    fn healthz_with_streaming_pipeline_means_server_is_streaming() {
+        let body = r#"{"status":"ok","version":"0.4.138","channel":"dev",
+            "ndi_pipelines":[{"source_id":"abc","state":"streaming"}]}"#;
+        assert!(healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_with_starting_pipeline_counts_as_streaming() {
+        // A "starting" pipeline is about to deliver frames — treat it as live
+        // so we still attempt the consumer-stuck reload.
+        let body = r#"{"ndi_pipelines":[{"source_id":"abc","state":"starting"}]}"#;
+        assert!(healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_empty_pipelines_means_source_down() {
+        // The exact #410 symptom: source offline → empty ndi_pipelines.
+        let body = r#"{"status":"ok","ndi_pipelines":[]}"#;
+        assert!(!healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_only_errored_or_stopped_pipeline_means_source_down() {
+        let body = r#"{"ndi_pipelines":[
+            {"source_id":"a","state":"errored","last_error":"no source"},
+            {"source_id":"b","state":"stopped"}]}"#;
+        assert!(!healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_missing_field_or_garbage_means_not_streaming() {
+        // No ndi_pipelines key, or unparseable body → not streaming (the
+        // SUCCESSFUL-but-malformed case; a FAILED fetch is the caller's
+        // reload-anyway default, not this function's).
+        assert!(!healthz_body_has_streaming_pipeline(r#"{"status":"ok"}"#));
+        assert!(!healthz_body_has_streaming_pipeline("not json at all"));
+    }
+}

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -340,7 +340,9 @@ pub(crate) fn healthz_body_has_streaming_pipeline(body: &str) -> bool {
 async fn fetch_healthz_has_streaming_pipeline() -> bool {
     async fn try_fetch() -> Option<bool> {
         let window = leptos::web_sys::window()?;
-        let resp_val = JsFuture::from(window.fetch_with_str("/healthz")).await.ok()?;
+        let resp_val = JsFuture::from(window.fetch_with_str("/healthz"))
+            .await
+            .ok()?;
         let resp: leptos::web_sys::Response = resp_val.dyn_into().ok()?;
         if !resp.ok() {
             return None;

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -180,6 +180,11 @@ struct FrameStats {
 pub(crate) struct ReloadEscalation {
     last_decoded_frame_at: Cell<f64>,
     reloaded: Cell<bool>,
+    /// True while a `/healthz` server-liveness check spawned by `maybe_reload`
+    /// is in flight (#410). Guards against the 1s health ticker spawning a
+    /// fresh fetch on every tick once the no-frames horizon is crossed — at
+    /// most one check is outstanding at a time. Cleared when the check resolves.
+    check_in_flight: Cell<bool>,
     /// The no-frames horizon (ms) for THIS page load. Defaults to
     /// `RELOAD_NO_FRAME_MS`; an explicit `?ndiReloadMs=<n>` URL query lowers
     /// it so the E2E can exercise the full reload path (incl. the real
@@ -197,6 +202,7 @@ impl ReloadEscalation {
         Rc::new(Self {
             last_decoded_frame_at: Cell::new(now_ms()),
             reloaded: Cell::new(false),
+            check_in_flight: Cell::new(false),
             threshold_ms: reload_threshold_ms_from_url(),
         })
     }
@@ -213,27 +219,131 @@ impl ReloadEscalation {
         now_ms() - self.last_decoded_frame_at.get()
     }
 
-    /// Evaluate the escalation rule and, if it trips, perform the one-shot
-    /// full-page reload. Returns true once it has reloaded (so callers stop).
-    /// Idempotent: the `reloaded` flag makes repeated ticks / multiple
-    /// sessions fire `window.location.reload()` at most once.
-    fn maybe_reload(&self) -> bool {
+    /// Evaluate the escalation rule. When the no-frames horizon is crossed,
+    /// the reload is NOT performed unconditionally: first a lightweight
+    /// `/healthz` check decides whether reloading can even help (#410).
+    ///
+    /// - If the SERVER has an actively-streaming NDI pipeline but THIS consumer
+    ///   still has no frames → the page/consumer is genuinely stuck → reload
+    ///   (the #401 recovery).
+    /// - If the server has NO streaming pipeline → the source itself is down
+    ///   (Resolume silent), reloading cannot conjure frames → SKIP the reload
+    ///   and reset the escalation timer so it re-evaluates after another full
+    ///   window instead of reloading every ~60s forever.
+    /// - If the `/healthz` fetch fails → fall back to the existing behavior and
+    ///   reload (a fetch error must never SUPPRESS a genuinely-needed reload).
+    ///
+    /// Returns true once the page is reloading OR a server check has been
+    /// spawned for this horizon crossing — in both cases the caller should stop
+    /// the rest of this tick (the async check, if any, owns the decision).
+    /// Idempotent: the `reloaded` one-shot and the `check_in_flight` guard make
+    /// repeated ticks / multiple sessions fire at most one `/healthz` check and
+    /// at most one `window.location.reload()`.
+    fn maybe_reload(self: &Rc<Self>) -> bool {
         if self.reloaded.get() {
             return true;
         }
         if !should_escalate_reload(self.ms_since_last_decoded_frame(), self.threshold_ms) {
             return false;
         }
-        self.reloaded.set(true);
-        leptos::logging::warn!(
-            "watchdog: no decoded frame for {:.0}ms across reconnect attempts — LAST-RESORT full page reload (#401)",
-            self.ms_since_last_decoded_frame()
-        );
-        if let Some(window) = leptos::web_sys::window() {
-            let _ = window.location().reload();
+        // Horizon crossed. Don't spawn a second check while one is in flight.
+        if self.check_in_flight.get() {
+            return true;
         }
+        self.check_in_flight.set(true);
+        let escalation = Rc::clone(self);
+        spawn_local(async move {
+            let has_streaming = fetch_healthz_has_streaming_pipeline().await;
+            escalation.check_in_flight.set(false);
+            // A frame may have decoded while the check was in flight — re-check
+            // the horizon so a recovered stream is never reloaded out from
+            // under itself.
+            if escalation.reloaded.get()
+                || !should_escalate_reload(
+                    escalation.ms_since_last_decoded_frame(),
+                    escalation.threshold_ms,
+                )
+            {
+                return;
+            }
+            if !should_reload_given_pipeline_state(has_streaming) {
+                // Source legitimately down — reloading can't help. Reset the
+                // page-session timer so the rule re-evaluates after another
+                // full window instead of looping reloads every ~60s.
+                leptos::logging::warn!(
+                    "watchdog: no decoded frame for {:.0}ms but server has NO streaming pipeline — source is down, SKIPPING reload (#410)",
+                    escalation.ms_since_last_decoded_frame()
+                );
+                escalation.last_decoded_frame_at.set(now_ms());
+                return;
+            }
+            escalation.reloaded.set(true);
+            leptos::logging::warn!(
+                "watchdog: no decoded frame for {:.0}ms across reconnect attempts AND server has a streaming pipeline — LAST-RESORT full page reload (#401)",
+                escalation.ms_since_last_decoded_frame()
+            );
+            if let Some(window) = leptos::web_sys::window() {
+                let _ = window.location().reload();
+            }
+        });
         true
     }
+}
+
+/// LAST-RESORT reload gate (#410): given whether the SERVER currently has an
+/// actively-streaming NDI pipeline, should the stuck stage page reload?
+///
+/// - `true` (server is streaming, but this consumer decoded nothing) → reload:
+///   the page/consumer is stuck and a fresh WHEP negotiation + DOM can recover
+///   it (the #401 case).
+/// - `false` (no streaming pipeline) → DON'T reload: the source itself is down
+///   (Resolume silent / `ndi_pipelines` empty), so reloading cannot produce
+///   frames — it would just loop every ~60s. Keep waiting instead.
+///
+/// Pure + side-effect-free so the gate is unit-testable on host without a
+/// browser or a running server. The fetch-failure case is handled by the
+/// caller (it defaults to reloading), NOT here.
+pub(crate) fn should_reload_given_pipeline_state(_server_has_streaming_pipeline: bool) -> bool {
+    // RED stub: pre-#410 behavior reloaded unconditionally, ignoring server
+    // state. Replaced by the real gate in the GREEN commit.
+    true
+}
+
+/// Parse a `/healthz` JSON body and decide whether the server has at least one
+/// actively-streaming NDI pipeline. An entry counts as "streaming" when its
+/// `state` is `"streaming"` or `"starting"` (about to deliver frames) — a
+/// `"stopped"` / `"errored"` pipeline, or an empty/absent `ndi_pipelines`
+/// array, means the source is NOT delivering media.
+///
+/// Pure over the response text so it is unit-testable on host. A body that
+/// fails to parse returns `false` here — but callers treat a FAILED fetch
+/// (network error, non-2xx) as "reload anyway", so a parse-of-garbage that
+/// only happens on a successful-but-malformed response stays conservative
+/// (no reload) rather than masking a real stuck consumer.
+pub(crate) fn healthz_body_has_streaming_pipeline(_body: &str) -> bool {
+    // RED stub: pre-#410 code never inspected /healthz. Replaced by the real
+    // parser in the GREEN commit.
+    false
+}
+
+/// Fetch `/healthz` and report whether the server has an actively-streaming NDI
+/// pipeline. Returns `true` on ANY fetch/response failure so a transient
+/// `/healthz` outage never SUPPRESSES a genuinely-needed last-resort reload
+/// (#410 — additive guard, must not break #401 recovery).
+async fn fetch_healthz_has_streaming_pipeline() -> bool {
+    async fn try_fetch() -> Option<bool> {
+        let window = leptos::web_sys::window()?;
+        let resp_val = JsFuture::from(window.fetch_with_str("/healthz")).await.ok()?;
+        let resp: leptos::web_sys::Response = resp_val.dyn_into().ok()?;
+        if !resp.ok() {
+            return None;
+        }
+        let text = JsFuture::from(resp.text().ok()?).await.ok()?;
+        let body = text.as_string()?;
+        Some(healthz_body_has_streaming_pipeline(&body))
+    }
+    // Fetch/parse failure → default to TRUE (reload), preserving #401 behavior.
+    try_fetch().await.unwrap_or(true)
 }
 
 /// Watchdog that fires `on_failure` when EITHER:
@@ -934,7 +1044,10 @@ fn install_ice_failure_listener<F: Fn() + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use super::{should_escalate_reload, Watchdog};
+    use super::{
+        healthz_body_has_streaming_pipeline, should_escalate_reload,
+        should_reload_given_pipeline_state, Watchdog,
+    };
 
     // ─────────────────────────────────────────────────────────────────────
     // #401 LAST-RESORT page-reload escalation.
@@ -1003,5 +1116,72 @@ mod tests {
             Watchdog::RELOAD_NO_FRAME_MS,
             reconnect_path_budget,
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #410 server-liveness reload gate.
+    //
+    // The #401 last-resort reload assumed reloading could recover any stuck
+    // stream. But when the SOURCE itself is legitimately offline (Resolume
+    // silent → the server has NO streaming pipeline, /healthz ndi_pipelines is
+    // empty), no consumer can ever decode a frame, so the page reloaded every
+    // ~60s forever — benign but wasteful. The gate distinguishes
+    // "source legitimately down" (don't reload, keep waiting) from
+    // "my page/consumer is stuck while the server IS streaming" (reload, the
+    // #401 recovery). A failed /healthz fetch must NOT suppress a needed
+    // reload, so the caller defaults to reloading on fetch error.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn reload_when_server_has_a_streaming_pipeline_but_consumer_is_stuck() {
+        // Server is streaming, but THIS page decoded nothing for the whole
+        // window → the consumer/page is stuck → reload (the #401 recovery).
+        assert!(should_reload_given_pipeline_state(true));
+    }
+
+    #[test]
+    fn suppress_reload_when_server_has_no_streaming_pipeline() {
+        // No streaming pipeline → the source itself is down → reloading cannot
+        // help → DON'T reload, keep waiting.
+        assert!(!should_reload_given_pipeline_state(false));
+    }
+
+    #[test]
+    fn healthz_with_streaming_pipeline_means_server_is_streaming() {
+        let body = r#"{"status":"ok","version":"0.4.138","channel":"dev",
+            "ndi_pipelines":[{"source_id":"abc","state":"streaming"}]}"#;
+        assert!(healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_with_starting_pipeline_counts_as_streaming() {
+        // A "starting" pipeline is about to deliver frames — treat it as live
+        // so we still attempt the consumer-stuck reload.
+        let body = r#"{"ndi_pipelines":[{"source_id":"abc","state":"starting"}]}"#;
+        assert!(healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_empty_pipelines_means_source_down() {
+        // The exact #410 symptom: source offline → empty ndi_pipelines.
+        let body = r#"{"status":"ok","ndi_pipelines":[]}"#;
+        assert!(!healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_only_errored_or_stopped_pipeline_means_source_down() {
+        let body = r#"{"ndi_pipelines":[
+            {"source_id":"a","state":"errored","last_error":"no source"},
+            {"source_id":"b","state":"stopped"}]}"#;
+        assert!(!healthz_body_has_streaming_pipeline(body));
+    }
+
+    #[test]
+    fn healthz_missing_field_or_garbage_means_not_streaming() {
+        // No ndi_pipelines key, or unparseable body → not streaming (the
+        // SUCCESSFUL-but-malformed case; a FAILED fetch is the caller's
+        // reload-anyway default, not this function's).
+        assert!(!healthz_body_has_streaming_pipeline(r#"{"status":"ok"}"#));
+        assert!(!healthz_body_has_streaming_pipeline("not json at all"));
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -253,7 +253,8 @@ impl ReloadEscalation {
         self.check_in_flight.set(true);
         let escalation = Rc::clone(self);
         spawn_local(async move {
-            let has_streaming = fetch_healthz_has_streaming_pipeline().await;
+            let has_streaming =
+                super::ndi_reload_guard::fetch_healthz_has_streaming_pipeline().await;
             escalation.check_in_flight.set(false);
             // A frame may have decoded while the check was in flight — re-check
             // the horizon so a recovered stream is never reloaded out from
@@ -266,7 +267,7 @@ impl ReloadEscalation {
             {
                 return;
             }
-            if !should_reload_given_pipeline_state(has_streaming) {
+            if !super::ndi_reload_guard::should_reload_given_pipeline_state(has_streaming) {
                 // Source legitimately down — reloading can't help. Reset the
                 // page-session timer so the rule re-evaluates after another
                 // full window instead of looping reloads every ~60s.
@@ -288,71 +289,6 @@ impl ReloadEscalation {
         });
         true
     }
-}
-
-/// LAST-RESORT reload gate (#410): given whether the SERVER currently has an
-/// actively-streaming NDI pipeline, should the stuck stage page reload?
-///
-/// - `true` (server is streaming, but this consumer decoded nothing) → reload:
-///   the page/consumer is stuck and a fresh WHEP negotiation + DOM can recover
-///   it (the #401 case).
-/// - `false` (no streaming pipeline) → DON'T reload: the source itself is down
-///   (Resolume silent / `ndi_pipelines` empty), so reloading cannot produce
-///   frames — it would just loop every ~60s. Keep waiting instead.
-///
-/// Pure + side-effect-free so the gate is unit-testable on host without a
-/// browser or a running server. The fetch-failure case is handled by the
-/// caller (it defaults to reloading), NOT here.
-pub(crate) fn should_reload_given_pipeline_state(server_has_streaming_pipeline: bool) -> bool {
-    server_has_streaming_pipeline
-}
-
-/// Parse a `/healthz` JSON body and decide whether the server has at least one
-/// actively-streaming NDI pipeline. An entry counts as "streaming" when its
-/// `state` is `"streaming"` or `"starting"` (about to deliver frames) — a
-/// `"stopped"` / `"errored"` pipeline, or an empty/absent `ndi_pipelines`
-/// array, means the source is NOT delivering media.
-///
-/// Pure over the response text so it is unit-testable on host. A body that
-/// fails to parse returns `false` here — but callers treat a FAILED fetch
-/// (network error, non-2xx) as "reload anyway", so a parse-of-garbage that
-/// only happens on a successful-but-malformed response stays conservative
-/// (no reload) rather than masking a real stuck consumer.
-pub(crate) fn healthz_body_has_streaming_pipeline(body: &str) -> bool {
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
-        return false;
-    };
-    let Some(pipelines) = json.get("ndi_pipelines").and_then(|v| v.as_array()) else {
-        return false;
-    };
-    pipelines.iter().any(|p| {
-        matches!(
-            p.get("state").and_then(|s| s.as_str()),
-            Some("streaming") | Some("starting")
-        )
-    })
-}
-
-/// Fetch `/healthz` and report whether the server has an actively-streaming NDI
-/// pipeline. Returns `true` on ANY fetch/response failure so a transient
-/// `/healthz` outage never SUPPRESSES a genuinely-needed last-resort reload
-/// (#410 — additive guard, must not break #401 recovery).
-async fn fetch_healthz_has_streaming_pipeline() -> bool {
-    async fn try_fetch() -> Option<bool> {
-        let window = leptos::web_sys::window()?;
-        let resp_val = JsFuture::from(window.fetch_with_str("/healthz"))
-            .await
-            .ok()?;
-        let resp: leptos::web_sys::Response = resp_val.dyn_into().ok()?;
-        if !resp.ok() {
-            return None;
-        }
-        let text = JsFuture::from(resp.text().ok()?).await.ok()?;
-        let body = text.as_string()?;
-        Some(healthz_body_has_streaming_pipeline(&body))
-    }
-    // Fetch/parse failure → default to TRUE (reload), preserving #401 behavior.
-    try_fetch().await.unwrap_or(true)
 }
 
 /// Watchdog that fires `on_failure` when EITHER:
@@ -1053,10 +989,7 @@ fn install_ice_failure_listener<F: Fn() + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        healthz_body_has_streaming_pipeline, should_escalate_reload,
-        should_reload_given_pipeline_state, Watchdog,
-    };
+    use super::{should_escalate_reload, Watchdog};
 
     // ─────────────────────────────────────────────────────────────────────
     // #401 LAST-RESORT page-reload escalation.
@@ -1125,72 +1058,5 @@ mod tests {
             Watchdog::RELOAD_NO_FRAME_MS,
             reconnect_path_budget,
         );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // #410 server-liveness reload gate.
-    //
-    // The #401 last-resort reload assumed reloading could recover any stuck
-    // stream. But when the SOURCE itself is legitimately offline (Resolume
-    // silent → the server has NO streaming pipeline, /healthz ndi_pipelines is
-    // empty), no consumer can ever decode a frame, so the page reloaded every
-    // ~60s forever — benign but wasteful. The gate distinguishes
-    // "source legitimately down" (don't reload, keep waiting) from
-    // "my page/consumer is stuck while the server IS streaming" (reload, the
-    // #401 recovery). A failed /healthz fetch must NOT suppress a needed
-    // reload, so the caller defaults to reloading on fetch error.
-    // ─────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn reload_when_server_has_a_streaming_pipeline_but_consumer_is_stuck() {
-        // Server is streaming, but THIS page decoded nothing for the whole
-        // window → the consumer/page is stuck → reload (the #401 recovery).
-        assert!(should_reload_given_pipeline_state(true));
-    }
-
-    #[test]
-    fn suppress_reload_when_server_has_no_streaming_pipeline() {
-        // No streaming pipeline → the source itself is down → reloading cannot
-        // help → DON'T reload, keep waiting.
-        assert!(!should_reload_given_pipeline_state(false));
-    }
-
-    #[test]
-    fn healthz_with_streaming_pipeline_means_server_is_streaming() {
-        let body = r#"{"status":"ok","version":"0.4.138","channel":"dev",
-            "ndi_pipelines":[{"source_id":"abc","state":"streaming"}]}"#;
-        assert!(healthz_body_has_streaming_pipeline(body));
-    }
-
-    #[test]
-    fn healthz_with_starting_pipeline_counts_as_streaming() {
-        // A "starting" pipeline is about to deliver frames — treat it as live
-        // so we still attempt the consumer-stuck reload.
-        let body = r#"{"ndi_pipelines":[{"source_id":"abc","state":"starting"}]}"#;
-        assert!(healthz_body_has_streaming_pipeline(body));
-    }
-
-    #[test]
-    fn healthz_empty_pipelines_means_source_down() {
-        // The exact #410 symptom: source offline → empty ndi_pipelines.
-        let body = r#"{"status":"ok","ndi_pipelines":[]}"#;
-        assert!(!healthz_body_has_streaming_pipeline(body));
-    }
-
-    #[test]
-    fn healthz_only_errored_or_stopped_pipeline_means_source_down() {
-        let body = r#"{"ndi_pipelines":[
-            {"source_id":"a","state":"errored","last_error":"no source"},
-            {"source_id":"b","state":"stopped"}]}"#;
-        assert!(!healthz_body_has_streaming_pipeline(body));
-    }
-
-    #[test]
-    fn healthz_missing_field_or_garbage_means_not_streaming() {
-        // No ndi_pipelines key, or unparseable body → not streaming (the
-        // SUCCESSFUL-but-malformed case; a FAILED fetch is the caller's
-        // reload-anyway default, not this function's).
-        assert!(!healthz_body_has_streaming_pipeline(r#"{"status":"ok"}"#));
-        assert!(!healthz_body_has_streaming_pipeline("not json at all"));
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -303,10 +303,8 @@ impl ReloadEscalation {
 /// Pure + side-effect-free so the gate is unit-testable on host without a
 /// browser or a running server. The fetch-failure case is handled by the
 /// caller (it defaults to reloading), NOT here.
-pub(crate) fn should_reload_given_pipeline_state(_server_has_streaming_pipeline: bool) -> bool {
-    // RED stub: pre-#410 behavior reloaded unconditionally, ignoring server
-    // state. Replaced by the real gate in the GREEN commit.
-    true
+pub(crate) fn should_reload_given_pipeline_state(server_has_streaming_pipeline: bool) -> bool {
+    server_has_streaming_pipeline
 }
 
 /// Parse a `/healthz` JSON body and decide whether the server has at least one
@@ -320,10 +318,19 @@ pub(crate) fn should_reload_given_pipeline_state(_server_has_streaming_pipeline:
 /// (network error, non-2xx) as "reload anyway", so a parse-of-garbage that
 /// only happens on a successful-but-malformed response stays conservative
 /// (no reload) rather than masking a real stuck consumer.
-pub(crate) fn healthz_body_has_streaming_pipeline(_body: &str) -> bool {
-    // RED stub: pre-#410 code never inspected /healthz. Replaced by the real
-    // parser in the GREEN commit.
-    false
+pub(crate) fn healthz_body_has_streaming_pipeline(body: &str) -> bool {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(pipelines) = json.get("ndi_pipelines").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    pipelines.iter().any(|p| {
+        matches!(
+            p.get("state").and_then(|s| s.as_str()),
+            Some("streaming") | Some("starting")
+        )
+    })
 }
 
 /// Fetch `/healthz` and report whether the server has an actively-streaming NDI


### PR DESCRIPTION
Bundles two small "reduce log/reload bloat" fixes onto one PR. Version 0.4.137 -> **0.4.138**.

## #375 — Audit spam: 30s auto-reconnect loop wrote a settings_audit row every ~30s for an unreachable active source

The NDI 30s auto-reconnect ticker re-calls `activate_video_source` every tick while the active source is unreachable (its pipeline start fails, but the DB row stays `is_active=true`). `repository.activate_video_source` ALWAYS bumped `updated_at` and ALWAYS wrote a settings_audit row, so the forensic log grew one no-op row every ~30s forever.

**Fix (root cause, option a):** `activate_video_source` is now idempotent — when the target is already `is_active=true` and there is no sibling to deactivate (before == after), it returns the existing row early without bumping `updated_at` or writing an audit row. A genuine activation (row was inactive) or switch (a sibling is active) still falls through and writes exactly the audit rows it always did, preserving the audit trail and the `second_startup_writes_no_audit_rows` invariant.

- RED `305a5a8` -> GREEN `99020f9`
- Regression test: `crates/presenter-persistence/src/repository/tests.rs::reactivating_already_active_source_writes_no_audit_row` — asserts repeated re-activation of the already-active source adds NO audit rows and does not bump `updated_at`, while a genuine A→B switch still writes its rows.

Closes #375

## #410 — #401 reload loops every ~60s while the active source is legitimately offline

When the source is legitimately offline (Resolume silent), the server has NO streaming pipeline (`/healthz` `ndi_pipelines` empty) and no consumer can ever decode a frame, so the #401 last-resort watchdog reloaded the stage page every ~60s forever (benign but wasteful).

**Fix (additive guard):** before the last-resort `window.location.reload()`, the page fetches `/healthz` and inspects `ndi_pipelines`:

- server has a `streaming`/`starting` pipeline but THIS consumer decoded nothing → page/consumer is stuck → reload (the #401 recovery, intact);
- empty / only `stopped`/`errored` pipelines → the source itself is down → SKIP the reload and reset the page-session escalation timer (re-evaluate after another full window instead of looping reloads);
- a failed `/healthz` fetch → default to reloading, so a transient health outage never suppresses a genuinely-needed reload.

Decision logic is split into pure, host-testable functions in a new `ndi_reload_guard` module; a `check_in_flight` guard ensures at most one `/healthz` probe per horizon crossing. Does NOT change the #401 stuck-consumer recovery.

- RED `5f99359` -> GREEN `b254570`
- Unit tests: `crates/presenter-ui/src/components/stage/ndi_reload_guard.rs` — streaming pipeline → reload; empty/errored/stopped → suppress; malformed body → not streaming (fetch-fail → reload-anyway is the caller's default).

Closes #410

## Local verification (dev2, builds allowed)
- `cargo fmt --all --check` + ui `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; ui `cargo clippy --lib -- -D warnings`: clean
- ui `cargo check --lib --target wasm32-unknown-unknown`: clean
- `cargo test -p presenter-persistence --lib`: 51 passed; `cargo test -p presenter-server`: 259 passed; ui `cargo test --lib`: 118 passed
- `bash scripts/dev/quality-check.sh --strict --against origin/main`: exit 0 (extracted #410 logic into `ndi_reload_guard.rs` to keep `ndi_watchdog.rs` under the 1000-line hard cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)