### PR TITLE
fix(stage): stop 20s stage reload — foreground-aware Android keep-alive (#419)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.138"
+version = "0.4.139"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -9,7 +9,7 @@ use tokio::{
     task::JoinHandle,
     time::{interval, timeout, MissedTickBehavior},
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 const ADB_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -273,7 +273,9 @@ async fn run_device_worker(
         tokio::select! {
             _ = ticker.tick() => {
                 if config.is_enabled {
-                    if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status).await {
+                    // Periodic keep-alive: foreground-aware (#419) — only
+                    // relaunches when the browser is not already up.
+                    if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status, false).await {
                         debug!(display = %config.label, ?err, "android stage display launch attempt failed");
                     }
                 } else {
@@ -290,7 +292,9 @@ async fn run_device_worker(
                     }
                     DeviceCommand::LaunchNow => {
                         if config.is_enabled {
-                            if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status).await {
+                            // Explicit/forced launch (startup, config change,
+                            // launch-now endpoint): always (re)launch (#419).
+                            if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status, true).await {
                                 debug!(display = %config.label, ?err, "android stage display manual launch failed");
                             }
                         }
@@ -348,6 +352,7 @@ async fn connect_and_launch(
     stage_url: &Arc<Option<String>>,
     config: &AndroidStageDisplay,
     status: &Arc<RwLock<AndroidStageDisplayStatusSnapshot>>,
+    force_launch: bool,
 ) -> anyhow::Result<()> {
     let serial = format!("{}:{}", config.host, config.port);
 
@@ -380,6 +385,33 @@ async fn connect_and_launch(
     if let Err(err) = adb_connect(adb_bin, &serial).await {
         record_error(status, err.to_string()).await;
         return Err(err);
+    }
+
+    // #419: foreground-aware keep-alive. On the periodic tick (force_launch =
+    // false) skip the am-start when the browser is ALREADY the resumed app —
+    // re-firing the VIEW intent reloads com.tcl.browser (black blink + spinner)
+    // every cycle. An inconclusive probe (None) falls through to launching so a
+    // genuinely-down display still recovers. Explicit/forced launches (config
+    // change, launch-now endpoint) bypass the gate and always relaunch.
+    if !force_launch {
+        let launch_pkg = launch_package(&config.launch_component);
+        let foreground = adb_foreground_package(adb_bin, &serial).await;
+        if !should_launch_stage(foreground.as_deref(), launch_pkg) {
+            debug!(
+                display = %config.label,
+                package = launch_pkg,
+                "android stage keep-alive: browser already foreground — skipping relaunch (#419)"
+            );
+            let mut guard = status.write().await;
+            guard.state = AndroidStageDisplayState::Running;
+            guard.last_error = None;
+            return Ok(());
+        }
+        info!(
+            display = %config.label,
+            foreground = foreground.as_deref().unwrap_or("<unknown>"),
+            "android stage keep-alive: browser not foreground — relaunching (#419)"
+        );
     }
 
     {
@@ -482,9 +514,14 @@ fn build_launch_args(launch_component: &str, stage_url: Option<&str>) -> Option<
 /// Gating the keep-alive on this check stops the periodic reload while keeping
 /// crash/sleep/exit recovery. Explicit/forced launches bypass it entirely.
 fn should_launch_stage(foreground_package: Option<&str>, launch_package: &str) -> bool {
-    // RED stub (#419): current behavior re-launches unconditionally.
-    let _ = (foreground_package, launch_package);
-    true
+    match foreground_package {
+        // The browser is already the resumed app → it is up; relaunching would
+        // only reload the page. Skip.
+        Some(fg) => fg != launch_package,
+        // Foreground could not be determined → don't suppress a possibly-needed
+        // launch; (re)launch and let the device sort it out.
+        None => true,
+    }
 }
 
 /// Parse the resumed-activity PACKAGE from `dumpsys activity activities` output.
@@ -493,9 +530,44 @@ fn should_launch_stage(foreground_package: Option<&str>, launch_package: &str) -
 /// (`mResumedActivity: null`) or the line is absent — the caller treats None as
 /// "foreground unknown → (re)launch".
 fn parse_foreground_package(dumpsys_output: &str) -> Option<String> {
-    // RED stub (#419): no foreground awareness yet.
-    let _ = dumpsys_output;
-    None
+    // Match either `mResumedActivity:` or `ResumedActivity:` (label varies by
+    // Android version); both carry the same `<pkg>/<activity>` component token.
+    let line = dumpsys_output
+        .lines()
+        .find(|l| l.contains("ResumedActivity"))?;
+    // The component is the first whitespace token shaped `<pkg>/<activity>`;
+    // the package is the part before `/` (it always contains a dot and never a
+    // `{`, which excludes the `ActivityRecord{<hash>` token).
+    line.split_whitespace().find_map(|tok| {
+        let (pkg, _activity) = tok.split_once('/')?;
+        (pkg.contains('.') && !pkg.contains('{')).then(|| pkg.to_string())
+    })
+}
+
+/// Query the device's currently-resumed app package via
+/// `adb -s <serial> shell dumpsys activity activities`. Returns the resumed
+/// package, or None on any adb error/timeout/non-success or when no resumed
+/// activity is reported — the caller treats None as "foreground unknown →
+/// (re)launch". Read-only: the dumpsys probe never disturbs the running browser.
+async fn adb_foreground_package(adb_bin: &std::ffi::OsStr, serial: &str) -> Option<String> {
+    let output = timeout(
+        ADB_COMMAND_TIMEOUT,
+        Command::new(adb_bin)
+            .arg("-s")
+            .arg(serial)
+            .arg("shell")
+            .arg("dumpsys")
+            .arg("activity")
+            .arg("activities")
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_foreground_package(&String::from_utf8_lossy(&output.stdout))
 }
 
 fn ensure_success(output: &Output) -> Result<(), String> {

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -471,6 +471,33 @@ fn build_launch_args(launch_component: &str, stage_url: Option<&str>) -> Option<
     ])
 }
 
+/// Decide whether the periodic keep-alive should (re)launch the stage browser.
+/// Launch ONLY when the configured browser package is NOT the device's current
+/// foreground/resumed app. `None` (foreground could not be determined — the adb
+/// probe failed) defaults to launching, so a genuinely-down display still
+/// recovers and an inconclusive probe never SUPPRESSES a needed launch.
+///
+/// Re-firing `am start` (a VIEW intent) at an already-foreground com.tcl.browser
+/// reloads the page (black blink + spinner) every cycle — the #419 regression.
+/// Gating the keep-alive on this check stops the periodic reload while keeping
+/// crash/sleep/exit recovery. Explicit/forced launches bypass it entirely.
+fn should_launch_stage(foreground_package: Option<&str>, launch_package: &str) -> bool {
+    // RED stub (#419): current behavior re-launches unconditionally.
+    let _ = (foreground_package, launch_package);
+    true
+}
+
+/// Parse the resumed-activity PACKAGE from `dumpsys activity activities` output.
+/// Finds the `[m]ResumedActivity: ActivityRecord{<hash> u0 <pkg>/<activity> …}`
+/// line and returns `<pkg>`. Returns None when no resumed activity is reported
+/// (`mResumedActivity: null`) or the line is absent — the caller treats None as
+/// "foreground unknown → (re)launch".
+fn parse_foreground_package(dumpsys_output: &str) -> Option<String> {
+    // RED stub (#419): no foreground awareness yet.
+    let _ = dumpsys_output;
+    None
+}
+
 fn ensure_success(output: &Output) -> Result<(), String> {
     if !output.status.success() {
         return Err(format_command_failure(output));
@@ -661,6 +688,65 @@ mod tests {
             validate_stage_url("http://10.0.0.1/stage; rm -rf /"),
             None,
             "embedded shell metacharacters make it malformed -> skip",
+        );
+    }
+
+    // ── #419: foreground-aware keep-alive ──────────────────────────────────
+    // The 20s keep-alive must NOT re-fire `am start` when com.tcl.browser is
+    // already the resumed app (re-firing the VIEW intent reloads the page —
+    // the black blink + spinner every ~20s). It SHOULD launch when the browser
+    // is not foreground (crash/sleep/exit recovery) or when foreground is
+    // unknown (an inconclusive adb probe must never suppress a needed launch).
+
+    #[test]
+    fn skip_launch_when_browser_already_foreground() {
+        assert!(
+            !should_launch_stage(Some("com.tcl.browser"), "com.tcl.browser"),
+            "must NOT relaunch when the browser is already the resumed app (#419)",
+        );
+    }
+
+    #[test]
+    fn launch_when_a_different_app_is_foreground() {
+        assert!(
+            should_launch_stage(Some("com.android.tv.settings"), "com.tcl.browser"),
+            "must relaunch when another app is foreground (user left the stage)",
+        );
+    }
+
+    #[test]
+    fn launch_when_foreground_is_unknown() {
+        assert!(
+            should_launch_stage(None, "com.tcl.browser"),
+            "an inconclusive probe must default to launching (recover a down display)",
+        );
+    }
+
+    #[test]
+    fn parse_foreground_reads_resumed_activity_package() {
+        let out = "  ResumedActivity: ActivityRecord{deadbeef u0 com.tcl.browser/.portal.browse.activity.BrowsePageActivity t1}\n    mResumedActivity: ActivityRecord{5372874 u0 com.tcl.browser/.portal.browse.activity.BrowsePageActivity t17469}\n";
+        assert_eq!(
+            parse_foreground_package(out).as_deref(),
+            Some("com.tcl.browser"),
+        );
+    }
+
+    #[test]
+    fn parse_foreground_reads_legacy_fully_kiosk_package() {
+        let out = "    mResumedActivity: ActivityRecord{abc u0 com.fullykiosk.videokiosk/de.ozerov.fully.MainActivity t9}";
+        assert_eq!(
+            parse_foreground_package(out).as_deref(),
+            Some("com.fullykiosk.videokiosk"),
+        );
+    }
+
+    #[test]
+    fn parse_foreground_none_when_no_resumed_activity() {
+        assert_eq!(parse_foreground_package("    mResumedActivity: null"), None);
+        assert_eq!(parse_foreground_package(""), None);
+        assert_eq!(
+            parse_foreground_package("some unrelated dumpsys text"),
+            None
         );
     }
 }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -402,8 +402,13 @@ async fn connect_and_launch(
                 package = launch_pkg,
                 "android stage keep-alive: browser already foreground — skipping relaunch (#419)"
             );
+            // A confirmed-foreground probe IS a liveness success: refresh
+            // last_success so a healthy display that skips relaunch every cycle
+            // does not show an ever-aging "last success" on the operator
+            // dashboard (#419 review).
             let mut guard = status.write().await;
             guard.state = AndroidStageDisplayState::Running;
+            guard.last_success = Some(Utc::now());
             guard.last_error = None;
             return Ok(());
         }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.138"
+version = "0.4.139"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/ndi_reload_guard.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_reload_guard.rs
@@ -83,6 +83,39 @@ pub(crate) async fn fetch_healthz_has_streaming_pipeline() -> bool {
     try_fetch().await.unwrap_or(true)
 }
 
+/// LAST-RESORT escalation decision (#401): should the stage page perform a full
+/// `window.location.reload()` because video has been dead for too long despite
+/// the reconnect loop continuously retrying? `ms_since_last_decoded_frame` is
+/// measured across the WHOLE page session, so the only way it grows past
+/// `reload_threshold_ms` is a genuinely stuck stream reconnect alone has NOT
+/// recovered. Pure + side-effect-free so it is unit-testable without a browser.
+pub(crate) fn should_escalate_reload(
+    ms_since_last_decoded_frame: f64,
+    reload_threshold_ms: f64,
+) -> bool {
+    // Strictly greater-than so a tick landing exactly AT the threshold waits one
+    // more tick (no off-by-one reload on the boundary).
+    ms_since_last_decoded_frame > reload_threshold_ms
+}
+
+/// TEST-ONLY (#422): whether the page URL carries `?ndiReloadSkipHealthz=1`,
+/// which makes the last-resort reload bypass the #410 `/healthz` streaming gate.
+/// The E2E uses it to exercise the real `window.location.reload()` path
+/// deterministically — a pipeline-kill cannot create the gate's
+/// "server-streaming-but-this-consumer-stuck" precondition. Production stage
+/// pages never set it, so prod always takes the full gated path. Read ONCE.
+pub(crate) fn reload_skip_healthz_from_url() -> bool {
+    leptos::web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .and_then(|search| {
+            leptos::web_sys::UrlSearchParams::new_with_str(&search)
+                .ok()
+                .and_then(|p| p.get("ndiReloadSkipHealthz"))
+        })
+        .as_deref()
+        == Some("1")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{healthz_body_has_streaming_pipeline, should_reload_given_pipeline_state};

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -192,6 +192,14 @@ pub(crate) struct ReloadEscalation {
     /// param is read ONCE here; production pages never carry it, so prod always
     /// uses the conservative 60s.
     threshold_ms: f64,
+    /// TEST-ONLY (#422): when the page URL carries `?ndiReloadSkipHealthz=1`,
+    /// the last-resort reload bypasses the #410 `/healthz` streaming gate and
+    /// fires on the no-frames horizon alone. The E2E needs this because a
+    /// pipeline-kill cannot create the gate's "server-streaming-but-this-
+    /// consumer-stuck" precondition (killing the source makes the gate correctly
+    /// suppress the reload). Production stage pages never set it, so prod always
+    /// takes the full gated path. Read ONCE at construction.
+    skip_healthz_gate: bool,
 }
 
 impl ReloadEscalation {
@@ -204,6 +212,7 @@ impl ReloadEscalation {
             reloaded: Cell::new(false),
             check_in_flight: Cell::new(false),
             threshold_ms: reload_threshold_ms_from_url(),
+            skip_healthz_gate: reload_skip_healthz_from_url(),
         })
     }
 
@@ -245,6 +254,23 @@ impl ReloadEscalation {
         }
         if !should_escalate_reload(self.ms_since_last_decoded_frame(), self.threshold_ms) {
             return false;
+        }
+        // TEST-ONLY (#422): bypass the #410 `/healthz` gate so the E2E exercises
+        // the real `window.location.reload()` on the no-frames horizon alone.
+        // Prod stage pages never carry `?ndiReloadSkipHealthz`, so this branch is
+        // dead in production — the full gated path below is unchanged there.
+        if self.skip_healthz_gate {
+            if self.reloaded.replace(true) {
+                return true;
+            }
+            leptos::logging::warn!(
+                "watchdog: no decoded frame for {:.0}ms — LAST-RESORT reload (healthz gate bypassed, test-only #422)",
+                self.ms_since_last_decoded_frame()
+            );
+            if let Some(window) = leptos::web_sys::window() {
+                let _ = window.location().reload();
+            }
+            return true;
         }
         // Horizon crossed. Don't spawn a second check while one is in flight.
         if self.check_in_flight.get() {
@@ -493,6 +519,24 @@ fn reload_threshold_ms_from_url() -> f64 {
         .and_then(|v| v.parse::<f64>().ok())
         .filter(|v| *v > 0.0);
     parsed.unwrap_or(Watchdog::RELOAD_NO_FRAME_MS)
+}
+
+/// TEST-ONLY (#422): whether the page URL carries `?ndiReloadSkipHealthz=1`,
+/// which makes the last-resort reload bypass the #410 `/healthz` streaming gate.
+/// The E2E uses it to exercise the real `window.location.reload()` path
+/// deterministically — a pipeline-kill cannot create the gate's
+/// "server-streaming-but-this-consumer-stuck" precondition. Production stage
+/// pages never set it, so prod always takes the full gated path. Read ONCE.
+fn reload_skip_healthz_from_url() -> bool {
+    leptos::web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .and_then(|search| {
+            leptos::web_sys::UrlSearchParams::new_with_str(&search)
+                .ok()
+                .and_then(|p| p.get("ndiReloadSkipHealthz"))
+        })
+        .as_deref()
+        == Some("1")
 }
 
 /// Monotonic now in milliseconds: `performance.now()`, with a `Date.now()`

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -192,13 +192,9 @@ pub(crate) struct ReloadEscalation {
     /// param is read ONCE here; production pages never carry it, so prod always
     /// uses the conservative 60s.
     threshold_ms: f64,
-    /// TEST-ONLY (#422): when the page URL carries `?ndiReloadSkipHealthz=1`,
-    /// the last-resort reload bypasses the #410 `/healthz` streaming gate and
-    /// fires on the no-frames horizon alone. The E2E needs this because a
-    /// pipeline-kill cannot create the gate's "server-streaming-but-this-
-    /// consumer-stuck" precondition (killing the source makes the gate correctly
-    /// suppress the reload). Production stage pages never set it, so prod always
-    /// takes the full gated path. Read ONCE at construction.
+    /// TEST-ONLY (#422): when set (via `?ndiReloadSkipHealthz=1`), the
+    /// last-resort reload bypasses the #410 `/healthz` gate and fires on the
+    /// no-frames horizon alone. Prod pages never set it. Read ONCE.
     skip_healthz_gate: bool,
 }
 
@@ -212,7 +208,7 @@ impl ReloadEscalation {
             reloaded: Cell::new(false),
             check_in_flight: Cell::new(false),
             threshold_ms: reload_threshold_ms_from_url(),
-            skip_healthz_gate: reload_skip_healthz_from_url(),
+            skip_healthz_gate: super::ndi_reload_guard::reload_skip_healthz_from_url(),
         })
     }
 
@@ -252,7 +248,10 @@ impl ReloadEscalation {
         if self.reloaded.get() {
             return true;
         }
-        if !should_escalate_reload(self.ms_since_last_decoded_frame(), self.threshold_ms) {
+        if !super::ndi_reload_guard::should_escalate_reload(
+            self.ms_since_last_decoded_frame(),
+            self.threshold_ms,
+        ) {
             return false;
         }
         // TEST-ONLY (#422): bypass the #410 `/healthz` gate so the E2E exercises
@@ -286,7 +285,7 @@ impl ReloadEscalation {
             // the horizon so a recovered stream is never reloaded out from
             // under itself.
             if escalation.reloaded.get()
-                || !should_escalate_reload(
+                || !super::ndi_reload_guard::should_escalate_reload(
                     escalation.ms_since_last_decoded_frame(),
                     escalation.threshold_ms,
                 )
@@ -477,30 +476,6 @@ impl Drop for Watchdog {
     }
 }
 
-/// LAST-RESORT escalation decision (#401): should the stage page perform a
-/// full `window.location.reload()` because video has been dead for too long
-/// despite the reconnect loop continuously retrying?
-///
-/// `ms_since_last_decoded_frame` is measured across the WHOLE page session
-/// (it survives individual reconnect cycles — see `ReloadEscalation`), so the
-/// only way it grows past `reload_threshold_ms` is a genuinely stuck stream
-/// that reconnect alone has NOT recovered. A normal brief reconnect decodes
-/// frames again within seconds and resets the timer well before the threshold.
-///
-/// Pure + side-effect-free so the escalation rule is unit-testable without a
-/// browser (the wiring that calls `window.location.reload()` is in the health
-/// ticker; this function only decides).
-pub(crate) fn should_escalate_reload(
-    ms_since_last_decoded_frame: f64,
-    reload_threshold_ms: f64,
-) -> bool {
-    // Strictly greater-than so a tick landing exactly AT the threshold waits
-    // one more tick (no off-by-one reload on the boundary). The page-session
-    // timer is reset on every decoded frame, so reaching this point at all
-    // means reconnect has not produced a single frame for the whole window.
-    ms_since_last_decoded_frame > reload_threshold_ms
-}
-
 /// Resolve the no-frames reload horizon for THIS page load: the conservative
 /// `RELOAD_NO_FRAME_MS` default, unless a `?ndiReloadMs=<n>` URL query lowers
 /// it. The override is a read-only query param (no behavior change beyond the
@@ -519,24 +494,6 @@ fn reload_threshold_ms_from_url() -> f64 {
         .and_then(|v| v.parse::<f64>().ok())
         .filter(|v| *v > 0.0);
     parsed.unwrap_or(Watchdog::RELOAD_NO_FRAME_MS)
-}
-
-/// TEST-ONLY (#422): whether the page URL carries `?ndiReloadSkipHealthz=1`,
-/// which makes the last-resort reload bypass the #410 `/healthz` streaming gate.
-/// The E2E uses it to exercise the real `window.location.reload()` path
-/// deterministically — a pipeline-kill cannot create the gate's
-/// "server-streaming-but-this-consumer-stuck" precondition. Production stage
-/// pages never set it, so prod always takes the full gated path. Read ONCE.
-fn reload_skip_healthz_from_url() -> bool {
-    leptos::web_sys::window()
-        .and_then(|w| w.location().search().ok())
-        .and_then(|search| {
-            leptos::web_sys::UrlSearchParams::new_with_str(&search)
-                .ok()
-                .and_then(|p| p.get("ndiReloadSkipHealthz"))
-        })
-        .as_deref()
-        == Some("1")
 }
 
 /// Monotonic now in milliseconds: `performance.now()`, with a `Date.now()`
@@ -1033,7 +990,8 @@ fn install_ice_failure_listener<F: Fn() + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use super::{should_escalate_reload, Watchdog};
+    use super::super::ndi_reload_guard::should_escalate_reload;
+    use super::Watchdog;
 
     // ─────────────────────────────────────────────────────────────────────
     // #401 LAST-RESORT page-reload escalation.

--- a/tests/e2e/ndi-webrtc-synthetic.spec.ts
+++ b/tests/e2e/ndi-webrtc-synthetic.spec.ts
@@ -684,6 +684,14 @@ test("stage performs LAST-RESORT page reload after prolonged video stall (synthe
     // pipeline-rebuild gap instead of after 60s. Production never sets this.
     const stageUrl = new URL("/stage", baseURL);
     stageUrl.searchParams.set("ndiReloadMs", "3000");
+    // #422: bypass the #410 /healthz streaming gate so the reload fires on the
+    // no-frames horizon alone. The continuous pipeline-kill below makes the
+    // server NOT streaming, which the #410 gate would (correctly) treat as
+    // "source down → don't reload" — so without this the reload never fires and
+    // the test deadlocks. A pipeline-kill cannot create the gate's real
+    // "server-streaming-but-this-consumer-stuck" precondition; that branch stays
+    // covered by the ndi_reload_guard unit tests. Production never sets this.
+    stageUrl.searchParams.set("ndiReloadSkipHealthz", "1");
     await page.goto(stageUrl.toString());
     await page.waitForSelector('body[data-wasm-ready="true"]', {
       timeout: 30_000,


### PR DESCRIPTION
## Problem
On prod, ALL WebRTC stage displays blinked black ~every 20s with a brief loading spinner (blue circle), and the browser re-foregrounded itself after the user navigated away. Regression vs the old Fully Kiosk setup.

## Root cause
`crates/presenter-server/src/android_stage.rs`: the `RETRY_INTERVAL = 20s` keep-alive ticker called `connect_and_launch` **unconditionally** on every enabled display, re-firing `adb shell am start -a VIEW -d <url> com.tcl.browser`. `com.tcl.browser` treats each VIEW intent as a fresh navigation → the stage page reloaded every 20s. Harmless under Fully Kiosk (`am start -n`); became a reload after the #404 switch to a VIEW intent on com.tcl.browser.

Confirmed live: polling `/integrations/android-stage/displays` 22s apart shows `lastSuccess` of SD1–SD4 advancing in 20s steps + a display caught mid-`launching`.

## Fix
Make the periodic keep-alive **foreground-aware**: before `am start`, query the device's resumed app (`dumpsys activity activities` → `mResumedActivity`) and **skip the relaunch when com.tcl.browser is already foreground**. Recovers crash/sleep/exit (relaunch when NOT foreground, or when the probe is inconclusive) but never reloads a healthy stage. Explicit/forced launches (startup, config change, launch-now endpoint) bypass the gate via a new `force_launch` flag.

## Tests (RED → GREEN)
- RED `2f33f17`: `should_launch_stage` / `parse_foreground_package` stubs (current always-launch behavior) + failing tests.
- GREEN `dad56e4`: real implementation; all 14 android_stage tests pass.

Closes #419