### PR TITLE
refactor(state): decompose AppState into Cache/Companion/Bible managers (#346)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.152"
+version = "0.4.153"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -51,7 +51,7 @@ impl AppState {
             .await?;
         self.ableset_bridge.apply_settings(settings.clone()).await?;
         {
-            let mut cache = self.ableset_cache.write().await;
+            let mut cache = self.caches.ableset.write().await;
             cache.invalidate();
             cache.library_name = None;
             cache.song_prefix_length = settings.song_prefix_length;
@@ -85,13 +85,13 @@ impl AppState {
         }
         self.ensure_ableset_cache(&settings).await?;
         let lookup = key.to_ascii_lowercase();
-        let cache = self.ableset_cache.read().await;
+        let cache = self.caches.ableset.read().await;
         Ok(cache.entries.get(&lookup).copied())
     }
 
     async fn ensure_ableset_cache(&self, settings: &AbleSetStatusSnapshot) -> anyhow::Result<()> {
         let needs_refresh = {
-            let cache = self.ableset_cache.read().await;
+            let cache = self.caches.ableset.read().await;
             !cache.matches(&settings.library_name, settings.song_prefix_length)
                 || cache.entries.is_empty()
         };
@@ -109,7 +109,7 @@ impl AppState {
         let target = summaries
             .into_iter()
             .find(|summary| summary.name.eq_ignore_ascii_case(&settings.library_name));
-        let mut cache = self.ableset_cache.write().await;
+        let mut cache = self.caches.ableset.write().await;
         cache.library_name = Some(settings.library_name.clone());
         cache.song_prefix_length = settings.song_prefix_length;
         cache.entries.clear();

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -434,7 +434,7 @@ impl AppState {
 
     // Bible broadcast methods
     pub async fn active_bible_broadcast(&self) -> Option<BibleBroadcast> {
-        self.bible_broadcast.read().await.clone()
+        self.bible.broadcast.read().await.clone()
     }
 
     pub async fn trigger_bible_passage(
@@ -537,7 +537,7 @@ impl AppState {
 
         let broadcast = BibleBroadcast::new(passage, Utc::now());
         {
-            let mut guard = self.bible_broadcast.write().await;
+            let mut guard = self.bible.broadcast.write().await;
             *guard = Some(broadcast.clone());
         }
         self.live_hub.publish(LiveEvent::Bible {
@@ -563,7 +563,7 @@ impl AppState {
     ) {
         // Store as the new active output
         {
-            let mut guard = self.bible_slide_output.write().await;
+            let mut guard = self.bible.slide_output.write().await;
             *guard = Some(output.clone());
         }
         // Also update legacy bible_broadcast for backwards compatibility with /bible/active endpoint
@@ -609,7 +609,7 @@ impl AppState {
         )
         .with_reference_label(output.main_reference.clone());
         {
-            let mut guard = self.bible_broadcast.write().await;
+            let mut guard = self.bible.broadcast.write().await;
             *guard = Some(legacy_broadcast.clone());
         }
         // Publish to WebSocket subscribers (both old and new formats)
@@ -628,16 +628,16 @@ impl AppState {
     /// Get the current active Bible slide output.
     /// Used by `/bible/active-slide` endpoint (stage page initial load).
     pub async fn active_bible_slide_output(&self) -> Option<BibleSlideOutput> {
-        self.bible_slide_output.read().await.clone()
+        self.bible.slide_output.read().await.clone()
     }
 
     pub async fn clear_bible_broadcast(&self) {
         {
-            let mut guard = self.bible_broadcast.write().await;
+            let mut guard = self.bible.broadcast.write().await;
             *guard = None;
         }
         {
-            let mut guard = self.bible_slide_output.write().await;
+            let mut guard = self.bible.slide_output.write().await;
             *guard = None;
         }
         self.live_hub.publish(LiveEvent::BibleCleared);
@@ -651,7 +651,7 @@ impl AppState {
         &self,
     ) -> anyhow::Result<Vec<BibleImportSummary>> {
         #[cfg(test)]
-        if let Some(ingestion) = &self.bible_ingestion_override {
+        if let Some(ingestion) = &self.bible.ingestion_override {
             return ingestion.ingest_default_translations().await;
         }
 
@@ -664,6 +664,6 @@ impl AppState {
         &mut self,
         ingestion: std::sync::Arc<dyn super::seed::TestBibleIngestion + Send + Sync>,
     ) {
-        self.bible_ingestion_override = Some(ingestion);
+        self.bible.ingestion_override = Some(ingestion);
     }
 }

--- a/crates/presenter-server/src/state/bible_manager.rs
+++ b/crates/presenter-server/src/state/bible_manager.rs
@@ -1,0 +1,47 @@
+//! Bible broadcast / slide-output state owned by [`AppState`].
+//!
+//! Groups the Bible-related fields that were previously inline on `AppState`:
+//!
+//! - `broadcast`: current active Bible passage broadcast (legacy `/bible/active`)
+//! - `slide_output`: single-source-of-truth Bible slide output
+//! - `ingestion_override` (test-only): swaps the ingestion service in tests
+//!
+//! Pure relocation: the two `Arc<RwLock<_>>` handles keep their exact types, so
+//! the documented single-lock-at-a-time acquisition policy (see the `state`
+//! module docs) is unchanged. `clear_bible_broadcast` still acquires `broadcast`
+//! and `slide_output` in two separate scoped blocks (one lock held at a time),
+//! exactly as before.
+
+use std::sync::Arc;
+
+use presenter_core::{BibleBroadcast, BibleSlideOutput};
+use tokio::sync::RwLock;
+
+/// Owns the Bible broadcast / slide-output state.
+///
+/// `Clone` shares the `Arc<RwLock<_>>` handles (and, in tests, the override
+/// `Arc`), matching the previous inline semantics on `AppState`.
+#[derive(Clone)]
+pub(crate) struct BibleManager {
+    /// Current active Bible passage broadcast (legacy `/bible/active`).
+    pub(crate) broadcast: Arc<RwLock<Option<BibleBroadcast>>>,
+    /// Single-source-of-truth Bible slide output.
+    pub(crate) slide_output: Arc<RwLock<Option<BibleSlideOutput>>>,
+    /// Test-only ingestion override (swaps the real ingestion service).
+    #[cfg(test)]
+    pub(crate) ingestion_override: Option<Arc<dyn super::seed::TestBibleIngestion + Send + Sync>>,
+}
+
+impl BibleManager {
+    /// Build a fresh manager with empty broadcast/slide-output state.
+    /// Mirrors the previous inline initialisation in
+    /// `AppState::new_with_heartbeat`.
+    pub(crate) fn new() -> Self {
+        Self {
+            broadcast: Arc::new(RwLock::new(None)),
+            slide_output: Arc::new(RwLock::new(None)),
+            #[cfg(test)]
+            ingestion_override: None,
+        }
+    }
+}

--- a/crates/presenter-server/src/state/cache_manager.rs
+++ b/crates/presenter-server/src/state/cache_manager.rs
@@ -1,0 +1,48 @@
+//! In-memory caches owned by [`AppState`].
+//!
+//! Groups the three `Arc<RwLock<_>>` caches that were previously inline fields
+//! on `AppState`:
+//!
+//! - `presentation`: cached presentation detail for stage display
+//! - `group_color`: cached group name → hex color mapping
+//! - `ableset`: cached AbleSet library-to-playlist mapping
+//!
+//! This is a pure container — it holds the same `Arc<RwLock<_>>` handles that
+//! `AppState` used to hold directly, so the documented single-lock-at-a-time
+//! acquisition policy (see the `state` module docs) is unchanged. Callers
+//! acquire exactly one of these locks at a time, exactly as before; the only
+//! difference is the field path (`state.caches.ableset` instead of
+//! `state.ableset_cache`).
+
+use std::{collections::HashMap, sync::Arc};
+
+use presenter_core::{Presentation, PresentationId};
+use tokio::sync::RwLock;
+
+use super::ableset::AbleSetLibraryCache;
+
+/// Owns the in-memory caches threaded through `AppState`.
+///
+/// `Clone` is cheap: every field is an `Arc`, so cloning shares the underlying
+/// locks (matching the previous inline-`Arc` semantics on `AppState`).
+#[derive(Clone)]
+pub(crate) struct CacheManager {
+    /// Cached presentation detail keyed by id (stage display fast path).
+    pub(crate) presentation: Arc<RwLock<HashMap<PresentationId, Arc<Presentation>>>>,
+    /// Cached group name → hex color mapping.
+    pub(crate) group_color: Arc<RwLock<HashMap<String, String>>>,
+    /// Cached AbleSet library-to-playlist mapping.
+    pub(crate) ableset: Arc<RwLock<AbleSetLibraryCache>>,
+}
+
+impl CacheManager {
+    /// Build a fresh, empty cache set. Mirrors the previous inline
+    /// initialisation in `AppState::new_with_heartbeat`.
+    pub(crate) fn new() -> Self {
+        Self {
+            presentation: Arc::new(RwLock::new(HashMap::new())),
+            group_color: Arc::new(RwLock::new(HashMap::new())),
+            ableset: Arc::new(RwLock::new(AbleSetLibraryCache::default())),
+        }
+    }
+}

--- a/crates/presenter-server/src/state/companion_manager.rs
+++ b/crates/presenter-server/src/state/companion_manager.rs
@@ -1,0 +1,51 @@
+//! Companion (Bitfocus) integration state owned by [`AppState`].
+//!
+//! Groups the four Companion-related fields that were previously inline on
+//! `AppState`:
+//!
+//! - `token`: optional shared auth token for the Companion websocket
+//! - `enabled`: runtime feature flag (atomic, hot-swappable via settings)
+//! - `port`: runtime listen port (atomic, hot-swappable via settings)
+//! - `server`: the running websocket server handle manager
+//!
+//! Pure relocation: the atomics and the server-manager handle keep their exact
+//! types and semantics, so the load/store ordering (`Ordering::SeqCst`) and the
+//! reconfigure/rollback flow in `AppState::set_companion_settings` are
+//! unchanged.
+
+use std::sync::{
+    atomic::{AtomicBool, AtomicU16},
+    Arc,
+};
+
+use super::companion::CompanionServerManager;
+
+/// Owns the Companion integration's runtime state.
+///
+/// `Clone` shares the atomics and the server handle (all `Arc`-backed),
+/// matching the previous inline semantics on `AppState`.
+#[derive(Clone)]
+pub(crate) struct CompanionManager {
+    /// Optional shared auth token for the Companion websocket.
+    pub(crate) token: Option<String>,
+    /// Runtime feature flag — hot-swappable via settings.
+    pub(crate) enabled: Arc<AtomicBool>,
+    /// Runtime listen port — hot-swappable via settings.
+    pub(crate) port: Arc<AtomicU16>,
+    /// The running websocket server handle manager.
+    pub(crate) server: CompanionServerManager,
+}
+
+impl CompanionManager {
+    /// Build the manager from the resolved startup token/enabled/port.
+    /// Mirrors the previous inline initialisation in
+    /// `AppState::new_with_heartbeat`.
+    pub(crate) fn new(token: Option<String>, enabled: bool, port: u16) -> Self {
+        Self {
+            token,
+            enabled: Arc::new(AtomicBool::new(enabled)),
+            port: Arc::new(AtomicU16::new(port)),
+            server: CompanionServerManager::default(),
+        }
+    }
+}

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -22,8 +22,11 @@
 
 mod ableset;
 pub(crate) mod bible;
+mod bible_manager;
 mod broadcasting;
+mod cache_manager;
 mod companion;
+mod companion_manager;
 mod integrations;
 mod presentations;
 mod seed;
@@ -48,16 +51,15 @@ use crate::{
 };
 use chrono::Utc;
 use presenter_core::{
-    BibleBroadcast, BibleSlideOutput, OscSettings, OscSettingsDraft, PlaylistId, Presentation,
-    PresentationId, Slide, SlideId, StageClientSnapshot, StageDisplayLayout, StageDisplaySlide,
-    StageDisplaySnapshot, StageState, TimersOverview, API_STAGE_LAYOUT_CODE,
-    DEFAULT_STAGE_LAYOUT_CODE,
+    OscSettings, OscSettingsDraft, PlaylistId, Presentation, PresentationId, Slide, SlideId,
+    StageClientSnapshot, StageDisplayLayout, StageDisplaySlide, StageDisplaySnapshot, StageState,
+    TimersOverview, API_STAGE_LAYOUT_CODE, DEFAULT_STAGE_LAYOUT_CODE,
 };
 use presenter_persistence::{DatabaseSettings, Repository};
 use std::{
     collections::HashMap,
     env,
-    sync::{atomic::AtomicBool, atomic::AtomicU16, atomic::Ordering, Arc},
+    sync::{atomic::AtomicBool, atomic::Ordering, Arc},
     time::Instant,
 };
 use tokio::{
@@ -67,11 +69,12 @@ use tokio::{
 use tracing::{instrument, warn};
 use uuid::Uuid;
 
-use ableset::AbleSetLibraryCache;
+use bible_manager::BibleManager;
+use cache_manager::CacheManager;
 use companion::{
-    parse_bool_flag, CompanionServerManager, COMPANION_FEATURE_KEY, COMPANION_PORT_KEY,
-    DEFAULT_COMPANION_PORT,
+    parse_bool_flag, COMPANION_FEATURE_KEY, COMPANION_PORT_KEY, DEFAULT_COMPANION_PORT,
 };
+use companion_manager::CompanionManager;
 #[cfg(test)]
 pub(crate) use seed::seed_sample_library;
 #[cfg(test)]
@@ -101,31 +104,25 @@ pub(crate) struct ApiStageState {
 pub struct AppState {
     repository: Repository,
     live_hub: LiveHub,
-    bible_broadcast: Arc<RwLock<Option<BibleBroadcast>>>,
-    /// New single-source-of-truth Bible slide output
-    bible_slide_output: Arc<RwLock<Option<BibleSlideOutput>>>,
-    companion_token: Option<String>,
-    companion_enabled: Arc<AtomicBool>,
-    companion_port: Arc<AtomicU16>,
-    companion_server: CompanionServerManager,
+    /// Bible broadcast / slide-output state (see [`BibleManager`]).
+    bible: BibleManager,
+    /// Companion (Bitfocus) integration state (see [`CompanionManager`]).
+    companion: CompanionManager,
     resolume_registry: ResolumeRegistry,
     android_stage_registry: AndroidStageRegistry,
     stage_connections: StageConnections,
     heartbeat_config: StageHeartbeatConfig,
-    presentation_cache: Arc<RwLock<HashMap<PresentationId, Arc<Presentation>>>>,
+    /// In-memory caches: presentation / group-color / ableset (see [`CacheManager`]).
+    caches: CacheManager,
     stage_layout: Arc<RwLock<String>>,
     osc_bridge: OscBridge,
     ableset_bridge: AbleSetBridge,
-    ableset_cache: Arc<RwLock<AbleSetLibraryCache>>,
     broadcast_live: Arc<AtomicBool>,
     ai_conversation: Arc<RwLock<Vec<ChatMessage>>>,
     ai_proxy: Arc<ProxyManager>,
     ndi_manager: Option<Arc<presenter_ndi::NdiManager>>,
-    group_color_cache: Arc<RwLock<HashMap<String, String>>>,
     api_stage: Arc<RwLock<ApiStageState>>,
     pub local_public_ip: Arc<Option<String>>,
-    #[cfg(test)]
-    bible_ingestion_override: Option<std::sync::Arc<dyn TestBibleIngestion + Send + Sync>>,
 }
 
 /// Gate predicate for the startup NDI auto-restore branch.
@@ -186,7 +183,6 @@ impl AppState {
             .map(|layout| layout.code)
             .find(|code| code == DEFAULT_STAGE_LAYOUT_CODE)
             .unwrap_or_else(|| DEFAULT_STAGE_LAYOUT_CODE.to_string());
-        let ableset_cache = Arc::new(RwLock::new(AbleSetLibraryCache::default()));
         let ndi_manager = presenter_ndi::NdiManager::try_new().map(Arc::new);
         if ndi_manager.is_some() {
             tracing::info!("NDI SDK loaded successfully");
@@ -196,30 +192,22 @@ impl AppState {
         let state = Self {
             repository,
             live_hub: LiveHub::new(),
-            bible_broadcast: Arc::new(RwLock::new(None)),
-            bible_slide_output: Arc::new(RwLock::new(None)),
-            companion_token,
-            companion_enabled: Arc::new(AtomicBool::new(companion_enabled)),
-            companion_port: Arc::new(AtomicU16::new(companion_port)),
-            companion_server: CompanionServerManager::default(),
+            bible: BibleManager::new(),
+            companion: CompanionManager::new(companion_token, companion_enabled, companion_port),
             resolume_registry,
             android_stage_registry,
             stage_connections,
             heartbeat_config,
-            presentation_cache: Arc::new(RwLock::new(HashMap::new())),
+            caches: CacheManager::new(),
             stage_layout: Arc::new(RwLock::new(default_layout)),
             osc_bridge,
             ableset_bridge,
-            ableset_cache,
             broadcast_live: Arc::new(AtomicBool::new(false)),
             ai_conversation: Arc::new(RwLock::new(Vec::new())),
             ai_proxy: Arc::new(ProxyManager::new(crate::ai::proxy::detect_deploy_dir())),
             ndi_manager,
-            group_color_cache: Arc::new(RwLock::new(HashMap::new())),
             api_stage: Arc::new(RwLock::new(ApiStageState::default())),
             local_public_ip,
-            #[cfg(test)]
-            bible_ingestion_override: None,
         };
         state.spawn_heartbeat_tasks();
         state
@@ -406,7 +394,7 @@ impl AppState {
             .load_all_group_colors()
             .await
             .unwrap_or_default();
-        *state.group_color_cache.write().await = group_colors;
+        *state.caches.group_color.write().await = group_colors;
 
         // Restore the operator-selected stage layout from the database (#384).
         // Without this, every restart/deploy reset the layout to the default
@@ -681,15 +669,15 @@ impl AppState {
 
     // Companion methods
     pub fn companion_token(&self) -> Option<&str> {
-        self.companion_token.as_deref()
+        self.companion.token.as_deref()
     }
 
     pub fn companion_enabled(&self) -> bool {
-        self.companion_enabled.load(Ordering::SeqCst)
+        self.companion.enabled.load(Ordering::SeqCst)
     }
 
     pub fn companion_port(&self) -> u16 {
-        self.companion_port.load(Ordering::SeqCst)
+        self.companion.port.load(Ordering::SeqCst)
     }
 
     // Broadcast live state
@@ -709,7 +697,8 @@ impl AppState {
         enabled: bool,
         port: u16,
     ) -> anyhow::Result<()> {
-        self.companion_server
+        self.companion
+            .server
             .reconfigure(self.clone(), enabled, port)
             .await
     }
@@ -769,8 +758,8 @@ impl AppState {
             return Err(err);
         }
 
-        self.companion_enabled.store(enabled, Ordering::SeqCst);
-        self.companion_port.store(port, Ordering::SeqCst);
+        self.companion.enabled.store(enabled, Ordering::SeqCst);
+        self.companion.port.store(port, Ordering::SeqCst);
         Ok(())
     }
 
@@ -780,7 +769,7 @@ impl AppState {
         presentation_id: PresentationId,
     ) -> anyhow::Result<Arc<Presentation>> {
         if let Some(cached) = {
-            let guard = self.presentation_cache.read().await;
+            let guard = self.caches.presentation.read().await;
             guard.get(&presentation_id).cloned()
         } {
             return Ok(cached);
@@ -793,25 +782,25 @@ impl AppState {
             return Err(anyhow::anyhow!("presentation not found"));
         };
         let arc = Arc::new(presentation);
-        let mut guard = self.presentation_cache.write().await;
+        let mut guard = self.caches.presentation.write().await;
         guard.insert(presentation_id, arc.clone());
         Ok(arc)
     }
 
     pub(crate) async fn get_all_group_colors(&self) -> HashMap<String, String> {
-        self.group_color_cache.read().await.clone()
+        self.caches.group_color.read().await.clone()
     }
 
     pub(crate) async fn resolve_group_color(&self, name: &str) -> Option<String> {
         {
-            let cache = self.group_color_cache.read().await;
+            let cache = self.caches.group_color.read().await;
             if let Some(color) = cache.get(name) {
                 return Some(color.clone());
             }
         }
         match self.repository.resolve_group_color(name).await {
             Ok(color) => {
-                let mut cache = self.group_color_cache.write().await;
+                let mut cache = self.caches.group_color.write().await;
                 cache.insert(name.to_string(), color.clone());
                 Some(color)
             }
@@ -914,12 +903,12 @@ impl AppState {
     }
 
     async fn cache_presentation_ref(&self, presentation: &Presentation) {
-        let mut guard = self.presentation_cache.write().await;
+        let mut guard = self.caches.presentation.write().await;
         guard.insert(presentation.id, Arc::new(presentation.clone()));
     }
 
     async fn cache_presentation_value(&self, presentation: Presentation) {
-        let mut guard = self.presentation_cache.write().await;
+        let mut guard = self.caches.presentation.write().await;
         guard.insert(presentation.id, Arc::new(presentation));
     }
 

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -68,7 +68,7 @@ impl AppState {
             .rename_presentation(presentation_id, name)
             .await?;
         {
-            let mut guard = self.presentation_cache.write().await;
+            let mut guard = self.caches.presentation.write().await;
             if let Some(entry) = guard.get_mut(&presentation_id) {
                 let pres = std::sync::Arc::make_mut(entry);
                 pres.name = name.to_string();
@@ -80,7 +80,7 @@ impl AppState {
     pub async fn delete_presentation(&self, presentation_id: PresentationId) -> anyhow::Result<()> {
         self.repository.delete_presentation(presentation_id).await?;
         {
-            let mut guard = self.presentation_cache.write().await;
+            let mut guard = self.caches.presentation.write().await;
             guard.remove(&presentation_id);
         }
         Ok(())

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1007,24 +1007,19 @@ async fn group_color_cache_resolves_and_lists() {
 }
 
 #[tokio::test]
-async fn presentation_cache_serves_repeat_reads() {
-    // Kills cache_presentation_ref / cache_presentation_value -> (): if caching
-    // is a no-op the second read still works (falls back to DB), so instead we
-    // assert the cached value is the SAME Arc as a follow-up read — proving the
-    // cache was populated and reused rather than re-fetched.
+async fn presentation_from_cache_serves_repeat_reads() {
+    // Kills presentation_from_cache's own cache write: a repeat read must return
+    // the very same Arc allocation (cache hit), only true if the value was
+    // actually inserted.
     let state = AppState::in_memory().await.unwrap();
     super::seed_sample_library(&state).await.unwrap();
     let libraries = state.libraries().await.unwrap();
     let presentation_id = libraries[0].presentations[0].id;
 
-    // First read populates the cache via presentation_from_cache.
     let first = state
         .presentation_from_cache(presentation_id)
         .await
         .expect("first cache read");
-    // Second read must return the very same Arc allocation (cache hit), which
-    // only holds if the value was actually inserted (not dropped by a `-> ()`
-    // mutant on the cache writers feeding this path).
     let second = state
         .presentation_from_cache(presentation_id)
         .await
@@ -1034,6 +1029,76 @@ async fn presentation_cache_serves_repeat_reads() {
         "presentation cache must return the same Arc on a repeat read (cache hit)"
     );
     assert_eq!(first.id, presentation_id);
+}
+
+#[tokio::test]
+async fn presentation_detail_populates_cache_via_cache_presentation_ref() {
+    // Kills cache_presentation_ref -> (): presentation_detail caches the fetched
+    // presentation as a side effect. A no-op write leaves the cache empty, so we
+    // assert the cache map directly contains the entry afterwards.
+    let state = AppState::in_memory().await.unwrap();
+    super::seed_sample_library(&state).await.unwrap();
+    let libraries = state.libraries().await.unwrap();
+    let presentation_id = libraries[0].presentations[0].id;
+
+    assert!(
+        !state
+            .caches
+            .presentation
+            .read()
+            .await
+            .contains_key(&presentation_id),
+        "cache should be empty before presentation_detail"
+    );
+
+    let detail = state.presentation_detail(presentation_id).await.unwrap();
+    assert!(detail.is_some(), "presentation should exist");
+
+    let cached = state.caches.presentation.read().await;
+    let entry = cached
+        .get(&presentation_id)
+        .expect("presentation_detail must cache the presentation via cache_presentation_ref");
+    assert_eq!(entry.id, presentation_id);
+}
+
+#[tokio::test]
+async fn slide_edit_refreshes_cache_via_cache_presentation_value() {
+    // Kills cache_presentation_value -> (): a slide edit re-caches the UPDATED
+    // presentation. A no-op write leaves the cache without the new text, so we
+    // assert the cache map holds the edited content afterwards.
+    let state = AppState::in_memory().await.unwrap();
+    super::seed_sample_library(&state).await.unwrap();
+    let libraries = state.libraries().await.unwrap();
+    let presentation = libraries[0].presentations[0].clone();
+    let slide_id = presentation.slides[0].id;
+
+    state
+        .update_slide_content(
+            presentation.id,
+            slide_id,
+            "Cache witness main".to_string(),
+            "Cache witness translation".to_string(),
+            "Cache witness stage".to_string(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let cached = state.caches.presentation.read().await;
+    let entry = cached
+        .get(&presentation.id)
+        .expect("a slide edit must (re)cache the presentation via cache_presentation_value");
+    let edited = entry
+        .slides
+        .iter()
+        .find(|s| s.id == slide_id)
+        .expect("edited slide present in cached presentation");
+    assert_eq!(
+        edited.content.main.value(),
+        "Cache witness main",
+        "the cached presentation must reflect the edit, not stale/absent content"
+    );
 }
 
 #[tokio::test]

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -2,8 +2,9 @@ use super::stage::{format_countdown_text, sanitize_song_title};
 use super::*;
 use crate::live::LiveEvent;
 use presenter_core::{
-    bible::BibleIngestionBatch, BiblePassage, BibleReference, BibleTranslation, Library, LibraryId,
-    SlideContent, SlideText, TimerCommand, TimerState,
+    bible::BibleIngestionBatch, AbleSetSettingsDraft, BiblePassage, BibleReference,
+    BibleSlideOutput, BibleTranslation, Library, LibraryId, SlideContent, SlideText, TimerCommand,
+    TimerState,
 };
 
 /// Regression for #333 item 6: the startup auto-restore branch must skip when
@@ -878,4 +879,282 @@ async fn set_stage_layout_code_rejects_camera_crew() {
         msg.contains("camera-crew") && msg.contains("not"),
         "error message should explain the rejection; got: {msg}"
     );
+}
+
+// --- #346 manager-decomposition coverage ------------------------------------
+//
+// The CacheManager / CompanionManager / BibleManager extraction was a pure
+// field relocation, but it touched one body line in each of the accessor /
+// cache methods below, pulling them into the diff-scoped mutation gate. These
+// tests pin the behaviors those methods promise so the gate's mutants die —
+// they exercise the real success paths, not the relocation per se.
+
+/// Build a token-bearing in-memory AppState (the `in_memory()` helper passes
+/// `None` for the token, so it cannot exercise `companion_token`).
+#[cfg(test)]
+async fn in_memory_with_companion_token(token: &str) -> AppState {
+    let repo = presenter_persistence::Repository::connect_in_memory()
+        .await
+        .unwrap();
+    let registry = crate::resolume::ResolumeRegistry::new().unwrap();
+    let android_stage_registry = crate::android_stage::AndroidStageRegistry::new();
+    let osc_bridge = crate::osc::OscBridge::new(&crate::config::OscConfig::default());
+    let ableset_bridge = crate::ableset::AbleSetBridge::new();
+    AppState::new(
+        repo,
+        Some(token.to_string()),
+        false,
+        super::DEFAULT_COMPANION_PORT,
+        registry,
+        android_stage_registry,
+        osc_bridge,
+        ableset_bridge,
+    )
+}
+
+#[tokio::test]
+async fn companion_token_returns_configured_token() {
+    // Kills companion_token -> {None, Some(""), Some("xyzzy")}: a state built
+    // with a real token must return exactly that token, not a stand-in.
+    let state = in_memory_with_companion_token("super-secret-token").await;
+    assert_eq!(state.companion_token(), Some("super-secret-token"));
+
+    // And the default (no-token) state returns None — kills the Some("") /
+    // Some("xyzzy") mutants which would force a token where none exists.
+    let no_token = AppState::in_memory().await.unwrap();
+    assert_eq!(no_token.companion_token(), None);
+}
+
+#[tokio::test]
+async fn set_companion_settings_updates_enabled_and_port() {
+    // Kills: companion_enabled -> {true,false}, companion_port -> {0,1},
+    // set_companion_settings -> Ok(()), configure_companion_service -> Ok(()).
+    // A no-op stub for any of these would leave the atomics at their defaults
+    // (disabled / DEFAULT_COMPANION_PORT) and the assertions below would fail.
+    let state = AppState::in_memory().await.unwrap();
+    assert!(!state.companion_enabled(), "fresh state is disabled");
+    assert_eq!(state.companion_port(), super::DEFAULT_COMPANION_PORT);
+
+    // Pick a free ephemeral port so enabling actually binds a real listener
+    // (configure_companion_service must run; a no-op stub would not change state).
+    let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    state.set_companion_settings(true, port).await.unwrap();
+    assert!(
+        state.companion_enabled(),
+        "companion must be enabled after set_companion_settings(true, _)"
+    );
+    assert_eq!(
+        state.companion_port(),
+        port,
+        "companion port must reflect the value just set"
+    );
+
+    // Disabling flips it back and persists a different port — proves the setter
+    // writes both fields, not a fixed value.
+    state
+        .set_companion_settings(false, super::DEFAULT_COMPANION_PORT)
+        .await
+        .unwrap();
+    assert!(!state.companion_enabled());
+    assert_eq!(state.companion_port(), super::DEFAULT_COMPANION_PORT);
+}
+
+#[tokio::test]
+async fn group_color_cache_resolves_and_lists() {
+    // Kills resolve_group_color -> {None, Some(""), Some("xyzzy")} and
+    // get_all_group_colors -> {empty / fabricated maps}. resolve_group_color
+    // returns a deterministic palette color and caches it; get_all_group_colors
+    // must then expose exactly that cached entry.
+    let state = AppState::in_memory().await.unwrap();
+
+    let color = state
+        .resolve_group_color("Intro")
+        .await
+        .expect("resolve_group_color must return a color for a group name");
+    assert!(
+        color.starts_with('#') && color.len() == 7,
+        "expected a #RRGGBB palette color, got {color:?}"
+    );
+
+    // Resolving again returns the SAME color (cache + DB are deterministic) —
+    // kills the Some("xyzzy") / Some("") mutants.
+    let again = state.resolve_group_color("Intro").await.unwrap();
+    assert_eq!(again, color, "group color must be stable across calls");
+
+    let all = state.get_all_group_colors().await;
+    assert_eq!(
+        all.get("Intro").map(String::as_str),
+        Some(color.as_str()),
+        "get_all_group_colors must expose the cached Intro color, not an \
+         empty or fabricated map"
+    );
+}
+
+#[tokio::test]
+async fn presentation_cache_serves_repeat_reads() {
+    // Kills cache_presentation_ref / cache_presentation_value -> (): if caching
+    // is a no-op the second read still works (falls back to DB), so instead we
+    // assert the cached value is the SAME Arc as a follow-up read — proving the
+    // cache was populated and reused rather than re-fetched.
+    let state = AppState::in_memory().await.unwrap();
+    super::seed_sample_library(&state).await.unwrap();
+    let libraries = state.libraries().await.unwrap();
+    let presentation_id = libraries[0].presentations[0].id;
+
+    // First read populates the cache via presentation_from_cache.
+    let first = state
+        .presentation_from_cache(presentation_id)
+        .await
+        .expect("first cache read");
+    // Second read must return the very same Arc allocation (cache hit), which
+    // only holds if the value was actually inserted (not dropped by a `-> ()`
+    // mutant on the cache writers feeding this path).
+    let second = state
+        .presentation_from_cache(presentation_id)
+        .await
+        .expect("second cache read");
+    assert!(
+        std::sync::Arc::ptr_eq(&first, &second),
+        "presentation cache must return the same Arc on a repeat read (cache hit)"
+    );
+    assert_eq!(first.id, presentation_id);
+}
+
+#[tokio::test]
+async fn delete_presentation_removes_it() {
+    // Kills delete_presentation -> Ok(()): a stub that skips the actual delete
+    // would leave the presentation retrievable.
+    let state = AppState::in_memory().await.unwrap();
+    super::seed_sample_library(&state).await.unwrap();
+    let libraries = state.libraries().await.unwrap();
+    let presentation_id = libraries[0].presentations[0].id;
+
+    assert!(
+        state
+            .presentation_detail(presentation_id)
+            .await
+            .unwrap()
+            .is_some(),
+        "presentation should exist before delete"
+    );
+
+    state.delete_presentation(presentation_id).await.unwrap();
+
+    assert!(
+        state
+            .presentation_detail(presentation_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "presentation must be gone after delete_presentation"
+    );
+}
+
+#[tokio::test]
+async fn trigger_and_read_bible_slide_output() {
+    // Kills trigger_bible_slide_output -> () and active_bible_slide_output -> None:
+    // after triggering an output it must be readable back verbatim.
+    let state = AppState::in_memory().await.unwrap();
+    assert!(
+        state.active_bible_slide_output().await.is_none(),
+        "no slide output before any trigger"
+    );
+
+    let output = BibleSlideOutput::new(
+        "For God so loved the world",
+        "John 3:16 (NIV)",
+        "",
+        "",
+        chrono::Utc::now(),
+    );
+    state
+        .trigger_bible_slide_output(
+            output.clone(),
+            super::bible::BibleSlideReferenceMetadata::default(),
+        )
+        .await;
+
+    let active = state
+        .active_bible_slide_output()
+        .await
+        .expect("slide output must be readable after trigger");
+    assert_eq!(active.main_text, "For God so loved the world");
+    assert_eq!(active.main_reference, "John 3:16 (NIV)");
+
+    // The legacy broadcast must also be set (trigger updates both) — a `-> ()`
+    // stub would leave both empty.
+    assert!(
+        state.active_bible_broadcast().await.is_some(),
+        "legacy bible broadcast must be set by trigger_bible_slide_output"
+    );
+}
+
+#[tokio::test]
+async fn ableset_resolves_presentation_through_cache() {
+    // Kills resolve_ableset_presentation -> Ok(None)/Ok(Some(default)),
+    // ensure_ableset_cache -> Ok(()), refresh_ableset_cache -> Ok(()): enabling
+    // AbleSet with a digit-prefixed library and resolving the prefix must return
+    // the matching presentation id (which requires the cache to be built).
+    let state = AppState::in_memory().await.unwrap();
+
+    // Seed a library with a digit-prefixed presentation so extract_song_prefix
+    // (length 3) yields a cacheable key "001".
+    let pres = Presentation::new(
+        "001 Amazing Grace",
+        vec![Slide::new(
+            0,
+            SlideContent::new(
+                SlideText::new("Amazing grace").unwrap(),
+                SlideText::new("Úžasná milosť").unwrap(),
+                SlideText::new("").unwrap(),
+                None,
+            ),
+        )
+        .with_id(SlideId::new())],
+    )
+    .unwrap()
+    .with_id(PresentationId::new());
+    let expected_id = pres.id;
+    let library = Library::new("Hymnal", vec![pres])
+        .unwrap()
+        .with_id(LibraryId::new());
+    state.repository().upsert_library(&library).await.unwrap();
+
+    // Enable AbleSet pointing at that library (start_tracker spawns async and
+    // returns Ok without a live host, so the snapshot reports enabled=true).
+    let draft = AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Hymnal".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(
+            draft,
+            presenter_persistence::SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+
+    let resolved = state
+        .resolve_ableset_presentation("001")
+        .await
+        .expect("resolve must not error");
+    assert_eq!(
+        resolved,
+        Some(expected_id),
+        "AbleSet prefix '001' must resolve to the seeded presentation via the \
+         (re)built cache — a None/default/no-op stub would not"
+    );
+
+    // Unknown prefix resolves to None — proves the lookup discriminates rather
+    // than always returning the same id.
+    let missing = state.resolve_ableset_presentation("999").await.unwrap();
+    assert_eq!(missing, None, "unknown prefix must resolve to None");
 }

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -952,8 +952,21 @@ async fn set_companion_settings_updates_enabled_and_port() {
         "companion port must reflect the value just set"
     );
 
+    // Side effect of configure_companion_service: the websocket server must be
+    // actually LISTENING on the port. This kills the `configure_companion_service
+    // -> Ok(())` mutant — a no-op stub would set the atomics (so the asserts
+    // above still pass) but never bind the listener, so this connect would fail.
+    let connected = tokio::net::TcpStream::connect(("127.0.0.1", port)).await;
+    assert!(
+        connected.is_ok(),
+        "companion server must be listening on port {port} after enable — \
+         configure_companion_service must have bound the listener, not no-op'd"
+    );
+    drop(connected);
+
     // Disabling flips it back and persists a different port — proves the setter
-    // writes both fields, not a fixed value.
+    // writes both fields, not a fixed value — AND tears the listener down so the
+    // port is free again (further proof configure_companion_service ran).
     state
         .set_companion_settings(false, super::DEFAULT_COMPANION_PORT)
         .await

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4,6 +4,15 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 
 ---
 
+## 2026-06-22 — #346 Decompose state/mod.rs AppState facade → subsystem managers (PR #456, v0.4.153)
+
+- **Validated still real:** `crates/presenter-server/src/state/mod.rs` = 1115 lines, `AppState` = 24 fields. NOT a 1000-line-cap fix — the CI fn-size gate miscounts this file (stops at the first `#[cfg(test)]` ~line 33; that undercount is open #407). So done as voluntary readability decomposition, not gate compliance.
+- **Version:** 0.4.152 → **0.4.153** (first commit `15ba9ab3`), after FF dev→main `0740b8d2`.
+- **Refactor (commit `4676e844`, `Closes #346`):** behavior-preserving — extracted 3 cohesive manager structs into new `state/` modules, shrinking AppState **24 → 18 fields**. `CacheManager` (`cache_manager.rs`) owns the 3 `Arc<RwLock>` caches (`presentation`/`group_color`/`ableset`); `CompanionManager` (`companion_manager.rs`) owns `token`/`enabled`(AtomicBool)/`port`(AtomicU16)/`server`; `BibleManager` (`bible_manager.rs`) owns `broadcast`/`slide_output` `Arc<RwLock>` + the `#[cfg(test)] ingestion_override`. Pure field relocation: every Arc/RwLock/atomic keeps its exact type → single-lock-at-a-time policy + Ordering::SeqCst + heartbeat/background-task/NDI-restore wiring unchanged; `clear_bible_broadcast` still takes the 2 bible locks in separate scoped blocks. All access is encapsulated within the `state/` module tree (submodules ableset.rs/bible.rs/presentations.rs use `self.caches.*`/`self.bible.*`); public accessors (`active_bible_broadcast`, `companion_enabled`, etc.) unchanged → zero cross-crate call-site churn.
+- **No new tests (no-behavior-change refactor):** existing `state/tests.rs` + `router/tests.rs` are the net (active/clear_bible_broadcast, set_test_bible_ingestion, `state.api_stage` direct read at tests.rs:665 — `api_stage` deliberately left inline so that test stays untouched). Marker commits `f64b7198`/`9b8769fd` carry `[no-test: ...]` per the pre-push hook contract (the multi-line bracket form is invisible to the single-line hook regex — must be one line).
+- **Local gates:** `cargo fmt --all --check` clean; `cargo check -p presenter-server --all-targets` clean; `cargo clippy -p presenter-server --all-targets -D warnings` clean (0 warnings).
+- **Shared branch:** `dev` concurrently owned by the #347 worker — its docs commit `d5439b23` (autopilot-log) rode onto this PR's diff (docs-only, no `Closes #347`); harmless.
+
 ## 2026-06-22 — #347 Migrate settings_script.js (1307-line JS blob) → Leptos WASM component
 
 - **Validated still real:** `settings_script.js` = 1307 lines, included via `ui/scripts/mod.rs`, injected in `ui/settings.rs:883`; route `/ui/settings` was pure SSR. The orphan `pages/settings.rs` (185-line NDI-only `SettingsPage`, zero callers) was NOT the migration — folded its NDI piece into the full page.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4,6 +4,16 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 
 ---
 
+## 2026-06-22 — #347 Migrate settings_script.js (1307-line JS blob) → Leptos WASM component
+
+- **Validated still real:** `settings_script.js` = 1307 lines, included via `ui/scripts/mod.rs`, injected in `ui/settings.rs:883`; route `/ui/settings` was pure SSR. The orphan `pages/settings.rs` (185-line NDI-only `SettingsPage`, zero callers) was NOT the migration — folded its NDI piece into the full page.
+- **Version:** 0.4.151 → **0.4.152** (first commit `b8ad2bb4`), after FF dev→main `aa6686ff`.
+- **Implementation (commit `a48949c7`, PR #454 → merge `0740b8d2`):** built `pages/settings/` Leptos module (mod + companion/preferences/resolume/android/ableton/video_sources cards) driven by signals + `on:*` + the existing `api::settings`/`api::ndi` client fns; added the resolume/android/osc/feature client fns + camelCase DTOs to `api/settings.rs`; wired `/ui/settings` → WASM shell (router + lib.rs route); folded settings CSS into the WASM bundle (`styles/settings.css` + index.html). **Deleted −1809 lines net:** `settings_script.js`, SSR `ui/settings.rs` (918), orphan `ui/components/settings.rs` (608), `ui/scripts/mod.rs`, `ui/styles/settings.css`, `escape_script_tag`, `styles::SETTINGS`, `AppState::feature_flags()`. 5s status poll, toast, and the #272 line-limit pref preserved (now keyed `presenter:lineLimit` to match what the operator reads — fixed a latent cross-page key mismatch). Split into 7 submodules to stay under the 1000-line file cap (`#[component]` fns are fn-length-exempt).
+- **Tests:** `tests/e2e/settings.spec.ts` updated to wait for `data-wasm-ready` + a migration safety-net test (all cards render, version label, toast on save, line-limit persists, **0 console errors**). `quality-check.sh` §3 UI-page gate dropped `settings` (migrated to WASM, like tablet); `router/tests.rs` → `settings_route_serves_wasm_shell` (accepts 503 when bundle unbuilt).
+- **Gates:** full Pipeline green — Clippy/Format/TS/Quality/Version/Coverage/Build, all 16 mutation shards, all 3 Playwright E2E shards, NDI synthetic E2E, Deploy-Dev + Deploy. mergeable=clean.
+- **Deploy verified (Playwright):** prod SNV `http://10.77.9.205/ui/settings` — WASM mounts, version label `v0.4.152` (matches deployed prod binary), all 6 cards render, real settings read back (3 resolume hosts, 4 android displays, ableset host `fohabl.lan`, OSC 39051, companion 18175), 0 console errors. Dev also verified `v0.4.152 (dev)`.
+- **Post-merge review findings → #455** (could not land in the already-merged #454; `dev` was concurrently owned by the #346 worker): (1) `parse_port` overflow silently substitutes fallback for >65535 ports (should reject); (2) video_sources activate/deactivate/delete discard the Result → false success toast. Both small, fully described + patch preserved on #455.
+
 ## 2026-06-16 — #374 CI: function-length gate self-test (regression guard for abs/rel no-op)
 
 - **Scope (rescoped by ticket-validator):** only the remaining-open item — add a self-test so the function-length gate's abs/rel no-op bug can't silently return. Gate fix (`5f5fe9f`) + the 4 over-cap NDI/WebRTC fns were already resolved (PR #368); not re-touched.


### PR DESCRIPTION
## Summary

Decomposes the `AppState` DI container (`crates/presenter-server/src/state/mod.rs`) by grouping cohesive subsystem fields into three focused manager structs, shrinking `AppState` from **24 → 18 fields**. Pure, behavior-preserving refactor — no functional change.

### New manager modules (`state/`)

- **`CacheManager`** (`cache_manager.rs`) — owns the three `Arc<RwLock<_>>` caches: `presentation`, `group_color`, `ableset`.
- **`CompanionManager`** (`companion_manager.rs`) — owns the Companion fields: `token`, `enabled` (atomic), `port` (atomic), `server` handle manager.
- **`BibleManager`** (`bible_manager.rs`) — owns the Bible broadcast / slide-output `Arc<RwLock<_>>` handles and the test-only ingestion override.

### Behavior preservation

- Every `Arc` / `RwLock` / atomic keeps its **exact type** — only the field path changes (`state.caches.ableset` instead of `state.ableset_cache`). The documented single-lock-at-a-time acquisition policy is unchanged; `clear_bible_broadcast` still takes the two bible locks in separate scoped blocks.
- The heartbeat / background-task / reconciliation wiring (`spawn_heartbeat_tasks`, `spawn_background_tasks`, NDI auto-restore gate) is untouched.
- All field access is **encapsulated within the `state/` module tree**; the public accessor methods (`active_bible_broadcast`, `companion_enabled`, `companion_port`, etc.) are unchanged, so cross-crate call sites (router, companion, resolume) are untouched.

### Verification

- `cargo fmt --all --check` ✅
- `cargo check -p presenter-server --all-targets` ✅
- `cargo clippy -p presenter-server --all-targets -- -D warnings` ✅ (zero warnings)
- No-behavior-change refactor: the existing `state/tests.rs` + `router/tests.rs` regression suites are the safety net — they still compile and exercise the moved code through the unchanged public API. (Marked `[no-test:]` per the pre-push hook contract for a no-logic-change refactor.)

Closes #346