### PR TITLE
Android stage launcher: install adb in bootstrap (#392) + integration-test keep-alive wiring via AdbRunner seam (#421)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -318,14 +318,40 @@ jobs:
   # ============================================
   # Diff-scoped PR gate (airuleset mutation-testing.md). Mutates ONLY the lines
   # changed in this PR vs the base branch — a REAL pass/fail gate, HARD-CAPPED at
-  # 20 min. The previous full-`--workspace --shard 1/12 ... || true` job timed
-  # out at its 45-min cap on every PR (#429), leaving the PR UNSTABLE. The
-  # full-tree catch-up runs on demand via mutation-full.yml (`/mutation-sweep`).
+  # 20 min PER SHARD. The previous full-`--workspace --shard 1/12 ... || true`
+  # job timed out at its 45-min cap on every PR (#429); the single-job diff gate
+  # that replaced it still timed out at the 20-min cap (#430) because the COLD
+  # cargo-mutants build dominates: cargo-mutants builds in an isolated dir that
+  # the `ci` rust-cache (keyed for the debug/test profile in target/) does not
+  # populate, so the heavy dep graph (gstreamer/NDI/leptos/seaorm) rebuilt from
+  # scratch (~15–19 min on a 2–4-core ubuntu-latest) and the run was cancelled
+  # before a single mutant was tested (CI run 27887309677: "Found 11 mutants",
+  # then cancelled at 20m16s with zero results).
+  #
+  # Fix (airuleset "Budget overrun = setup bug" — SHARD + WARM, NEVER raise the
+  # cap), closes #430:
+  #   1. SHARD across a 4-job matrix (`--shard k/4`, 0-indexed per cargo-mutants:
+  #      valid range 0/4..3/4) so the diff's mutants are split 4 ways.
+  #   2. WARM the build: pre-build the `mutants` profile into the source target/
+  #      with a dedicated rust-cache key, then run cargo-mutants `--in-place` so
+  #      it reuses that warm target directly instead of cold-building an isolated
+  #      copy per mutant. After warm-up every mutant is an incremental rebuild.
+  # Each shard = warm/restore the build once + test ~1/4 of the diff's mutants,
+  # which fits the 20-min cap even on the first (cold-cache) run.
+  #
+  # The full-tree catch-up still runs on demand via mutation-full.yml
+  # (`/mutation-sweep`).
   mutation:
-    name: Mutation Testing
+    name: Mutation Testing (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # cargo-mutants shards are 0-indexed (valid range 0/4..3/4); `--shard
+        # 4/4` is rejected ("shard k must be less than n"). Four shards = 0..3.
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -337,10 +363,16 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Rust cache
+      # Dedicated cache for the `mutants` build profile. The main `ci` cache key
+      # holds the debug/test-profile target/ and does NOT warm the separate
+      # `mutants` profile cargo-mutants builds — that gap (#430) is the cold
+      # build that blew the cap. A `mutants`-keyed cache persists the warmed
+      # target/ across runs; the matrix shards share one key (the warmed deps
+      # are identical for every shard) so only the first job populates it.
+      - name: Setup Rust cache (mutants profile)
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          shared-key: mutants
           cache-on-failure: false
 
       - name: Install cargo-mutants + cargo-nextest (prebuilt)
@@ -348,16 +380,25 @@ jobs:
         with:
           tool: cargo-mutants,cargo-nextest
 
-      - name: Run diff-scoped mutation testing (real gate)
+      # Warm target/ for the mutants profile so cargo-mutants --in-place reuses
+      # compiled deps instead of cold-building. On a warm cache this restores in
+      # seconds; on a cold cache it pays the full build ONCE, after which every
+      # per-mutant rebuild is incremental. Builds all test targets to match what
+      # the per-mutant `-- --all-targets` runs link against.
+      - name: Warm mutants-profile build
+        run: cargo build --tests --profile mutants --workspace --all-targets
+
+      - name: Run diff-scoped mutation testing (real gate, shard ${{ matrix.shard }}/4)
         run: |
           git diff origin/${{ github.base_ref || 'main' }}...HEAD > pr.diff
-          cargo mutants --in-diff pr.diff --baseline=skip --timeout 300 --test-tool=nextest --jobs 2 -- --all-targets
+          cargo mutants --in-diff pr.diff --shard ${{ matrix.shard }}/4 --in-place \
+            --baseline=skip --timeout 300 --test-tool=nextest -- --all-targets
 
       - name: Upload mutation results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: mutation-results-${{ github.run_id }}
+          name: mutation-results-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: mutants.out/
           retention-days: 14
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -306,6 +306,12 @@ jobs:
           # rg errors). This self-test proves the gate FIRES on a deeply-nested
           # marker, passes a clean tree, and fails loudly on a real scan error.
           bash tests/ci/placeholder-gate.test.sh
+          # Regression guard for #392: bootstrap-host.sh must install adb
+          # (android-tools-adb), a hard runtime dependency of the Android Stage
+          # Launcher. This self-test FAILS if adb is dropped from APT_PACKAGES,
+          # which would let un-provisioned controllers silently fail their
+          # stage launchers.
+          bash tests/ci/bootstrap-adb.test.sh
 
   # ============================================
   # Mutation Testing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Ensure ADB is installed
         run: |
           ssh deploy-target << 'REMOTE_SCRIPT'
+          set -e
           if ! command -v adb &> /dev/null; then
             echo "Installing ADB..."
             sudo apt-get update -qq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,17 @@ jobs:
         run: |
           ssh deploy-target "sudo mkdir -p ${{ env.DEPLOY_DIR }} && sudo chown -R ${{ env.DEPLOY_USER }}:${{ env.DEPLOY_USER }} ${{ env.DEPLOY_DIR }}"
 
+      - name: Ensure ADB is installed
+        run: |
+          ssh deploy-target << 'REMOTE_SCRIPT'
+          if ! command -v adb &> /dev/null; then
+            echo "Installing ADB..."
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq android-tools-adb
+          fi
+          echo "ADB version: $(adb --version | head -1)"
+          REMOTE_SCRIPT
+
       - name: Stop service (if running)
         run: |
           ssh deploy-target "if systemctl is-active --quiet ${{ env.SERVICE_NAME }}; then sudo systemctl stop ${{ env.SERVICE_NAME }}; echo 'Service stopped'; else echo 'Service not running'; fi"

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ NDI SDK for Linux/
 /*.jpeg
 /*.jpg
 
-# cargo-mutants output + the diff the in-diff PR gate writes (CI + local runs)
+# cargo-mutants output + the diff the in-diff PR gate writes (CI + local runs).
+# mutants.out.old/ is the previous run's output that cargo-mutants rotates aside.
 mutants.out/
+mutants.out.old/
 /pr.diff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.142"
+version = "0.4.143"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.142"
+version = "0.4.143"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/Cargo.toml
+++ b/crates/presenter-server/Cargo.toml
@@ -35,6 +35,7 @@ rosc = "0.10"
 include_dir = "0.7"
 async-stream = "0.3"
 regex = "1"
+async-trait.workspace = true
 
 [features]
 default = []
@@ -47,7 +48,6 @@ serde_json.workspace = true
 tokio.workspace = true
 tower.workspace = true
 presenter-persistence = { path = "../presenter-persistence" }
-async-trait.workspace = true
 wiremock = "0.6"
 tempfile = "3.10"
 

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -1,8 +1,16 @@
 use anyhow::anyhow;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use presenter_core::{AndroidStageDisplay, AndroidStageDisplayId};
 use serde::Serialize;
-use std::{collections::HashMap, env, ffi::OsString, process::Output, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    env,
+    ffi::{OsStr, OsString},
+    process::Output,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::{
     process::Command,
     sync::{mpsc, RwLock},
@@ -12,6 +20,56 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 const ADB_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Injection seam for adb invocation (#421). All device I/O goes through this
+/// trait so the keep-alive wiring (`run_device_worker` → `connect_and_launch`
+/// → the adb helpers) is testable without a real `adb` binary or device: the
+/// production impl (`ProcessAdbRunner`) spawns `adb`, while tests inject a fake
+/// that records the invocations and returns canned `Output`.
+///
+/// `args` is the full adb argument vector (e.g. `["-s", serial, "shell", …]`).
+/// The implementation is responsible for applying `ADB_COMMAND_TIMEOUT`.
+#[async_trait]
+pub trait AdbRunner: Send + Sync {
+    async fn run(&self, args: &[OsString]) -> std::io::Result<Output>;
+}
+
+/// Production [`AdbRunner`]: spawns the configured `adb` binary with a timeout.
+/// A timeout maps to an `io::Error` of kind `TimedOut` so callers handle it
+/// identically to a spawn failure.
+struct ProcessAdbRunner {
+    adb_bin: Arc<OsString>,
+}
+
+#[async_trait]
+impl AdbRunner for ProcessAdbRunner {
+    async fn run(&self, args: &[OsString]) -> std::io::Result<Output> {
+        match timeout(
+            ADB_COMMAND_TIMEOUT,
+            Command::new(self.adb_bin.as_os_str()).args(args).output(),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "adb command timed out",
+            )),
+        }
+    }
+}
+
+/// Convenience for building an adb argument vector from string-ish parts.
+fn adb_args<I, S>(parts: I) -> Vec<OsString>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    parts
+        .into_iter()
+        .map(|p| p.as_ref().to_os_string())
+        .collect()
+}
 
 const COMMAND_CHANNEL_CAPACITY: usize = 8;
 const RETRY_INTERVAL: Duration = Duration::from_secs(20);
@@ -87,7 +145,9 @@ impl AndroidStageDisplayStatusSnapshot {
 
 #[derive(Clone)]
 pub struct AndroidStageRegistry {
-    adb_path: Arc<OsString>,
+    /// adb invocation seam (#421). Production wraps `Command::new(adb)`; tests
+    /// inject a fake. Shared by every spawned device worker.
+    runner: Arc<dyn AdbRunner>,
     /// The stage URL opened on every display, read once from
     /// `PRESENTER_ANDROID_STAGE_URL` at construction. `None` when unset/empty —
     /// the launcher then warns and skips rather than firing a broken intent.
@@ -111,9 +171,10 @@ enum DeviceCommand {
 
 impl AndroidStageRegistry {
     pub fn new() -> Self {
-        let adb_path = env::var_os("PRESENTER_ANDROID_ADB_BIN")
+        let adb_bin = env::var_os("PRESENTER_ANDROID_ADB_BIN")
             .map(Arc::from)
             .unwrap_or_else(|| Arc::new(OsString::from("adb")));
+        let runner: Arc<dyn AdbRunner> = Arc::new(ProcessAdbRunner { adb_bin });
         let raw_stage_url = env::var(STAGE_URL_ENV).ok();
         let stage_url = raw_stage_url.as_deref().and_then(validate_stage_url);
         match (&stage_url, raw_stage_url.as_deref().map(str::trim)) {
@@ -136,7 +197,20 @@ impl AndroidStageRegistry {
             }
         }
         Self {
-            adb_path,
+            runner,
+            stage_url: Arc::new(stage_url),
+            displays: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Construct a registry with an injected [`AdbRunner`] and explicit stage
+    /// URL — the test seam (#421). Production code uses [`Self::new`]; this
+    /// lets integration tests drive `run_device_worker`/`connect_and_launch`
+    /// with a fake runner and no real device.
+    #[cfg(test)]
+    fn with_runner(runner: Arc<dyn AdbRunner>, stage_url: Option<String>) -> Self {
+        Self {
+            runner,
             stage_url: Arc::new(stage_url),
             displays: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -236,13 +310,13 @@ impl AndroidStageRegistry {
         } else {
             AndroidStageDisplayStatusSnapshot::disabled()
         }));
-        let adb_path = Arc::clone(&self.adb_path);
+        let runner = Arc::clone(&self.runner);
         let stage_url = Arc::clone(&self.stage_url);
         let status_clone = Arc::clone(&status);
         let config_clone = display.clone();
         let handle = tokio::spawn(async move {
             if let Err(err) =
-                run_device_worker(adb_path, stage_url, config_clone, status_clone, command_rx).await
+                run_device_worker(runner, stage_url, config_clone, status_clone, command_rx).await
             {
                 error!(?err, "android stage display worker exited");
             }
@@ -260,7 +334,7 @@ impl AndroidStageRegistry {
 }
 
 async fn run_device_worker(
-    adb_path: Arc<OsString>,
+    runner: Arc<dyn AdbRunner>,
     stage_url: Arc<Option<String>>,
     mut config: AndroidStageDisplay,
     status: Arc<RwLock<AndroidStageDisplayStatusSnapshot>>,
@@ -275,7 +349,7 @@ async fn run_device_worker(
                 if config.is_enabled {
                     // Periodic keep-alive: foreground-aware (#419) — only
                     // relaunches when the browser is not already up.
-                    if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status, false).await {
+                    if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &config, &status, false).await {
                         debug!(display = %config.label, ?err, "android stage display launch attempt failed");
                     }
                 } else {
@@ -294,7 +368,7 @@ async fn run_device_worker(
                         if config.is_enabled {
                             // Explicit/forced launch (startup, config change,
                             // launch-now endpoint): always (re)launch (#419).
-                            if let Err(err) = connect_and_launch(&adb_path, &stage_url, &config, &status, true).await {
+                            if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &config, &status, true).await {
                                 debug!(display = %config.label, ?err, "android stage display manual launch failed");
                             }
                         }
@@ -318,26 +392,13 @@ async fn run_device_worker(
 /// cycle, which otherwise make subsequent `-s serial` commands fail until the
 /// daemon restarts. Its result is intentionally ignored — the typical case is
 /// "not connected", a non-zero exit we don't care about.
-async fn adb_connect(adb_bin: &std::ffi::OsStr, serial: &str) -> anyhow::Result<()> {
-    let _ = timeout(
-        ADB_COMMAND_TIMEOUT,
-        Command::new(adb_bin).arg("disconnect").arg(serial).output(),
-    )
-    .await;
+async fn adb_connect(runner: &dyn AdbRunner, serial: &str) -> anyhow::Result<()> {
+    let _ = runner.run(&adb_args(["disconnect", serial])).await;
 
-    let connect_result = timeout(
-        ADB_COMMAND_TIMEOUT,
-        Command::new(adb_bin).arg("connect").arg(serial).output(),
-    )
-    .await;
-
-    let connect_output = match connect_result {
-        Ok(Ok(output)) => output,
-        Ok(Err(io_err)) => {
+    let connect_output = match runner.run(&adb_args(["connect", serial])).await {
+        Ok(output) => output,
+        Err(io_err) => {
             return Err(anyhow!("failed to execute adb for {}: {}", serial, io_err));
-        }
-        Err(_elapsed) => {
-            return Err(anyhow!("adb connect timed out for {}", serial));
         }
     };
 
@@ -348,7 +409,7 @@ async fn adb_connect(adb_bin: &std::ffi::OsStr, serial: &str) -> anyhow::Result<
 }
 
 async fn connect_and_launch(
-    adb_path: &Arc<OsString>,
+    runner: &dyn AdbRunner,
     stage_url: &Arc<Option<String>>,
     config: &AndroidStageDisplay,
     status: &Arc<RwLock<AndroidStageDisplayStatusSnapshot>>,
@@ -380,9 +441,7 @@ async fn connect_and_launch(
         guard.last_error = None;
     }
 
-    let adb_bin = adb_path.as_os_str();
-
-    if let Err(err) = adb_connect(adb_bin, &serial).await {
+    if let Err(err) = adb_connect(runner, &serial).await {
         record_error(status, err.to_string()).await;
         return Err(err);
     }
@@ -395,7 +454,7 @@ async fn connect_and_launch(
     // change, launch-now endpoint) bypass the gate and always relaunch.
     if !force_launch {
         let launch_pkg = launch_package(&config.launch_component);
-        let foreground = adb_foreground_package(adb_bin, &serial).await;
+        let foreground = adb_foreground_package(runner, &serial).await;
         if !should_launch_stage(foreground.as_deref(), launch_pkg) {
             debug!(
                 display = %config.label,
@@ -424,7 +483,7 @@ async fn connect_and_launch(
         guard.state = AndroidStageDisplayState::Launching;
     }
 
-    if let Err(err) = adb_launch(adb_bin, &serial, &launch_args).await {
+    if let Err(err) = adb_launch(runner, &serial, &launch_args).await {
         record_error(status, err.to_string()).await;
         return Err(err);
     }
@@ -441,32 +500,21 @@ async fn connect_and_launch(
 /// returning an error (without recording status) on timeout, exec failure, or
 /// a non-success `am start` result.
 async fn adb_launch(
-    adb_bin: &std::ffi::OsStr,
+    runner: &dyn AdbRunner,
     serial: &str,
     launch_args: &[String],
 ) -> anyhow::Result<()> {
-    let launch_result = timeout(
-        ADB_COMMAND_TIMEOUT,
-        Command::new(adb_bin)
-            .arg("-s")
-            .arg(serial)
-            .arg("shell")
-            .args(launch_args)
-            .output(),
-    )
-    .await;
+    let mut args = adb_args(["-s", serial, "shell"]);
+    args.extend(launch_args.iter().map(OsString::from));
 
-    let launch_output = match launch_result {
-        Ok(Ok(output)) => output,
-        Ok(Err(io_err)) => {
+    let launch_output = match runner.run(&args).await {
+        Ok(output) => output,
+        Err(io_err) => {
             return Err(anyhow!(
                 "failed to execute adb shell for {}: {}",
                 serial,
                 io_err
             ));
-        }
-        Err(_elapsed) => {
-            return Err(anyhow!("adb shell am start timed out for {}", serial));
         }
     };
 
@@ -554,21 +602,18 @@ fn parse_foreground_package(dumpsys_output: &str) -> Option<String> {
 /// package, or None on any adb error/timeout/non-success or when no resumed
 /// activity is reported — the caller treats None as "foreground unknown →
 /// (re)launch". Read-only: the dumpsys probe never disturbs the running browser.
-async fn adb_foreground_package(adb_bin: &std::ffi::OsStr, serial: &str) -> Option<String> {
-    let output = timeout(
-        ADB_COMMAND_TIMEOUT,
-        Command::new(adb_bin)
-            .arg("-s")
-            .arg(serial)
-            .arg("shell")
-            .arg("dumpsys")
-            .arg("activity")
-            .arg("activities")
-            .output(),
-    )
-    .await
-    .ok()?
-    .ok()?;
+async fn adb_foreground_package(runner: &dyn AdbRunner, serial: &str) -> Option<String> {
+    let output = runner
+        .run(&adb_args([
+            "-s",
+            serial,
+            "shell",
+            "dumpsys",
+            "activity",
+            "activities",
+        ]))
+        .await
+        .ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -203,19 +203,6 @@ impl AndroidStageRegistry {
         }
     }
 
-    /// Construct a registry with an injected [`AdbRunner`] and explicit stage
-    /// URL — the test seam (#421). Production code uses [`Self::new`]; this
-    /// lets integration tests drive `run_device_worker`/`connect_and_launch`
-    /// with a fake runner and no real device.
-    #[cfg(test)]
-    fn with_runner(runner: Arc<dyn AdbRunner>, stage_url: Option<String>) -> Self {
-        Self {
-            runner,
-            stage_url: Arc::new(stage_url),
-            displays: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-
     pub async fn set_displays(&self, displays: Vec<AndroidStageDisplay>) {
         let mut guard = self.displays.write().await;
         let mut desired: HashMap<AndroidStageDisplayId, AndroidStageDisplay> = displays
@@ -869,6 +856,273 @@ mod tests {
         assert_eq!(
             parse_foreground_package("some unrelated dumpsys text"),
             None
+        );
+    }
+
+    // ── #421: keep-alive wiring integration tests (fake AdbRunner) ──────────
+    //
+    // These exercise the WIRING — the force_launch dispatch + the foreground
+    // gate consulted only when !force_launch — with a fake adb runner that
+    // records every invocation and returns canned output, so no real `adb`
+    // binary or device is needed. The pure helpers are unit-tested above; this
+    // proves the helpers are wired together correctly:
+    //   (a) a periodic tick (force_launch=false) fires NO `am start` when the
+    //       browser is already foreground,
+    //   (b) a tick fires `am start` when the device is backgrounded/unknown,
+    //   (c) LaunchNow (force_launch=true) always fires `am start`, regardless
+    //       of foreground state and WITHOUT probing it.
+
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+    use std::sync::Mutex;
+    use tokio::sync::mpsc;
+
+    const TEST_STAGE_URL: &str = "http://10.77.9.205/stage";
+    const TEST_PKG: &str = "com.tcl.browser";
+
+    fn ok_output(stdout: &str) -> Output {
+        Output {
+            status: ExitStatus::from_raw(0),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    /// Whether `dumpsys activity activities` reports the stage browser as the
+    /// resumed app, another app, or fails (probe inconclusive).
+    #[derive(Clone, Copy)]
+    enum Foreground {
+        Browser,
+        OtherApp,
+        ProbeFails,
+    }
+
+    /// Fake [`AdbRunner`] recording every invocation as a single space-joined
+    /// string, and answering `dumpsys` per the configured foreground state.
+    struct FakeAdbRunner {
+        foreground: Foreground,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl FakeAdbRunner {
+        fn new(foreground: Foreground) -> Self {
+            Self {
+                foreground,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn invocations(&self) -> Vec<String> {
+            self.calls.lock().expect("calls mutex poisoned").clone()
+        }
+
+        fn am_start_calls(&self) -> usize {
+            self.invocations()
+                .iter()
+                .filter(|c| c.contains("am start"))
+                .count()
+        }
+
+        fn dumpsys_calls(&self) -> usize {
+            self.invocations()
+                .iter()
+                .filter(|c| c.contains("dumpsys activity activities"))
+                .count()
+        }
+    }
+
+    #[async_trait]
+    impl AdbRunner for FakeAdbRunner {
+        async fn run(&self, args: &[OsString]) -> std::io::Result<Output> {
+            let joined = args
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(" ");
+            self.calls
+                .lock()
+                .expect("calls mutex poisoned")
+                .push(joined.clone());
+
+            if joined.contains("dumpsys activity activities") {
+                return match self.foreground {
+                    Foreground::Browser => Ok(ok_output(&format!(
+                        "    mResumedActivity: ActivityRecord{{abc u0 {TEST_PKG}/.Main t1}}"
+                    ))),
+                    Foreground::OtherApp => Ok(ok_output(
+                        "    mResumedActivity: ActivityRecord{def u0 com.android.tv.settings/.Main t2}",
+                    )),
+                    // An inconclusive probe = adb exec failure (None foreground).
+                    Foreground::ProbeFails => {
+                        Err(std::io::Error::other("simulated dumpsys failure"))
+                    }
+                };
+            }
+
+            // connect / disconnect / `am start` all succeed cleanly.
+            Ok(ok_output(""))
+        }
+    }
+
+    fn test_display() -> AndroidStageDisplay {
+        let now = Utc::now();
+        AndroidStageDisplay::new(
+            AndroidStageDisplayId::from_uuid(Uuid::new_v4()),
+            "Stage TV".to_string(),
+            "10.0.0.42".to_string(),
+            5555,
+            TEST_PKG.to_string(),
+            true,
+            now,
+            now,
+        )
+    }
+
+    fn test_status() -> Arc<RwLock<AndroidStageDisplayStatusSnapshot>> {
+        Arc::new(RwLock::new(AndroidStageDisplayStatusSnapshot {
+            state: AndroidStageDisplayState::Connecting,
+            last_attempt: None,
+            last_success: None,
+            last_error: None,
+        }))
+    }
+
+    // (a) Periodic keep-alive, browser already foreground → NO `am start`.
+    #[tokio::test]
+    async fn tick_skips_am_start_when_browser_foreground() {
+        let runner = FakeAdbRunner::new(Foreground::Browser);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        // force_launch=false models the periodic tick.
+        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        assert!(
+            result.is_ok(),
+            "keep-alive on a healthy display must succeed"
+        );
+
+        assert_eq!(
+            runner.dumpsys_calls(),
+            1,
+            "the tick MUST consult the foreground gate (dumpsys) when !force_launch",
+        );
+        assert_eq!(
+            runner.am_start_calls(),
+            0,
+            "the tick must NOT re-fire `am start` when the browser is already foreground (#419 wiring)",
+        );
+        assert_eq!(
+            status.read().await.state,
+            AndroidStageDisplayState::Running,
+            "a confirmed-foreground probe is a liveness success → Running",
+        );
+    }
+
+    // (b) Periodic keep-alive, another app foreground → DOES fire `am start`.
+    #[tokio::test]
+    async fn tick_fires_am_start_when_backgrounded() {
+        let runner = FakeAdbRunner::new(Foreground::OtherApp);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        assert!(
+            result.is_ok(),
+            "a backgrounded display must relaunch and succeed"
+        );
+
+        assert_eq!(
+            runner.dumpsys_calls(),
+            1,
+            "the tick MUST consult the foreground gate when !force_launch",
+        );
+        assert_eq!(
+            runner.am_start_calls(),
+            1,
+            "the tick MUST fire `am start` when the browser is not foreground (recovery wiring)",
+        );
+    }
+
+    // (b') Periodic keep-alive, foreground probe inconclusive → still launches.
+    #[tokio::test]
+    async fn tick_fires_am_start_when_foreground_unknown() {
+        let runner = FakeAdbRunner::new(Foreground::ProbeFails);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        assert!(result.is_ok());
+
+        assert_eq!(runner.dumpsys_calls(), 1, "the gate is consulted on a tick");
+        assert_eq!(
+            runner.am_start_calls(),
+            1,
+            "an inconclusive foreground probe must NOT suppress a needed launch",
+        );
+    }
+
+    // (c) LaunchNow / forced launch → always `am start`, NEVER probes foreground.
+    #[tokio::test]
+    async fn launch_now_always_fires_am_start_without_probing() {
+        // Even with the browser already foreground, force_launch=true must
+        // relaunch and must NOT consult the gate.
+        let runner = FakeAdbRunner::new(Foreground::Browser);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let result = connect_and_launch(&runner, &stage_url, &config, &status, true).await;
+        assert!(result.is_ok(), "a forced launch must succeed");
+
+        assert_eq!(
+            runner.dumpsys_calls(),
+            0,
+            "a forced launch (force_launch=true) MUST bypass the foreground gate",
+        );
+        assert_eq!(
+            runner.am_start_calls(),
+            1,
+            "a forced launch MUST always fire `am start` regardless of foreground state",
+        );
+    }
+
+    // The DISPATCH wiring end-to-end: a LaunchNow command through the worker
+    // fires `am start` even when the browser is already foreground (proving the
+    // worker dispatches force_launch=true for LaunchNow, never consulting the
+    // gate). Drives run_device_worker directly so the command→force_launch
+    // mapping is exercised, not just connect_and_launch.
+    #[tokio::test]
+    async fn worker_launch_now_command_forces_am_start() {
+        // Keep a concrete Arc to read recorded calls after the worker exits;
+        // hand a coerced `Arc<dyn AdbRunner>` clone to the worker (no downcast).
+        let fake = Arc::new(FakeAdbRunner::new(Foreground::Browser));
+        let runner: Arc<dyn AdbRunner> = Arc::clone(&fake) as Arc<dyn AdbRunner>;
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+        // LaunchNow then Shutdown so the worker processes the command and exits
+        // promptly (the 20s tick never fires within this test window).
+        tx.try_send(DeviceCommand::LaunchNow).unwrap();
+        tx.try_send(DeviceCommand::Shutdown).unwrap();
+
+        run_device_worker(runner, stage_url, config, status, rx)
+            .await
+            .expect("worker should exit cleanly on Shutdown");
+
+        assert_eq!(
+            fake.dumpsys_calls(),
+            0,
+            "LaunchNow must dispatch force_launch=true → the gate is never consulted",
+        );
+        assert_eq!(
+            fake.am_start_calls(),
+            1,
+            "LaunchNow must fire `am start` even when the browser is already foreground",
         );
     }
 }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -897,10 +897,21 @@ mod tests {
         ProbeFails,
     }
 
+    fn err_output(stderr: &str) -> Output {
+        Output {
+            status: ExitStatus::from_raw(1 << 8), // non-zero exit (wait-status)
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
     /// Fake [`AdbRunner`] recording every invocation as a single space-joined
     /// string, and answering `dumpsys` per the configured foreground state.
     struct FakeAdbRunner {
         foreground: Foreground,
+        /// When true, `adb connect <serial>` returns a failed/non-success
+        /// Output so `adb_connect` errors (modeling an unreachable device).
+        connect_fails: bool,
         calls: Mutex<Vec<String>>,
     }
 
@@ -908,6 +919,15 @@ mod tests {
         fn new(foreground: Foreground) -> Self {
             Self {
                 foreground,
+                connect_fails: false,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_connect_failure(foreground: Foreground) -> Self {
+            Self {
+                foreground,
+                connect_fails: true,
                 calls: Mutex::new(Vec::new()),
             }
         }
@@ -920,6 +940,13 @@ mod tests {
             self.invocations()
                 .iter()
                 .filter(|c| c.contains("am start"))
+                .count()
+        }
+
+        fn connect_calls(&self) -> usize {
+            self.invocations()
+                .iter()
+                .filter(|c| c.starts_with("connect "))
                 .count()
         }
 
@@ -957,6 +984,11 @@ mod tests {
                         Err(std::io::Error::other("simulated dumpsys failure"))
                     }
                 };
+            }
+
+            // `adb connect <serial>` fails when the device is unreachable.
+            if self.connect_fails && joined.starts_with("connect ") {
+                return Ok(err_output("error: failed to connect to 'host:port'"));
             }
 
             // connect / disconnect / `am start` all succeed cleanly.
@@ -1002,6 +1034,11 @@ mod tests {
             "keep-alive on a healthy display must succeed"
         );
 
+        assert_eq!(
+            runner.connect_calls(),
+            1,
+            "connect_and_launch MUST `adb connect` the device before probing/launching",
+        );
         assert_eq!(
             runner.dumpsys_calls(),
             1,
@@ -1086,6 +1123,41 @@ mod tests {
             runner.am_start_calls(),
             1,
             "a forced launch MUST always fire `am start` regardless of foreground state",
+        );
+    }
+
+    // A failing `adb connect` MUST abort the launch: connect_and_launch errors,
+    // records the error, and fires NO `am start` (and never probes foreground).
+    // This pins the adb_connect call into the launch path — a no-op connect that
+    // always succeeded would let the launch proceed against an unreachable
+    // device.
+    #[tokio::test]
+    async fn launch_aborts_when_adb_connect_fails() {
+        let runner = FakeAdbRunner::with_connect_failure(Foreground::Browser);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let result = connect_and_launch(&runner, &stage_url, &config, &status, true).await;
+        assert!(
+            result.is_err(),
+            "a failed `adb connect` MUST abort the launch with an error",
+        );
+
+        assert_eq!(
+            runner.connect_calls(),
+            1,
+            "connect_and_launch MUST attempt `adb connect` before launching",
+        );
+        assert_eq!(
+            runner.am_start_calls(),
+            0,
+            "no `am start` may fire once `adb connect` has failed",
+        );
+        assert_eq!(
+            status.read().await.state,
+            AndroidStageDisplayState::Error,
+            "a connect failure must surface as Error on the operator dashboard",
         );
     }
 

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -80,3 +80,13 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 - **Diff mutation result (local, verified):** 3 mutants in the PR diff — 1 CaughtMutant (`stage_display_snapshot` match-arm, killed by #383 unit tests), 2 Unviable, **0 survivors** → no new tests needed. `Closes #429`.
 
 **Cycle:** local fmt + clippy (`-D warnings`) + `cargo test --workspace` (all green) + quality-check `--strict --against origin/main` (exit 0) + diff-scoped `cargo mutants` (0 survivors). PR #428 body extended with `Closes #429`.
+
+## 2026-06-21 — batch #392 + #421 (Android stage launcher) — PR #432, v0.4.143
+
+- **#392** (provisioning bug): `bootstrap-host.sh` did not install `adb` (hard runtime dep of the Android Stage Launcher). RED `caa6abe` (tests/ci/bootstrap-adb.test.sh asserts `android-tools-adb` in APT_PACKAGES — failed against adb-less bootstrap) → GREEN `0d4b4f9` (added the package; updated runbook.md; added "Ensure ADB is installed" step to release.yml PP deploy, mirroring deploy.yml — closes PP coverage gap). CI self-test wired into pipeline.yml "Run CI shell tests".
+- **#421** (test-addition gated on DI refactor): keep-alive wiring untested (bare `Command::new(adb_bin)`, no seam). Seam refactor `3d0cd79` (`trait AdbRunner`; `ProcessAdbRunner` prod impl; `&dyn AdbRunner` threaded through run_device_worker/connect_and_launch/adb_connect/adb_launch/adb_foreground_package; `async-trait` moved dev-dep→dep). Wiring test `4d705ba` (FakeAdbRunner; tests: tick_skips_am_start_when_browser_foreground, tick_fires_am_start_when_backgrounded, tick_fires_am_start_when_foreground_unknown, launch_now_always_fires_am_start_without_probing, worker_launch_now_command_forces_am_start). Proven non-tautological: bypassing `if !force_launch` failed all 3 tick tests (reverted).
+- **Mutation:** diff-scoped `cargo mutants` first run = 1 survivor (`adb_connect -> Ok(())`). Killed by `61208d9` (launch_aborts_when_adb_connect_fails + connect_calls assertion); targeted re-run = 1 caught → **0 survivors**.
+- **Reviews:** /review correctness (2 cosmetic notes — timeout wording, fact still surfaced), /review ci-ops ([]), requesting-code-review (Ready to merge, 0 Critical/Important).
+- Decision: the two cosmetic timeout-message notes left as-is — the propagated io error message still names "adb command timed out", so the timeout fact is preserved on the operator dashboard's last_error.
+
+**Cycle:** local fmt + clippy (`-D warnings`) + `cargo test --workspace` (277 passed, 0 fail) + diff-scoped `cargo mutants` (0 survivors after the kill). One push, one Pipeline CI run, PR #432 (`Closes #392`, `Closes #421`).

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -90,3 +90,13 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 - Decision: the two cosmetic timeout-message notes left as-is — the propagated io error message still names "adb command timed out", so the timeout fact is preserved on the operator dashboard's last_error.
 
 **Cycle:** local fmt + clippy (`-D warnings`) + `cargo test --workspace` (277 passed, 0 fail) + diff-scoped `cargo mutants` (0 survivors after the kill). One push, one Pipeline CI run, PR #432 (`Closes #392`, `Closes #421`).
+
+### Follow-up on PR #432 — mutation gate timed out (#430), sharded + warmed
+
+- **Root cause (#430):** the single-job diff-scoped `mutation` gate (#429) hit its 20-min `timeout-minutes` cap. cargo-mutants builds the `mutants` profile in an isolated dir that the `ci` rust-cache (keyed for the debug/test profile in `target/`) does NOT warm, so the heavy dep graph (gstreamer/NDI/leptos/seaorm) cold-built from scratch; CI run 27887309677 logged "Found 11 mutants" then cancelled at 20m16s with ZERO mutants tested → PR mergeStateStatus UNSTABLE (all REQUIRED checks green; mutation is non-required, deploy-dev does not `needs` it, so v0.4.143 already deployed to dev).
+- **Fix (airuleset `ci/mutation-testing.md` "Budget overrun = setup bug" — SHARD + WARM, never raise the cap):**
+  - `pipeline.yml` `mutation` job → 4-job matrix `shard: [0,1,2,3]` (cargo-mutants `--shard k/4` is 0-indexed; `4/4` is rejected). `--in-diff` then `--shard` splits the 11 diff mutants 3+3+3+2.
+  - Dedicated `mutants`-keyed `Swatinem/rust-cache` (separate from `ci`) + a `cargo build --tests --profile mutants --workspace --all-targets` warm step, then `cargo mutants --in-place` reuses the warm `target/` directly (dropped `--jobs 2` — in-place serializes). `timeout-minutes: 20` UNCHANGED (now per shard).
+  - `.gitignore`: added `mutants.out.old/` (cargo-mutants rotates the previous run aside).
+- **Local verification (warm):** cold warm-build 7m21s (8-core dev2 under GPU load); full-diff `cargo mutants --in-place` = **11 mutants in 6m: 9 caught, 2 unviable, 0 survivors** (exit 0). With 4 shards each ≈ warm build + ~3 mutants → comfortably under the 20-min cap. No new tests needed — the seam diff is fully covered.
+- **PR #432 body** extended with `Closes #430` (keeps `Closes #392`, `Closes #421`).

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -15,7 +15,10 @@ The script installs build essentials, browser/runtime libraries, the Rust toolch
 
 ## Android Stage Launchers
 
-- Install the Android platform tools on every controller (and CI runner that executes `verify-and-refresh`):
+- The Android platform tools (`android-tools-adb`) are now installed automatically by
+  `scripts/ops/bootstrap-host.sh` (#392), so a freshly bootstrapped controller already has `adb`.
+  Only run the manual install on a host that was provisioned before this change or where bootstrap
+  was skipped (CI runners that execute `verify-and-refresh` are provisioned by the bootstrap script):
   ```bash
   sudo apt install android-tools-adb
   ```

--- a/scripts/ops/bootstrap-host.sh
+++ b/scripts/ops/bootstrap-host.sh
@@ -14,6 +14,10 @@ APT_PACKAGES=(
   pkg-config
   libssl-dev
   protobuf-compiler
+  # Android Stage Launcher runtime dependency (#392): the launcher spawns
+  # `adb` (android_stage.rs) to connect to and drive Android TV stage displays.
+  # Without it, an un-provisioned controller's stage launchers silently fail.
+  android-tools-adb
   # Playwright/browser runtime dependencies
   libasound2t64
   libatk-bridge2.0-0t64

--- a/tests/ci/bootstrap-adb.test.sh
+++ b/tests/ci/bootstrap-adb.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression guard for #392: scripts/ops/bootstrap-host.sh MUST install adb.
+#
+# adb is a hard runtime dependency of the Android Stage Launcher
+# (crates/presenter-server/src/android_stage.rs falls back to `adb` on PATH and
+# spawns it in adb_connect/adb_launch/adb_foreground_package). When the
+# provisioning script does not install it, an un-provisioned controller's stage
+# launchers silently fail. The deploy-time installs (deploy.yml / pipeline.yml /
+# release.yml) only cover the deploy hosts — a freshly bootstrapped controller
+# must already have adb. This test FAILS if the package is dropped from the
+# bootstrap script's APT_PACKAGES list again.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP="$SCRIPT_DIR/../../scripts/ops/bootstrap-host.sh"
+
+fail=0
+
+if [ ! -f "$BOOTSTRAP" ]; then
+    echo "FAIL: bootstrap script not found at $BOOTSTRAP" >&2
+    exit 1
+fi
+
+# The Debian/Ubuntu adb package is `android-tools-adb` (provides /usr/bin/adb).
+# Assert it appears inside the APT_PACKAGES=( … ) array literal, not merely
+# anywhere in the file (so a stray comment can't make the gate pass).
+pkg_block="$(awk '/^APT_PACKAGES=\(/{flag=1} flag{print} /^\)/{if(flag)exit}' "$BOOTSTRAP")"
+
+if [ -z "$pkg_block" ]; then
+    echo "FAIL: could not locate APT_PACKAGES=( … ) array in $BOOTSTRAP" >&2
+    exit 1
+fi
+
+# Match the package as a standalone array element (its own line, allowing a
+# trailing inline comment), so a substring elsewhere does not satisfy the gate.
+if ! grep -Eq '^[[:space:]]*android-tools-adb([[:space:]]+#.*)?[[:space:]]*$' <<<"$pkg_block"; then
+    echo "FAIL (#392): scripts/ops/bootstrap-host.sh APT_PACKAGES must include" >&2
+    echo "             'android-tools-adb' — adb is a hard runtime dependency of" >&2
+    echo "             the Android Stage Launcher. Un-provisioned controllers" >&2
+    echo "             silently fail their stage launchers without it." >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "Shell tests for scripts/ops/bootstrap-host.sh (adb): FAILED" >&2
+    exit 1
+fi
+
+echo "Shell tests for scripts/ops/bootstrap-host.sh (adb): all passed"


### PR DESCRIPTION
Bundles two Android-stage-launcher issues that touch disjoint files.

## Closes #392 — bootstrap-host.sh does not install adb (provisioning bug)

`adb` is a hard runtime dependency of the Android Stage Launcher (`android_stage.rs` spawns it), but `scripts/ops/bootstrap-host.sh` never installed it, so un-provisioned controllers silently failed their stage launchers.

- Added `android-tools-adb` to the bootstrap `APT_PACKAGES`.
- Added a CI self-test `tests/ci/bootstrap-adb.test.sh` (committed RED-first, then GREEN) asserting the package is listed; wired into the pipeline "Run CI shell tests" step.
- `docs/ops/runbook.md`: noted adb install is now automated (was a manual step).
- `release.yml`: added an "Ensure ADB is installed" step to the PP deploy job (companion-pp.lan), mirroring `deploy.yml` — closes the PP coverage gap (prod+dev already installed adb at deploy; PP did not).

## Closes #421 — integration-test the keep-alive wiring (AdbRunner seam)

The keep-alive wiring was untested because adb was invoked via bare `Command::new(adb_bin)` with no injection seam.

- Introduced `trait AdbRunner { async fn run(args) -> io::Result<Output> }`; production `ProcessAdbRunner` wraps `Command` + the timeout; tests inject a fake. Threaded `&dyn AdbRunner` through `run_device_worker` / `connect_and_launch` / `adb_connect` / `adb_launch` / `adb_foreground_package` (behavior-preserving refactor).
- Added integration tests via a `FakeAdbRunner`: (a) periodic tick (`force_launch=false`) fires NO `am start` when the browser is foreground; (b) tick fires `am start` when backgrounded/unknown; (c) `LaunchNow` (`force_launch=true`) always fires `am start` without probing; plus a worker-level dispatch test and a connect-failure abort test.
- Tests proven non-tautological: temporarily bypassing the `if !force_launch` gate made all three tick tests fail (reverted). Diff-scoped `cargo mutants`: 0 survivors (the `adb_connect`→`Ok(())` survivor is killed by `launch_aborts_when_adb_connect_fails`).

Version bumped to 0.4.143.

## Closes #430 — diff-scoped mutation gate vs the 20-min cap (cold mutants-profile build)

The single-job diff-scoped Mutation Testing gate (#429) timed out at its 20-min cap: cargo-mutants builds in an isolated dir that the `ci` rust-cache (keyed for the debug/test profile in `target/`) does not warm, so the heavy dep graph (gstreamer/NDI/leptos/seaorm) cold-built from scratch (~15–19 min on a 2–4-core `ubuntu-latest`) and the run was cancelled before a single mutant was tested ("Found 11 mutants" → cancelled at 20m16s, zero results), leaving the PR UNSTABLE.

Fix per airuleset `ci/mutation-testing.md` ("Budget overrun = setup bug — SHARD + WARM, NEVER raise the cap"):

- **Shard** the diff gate across a 4-job matrix (`--shard k/4`, 0-indexed per cargo-mutants — valid range `0/4..3/4`) so the diff's mutants split 4 ways.
- **Warm** the build: a dedicated `mutants`-keyed rust-cache + a `cargo build --tests --profile mutants --workspace --all-targets` step, then `cargo mutants --in-place` reuses that warm `target/` directly instead of cold-building an isolated copy per mutant. After warm-up every mutant is an incremental rebuild.
- The 20-min `timeout-minutes` cap is **unchanged** (now per shard) — never raised.

Each shard = warm/restore once + test ~1/4 of the diff's mutants, fitting the 20-min cap even on the first (cold-cache) run.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRqNtdtRVvCfp6c9o7ei79