### PR TITLE
fix(stage): auto-recover Android displays after restart — launch after listener bound (#423)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.139"
+version = "0.4.140"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.139"
+version = "0.4.140"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/main.rs
+++ b/crates/presenter-server/src/main.rs
@@ -125,12 +125,22 @@ async fn main() -> anyhow::Result<()> {
     let config = ServerConfig::load()?;
     let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], config.http.port));
     let state = AppState::from_config(config).await?;
-    let app = build_router(state);
+    let app = build_router(state.clone());
 
     let listener = TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind to {addr}"))?;
     tracing::info!(%addr, "presenter server listening");
+
+    // #423: launch the Android stage displays NOW that the listener is bound, so
+    // the on-device `am start` lands on a serving server. Doing this during
+    // `from_config` (before bind) raced the listener — the TV hit
+    // connection-refused, showed the browser error page, and the #419
+    // foreground-aware keep-alive then skipped the relaunch forever. Non-fatal:
+    // a launch failure must never stop the server from serving.
+    if let Err(err) = state.start_android_stage_displays().await {
+        tracing::warn!(?err, "failed to launch android stage displays on startup");
+    }
     // Mock integrations (OSC/AbleSet/Resolume) bind FIXED localhost ports
     // (e.g. 127.0.0.1:8091). When a test server is spawned on a host that
     // already runs another mock-integrations build (e.g. the deployed

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -158,6 +158,18 @@ impl AppState {
         Ok(())
     }
 
+    /// Populate + launch the Android stage displays. Called ONCE at startup from
+    /// `main` AFTER the HTTP listener is bound (#423), not during `from_config`:
+    /// firing the launcher before the server is serving made the on-device
+    /// `am start` hit a connection-refused, the TV showed the browser error
+    /// page, and the #419 foreground-aware keep-alive then skipped the relaunch
+    /// forever (the browser was foreground on the error page). Triggering it once
+    /// the listener is up means the startup launch always lands on a serving
+    /// server, so a deploy/restart never strands a display.
+    pub async fn start_android_stage_displays(&self) -> anyhow::Result<()> {
+        self.sync_android_stage_displays().await
+    }
+
     // Video source methods
     pub async fn list_video_sources(&self) -> anyhow::Result<Vec<VideoSource>> {
         self.repository.list_video_sources().await

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -422,7 +422,13 @@ impl AppState {
 
         state.ensure_demo_playlist().await?;
         state.sync_resolume_hosts().await?;
-        state.sync_android_stage_displays().await?;
+        // NOTE: Android stage displays are launched by `main` AFTER the HTTP
+        // listener is bound (`start_android_stage_displays`), NOT here (#423).
+        // Launching during `from_config` raced the listener: the on-device
+        // `am start` hit a not-yet-serving server, the TV showed the browser
+        // connection-refused error page, and the #419 foreground-aware keep-alive
+        // then skipped the relaunch forever. The test-only `in_memory`
+        // constructor still calls `sync_android_stage_displays` directly.
 
         // Restore the active NDI video source from the database on startup
         // (encoder-gated, #333 item 6). Extracted to keep from_config under the

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -422,13 +422,7 @@ impl AppState {
 
         state.ensure_demo_playlist().await?;
         state.sync_resolume_hosts().await?;
-        // NOTE: Android stage displays are launched by `main` AFTER the HTTP
-        // listener is bound (`start_android_stage_displays`), NOT here (#423).
-        // Launching during `from_config` raced the listener: the on-device
-        // `am start` hit a not-yet-serving server, the TV showed the browser
-        // connection-refused error page, and the #419 foreground-aware keep-alive
-        // then skipped the relaunch forever. The test-only `in_memory`
-        // constructor still calls `sync_android_stage_displays` directly.
+        // #423: android stage displays are launched from `main` AFTER bind, not here (raced the listener) — see start_android_stage_displays.
 
         // Restore the active NDI video source from the database on startup
         // (encoder-gated, #333 item 6). Extracted to keep from_config under the


### PR DESCRIPTION
## Problem (found verifying the v0.4.139 deploy)
After the prod deploy, all stage TVs were stranded on com.tcl.browser's **connection-refused error page**. During the server restart the browser tried to load `/stage`, hit a not-yet-serving server, showed the error page, and the #419 foreground-aware keep-alive then skipped the relaunch forever (browser foreground on the error page).

## Root cause
`from_config` fired the Android stage launcher (`am start`) **before** `main` bound the HTTP listener — a startup race. The on-device `am start` raced the listener and landed on a dead server.

## Fix (server-side only — com.tcl.browser + low-latency NDI untouched)
Move the startup launch out of `from_config` to `main`, **after** `TcpListener::bind`, via `AppState::start_android_stage_displays()`. Every deploy/restart re-runs startup and the launch now always lands on a serving server, so displays auto-recover from the error page. Non-fatal on error. CRUD-triggered launches (post-startup) unaffected; the `in_memory` test constructor still calls `sync_android_stage_displays`.

No browser change, no NDI change — purely fixes the startup ordering.

Closes #423