### PR TITLE
Guard #370 activate-switch reap wiring with a test (NdiManagerHandle seam) (#406)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -36,6 +36,19 @@ exclude_globs = [
 #     drive the GStreamer/NDI pipeline this fn builds. Faking a test that didn't
 #     really exercise it would be a no-op, so the mutant (lifecycle.rs:97 →
 #     `Ok(())`, and the in-body match-arm mutants) is excluded here instead.
+#   - NdiManagerHandle::* pure-delegation forwarders (#406 seam, ndi_control.rs):
+#     these forward to the libndi-bound NdiManager (Real arm) so they are NOT
+#     exercisable on a libndi-free CI host. The seam exists for the #370 reap
+#     WIRING test, which exercises (and kills the mutants in) start_pipeline +
+#     stop_other_pipelines via the Fake — those two are NOT excluded. The other
+#     forwarders carry no CI-testable behavior; excluding them is the same
+#     hardware-boundary rationale as NdiManager::start_pipeline above.
 exclude_re = [
     "NdiManager::start_pipeline",
+    "NdiManagerHandle::stop_pipeline",
+    "NdiManagerHandle::stop_all",
+    "NdiManagerHandle::discover_sources",
+    "NdiManagerHandle::pipeline_snapshots",
+    "NdiManagerHandle::pipeline_snapshot",
+    "NdiManagerHandle::simulate_pipeline_error",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.153"
+version = "0.4.154"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.153"
+version = "0.4.154"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -350,6 +350,145 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::{ndi_status_for_start_error, PipelineStartError};
+    use crate::state::ndi_control::{NdiCall, NdiManagerHandle, StartOutcome};
+    use crate::state::AppState;
+    use presenter_core::{VideoSourceDraft, VideoSourceId};
+    use presenter_persistence::SettingsAuditSource;
+
+    // ── #406: GUARD the #370 source-switch reap WIRING ───────────────────────
+    //
+    // The #370 fix reaps stale sibling pipelines on a source switch by calling
+    // `manager.stop_other_pipelines(new_id)` inside `activate_video_source`
+    // AFTER `start_pipeline` returns Ok. The reap HELPER is unit-tested in the
+    // NDI crate, but NOTHING tested the WIRING — that `activate_video_source`
+    // actually CALLS the reap. A refactor could silently delete that call and
+    // reintroduce the #370 two-encoder NVENC leak with all tests still green.
+    //
+    // These tests inject a recording `FakeNdiControl` (a stand-in for the
+    // libndi/GPU hardware boundary — see `ndi_control` module docs) so the
+    // hardware-gated `if let Some(manager) = &self.ndi_manager` branch is
+    // reachable on the libndi-free `Rust Tests` CI host.
+    //
+    // ACCEPTANCE (#406): deleting the `manager.stop_other_pipelines(...)` call
+    // in `activate_video_source` MUST make `activation_reaps_siblings_after_…`
+    // FAIL — proving it guards the wiring, not just the helper.
+
+    /// Build an in-memory AppState with a `FakeNdiControl` injected and one
+    /// video source created. Returns the state, the new source id (and its
+    /// string form, which is the key the reap is expected to keep), and the
+    /// fake for assertions.
+    async fn state_with_fake(
+        outcome: StartOutcome,
+    ) -> (
+        AppState,
+        VideoSourceId,
+        String,
+        std::sync::Arc<crate::state::ndi_control::FakeNdiControl>,
+    ) {
+        let mut state = AppState::in_memory().await.expect("in-memory AppState");
+        let fake = crate::state::ndi_control::FakeNdiControl::with_outcome(outcome);
+        state.set_ndi_handle(NdiManagerHandle::Fake(fake.clone()));
+        let source = state
+            .create_video_source(
+                VideoSourceDraft::new("Cam 1", "STREAM-SNV (stream)"),
+                SettingsAuditSource::HttpSetter,
+                "test",
+            )
+            .await
+            .expect("create video source");
+        (state, source.id, source.id.to_string(), fake)
+    }
+
+    #[tokio::test]
+    async fn activation_reaps_siblings_after_successful_start() {
+        let (state, source_id, id, fake) = state_with_fake(StartOutcome::Ok).await;
+
+        let activated = state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("activation succeeds");
+        assert_eq!(activated.id.to_string(), id);
+
+        let calls = fake.calls();
+        // start_pipeline must have been called for the new source…
+        assert!(
+            matches!(
+                calls.first(),
+                Some(NdiCall::StartPipeline { source_id, .. }) if *source_id == id
+            ),
+            "activate_video_source must call start_pipeline(new_id); calls = {calls:?}",
+        );
+        // …and the reap must have been called for the SAME id, AFTER the start.
+        // This is the line guarded by #406: deleting the reap call in
+        // activate_video_source makes this assertion fail.
+        assert!(
+            fake.reaped(&id),
+            "after a successful start, activate_video_source MUST reap siblings via \
+             stop_other_pipelines(new_id) (#370 single-active-source invariant); calls = {calls:?}",
+        );
+        assert_eq!(
+            calls,
+            vec![
+                NdiCall::StartPipeline {
+                    source_id: id.clone(),
+                    ndi_name: "STREAM-SNV (stream)".to_string(),
+                },
+                NdiCall::StopOtherPipelines {
+                    keep_id: id.clone()
+                },
+            ],
+            "the reap must run exactly once, AFTER start_pipeline, keeping the new id",
+        );
+    }
+
+    #[tokio::test]
+    async fn activation_does_not_reap_when_start_hard_errors() {
+        let (state, source_id, id, fake) = state_with_fake(StartOutcome::HardError).await;
+
+        let result = state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await;
+        assert!(
+            result.is_err(),
+            "a hard start_pipeline failure must fail the activation",
+        );
+
+        // start was attempted, but the reap must NOT run on a hard error —
+        // there is no new active pipeline to keep, so reaping siblings would
+        // be wrong.
+        assert!(
+            !fake.reaped(&id),
+            "on a hard start failure the reap MUST NOT run; calls = {:?}",
+            fake.calls(),
+        );
+        assert_eq!(
+            fake.calls(),
+            vec![NdiCall::StartPipeline {
+                source_id: id.clone(),
+                ndi_name: "STREAM-SNV (stream)".to_string(),
+            }],
+            "only start_pipeline should have been attempted on a hard error",
+        );
+    }
+
+    #[tokio::test]
+    async fn activation_reaps_siblings_for_silent_source() {
+        // #448 path: a silent broadcaster is an Ok-returning activation, and it
+        // must STILL reap siblings (a switch to a not-yet-live source still
+        // tears down the previous source's encoder).
+        let (state, source_id, id, fake) = state_with_fake(StartOutcome::SilentSource).await;
+
+        state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("silent-source activation still succeeds (#448)");
+
+        assert!(
+            fake.reaped(&id),
+            "a silent-source (Ok) activation MUST also reap siblings (#370 + #448); calls = {:?}",
+            fake.calls(),
+        );
+    }
 
     // ── #448: an off/silent source is NOT a hard error / red overlay ─────────
     //

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -28,6 +28,7 @@ mod cache_manager;
 mod companion;
 mod companion_manager;
 mod integrations;
+mod ndi_control;
 mod presentations;
 mod seed;
 pub(crate) mod slides;
@@ -120,7 +121,7 @@ pub struct AppState {
     broadcast_live: Arc<AtomicBool>,
     ai_conversation: Arc<RwLock<Vec<ChatMessage>>>,
     ai_proxy: Arc<ProxyManager>,
-    ndi_manager: Option<Arc<presenter_ndi::NdiManager>>,
+    ndi_manager: Option<ndi_control::NdiManagerHandle>,
     api_stage: Arc<RwLock<ApiStageState>>,
     pub local_public_ip: Arc<Option<String>>,
 }
@@ -183,7 +184,9 @@ impl AppState {
             .map(|layout| layout.code)
             .find(|code| code == DEFAULT_STAGE_LAYOUT_CODE)
             .unwrap_or_else(|| DEFAULT_STAGE_LAYOUT_CODE.to_string());
-        let ndi_manager = presenter_ndi::NdiManager::try_new().map(Arc::new);
+        let ndi_manager = presenter_ndi::NdiManager::try_new()
+            .map(Arc::new)
+            .map(ndi_control::NdiManagerHandle::Real);
         if ndi_manager.is_some() {
             tracing::info!("NDI SDK loaded successfully");
         } else {
@@ -655,8 +658,18 @@ impl AppState {
         &self.ai_proxy
     }
 
-    pub fn ndi_manager(&self) -> Option<&Arc<presenter_ndi::NdiManager>> {
+    pub(crate) fn ndi_manager(&self) -> Option<&ndi_control::NdiManagerHandle> {
         self.ndi_manager.as_ref()
+    }
+
+    /// Test-only: replace the NDI manager handle with a recording fake.
+    ///
+    /// Used by the #406 activation-wiring tests to inject a libndi-free
+    /// [`ndi_control::FakeNdiControl`] so the hardware-gated reap branch in
+    /// [`Self::activate_video_source`] is reachable on CI hosts without libndi.
+    #[cfg(test)]
+    pub(crate) fn set_ndi_handle(&mut self, handle: ndi_control::NdiManagerHandle) {
+        self.ndi_manager = Some(handle);
     }
 
     pub fn stage_connections_handle(&self) -> StageConnections {

--- a/crates/presenter-server/src/state/ndi_control.rs
+++ b/crates/presenter-server/src/state/ndi_control.rs
@@ -1,0 +1,245 @@
+//! Hardware-boundary seam over the NDI manager surface the server invokes.
+//!
+//! # Why this seam exists (a HARDWARE-dependency boundary, not internal mocking)
+//!
+//! The real [`presenter_ndi::NdiManager`] talks to libndi + a GStreamer/NVENC
+//! pipeline — physical, host-specific resources. `NdiManager::try_new()` returns
+//! `None` on any host without libndi (the GitHub-hosted `Rust Tests` and
+//! mutation runners have no libndi), so the `if let Some(manager) = …` block in
+//! [`crate::state::AppState::activate_video_source`] — and therefore the #370
+//! source-switch reap wiring inside it — is **unreachable by any libndi-free
+//! unit test**. Without a seam, a refactor could silently delete the
+//! `stop_other_pipelines(...)` reap call and reintroduce the #370 two-encoder
+//! NVENC leak with every existing test still green.
+//!
+//! [`NdiManagerHandle`] is the seam: in production it is always
+//! [`NdiManagerHandle::Real`], a zero-cost forwarder to the real `NdiManager`
+//! (production behaviour is byte-for-byte unchanged). In `cfg(test)` it can also
+//! be [`NdiManagerHandle::Fake`], a recording stand-in that lets a libndi-free
+//! test assert the activation WIRING (does `activate_video_source` actually call
+//! the reap after a successful `start_pipeline`?).
+//!
+//! Per `test-strictness.md`, the fake is acceptable **only** because it stands in
+//! for the libndi/GPU hardware boundary — it does NOT mock internal server logic.
+//! It exists purely to make the hardware-gated branch reachable on CI hosts that
+//! physically lack the NDI SDK and an NVENC-capable GPU.
+
+use std::sync::Arc;
+
+use presenter_ndi::{NdiManager, PipelineStartError};
+
+#[cfg(test)]
+use std::sync::Mutex;
+
+/// A handle to the NDI manager surface used by the server.
+///
+/// `Real` wraps the production [`NdiManager`] (the only variant that exists at
+/// runtime). `Fake` is a `cfg(test)`-only recording stand-in for the
+/// libndi/GPU hardware boundary, used to guard the #370 reap wiring.
+///
+/// `Clone` is cheap — every variant holds an `Arc`, so cloning a handle (as
+/// happens whenever [`crate::state::AppState`] is cloned) is a refcount bump.
+#[derive(Clone)]
+pub(crate) enum NdiManagerHandle {
+    /// Production variant — forwards every call to the real `NdiManager`.
+    Real(Arc<NdiManager>),
+    /// Test-only recording stand-in for the libndi/GPU hardware boundary.
+    #[cfg(test)]
+    Fake(Arc<FakeNdiControl>),
+}
+
+impl NdiManagerHandle {
+    /// Forward to [`NdiManager::start_pipeline`].
+    pub(crate) async fn start_pipeline(
+        &self,
+        source_id: &str,
+        ndi_name: &str,
+    ) -> Result<(), PipelineStartError> {
+        match self {
+            Self::Real(m) => m.start_pipeline(source_id, ndi_name).await,
+            #[cfg(test)]
+            Self::Fake(f) => f.start_pipeline(source_id, ndi_name).await,
+        }
+    }
+
+    /// Forward to [`NdiManager::stop_pipeline`].
+    pub(crate) async fn stop_pipeline(&self, source_id: &str) {
+        match self {
+            Self::Real(m) => m.stop_pipeline(source_id).await,
+            #[cfg(test)]
+            Self::Fake(f) => f.stop_pipeline(source_id).await,
+        }
+    }
+
+    /// Forward to [`NdiManager::stop_other_pipelines`] — the #370 reap.
+    pub(crate) async fn stop_other_pipelines(&self, keep_id: &str) {
+        match self {
+            Self::Real(m) => m.stop_other_pipelines(keep_id).await,
+            #[cfg(test)]
+            Self::Fake(f) => f.stop_other_pipelines(keep_id).await,
+        }
+    }
+
+    /// Forward to [`NdiManager::stop_all`].
+    pub(crate) async fn stop_all(&self) {
+        match self {
+            Self::Real(m) => m.stop_all().await,
+            #[cfg(test)]
+            Self::Fake(_) => unreachable!("FakeNdiControl::stop_all is never exercised"),
+        }
+    }
+
+    /// Forward to [`NdiManager::discover_sources`].
+    pub(crate) fn discover_sources(
+        &self,
+        timeout_ms: u32,
+    ) -> anyhow::Result<Vec<presenter_ndi::discovery::NdiSourceInfo>> {
+        match self {
+            Self::Real(m) => m.discover_sources(timeout_ms),
+            #[cfg(test)]
+            Self::Fake(_) => unreachable!("FakeNdiControl::discover_sources is never exercised"),
+        }
+    }
+
+    /// Forward to [`NdiManager::pipeline_snapshots`].
+    pub(crate) async fn pipeline_snapshots(
+        &self,
+    ) -> Vec<(String, presenter_ndi::pipeline::PipelineState)> {
+        match self {
+            Self::Real(m) => m.pipeline_snapshots().await,
+            #[cfg(test)]
+            Self::Fake(_) => unreachable!("FakeNdiControl::pipeline_snapshots is never exercised"),
+        }
+    }
+
+    /// Forward to [`NdiManager::pipeline_snapshot`].
+    pub(crate) async fn pipeline_snapshot(
+        &self,
+        source_id: &str,
+    ) -> Option<presenter_ndi::PipelineSnapshot> {
+        match self {
+            Self::Real(m) => m.pipeline_snapshot(source_id).await,
+            #[cfg(test)]
+            Self::Fake(_) => unreachable!("FakeNdiControl::pipeline_snapshot is never exercised"),
+        }
+    }
+
+    /// Forward to [`NdiManager::whep_signaller_call`].
+    pub(crate) async fn whep_signaller_call(
+        &self,
+        source_id: &str,
+        op: presenter_ndi::manager::WhepOp,
+    ) -> anyhow::Result<presenter_ndi::manager::WhepReply> {
+        match self {
+            Self::Real(m) => m.whep_signaller_call(source_id, op).await,
+            #[cfg(test)]
+            Self::Fake(_) => unreachable!("FakeNdiControl::whep_signaller_call is never exercised"),
+        }
+    }
+
+    /// Forward to [`NdiManager::simulate_pipeline_error`] (test-helpers feature).
+    #[cfg(feature = "test-helpers")]
+    pub(crate) async fn simulate_pipeline_error(&self, source_id: &str, msg: &str) -> bool {
+        match self {
+            Self::Real(m) => m.simulate_pipeline_error(source_id, msg).await,
+            #[cfg(test)]
+            Self::Fake(_) => {
+                unreachable!("FakeNdiControl::simulate_pipeline_error is never exercised")
+            }
+        }
+    }
+}
+
+/// Recording stand-in for the libndi/GPU hardware boundary.
+///
+/// Records the ordered sequence of activation-path calls so a libndi-free test
+/// can assert the #370 reap WIRING in
+/// [`crate::state::AppState::activate_video_source`]: after `start_pipeline`
+/// returns `Ok`, the activation MUST call `stop_other_pipelines(new_id)`; on
+/// `start_pipeline` `Err` it must NOT. `start_outcome` lets a test choose what
+/// `start_pipeline` returns (Ok / silent-source Ok / hard Err).
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct FakeNdiControl {
+    calls: Mutex<Vec<NdiCall>>,
+    start_outcome: Mutex<StartOutcome>,
+}
+
+/// One recorded call against [`FakeNdiControl`].
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NdiCall {
+    /// `start_pipeline(source_id, ndi_name)`.
+    StartPipeline { source_id: String, ndi_name: String },
+    /// `stop_other_pipelines(keep_id)` — the #370 reap.
+    StopOtherPipelines { keep_id: String },
+}
+
+/// What [`FakeNdiControl::start_pipeline`] should return.
+#[cfg(test)]
+#[derive(Default, Clone, Copy)]
+pub(crate) enum StartOutcome {
+    /// Pipeline reached Streaming — the success path (default).
+    #[default]
+    Ok,
+    /// Broadcaster silent / not producing — an Ok-returning activation (#448).
+    SilentSource,
+    /// A genuine hard failure — activation returns Err.
+    HardError,
+}
+
+#[cfg(test)]
+impl FakeNdiControl {
+    /// A fake whose `start_pipeline` returns the chosen outcome.
+    pub(crate) fn with_outcome(outcome: StartOutcome) -> Arc<Self> {
+        let fake = Self::default();
+        *fake.start_outcome.lock().expect("start_outcome lock") = outcome;
+        Arc::new(fake)
+    }
+
+    /// The ordered sequence of calls recorded so far.
+    pub(crate) fn calls(&self) -> Vec<NdiCall> {
+        self.calls.lock().expect("calls lock").clone()
+    }
+
+    /// Whether `stop_other_pipelines(keep_id)` was recorded with this id.
+    pub(crate) fn reaped(&self, keep_id: &str) -> bool {
+        self.calls()
+            .iter()
+            .any(|c| matches!(c, NdiCall::StopOtherPipelines { keep_id: k } if k == keep_id))
+    }
+
+    fn record(&self, call: NdiCall) {
+        self.calls.lock().expect("calls lock").push(call);
+    }
+
+    async fn start_pipeline(
+        &self,
+        source_id: &str,
+        ndi_name: &str,
+    ) -> Result<(), PipelineStartError> {
+        self.record(NdiCall::StartPipeline {
+            source_id: source_id.to_string(),
+            ndi_name: ndi_name.to_string(),
+        });
+        match *self.start_outcome.lock().expect("start_outcome lock") {
+            StartOutcome::Ok => Ok(()),
+            StartOutcome::SilentSource => Err(PipelineStartError::SourceSilent {
+                ndi_name: ndi_name.to_string(),
+            }),
+            StartOutcome::HardError => Err(PipelineStartError::Failed(anyhow::anyhow!(
+                "simulated start failure"
+            ))),
+        }
+    }
+
+    async fn stop_pipeline(&self, _source_id: &str) {
+        // Not exercised by the wiring test; recorded for completeness.
+    }
+
+    async fn stop_other_pipelines(&self, keep_id: &str) {
+        self.record(NdiCall::StopOtherPipelines {
+            keep_id: keep_id.to_string(),
+        });
+    }
+}


### PR DESCRIPTION
## What

Guards the #370 source-switch pipeline reap **wiring** with a server-layer test, behind a minimal `NdiManagerHandle` seam.

The #370 fix reaps stale sibling pipelines on a source switch by calling `manager.stop_other_pipelines(new_id)` inside `activate_video_source` AFTER `start_pipeline` returns Ok. The reap *helper* was unit-tested in the NDI crate, but **nothing tested the wiring** — that `activate_video_source` actually CALLS the reap. A refactor could silently delete that call and reintroduce the #370 two-encoder NVENC leak with all tests still green.

## The seam (hardware-dependency boundary, not internal mocking)

`AppState.ndi_manager` was a concrete `Option<Arc<NdiManager>>`. The real `NdiManager` needs libndi/GPU (`NdiManager::try_new()` returns `None` on the GitHub-hosted Rust Tests / mutation runners), so the `Some(manager)` reap branch was unreachable by any libndi-free host unit test.

- New `NdiManagerHandle` enum forwards the NDI surface the server uses. In production it is always `Real(Arc<NdiManager>)` — a zero-cost forwarder, **production path byte-for-byte unchanged**. In `cfg(test)` it can be `Fake(Arc<FakeNdiControl>)`, a recording stand-in for the libndi/GPU hardware boundary.
- `start_pipeline`'s `Arc<Self>` receiver makes a `dyn`-trait seam too invasive across the manager surface, so the enum-handle fallback (explicitly blessed in the issue) keeps the diff small and the production path untouched.
- Per `test-strictness.md`, the fake is acceptable only because it stands in for the libndi/GPU hardware boundary — it does NOT mock internal server logic (documented in the module).

## Tests

Three server-layer wiring tests in `state/integrations.rs` (run on the libndi-free `Rust Tests` job):
- `activation_reaps_siblings_after_successful_start` — after `start_pipeline` Ok, the activation calls `stop_other_pipelines(new_id)`.
- `activation_does_not_reap_when_start_hard_errors` — on a hard `Err`, no reap.
- `activation_reaps_siblings_for_silent_source` — the #448 silent-source (Ok) path also reaps.

**ACCEPTANCE (#406):** deleting the reap call in `activate_video_source` makes `activation_reaps_siblings_after_successful_start` FAIL — verified locally (GREEN with reap → RED without → GREEN restored).

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRqNtdtRVvCfp6c9o7ei79