### PR TITLE
test(e2e): skip videoWidth test when no live NDI source (#441)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.149"
+version = "0.4.151"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.150"
+version = "0.4.151"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/tests/e2e/ndi-webrtc.spec.ts
+++ b/tests/e2e/ndi-webrtc.spec.ts
@@ -255,9 +255,24 @@ test("NdiVideo videoWidth resolves above zero within 5 seconds of mount", async 
   const { available } = await status.json();
   test.skip(!available, "NDI SDK not available on this host");
 
+  // #441: libndi being loaded (available=true) does NOT mean a live NDI source
+  // is broadcasting. On a libndi host with no broadcaster (the dev2 runner /
+  // local runs) the videoWidth assertion below can never pass, so this test
+  // would FAIL (not skip). Gate on /ndi/sources being non-empty and use the
+  // discovered source — mirroring the sibling tests in this file.
+  const sourcesResp = await page.request.get(
+    new URL("/ndi/sources", baseURL).toString(),
+  );
+  const sources = sourcesResp.ok() ? await sourcesResp.json() : [];
+  test.skip(
+    !Array.isArray(sources) || sources.length === 0,
+    "No live NDI source on network — videoWidth test can't be exercised",
+  );
+  const ndiName = sources[0].name;
+
   const created = await page.request.post(
     new URL("/integrations/video-sources", baseURL).toString(),
-    { data: { label: "TEST-SNV", ndiName: "STREAM-SNV (stream)" } },
+    { data: { label: "TEST-SNV", ndiName } },
   );
   const src = await created.json();
   await page.request.post(


### PR DESCRIPTION
Closes #441

The line-251 `NdiVideo videoWidth` test gated only on libndi being loaded, then used a hardcoded source — so on a libndi host with no live broadcaster (dev2 runner / local) it failed instead of skipping. Now gates on /ndi/sources non-empty + uses the discovered source, like the sibling tests. CI unaffected.