### PR TITLE
feat(ci): tsc type-check gate for e2e tests (#426)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -105,6 +105,32 @@ jobs:
         run: npm run test:companion
 
   # ============================================
+  # TypeScript type-check (e2e/tests) — #426
+  # ============================================
+  # The 63 e2e .ts files are otherwise compiled by Playwright/esbuild WITHOUT
+  # type-checking, so type errors in the test harness ship invisibly. This gate
+  # runs `tsc --noEmit` against tsconfig.json so a type error (e.g. a regressed
+  # ServerHandle field, a wrong Locator.evaluate signature) fails CI loudly.
+  typecheck:
+    name: TypeScript Type Check
+    runs-on: ubuntu-latest
+    needs: branch-sync
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check e2e tests (tsc --noEmit)
+        run: npm run typecheck
+
+  # ============================================
   # Version Check
   # ============================================
   version-check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.149"
+version = "0.4.150"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.55.1",
+        "@types/node": "^26.0.0",
+        "@types/ws": "^8.18.1",
+        "typescript": "^6.0.3",
         "ws": "^8.18.3"
       }
     },
@@ -27,6 +30,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/fsevents": {
@@ -75,6 +98,27 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "npm run test:companion && npm run test:playwright",
     "test:playwright": "playwright test",
     "test:playwright:headed": "playwright test --headed",
-    "test:companion": "node --test ops/companion/presenter/lib/time.test.js ops/companion/presenter/lib/commands.test.js ops/companion/presenter/lib/variable-batch.test.js"
+    "test:companion": "node --test ops/companion/presenter/lib/time.test.js ops/companion/presenter/lib/commands.test.js ops/companion/presenter/lib/variable-batch.test.js",
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,9 @@
   "homepage": "https://github.com/zbynekdrlik/presenter#readme",
   "devDependencies": {
     "@playwright/test": "^1.55.1",
+    "@types/node": "^26.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^6.0.3",
     "ws": "^8.18.3"
   }
 }

--- a/tests/e2e/api-stage.spec.ts
+++ b/tests/e2e/api-stage.spec.ts
@@ -357,3 +357,9 @@ test("api put does not switch preview when layout is worship-snv", async ({
   // symmetry with other tests in this file that use it).
   void context;
 });
+
+declare global {
+  interface Window {
+    __presenterStageLayout?: string;
+  }
+}

--- a/tests/e2e/ndi-webrtc-recovery.spec.ts
+++ b/tests/e2e/ndi-webrtc-recovery.spec.ts
@@ -140,7 +140,7 @@ test("NDI WebRTC recovery @video-codec — video resumes within 10s after server
     .poll(
       async () =>
         await video.evaluate(
-          ({ beforeKillTime }: { beforeKillTime: number }) =>
+          (_el: Element, { beforeKillTime }: { beforeKillTime: number }) =>
             (() => {
               const v = document.querySelector(
                 'video[data-role="ndi-video"]',

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   deriveTestConfig,
   refreshDevData,
@@ -57,14 +57,14 @@ test.afterAll(async () => {
   }
 });
 
-async function waitForToast(page, expected: string | RegExp) {
+async function waitForToast(page: Page, expected: string | RegExp) {
   const toast = page.locator(selectors.toast);
   await expect(toast).toHaveAttribute('data-visible', 'true', { timeout: 20_000 });
   await expect(toast).toHaveText(expected);
   await expect(toast).toHaveAttribute('data-visible', 'false');
 }
 
-async function getHostsViaApi(page) {
+async function getHostsViaApi(page: Page) {
   const response = await page.request.get(new URL('/integrations/resolume/hosts', baseURL).toString(), {
     timeout: 60_000,
   });
@@ -77,7 +77,7 @@ async function getHostsViaApi(page) {
   }>;
 }
 
-async function getAndroidDisplaysViaApi(page) {
+async function getAndroidDisplaysViaApi(page: Page) {
   const response = await page.request.get(
     new URL('/integrations/android-stage/displays', baseURL).toString(),
     { timeout: 60_000 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Closes #426

Adds a `tsc --noEmit` type-check gate for the 63 e2e TypeScript files (compiled by Playwright/esbuild without type-checking until now). Includes tsconfig.json, typescript/@types devDeps, a typecheck npm script + CI job, and fixes for the 13 type errors it surfaced (incl. a latent runtime bug in ndi-webrtc-recovery.spec's evaluate callback).