### PR TITLE
Bundle: adb keygen in bootstrap (#393) + post-#394 AI bible prompt (#434)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -318,6 +318,14 @@ jobs:
           # loudly instead of passing silently (the trailing echo returns 0
           # regardless). FAILS if any ADB-install heredoc loses `set -e`.
           bash tests/ci/adb-install-set-e.test.sh
+          # Regression guard for #393: bootstrap-host.sh must generate adb's
+          # RSA keypair at ~/.android/adbkey when absent. The hardened
+          # presenter.service (ProtectHome=read-only) cannot mkdir ~/.android to
+          # generate the key on first run, so a freshly provisioned controller
+          # cannot bootstrap adb without it. The step is guarded to run only when
+          # the key is absent (adb keygen overwrites an existing key). FAILS if
+          # the keygen step or its absent-only guard is removed.
+          bash tests/ci/bootstrap-adb-keygen.test.sh
           # Regression guard for #439: the diff-scoped mutation PR gate must
           # bootstrap its `mutants`-profile build cache via a dedicated
           # `mutation-warm` job that the sharded `mutation` jobs depend on.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.147"
+version = "0.4.148"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.147"
+version = "0.4.148"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -197,12 +197,8 @@ async fn build_system_prompt(state: &AppState, extra: Option<&str>) -> (String, 
     let prefs = state.get_bible_preferences().await.unwrap_or_default();
     let char_limit = prefs.character_limit;
 
-    let mut prompt = render_system_prompt(
-        &libraries_str,
-        &bible_str,
-        &translations_str,
-        char_limit,
-    );
+    let mut prompt =
+        render_system_prompt(&libraries_str, &bible_str, &translations_str, char_limit);
 
     if let Some(extra_prompt) = extra {
         if !extra_prompt.is_empty() {
@@ -290,10 +286,15 @@ how many slides they become.
    reference labels like "Ján 1:1-2 (SEB)".
 
 8. If a single verse is longer than the character limit on its own
-   (rare), the validator returns main_exceeds_character_limit. Recovery:
-   split that verse into multiple verse items with the same number —
-   the server will emit them as separate slides both labeled with the
-   same verse number.
+   (rare), DO NOTHING SPECIAL — submit it as one normal verse item. A lone
+   whole verse over the limit is accepted whole on its own slide and shrunk
+   to fit by display autofit; it is NOT an error and you must NOT split it
+   across items. If you do supply several continuation items that share the
+   same verse number, the server merges them back into ONE whole verse on a
+   single slide (a verse is never split mid-text). So
+   main_exceeds_character_limit only ever means a slide over-packed MULTIPLE
+   distinct verses, or an emphasis/title slide is too long — keep verses as
+   separate items (let the server pack them) or shorten the emphasis text.
 
 9. The server validates composed slides and returns a rule-keyed JSON
    error on failure (rules: main_exceeds_character_limit,
@@ -331,6 +332,157 @@ claim success for tools that errored."#,
     )
 }
 
+/// Build the OpenAI-style messages array for one API call: the system prompt
+/// followed by every conversation message (content / tool_calls / tool_call_id
+/// / name copied through). Extracted from `run_agent` to keep it under the
+/// 120-line cap; pure transformation, no behavior change.
+fn build_api_messages(
+    system_prompt: &str,
+    conversation: &[ChatMessage],
+) -> anyhow::Result<Vec<Value>> {
+    let mut messages: Vec<Value> = vec![json!({
+        "role": "system",
+        "content": system_prompt
+    })];
+
+    for msg in conversation.iter() {
+        let mut m = json!({"role": msg.role});
+        if let Some(ref content) = msg.content {
+            m["content"] = json!(content);
+        }
+        if let Some(ref tool_calls) = msg.tool_calls {
+            m["tool_calls"] = serde_json::to_value(tool_calls)?;
+        }
+        if let Some(ref tool_call_id) = msg.tool_call_id {
+            m["tool_call_id"] = json!(tool_call_id);
+        }
+        if let Some(ref name) = msg.name {
+            m["name"] = json!(name);
+        }
+        messages.push(m);
+    }
+
+    Ok(messages)
+}
+
+/// Execute each tool call from one assistant turn: apply the delete-intent
+/// gate, run the tool, push progress events + the tool-result message into the
+/// conversation, and record each `ToolAction`. Extracted from `run_agent` to
+/// keep it under the 120-line cap; the loop body is unchanged.
+async fn execute_tool_calls(
+    tool_calls: &[super::client::ResponseToolCall],
+    conversation: &mut Vec<ChatMessage>,
+    actions: &mut Vec<ToolAction>,
+    state: &AppState,
+    char_limit: u32,
+    original_user_message: &str,
+    progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<ProgressEvent>>,
+) {
+    for tc in tool_calls {
+        // Delete-intent gate: block any delete_* tool unless either the
+        // current user message OR a deferred-intent pattern across prior
+        // user messages signals an explicit delete request. Prevents
+        // model hallucinations from causing data loss while still
+        // allowing the "user asks to delete → AI defers for confirmation
+        // → user replies 'yes'" workflow that the single-message gate
+        // mistakenly blocked (#310). See spec
+        // docs/superpowers/specs/2026-04-11-ai-mode-cleanup-design.md
+        if tc.function.name.starts_with("delete_")
+            && !delete_intent_for_turn(original_user_message, conversation)
+        {
+            warn!(
+                tool = %tc.function.name,
+                "blocked delete tool call — user message did not contain delete intent"
+            );
+            let error_json = serde_json::json!({
+                "error": "delete_blocked",
+                "reason": "Delete operations require explicit user intent. The user's message did not contain any delete keywords (delete, remove, vymazať, odstrániť, zmazať, etc.). Ask the user to confirm the deletion explicitly before retrying."
+            })
+            .to_string();
+            let preview = "BLOCKED: delete requires explicit user intent".to_string();
+
+            if let Some(tx) = progress_tx {
+                let _ = tx.send(ProgressEvent::ToolDone {
+                    tool: tc.function.name.clone(),
+                    preview: preview.clone(),
+                });
+            }
+            actions.push(ToolAction {
+                tool: tc.function.name.clone(),
+                result_preview: preview.clone(),
+            });
+            conversation.push(ChatMessage {
+                role: "tool".to_string(),
+                content: Some(error_json),
+                tool_calls: None,
+                tool_call_id: Some(tc.id.clone()),
+                name: Some(tc.function.name.clone()),
+                preview: Some(preview),
+            });
+            continue;
+        }
+
+        info!(tool = %tc.function.name, "executing AI tool call");
+
+        // Send progress: tool starting
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressEvent::ToolStart {
+                tool: tc.function.name.clone(),
+            });
+        }
+
+        let (result, preview) = match super::tools::execute_tool(
+            &tc.function.name,
+            &tc.function.arguments,
+            state,
+            char_limit,
+        )
+        .await
+        {
+            Ok((result, preview)) => {
+                // Send progress: tool done
+                if let Some(tx) = progress_tx {
+                    let _ = tx.send(ProgressEvent::ToolDone {
+                        tool: tc.function.name.clone(),
+                        preview: preview.clone(),
+                    });
+                }
+                actions.push(ToolAction {
+                    tool: tc.function.name.clone(),
+                    result_preview: preview.clone(),
+                });
+                (result, preview)
+            }
+            Err(err) => {
+                warn!(tool = %tc.function.name, ?err, "AI tool call failed");
+                let preview = format!("Error: {err}");
+                if let Some(tx) = progress_tx {
+                    let _ = tx.send(ProgressEvent::ToolDone {
+                        tool: tc.function.name.clone(),
+                        preview: preview.clone(),
+                    });
+                }
+                actions.push(ToolAction {
+                    tool: tc.function.name.clone(),
+                    result_preview: preview.clone(),
+                });
+                (json!({"error": err.to_string()}).to_string(), preview)
+            }
+        };
+
+        // Add tool result to conversation (preview is internal-only,
+        // not sent to the LLM — it's used for UI badges after reload).
+        conversation.push(ChatMessage {
+            role: "tool".to_string(),
+            content: Some(result),
+            tool_calls: None,
+            tool_call_id: Some(tc.id.clone()),
+            name: Some(tc.function.name.clone()),
+            preview: Some(preview),
+        });
+    }
+}
+
 /// Run the agentic loop: send to LLM, execute tools, repeat until text response.
 ///
 /// If `progress_tx` is provided, sends real-time progress events for each tool execution.
@@ -361,28 +513,7 @@ pub async fn run_agent(
     let original_user_message = user_message.to_string();
 
     for iteration in 0..MAX_ITERATIONS {
-        // Build messages array for API call
-        let mut messages: Vec<Value> = vec![json!({
-            "role": "system",
-            "content": system_prompt
-        })];
-
-        for msg in conversation.iter() {
-            let mut m = json!({"role": msg.role});
-            if let Some(ref content) = msg.content {
-                m["content"] = json!(content);
-            }
-            if let Some(ref tool_calls) = msg.tool_calls {
-                m["tool_calls"] = serde_json::to_value(tool_calls)?;
-            }
-            if let Some(ref tool_call_id) = msg.tool_call_id {
-                m["tool_call_id"] = json!(tool_call_id);
-            }
-            if let Some(ref name) = msg.name {
-                m["name"] = json!(name);
-            }
-            messages.push(m);
-        }
+        let messages = build_api_messages(&system_prompt, conversation)?;
 
         info!(iteration, "AI agent loop iteration");
         let response =
@@ -421,110 +552,16 @@ pub async fn run_agent(
                     preview: None,
                 });
 
-                // Execute each tool call
-                for tc in tool_calls {
-                    // Delete-intent gate: block any delete_* tool unless either the
-                    // current user message OR a deferred-intent pattern across prior
-                    // user messages signals an explicit delete request. Prevents
-                    // model hallucinations from causing data loss while still
-                    // allowing the "user asks to delete → AI defers for confirmation
-                    // → user replies 'yes'" workflow that the single-message gate
-                    // mistakenly blocked (#310). See spec
-                    // docs/superpowers/specs/2026-04-11-ai-mode-cleanup-design.md
-                    if tc.function.name.starts_with("delete_")
-                        && !delete_intent_for_turn(&original_user_message, &conversation)
-                    {
-                        warn!(
-                            tool = %tc.function.name,
-                            "blocked delete tool call — user message did not contain delete intent"
-                        );
-                        let error_json = serde_json::json!({
-                            "error": "delete_blocked",
-                            "reason": "Delete operations require explicit user intent. The user's message did not contain any delete keywords (delete, remove, vymazať, odstrániť, zmazať, etc.). Ask the user to confirm the deletion explicitly before retrying."
-                        })
-                        .to_string();
-                        let preview = "BLOCKED: delete requires explicit user intent".to_string();
-
-                        if let Some(ref tx) = progress_tx {
-                            let _ = tx.send(ProgressEvent::ToolDone {
-                                tool: tc.function.name.clone(),
-                                preview: preview.clone(),
-                            });
-                        }
-                        actions.push(ToolAction {
-                            tool: tc.function.name.clone(),
-                            result_preview: preview.clone(),
-                        });
-                        conversation.push(ChatMessage {
-                            role: "tool".to_string(),
-                            content: Some(error_json),
-                            tool_calls: None,
-                            tool_call_id: Some(tc.id.clone()),
-                            name: Some(tc.function.name.clone()),
-                            preview: Some(preview),
-                        });
-                        continue;
-                    }
-
-                    info!(tool = %tc.function.name, "executing AI tool call");
-
-                    // Send progress: tool starting
-                    if let Some(ref tx) = progress_tx {
-                        let _ = tx.send(ProgressEvent::ToolStart {
-                            tool: tc.function.name.clone(),
-                        });
-                    }
-
-                    let (result, preview) = match super::tools::execute_tool(
-                        &tc.function.name,
-                        &tc.function.arguments,
-                        state,
-                        char_limit,
-                    )
-                    .await
-                    {
-                        Ok((result, preview)) => {
-                            // Send progress: tool done
-                            if let Some(ref tx) = progress_tx {
-                                let _ = tx.send(ProgressEvent::ToolDone {
-                                    tool: tc.function.name.clone(),
-                                    preview: preview.clone(),
-                                });
-                            }
-                            actions.push(ToolAction {
-                                tool: tc.function.name.clone(),
-                                result_preview: preview.clone(),
-                            });
-                            (result, preview)
-                        }
-                        Err(err) => {
-                            warn!(tool = %tc.function.name, ?err, "AI tool call failed");
-                            let preview = format!("Error: {err}");
-                            if let Some(ref tx) = progress_tx {
-                                let _ = tx.send(ProgressEvent::ToolDone {
-                                    tool: tc.function.name.clone(),
-                                    preview: preview.clone(),
-                                });
-                            }
-                            actions.push(ToolAction {
-                                tool: tc.function.name.clone(),
-                                result_preview: preview.clone(),
-                            });
-                            (json!({"error": err.to_string()}).to_string(), preview)
-                        }
-                    };
-
-                    // Add tool result to conversation (preview is internal-only,
-                    // not sent to the LLM — it's used for UI badges after reload).
-                    conversation.push(ChatMessage {
-                        role: "tool".to_string(),
-                        content: Some(result),
-                        tool_calls: None,
-                        tool_call_id: Some(tc.id.clone()),
-                        name: Some(tc.function.name.clone()),
-                        preview: Some(preview),
-                    });
-                }
+                execute_tool_calls(
+                    tool_calls,
+                    conversation,
+                    &mut actions,
+                    state,
+                    char_limit,
+                    &original_user_message,
+                    progress_tx.as_ref(),
+                )
+                .await;
 
                 continue; // Call LLM again with tool results
             }

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -980,4 +980,185 @@ mod tests {
             "system prompt must state same-number continuation items are merged (post-#394)"
         );
     }
+
+    // --- coverage for the run_agent helpers extracted in #434 ---
+
+    fn response_tool_call(
+        id: &str,
+        name: &str,
+        args: &str,
+    ) -> super::super::client::ResponseToolCall {
+        super::super::client::ResponseToolCall {
+            id: id.to_string(),
+            call_type: "function".to_string(),
+            function: super::super::client::ResponseFunction {
+                name: name.to_string(),
+                arguments: args.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn build_api_messages_prepends_system_and_maps_each_message() {
+        let conv = vec![
+            user_msg("hello"),
+            assistant_tool_call_msg("call_1", "create_presentation"),
+            tool_result_msg("call_1", "create_presentation", "{\"ok\":true}"),
+            assistant_msg("done"),
+        ];
+        let messages = build_api_messages("SYSTEM-PROMPT", &conv).expect("must build");
+
+        // System prompt is element 0, with the exact content (kills the
+        // empty-vec / default-vec / wrong-content mutants).
+        assert_eq!(messages.len(), conv.len() + 1);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "SYSTEM-PROMPT");
+
+        // Conversation messages are mapped through with their fields.
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "hello");
+
+        // The tool-call assistant message carries its tool_calls array.
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[2]["tool_calls"][0]["id"], "call_1");
+
+        // The tool result carries tool_call_id + name + content.
+        assert_eq!(messages[3]["role"], "tool");
+        assert_eq!(messages[3]["tool_call_id"], "call_1");
+        assert_eq!(messages[3]["name"], "create_presentation");
+        assert_eq!(messages[3]["content"], "{\"ok\":true}");
+
+        assert_eq!(messages[4]["content"], "done");
+    }
+
+    #[tokio::test]
+    async fn build_system_prompt_returns_real_prompt_and_appends_extra() {
+        let state = AppState::in_memory().await.unwrap();
+
+        // No extra: prompt is non-empty, contains the bible-slide guidance, and
+        // does NOT carry an Additional Instructions section. char_limit is the
+        // real configured value, not 0/1 (kills the (String::new(),0/1) and
+        // ("xyzzy",0/1) return-value mutants).
+        let (prompt, char_limit) = build_system_prompt(&state, None).await;
+        assert!(prompt.contains("presentation assistant for a church worship app"));
+        assert!(prompt.contains("## Creating Bible slides"));
+        assert!(!prompt.contains("## Additional Instructions"));
+        assert!(char_limit > 1, "char_limit must be the real limit, not 0/1");
+
+        // An EMPTY extra must NOT append the section (the `!extra.is_empty()`
+        // guard — kills the `delete !` mutant at the guard).
+        let (prompt_empty_extra, _) = build_system_prompt(&state, Some("")).await;
+        assert!(!prompt_empty_extra.contains("## Additional Instructions"));
+
+        // A NON-empty extra MUST append it (kills the guard-removed mutant the
+        // other way and proves the append path runs).
+        let (prompt_with_extra, _) = build_system_prompt(&state, Some("CUSTOM RULE 42")).await;
+        assert!(prompt_with_extra.contains("## Additional Instructions"));
+        assert!(prompt_with_extra.contains("CUSTOM RULE 42"));
+    }
+
+    #[tokio::test]
+    async fn execute_tool_calls_blocks_delete_without_intent_and_runs_otherwise() {
+        let state = AppState::in_memory().await.unwrap();
+
+        // 1. A delete_* tool with NO delete intent in the user message must be
+        //    BLOCKED: a delete_blocked tool message is pushed and the tool is
+        //    NOT executed. This kills: the body→() mutant (conversation/actions
+        //    would not change), the `&&`→`||` mutant (would also block a
+        //    non-delete tool), and the `delete !` mutant (would allow the
+        //    delete through without intent).
+        let mut conversation: Vec<ChatMessage> = Vec::new();
+        let mut actions: Vec<ToolAction> = Vec::new();
+        let calls = vec![response_tool_call(
+            "c1",
+            "delete_presentation",
+            "{\"id\":1}",
+        )];
+        execute_tool_calls(
+            &calls,
+            &mut conversation,
+            &mut actions,
+            &state,
+            320,
+            "please create a presentation", // no delete keyword
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            conversation.len(),
+            1,
+            "a tool result message must be pushed"
+        );
+        assert_eq!(conversation[0].role, "tool");
+        assert_eq!(conversation[0].tool_call_id.as_deref(), Some("c1"));
+        let content = conversation[0].content.as_deref().unwrap_or_default();
+        assert!(
+            content.contains("delete_blocked"),
+            "delete without intent must be blocked, got: {content}"
+        );
+        assert_eq!(actions.len(), 1);
+        assert!(actions[0].result_preview.contains("BLOCKED"));
+
+        // 2. The SAME delete tool WITH explicit delete intent must NOT be
+        //    blocked — it reaches execution (the in-memory state has no such
+        //    presentation, so the tool errors, but the point is the gate let it
+        //    through: no delete_blocked message). This proves the `&&`/`!`
+        //    operands are evaluated correctly, not short-circuited the wrong way.
+        let mut conversation2: Vec<ChatMessage> = Vec::new();
+        let mut actions2: Vec<ToolAction> = Vec::new();
+        let calls2 = vec![response_tool_call(
+            "c2",
+            "delete_presentation",
+            "{\"id\":1}",
+        )];
+        execute_tool_calls(
+            &calls2,
+            &mut conversation2,
+            &mut actions2,
+            &state,
+            320,
+            "delete that presentation please", // explicit delete intent
+            None,
+        )
+        .await;
+
+        assert_eq!(conversation2.len(), 1);
+        let content2 = conversation2[0].content.as_deref().unwrap_or_default();
+        assert!(
+            !content2.contains("delete_blocked"),
+            "delete WITH intent must not be gate-blocked, got: {content2}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_agent_propagates_error_when_llm_unreachable() {
+        // run_agent's first action each iteration is to call the LLM. With an
+        // unreachable endpoint, call_chat_completions fails and run_agent
+        // propagates the error via `?` — it returns Err, NOT Ok. This exercises
+        // the real run_agent body (kills the `replace run_agent body with
+        // Ok((..., vec![]))` mutants) without needing a live LLM: the mutant
+        // would return Ok and this assertion would fail.
+        let state = AppState::in_memory().await.unwrap();
+        let settings = AiSettings {
+            // Port 1 is reserved/unbound — the connection is refused immediately.
+            api_url: "http://127.0.0.1:1/v1".to_string(),
+            api_key: None,
+            model: "test-model".to_string(),
+            system_prompt_extra: None,
+        };
+        let mut conversation: Vec<ChatMessage> = Vec::new();
+
+        let result = run_agent("hello", &mut conversation, &state, &settings, None).await;
+        assert!(
+            result.is_err(),
+            "run_agent must propagate the LLM error (Err), not return a canned Ok value"
+        );
+
+        // The user message is pushed before the (failing) LLM call, so the
+        // conversation is not left empty — further proof the real body ran.
+        assert_eq!(conversation.len(), 1);
+        assert_eq!(conversation[0].role, "user");
+        assert_eq!(conversation[0].content.as_deref(), Some("hello"));
+    }
 }

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -197,7 +197,34 @@ async fn build_system_prompt(state: &AppState, extra: Option<&str>) -> (String, 
     let prefs = state.get_bible_preferences().await.unwrap_or_default();
     let char_limit = prefs.character_limit;
 
-    let mut prompt = format!(
+    let mut prompt = render_system_prompt(
+        &libraries_str,
+        &bible_str,
+        &translations_str,
+        char_limit,
+    );
+
+    if let Some(extra_prompt) = extra {
+        if !extra_prompt.is_empty() {
+            prompt.push_str("\n\n## Additional Instructions\n");
+            prompt.push_str(extra_prompt);
+        }
+    }
+
+    (prompt, char_limit)
+}
+
+/// Render the static system-prompt template, interpolating the live-context
+/// strings and the character limit. Pure (no DB / async) so it is unit-tested
+/// directly. Extracted from `build_system_prompt` to keep that function under
+/// the 120-line cap and to give the prompt's wording a direct test target.
+fn render_system_prompt(
+    libraries: &str,
+    bibles: &str,
+    translations: &str,
+    char_limit: u32,
+) -> String {
+    format!(
         r#"You are a presentation assistant for a church worship app.
 
 ## Live context
@@ -297,20 +324,11 @@ how many slides they become.
 Respond in the user's language (typically Slovak). Keep responses
 concise. Summarize what you actually did based on tool results. Do not
 claim success for tools that errored."#,
-        libraries = libraries_str,
-        bibles = bible_str,
-        translations = translations_str,
+        libraries = libraries,
+        bibles = bibles,
+        translations = translations,
         char_limit = char_limit,
-    );
-
-    if let Some(extra_prompt) = extra {
-        if !extra_prompt.is_empty() {
-            prompt.push_str("\n\n## Additional Instructions\n");
-            prompt.push_str(extra_prompt);
-        }
-    }
-
-    (prompt, char_limit)
+    )
 }
 
 /// Run the agentic loop: send to LLM, execute tools, repeat until text response.
@@ -887,5 +905,40 @@ mod tests {
         assert!(!"create_presentation".starts_with("delete_"));
         assert!(!"update_slide".starts_with("delete_"));
         assert!(!"trigger_slide".starts_with("delete_"));
+    }
+
+    // --- #434: system prompt reflects post-#394 whole-verse behavior ---
+
+    #[test]
+    fn system_prompt_describes_post_394_whole_verse_behavior() {
+        // The prompt's bible-slide guidance must match the shipped #394 composer
+        // behavior: a lone oversized verse is ACCEPTED WHOLE automatically (the
+        // model does not split it), and same-number continuation items are MERGED
+        // into one whole verse. It must NOT carry the pre-#394 "split that verse
+        // into multiple items, emitted as separate slides" recovery — that
+        // instruction now misleads the model.
+        let prompt = render_system_prompt("(none)", "(none yet)", "SEB", 320);
+
+        // Stale wording must be gone.
+        assert!(
+            !prompt.contains("split that verse into multiple verse items"),
+            "system prompt still tells the model to split a verse into multiple items (pre-#394)"
+        );
+        assert!(
+            !prompt.contains("emit them as separate slides"),
+            "system prompt still says same-number items are emitted as separate slides (pre-#394)"
+        );
+
+        // New behavior must be described: lone oversized verse accepted whole.
+        let lower = prompt.to_lowercase();
+        assert!(
+            lower.contains("accepted whole") || lower.contains("kept whole"),
+            "system prompt must state a lone oversized verse is accepted/kept whole (post-#394)"
+        );
+        // And same-number continuation items merge into one whole verse.
+        assert!(
+            lower.contains("merged") || lower.contains("merge"),
+            "system prompt must state same-number continuation items are merged (post-#394)"
+        );
     }
 }

--- a/crates/presenter-server/src/ai/agent.rs
+++ b/crates/presenter-server/src/ai/agent.rs
@@ -198,7 +198,7 @@ async fn build_system_prompt(state: &AppState, extra: Option<&str>) -> (String, 
     let char_limit = prefs.character_limit;
 
     let mut prompt =
-        render_system_prompt(&libraries_str, &bible_str, &translations_str, char_limit);
+        format_system_prompt(&libraries_str, &bible_str, &translations_str, char_limit);
 
     if let Some(extra_prompt) = extra {
         if !extra_prompt.is_empty() {
@@ -210,11 +210,13 @@ async fn build_system_prompt(state: &AppState, extra: Option<&str>) -> (String, 
     (prompt, char_limit)
 }
 
-/// Render the static system-prompt template, interpolating the live-context
+/// Format the static system-prompt template, interpolating the live-context
 /// strings and the character limit. Pure (no DB / async) so it is unit-tested
 /// directly. Extracted from `build_system_prompt` to keep that function under
 /// the 120-line cap and to give the prompt's wording a direct test target.
-fn render_system_prompt(
+/// Named `format_*` (not `render_*`) deliberately so the function-length gate
+/// still applies — `render_*` is the Leptos-UI exemption prefix.
+fn format_system_prompt(
     libraries: &str,
     bibles: &str,
     translations: &str,
@@ -954,7 +956,7 @@ mod tests {
         // into one whole verse. It must NOT carry the pre-#394 "split that verse
         // into multiple items, emitted as separate slides" recovery — that
         // instruction now misleads the model.
-        let prompt = render_system_prompt("(none)", "(none yet)", "SEB", 320);
+        let prompt = format_system_prompt("(none)", "(none yet)", "SEB", 320);
 
         // Stale wording must be gone.
         assert!(

--- a/crates/presenter-server/src/ai/bible_validator.rs
+++ b/crates/presenter-server/src/ai/bible_validator.rs
@@ -64,10 +64,12 @@ impl ValidationRule {
             }
             Self::MainExceedsCharacterLimit => {
                 "Slide main text exceeds the character limit. The server composes \
-                 slides from your verse items automatically — this error means a \
-                 single verse is longer than the limit on its own. Recovery: split \
-                 the verse text across multiple verse items with the same verse \
-                 number, or reduce the sermon's custom wording."
+                 slides from your verse items automatically. A LONE whole verse \
+                 over the limit is accepted as-is (autofit shrinks it) — do NOT \
+                 split a single verse. This error means the slide over-packed \
+                 MULTIPLE distinct verses, or an emphasis/title slide is too long. \
+                 Recovery: submit each verse as its own item and let the server \
+                 pack them, or shorten the emphasis/title text."
             }
         }
     }
@@ -116,10 +118,12 @@ impl ValidationError {
             if self.rule == ValidationRule::MainExceedsCharacterLimit {
                 let with_limit = format!(
                     "Slide main text exceeds the character limit ({limit} characters). \
-                     The server composes slides from your verse items automatically — this \
-                     error means a single verse is longer than the limit on its own. Recovery: \
-                     split the verse text across multiple verse items with the same verse \
-                     number, or reduce the sermon's custom wording."
+                     The server composes slides from your verse items automatically. A LONE \
+                     whole verse over the limit is accepted as-is (autofit shrinks it) — do \
+                     NOT split a single verse. This error means the slide over-packed MULTIPLE \
+                     distinct verses, or an emphasis/title slide is too long. Recovery: submit \
+                     each verse as its own item and let the server pack them, or shorten the \
+                     emphasis/title text."
                 );
                 obj["expected"] = serde_json::json!(with_limit);
             }

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -22,10 +22,18 @@ The script installs build essentials, browser/runtime libraries, the Rust toolch
   ```bash
   sudo apt install android-tools-adb
   ```
+- `scripts/ops/bootstrap-host.sh` also **generates adb's RSA keypair** at `~/.android/adbkey` on a
+  fresh host (#393). This matters because the hardened `presenter.service`
+  (`ProtectHome=read-only`, `ReadWritePaths=/opt/presenter*`) cannot create `~/.android` to generate
+  the key on adb's first `start-server` — without a pre-generated key the service's first `adb connect`
+  fails with "ADB server didn't ACK". Bootstrap generates the key only when it is **absent**, so an
+  already-keyed host keeps its existing keypair and device authorizations. The manual `cp` below is no
+  longer the only source of the key — it is needed only to **share** a single keypair across multiple
+  runtimes.
 - Create a shared key directory so all runtimes reuse the same trusted keypair:
   ```bash
   mkdir -p ~/.config/presenter/adb
-  cp ~/.android/adbkey ~/.config/presenter/adb/  # after first successful pairing
+  cp ~/.android/adbkey ~/.config/presenter/adb/      # bootstrap generates this on a fresh host (#393)
   cp ~/.android/adbkey.pub ~/.config/presenter/adb/
   ```
   All docker stacks mount this folder at `/root/.android`, so when one environment authorizes a TV the

--- a/scripts/ops/bootstrap-host.sh
+++ b/scripts/ops/bootstrap-host.sh
@@ -108,6 +108,27 @@ sudo apt-get update
 printf '[bootstrap] Installing base packages...\n'
 sudo apt-get install -y "${APT_PACKAGES[@]}"
 
+# Generate adb's RSA keypair while HOME is still writable (#393). The hardened
+# presenter.service runs with ProtectHome=read-only and ReadWritePaths limited
+# to /opt/presenter*, so adb cannot mkdir ~/.android to generate its keypair on
+# its first `start-server` — the server never ACKs ("ADB server didn't ACK") and
+# a freshly provisioned controller (or one whose ~/.android was wiped) cannot
+# bootstrap adb at all. Generating the key here, under the normal user with a
+# writable HOME, lets the read-only-HOME service merely READ the key thereafter
+# (which ProtectHome=read-only permits) without widening its writable surface.
+#
+# `adb keygen` overwrites the target file with a fresh key on every call, so it
+# is guarded to run ONLY when the key is absent — an already-keyed host (prod,
+# dev) keeps its existing keypair and its established device authorizations.
+ADB_KEY="$HOME/.android/adbkey"
+if [ ! -f "$ADB_KEY" ]; then
+  printf '[bootstrap] Generating adb keypair at %s...\n' "$ADB_KEY"
+  mkdir -p "$(dirname "$ADB_KEY")"
+  adb keygen "$ADB_KEY"
+else
+  printf '[bootstrap] adb keypair already present at %s — leaving it untouched.\n' "$ADB_KEY"
+fi
+
 # Rust toolchain
 if ! command -v rustup >/dev/null 2>&1; then
   printf '[bootstrap] Installing Rust toolchain via rustup...\n'

--- a/tests/ci/bootstrap-adb-keygen.test.sh
+++ b/tests/ci/bootstrap-adb-keygen.test.sh
@@ -31,8 +31,9 @@ if [ ! -f "$BOOTSTRAP" ]; then
 fi
 
 # 1. The script must invoke `adb keygen` (the command that creates the keypair).
-#    Match it as an executed command, not merely a mention in a comment line.
-if ! grep -Eq '^[[:space:]]*adb[[:space:]]+keygen[[:space:]]' "$BOOTSTRAP"; then
+#    Match it as an executed command on a non-comment line (it may follow a
+#    `then ` on a one-line guard), not merely a mention in a comment.
+if ! grep -Eq '(^|[^#])[[:space:]]*adb[[:space:]]+keygen[[:space:]]|;[[:space:]]*adb[[:space:]]+keygen[[:space:]]' "$BOOTSTRAP"; then
     echo "FAIL (#393): scripts/ops/bootstrap-host.sh must run 'adb keygen' so a" >&2
     echo "             freshly provisioned controller can bootstrap adb under the" >&2
     echo "             hardened (ProtectHome=read-only) presenter.service." >&2
@@ -48,14 +49,31 @@ if ! grep -Eq '\.android/adbkey' "$BOOTSTRAP"; then
     fail=1
 fi
 
-# 3. The keygen MUST be guarded so it only runs when the key is absent (adb
-#    keygen overwrites an existing key, which would clobber a keyed host's
-#    device authorizations). Assert an absence test (! -f / ! -e) is present.
-if ! grep -Eq '!\s*-(f|e)\s' "$BOOTSTRAP"; then
-    echo "FAIL (#393): the adb keygen step must be guarded to run only when the" >&2
-    echo "             adb key is ABSENT (e.g. 'if [ ! -f \"\$ADB_KEY\" ]')." >&2
-    echo "             'adb keygen' overwrites an existing key, which would" >&2
-    echo "             clobber an already-keyed host's device authorizations." >&2
+# 3. The keygen MUST be GUARDED by an absence test (adb keygen overwrites an
+#    existing key, which would clobber a keyed host's device authorizations).
+#    Assert the guard actually WRAPS the keygen call: an absence test (! -f /
+#    ! -e) must open a conditional block, and `adb keygen` must appear inside
+#    that block before its closing `fi`. A bare file-wide grep would pass even
+#    if the keygen were moved OUTSIDE an unrelated absence test, so this checks
+#    containment, not mere presence.
+# Accepts both the multi-line form (if ...; then \n adb keygen \n fi) and the
+# one-line form (if ...; then adb keygen ...; fi): the opening-if line is NOT
+# skipped, so a same-line keygen after `then` is still seen inside the guard.
+guarded=$(awk '
+    {
+        opened = 0
+        if ($0 ~ /if[[:space:]].*![[:space:]]*-(f|e)[[:space:]]/) { depth = 1; opened = 1 }
+        else if (depth > 0 && $0 ~ /(^|[[:space:]])if([[:space:]]|$)/) { depth++ }
+        if (depth > 0 && $0 ~ /adb[[:space:]]+keygen[[:space:]]/) { print "yes"; exit }
+        if (!opened && depth > 0 && $0 ~ /(^|[[:space:]])fi([[:space:]]|;|$)/) { depth-- }
+    }
+' "$BOOTSTRAP")
+if [ "$guarded" != "yes" ]; then
+    echo "FAIL (#393): the 'adb keygen' call must be INSIDE an absence-test guard" >&2
+    echo "             (e.g. 'if [ ! -f \"\$ADB_KEY\" ]; then ... adb keygen ... fi')," >&2
+    echo "             so it runs only when the adb key is absent. 'adb keygen'" >&2
+    echo "             overwrites an existing key, which would clobber an" >&2
+    echo "             already-keyed host's device authorizations." >&2
     fail=1
 fi
 

--- a/tests/ci/bootstrap-adb-keygen.test.sh
+++ b/tests/ci/bootstrap-adb-keygen.test.sh
@@ -30,21 +30,30 @@ if [ ! -f "$BOOTSTRAP" ]; then
     exit 1
 fi
 
-# 1. The script must invoke `adb keygen` targeting the .android/adbkey path.
-if ! grep -Eq 'adb[[:space:]]+keygen[[:space:]]+.*\.android/adbkey' "$BOOTSTRAP"; then
-    echo "FAIL (#393): scripts/ops/bootstrap-host.sh must run" >&2
-    echo "             'adb keygen \"\$HOME/.android/adbkey\"' so a freshly" >&2
-    echo "             provisioned controller can bootstrap adb under the" >&2
+# 1. The script must invoke `adb keygen` (the command that creates the keypair).
+#    Match it as an executed command, not merely a mention in a comment line.
+if ! grep -Eq '^[[:space:]]*adb[[:space:]]+keygen[[:space:]]' "$BOOTSTRAP"; then
+    echo "FAIL (#393): scripts/ops/bootstrap-host.sh must run 'adb keygen' so a" >&2
+    echo "             freshly provisioned controller can bootstrap adb under the" >&2
     echo "             hardened (ProtectHome=read-only) presenter.service." >&2
     fail=1
 fi
 
-# 2. The keygen MUST be guarded so it only runs when the key is absent (adb
-#    keygen overwrites an existing key, which would break a keyed host). Assert
-#    the script tests for the absence of the adbkey file near the keygen call.
-if ! grep -Eq '! *-(f|e) .*\.android/adbkey|-(f|e) .*\.android/adbkey.*\|\||\[\[ *! *-(f|e)' "$BOOTSTRAP"; then
-    echo "FAIL (#393): the adb keygen step must be guarded to run only when" >&2
-    echo "             \$HOME/.android/adbkey is ABSENT (e.g. 'if [ ! -f ... ]')." >&2
+# 2. The keygen must target the adb keypair path ~/.android/adbkey (the path adb
+#    reads on start-server). Assert the script references it (directly or via a
+#    variable assigned that path), so a keygen pointed at the wrong file fails.
+if ! grep -Eq '\.android/adbkey' "$BOOTSTRAP"; then
+    echo "FAIL (#393): the keygen step must target \$HOME/.android/adbkey — the" >&2
+    echo "             path adb reads when starting its server." >&2
+    fail=1
+fi
+
+# 3. The keygen MUST be guarded so it only runs when the key is absent (adb
+#    keygen overwrites an existing key, which would clobber a keyed host's
+#    device authorizations). Assert an absence test (! -f / ! -e) is present.
+if ! grep -Eq '!\s*-(f|e)\s' "$BOOTSTRAP"; then
+    echo "FAIL (#393): the adb keygen step must be guarded to run only when the" >&2
+    echo "             adb key is ABSENT (e.g. 'if [ ! -f \"\$ADB_KEY\" ]')." >&2
     echo "             'adb keygen' overwrites an existing key, which would" >&2
     echo "             clobber an already-keyed host's device authorizations." >&2
     fail=1

--- a/tests/ci/bootstrap-adb-keygen.test.sh
+++ b/tests/ci/bootstrap-adb-keygen.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression guard for #393: scripts/ops/bootstrap-host.sh MUST generate adb's
+# RSA keypair at $HOME/.android/adbkey when it is absent.
+#
+# presenter.service runs hardened with ProtectHome=read-only and
+# ReadWritePaths=/opt/presenter* only (no ~/.android), so adb's first
+# `start-server` cannot mkdir ~/.android to generate its keypair and the server
+# never ACKs ("ADB server didn't ACK"). A freshly-provisioned controller (or one
+# whose ~/.android was wiped) therefore cannot bootstrap adb from the hardened
+# service. Generating the key during bootstrap — when HOME is still writable —
+# fixes the cold-start race without widening the service's writable surface.
+#
+# `adb keygen FILE` is NOT idempotent: it overwrites FILE with a fresh key on
+# every invocation, which would clobber an already-keyed host's established
+# device authorizations. So the bootstrap step MUST be guarded to run keygen
+# only when ~/.android/adbkey does not already exist — leaving prod/dev (which
+# already have a key) untouched.
+#
+# This test FAILS if the keygen step is removed, if it stops targeting
+# ~/.android/adbkey, or if the absent-only guard is dropped.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP="$SCRIPT_DIR/../../scripts/ops/bootstrap-host.sh"
+
+fail=0
+
+if [ ! -f "$BOOTSTRAP" ]; then
+    echo "FAIL: bootstrap script not found at $BOOTSTRAP" >&2
+    exit 1
+fi
+
+# 1. The script must invoke `adb keygen` targeting the .android/adbkey path.
+if ! grep -Eq 'adb[[:space:]]+keygen[[:space:]]+.*\.android/adbkey' "$BOOTSTRAP"; then
+    echo "FAIL (#393): scripts/ops/bootstrap-host.sh must run" >&2
+    echo "             'adb keygen \"\$HOME/.android/adbkey\"' so a freshly" >&2
+    echo "             provisioned controller can bootstrap adb under the" >&2
+    echo "             hardened (ProtectHome=read-only) presenter.service." >&2
+    fail=1
+fi
+
+# 2. The keygen MUST be guarded so it only runs when the key is absent (adb
+#    keygen overwrites an existing key, which would break a keyed host). Assert
+#    the script tests for the absence of the adbkey file near the keygen call.
+if ! grep -Eq '! *-(f|e) .*\.android/adbkey|-(f|e) .*\.android/adbkey.*\|\||\[\[ *! *-(f|e)' "$BOOTSTRAP"; then
+    echo "FAIL (#393): the adb keygen step must be guarded to run only when" >&2
+    echo "             \$HOME/.android/adbkey is ABSENT (e.g. 'if [ ! -f ... ]')." >&2
+    echo "             'adb keygen' overwrites an existing key, which would" >&2
+    echo "             clobber an already-keyed host's device authorizations." >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "Shell tests for scripts/ops/bootstrap-host.sh (adb keygen): FAILED" >&2
+    exit 1
+fi
+
+echo "Shell tests for scripts/ops/bootstrap-host.sh (adb keygen): all passed"


### PR DESCRIPTION
Bundled batch of two independent, bundle-safe fixes (v0.4.148).

## #393 — Android Stage: adb keypair generated in bootstrap (BUG)

A freshly provisioned controller cannot bootstrap adb from the hardened
`presenter.service`: the unit runs `ProtectHome=read-only` with
`ReadWritePaths=/opt/presenter*` only (no `~/.android`), so adb's first
`start-server` fails trying to `mkdir ~/.android` for its RSA keypair
("ADB server didn't ACK"). Masked on dev/prod only because a pre-hardening
adbkey already exists there.

- Add a guarded `adb keygen "$HOME/.android/adbkey"` step to
  `scripts/ops/bootstrap-host.sh` after `android-tools-adb` is installed,
  run only when the key is **absent** (adb keygen overwrites an existing key,
  so this leaves an already-keyed host's keypair + device authorizations
  untouched). The systemd `ReadWritePaths` is deliberately NOT widened.
- RED→GREEN: `tests/ci/bootstrap-adb-keygen.test.sh` (mirrors
  `bootstrap-adb.test.sh`), wired into the pipeline.yml "Run CI shell tests"
  step. Verified failing before the fix, passing after.
- Runbook updated: bootstrap now generates the key (manual copy is only for
  sharing a keypair across runtimes).

## #434 — AI bible prompt + validator guidance aligned with post-#394 behavior

`build_system_prompt` step 8 and the two `MainExceedsCharacterLimit`
validator messages still told the LLM the pre-#394 recovery (split an
oversized verse into same-number items "emitted as separate slides"). After
#394 a lone oversized verse is accepted whole (autofit shrinks it) and
same-number continuation items are merged into one slide — the old guidance
misleads the model.

- Rewrite step 8 + both validator messages to the post-#394 reality.
- TDD: new `system_prompt_describes_post_394_whole_verse_behavior` test
  (RED before the rewrite, GREEN after).
- Required mechanical refactor (function-length cap on the edited file, no
  behavior change): extract `render_system_prompt`, `build_api_messages`,
  `execute_tool_calls`. All functions in agent.rs now ≤120 lines.

## Verification (local, dev2)

- `cargo fmt --all --check` clean
- `cargo clippy -p presenter-server --all-targets -- -D warnings` clean
- `cargo test --workspace` — 296 + all crates pass, 0 failed
- All CI shell self-tests pass (incl. the new keygen guard)
- `fn_length_check.py` clean on changed files

Closes #393
Closes #434