### PR TITLE
Universal Presenter Stage WebView app — no kiosk browser, any Android TV (#472)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -47,6 +47,19 @@ Build order matters (WASM embedded into server at compile time via `include_dir!
 - For UI changes that need a real built artifact, **push and let CI build it**, then verify on the live dev server (`10.77.8.134:8080`) with Playwright. Don't fight the local trunk build.
 - `presenter-ui` is OUTSIDE the workspace (own `Cargo.lock`, version `0.1.x`): `cargo <cmd> -p presenter-ui` from root fails — run from `crates/presenter-ui/`.
 
+## PP location (companion-pp.lan) — release + manual recovery
+
+PP is upgraded via a **GitHub Release** (`gh release create vX.Y.Z --target main --generate-notes`, X.Y.Z = current main version) → `release.yml` builds + `deploy-pp` SSH-deploys. SSH from dev2: `newlevel@companion-pp.lan` (creds in memory `project-pp-location-upgrade`; no `sqlite3` CLI on the box — use `python3 -c "import sqlite3; ..."`).
+
+⚠️ **`release.yml` deploy-pp is currently BROKEN for PP (#469):** it hard-fails the VA-API check (`vah264enc not available` — PP has no GPU/NDI) AND stops the service + swaps the binary BEFORE that check, so a failure leaves PP **DOWN**. Until #469 is fixed, expect to finish a PP release by hand.
+
+**Manual recovery (binary is already deployed when it fails):**
+1. Backup: `cp /opt/presenter/presenter.db /opt/presenter/backups/presenter-prerelease-$(date +%Y%m%d-%H%M%S).db`
+2. Schema-validate on a COPY: run the new binary with `PRESENTER_DB_URL=sqlite:///tmp/x.db PRESENTER_PORT=18099`, poll `/healthz` (migrations apply) + `/libraries/summary` (data survives), kill + rm the copy.
+3. `sudo systemctl start presenter`; verify `/healthz` version, `/libraries/summary` non-empty, `/stage` + `/ui/operator` = 200.
+
+Deploy is DB-safe — ProPresenter import is skipped on an existing DB ("preserving presentations"). DBs predating `video_sources` (PP) lack that table → `/integrations/video-sources` 500s; proper fix is an idempotent incremental migration (#468).
+
 ## CLIProxyAPI Login Flow
 
 Use `cli-proxy-api -claude-login -no-browser` with callback URL paste.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -39,6 +39,14 @@ Build order matters (WASM embedded into server at compile time via `include_dir!
 
 5. **Verify**: `curl http://10.77.8.134:8080/healthz`
 
+### ⚠️ Known issue — local WASM build currently BROKEN (#465)
+
+`trunk build` fails at wasm-bindgen with `failed to find the __wbindgen_externref_table_alloc function`: the trunk-cached wasm-bindgen 0.2.122 CLI is incompatible with rustc 1.96 (reference-types enabled by default). `RUSTFLAGS=-Ctarget-feature=-reference-types` does NOT fix it. **CI builds WASM fine** (it deploys), so until #465 is fixed:
+
+- Validate Rust locally with the cheap path: `cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown` (and `cargo clippy ... --target wasm32-unknown-unknown -- -D warnings`). These skip wasm-bindgen, so they work.
+- For UI changes that need a real built artifact, **push and let CI build it**, then verify on the live dev server (`10.77.8.134:8080`) with Playwright. Don't fight the local trunk build.
+- `presenter-ui` is OUTSIDE the workspace (own `Cargo.lock`, version `0.1.x`): `cargo <cmd> -p presenter-ui` from root fails — run from `crates/presenter-ui/`.
+
 ## CLIProxyAPI Login Flow
 
 Use `cli-proxy-api -claude-login -no-browser` with callback URL paste.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,22 @@ jobs:
         env:
           PRESENTER_BUILD_CHANNEL: release
 
+      - name: Set up JDK 17 (Android Stage APK)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Android Stage APK
+        working-directory: android/presenter-stage
+        run: gradle assembleDebug --no-daemon --stacktrace
+
+      - name: Stage APK into release dir
+        run: cp android/presenter-stage/app/build/outputs/apk/debug/app-debug.apk target/release/presenter-stage.apk
+
       - name: Verify prod artifact has no test-only features
         run: |
           if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset|kill_pipeline_for_test|simulate_error_for_test|simulate_pipeline_error" >/dev/null; then
@@ -92,6 +108,7 @@ jobs:
             target/release/presenter-server
             target/release/import_propresenter
             target/release/ingest_bibles
+            target/release/presenter-stage.apk
 
   deploy:
     name: Deploy to Production
@@ -117,8 +134,9 @@ jobs:
           cp _artifacts/presenter-server target/release/
           cp _artifacts/import_propresenter target/release/
           cp _artifacts/ingest_bibles target/release/
+          cp _artifacts/presenter-stage.apk target/release/
           chmod +x target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles
-          ls -la target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles
+          ls -la target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles target/release/presenter-stage.apk
 
       - name: Setup SSH for deployment
         run: |
@@ -218,6 +236,11 @@ jobs:
             target/release/ingest_bibles \
             deploy-target:${{ env.DEPLOY_DIR }}/
           ssh deploy-target "chmod +x ${{ env.DEPLOY_DIR }}/presenter-server ${{ env.DEPLOY_DIR }}/import_propresenter ${{ env.DEPLOY_DIR }}/ingest_bibles"
+
+      - name: Deploy Android Stage APK
+        run: |
+          scp -i ~/.ssh/id_deploy target/release/presenter-stage.apk deploy-target:${{ env.DEPLOY_DIR }}/presenter-stage.apk
+          echo "Presenter Stage APK deployed to ${{ env.DEPLOY_DIR }}/presenter-stage.apk"
 
       - name: Deploy CLIProxyAPI
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -652,6 +652,42 @@ jobs:
             target/release/ingest_bibles
 
   # ============================================
+  # Android Stage APK (the universal stage-display app the server installs on TVs)
+  # ============================================
+  build-android:
+    name: Build Android Stage APK
+    runs-on: ubuntu-latest
+    needs: branch-sync
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build debug APK
+        working-directory: android/presenter-stage
+        run: gradle assembleDebug --no-daemon --stacktrace
+
+      - name: Stage APK artifact
+        run: |
+          mkdir -p _apk
+          cp android/presenter-stage/app/build/outputs/apk/debug/app-debug.apk _apk/presenter-stage.apk
+          ls -la _apk/presenter-stage.apk
+
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          retention-days: 1
+          path: _apk/presenter-stage.apk
+
+  # ============================================
   # E2E Tests (GitHub-hosted runners, 3 parallel shards)
   # ============================================
   e2e:
@@ -892,7 +928,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     runs-on: self-hosted
-    needs: [e2e, e2e-ndi]
+    needs: [e2e, e2e-ndi, build-android]
     concurrency:
       group: deploy-dev
       cancel-in-progress: false
@@ -909,6 +945,12 @@ jobs:
         with:
           name: build-artifacts
           path: _artifacts
+
+      - name: Download Android Stage APK
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: _apk
 
       - name: Place binaries
         run: |
@@ -1067,6 +1109,11 @@ jobs:
             target/release/ingest_bibles \
             deploy-target:${{ env.DEPLOY_DIR }}/
           ssh deploy-target "chmod +x ${{ env.DEPLOY_DIR }}/presenter-server ${{ env.DEPLOY_DIR }}/import_propresenter ${{ env.DEPLOY_DIR }}/ingest_bibles"
+
+      - name: Deploy Android Stage APK
+        run: |
+          scp -i ~/.ssh/id_deploy _apk/presenter-stage.apk deploy-target:${{ env.DEPLOY_DIR }}/presenter-stage.apk
+          echo "Presenter Stage APK deployed to ${{ env.DEPLOY_DIR }}/presenter-stage.apk"
 
       - name: Deploy CLIProxyAPI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,22 @@ jobs:
         env:
           PRESENTER_BUILD_CHANNEL: release
 
+      - name: Set up JDK 17 (Android Stage APK)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Android Stage APK
+        working-directory: android/presenter-stage
+        run: gradle assembleDebug --no-daemon --stacktrace
+
+      - name: Stage APK into release dir
+        run: cp android/presenter-stage/app/build/outputs/apk/debug/app-debug.apk target/release/presenter-stage.apk
+
       - name: Verify prod artifact has no test-only features
         run: |
           if strings target/release/presenter-server | grep -E "mock_integrations|MOCK_RESOLUME_ADDR|MOCK_ABLESET_ADDR|mock-resolume|mock-ableset|kill_pipeline_for_test|simulate_error_for_test|simulate_pipeline_error" >/dev/null; then
@@ -84,6 +100,7 @@ jobs:
           cp target/release/presenter-server release/
           cp target/release/import_propresenter release/
           cp target/release/ingest_bibles release/
+          cp target/release/presenter-stage.apk release/
           cp data/bibles/*.zip release/bibles/
           cp -r data/libraries/* release/libraries/
           tar -czvf presenter-${{ github.event.release.tag_name }}-linux-x64.tar.gz -C release .
@@ -103,6 +120,7 @@ jobs:
             target/release/presenter-server
             target/release/import_propresenter
             target/release/ingest_bibles
+            target/release/presenter-stage.apk
 
   deploy-pp:
     name: Deploy to companion-pp.lan
@@ -167,6 +185,11 @@ jobs:
             binaries/ingest_bibles \
             deploy-target:${{ env.DEPLOY_DIR }}/
           ssh deploy-target "chmod +x ${{ env.DEPLOY_DIR }}/presenter-server ${{ env.DEPLOY_DIR }}/import_propresenter ${{ env.DEPLOY_DIR }}/ingest_bibles"
+
+      - name: Deploy Android Stage APK
+        run: |
+          scp -i ~/.ssh/id_deploy binaries/presenter-stage.apk deploy-target:${{ env.DEPLOY_DIR }}/presenter-stage.apk
+          echo "Presenter Stage APK deployed to ${{ env.DEPLOY_DIR }}/presenter-stage.apk"
 
       - name: Deploy CLIProxyAPI
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.156"
+version = "0.4.157"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/android/presenter-stage/app/build.gradle.kts
+++ b/android/presenter-stage/app/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "sk.newlevel.presenterstage"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "sk.newlevel.presenterstage"
+        minSdk = 22
+        targetSdk = 34
+        // versionCode is the stable, monotonic upgrade key the server watchdog
+        // compares against the installed app to decide whether to reinstall.
+        // Bump it whenever the APK content changes. Keep versionName human-readable.
+        versionCode = 1
+        versionName = "1.0.0"
+    }
+
+    buildTypes {
+        // We ship a debug-signed APK: it installs via `adb install` on any TV
+        // without Play, and the server watchdog handles signature changes by
+        // uninstall+reinstall. No release keystore / Play distribution needed.
+        getByName("debug") {
+            isMinifyEnabled = false
+        }
+        getByName("release") {
+            isMinifyEnabled = false
+            // Reuse the debug signing config so `assembleRelease` is also
+            // ADB-installable without a managed keystore.
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    // Intentionally tiny: a single Activity + the platform WebView. No AndroidX
+    // UI libs needed — keeps the APK small and the attack/maintenance surface low.
+    implementation("androidx.core:core-ktx:1.13.1")
+}

--- a/android/presenter-stage/app/src/main/AndroidManifest.xml
+++ b/android/presenter-stage/app/src/main/AndroidManifest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- TV app, but keep it installable on phones/tablets too (required=false). -->
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
+    <application
+        android:allowBackup="false"
+        android:banner="@drawable/banner"
+        android:hardwareAccelerated="true"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
+        android:theme="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen">
+
+        <activity
+            android:name=".StageActivity"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode|density|fontScale"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:screenOrientation="landscape"
+            android:theme="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen">
+
+            <!-- Launchable from the TV home (LEANBACK) and the phone launcher. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+
+            <!-- The server watchdog opens the stage with:
+                 am start -a android.intent.action.VIEW -d <stage-url> sk.newlevel.presenterstage
+                 so the activity must handle VIEW http/https intents. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/presenter-stage/app/src/main/java/sk/newlevel/presenterstage/StageActivity.kt
+++ b/android/presenter-stage/app/src/main/java/sk/newlevel/presenterstage/StageActivity.kt
@@ -1,0 +1,156 @@
+package sk.newlevel.presenterstage
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.WindowManager
+import android.webkit.PermissionRequest
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * Presenter Stage — a deliberately tiny, full-screen WebView kiosk for church
+ * stage displays. It exists so the stage runs on ANY Android TV without a
+ * third-party kiosk browser (Fully Kiosk) and without depending on a per-brand
+ * browser (e.g. com.tcl.browser, absent on Sharp/MediaTek TVs).
+ *
+ * The server watchdog (presenter-server `android_stage.rs`) installs this APK
+ * via ADB and opens it with:
+ *   am start -a android.intent.action.VIEW -d <stage-url> sk.newlevel.presenterstage
+ * The activity reads the URL from the VIEW intent and shows it full-screen,
+ * with autoplay + WebRTC (WHEP/NDI video) enabled and the screen kept on.
+ */
+class StageActivity : android.app.Activity() {
+
+    private lateinit var webView: WebView
+    private val handler = Handler(Looper.getMainLooper())
+    private var currentUrl: String? = null
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        webView = WebView(this)
+        setContentView(webView)
+
+        // Allow `chrome://inspect` debugging of the stage from a dev machine.
+        WebView.setWebContentsDebuggingEnabled(true)
+
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            // Stage video (NDI WHEP / HTML5) must autoplay without a user gesture.
+            mediaPlaybackRequiresUserGesture = false
+            loadWithOverviewMode = true
+            useWideViewPort = true
+            cacheMode = WebSettings.LOAD_DEFAULT
+            // The stage is served over http on the LAN.
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        }
+
+        webView.webChromeClient = object : WebChromeClient() {
+            override fun onPermissionRequest(request: PermissionRequest) {
+                // The stage uses WebRTC (WHEP) to receive NDI video; grant the
+                // web resources it asks for so playback is never blocked.
+                runOnUiThread { request.grant(request.resources) }
+            }
+        }
+
+        webView.webViewClient = object : WebViewClient() {
+            override fun onReceivedError(
+                view: WebView,
+                request: WebResourceRequest,
+                error: WebResourceError,
+            ) {
+                // Retry only the main stage page (not every failed subresource),
+                // so a transient server/network blip self-heals.
+                if (request.isForMainFrame) scheduleReload()
+            }
+        }
+
+        loadFromIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // singleTask: a relaunch (watchdog re-firing the VIEW intent, possibly
+        // with a new URL) reuses this instance — load the new URL.
+        setIntent(intent)
+        loadFromIntent(intent)
+    }
+
+    private fun loadFromIntent(intent: Intent?) {
+        val url = intent?.dataString?.takeIf { it.isNotBlank() }
+        when {
+            url != null -> {
+                currentUrl = url
+                webView.loadUrl(url)
+            }
+            // Opened from the launcher with no URL (and none loaded yet): show a
+            // placeholder rather than a blank screen until the server launches us.
+            currentUrl == null -> webView.loadData(
+                "<html><body style=\"margin:0;background:#0f172a;color:#94a3b8;" +
+                    "font-family:sans-serif;display:flex;align-items:center;" +
+                    "justify-content:center;height:100vh\">" +
+                    "<h2>Presenter Stage — waiting for server…</h2></body></html>",
+                "text/html",
+                "utf-8",
+            )
+        }
+    }
+
+    private fun scheduleReload() {
+        handler.removeCallbacksAndMessages(null)
+        handler.postDelayed({ currentUrl?.let { webView.loadUrl(it) } }, RELOAD_DELAY_MS)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        enterImmersive()
+        webView.onResume()
+    }
+
+    override fun onPause() {
+        webView.onPause()
+        super.onPause()
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) enterImmersive()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun enterImmersive() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+        }
+        window.decorView.systemUiVisibility = (
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            )
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacksAndMessages(null)
+        webView.destroy()
+        super.onDestroy()
+    }
+
+    private companion object {
+        const val RELOAD_DELAY_MS = 3000L
+    }
+}

--- a/android/presenter-stage/app/src/main/res/drawable/banner.xml
+++ b/android/presenter-stage/app/src/main/res/drawable/banner.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Leanback launcher banner (320x180). Solid dark card with the app accent. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#0F172A" />
+        </shape>
+    </item>
+    <item
+        android:width="96dp"
+        android:height="64dp"
+        android:gravity="center">
+        <shape android:shape="rectangle">
+            <solid android:color="#3B82F6" />
+            <corners android:radius="6dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/android/presenter-stage/app/src/main/res/drawable/ic_launcher.xml
+++ b/android/presenter-stage/app/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#0F172A"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#3B82F6"
+        android:pathData="M30,32h48a4,4 0 0 1 4,4v30a4,4 0 0 1 -4,4h-48a4,4 0 0 1 -4,-4v-30a4,4 0 0 1 4,-4z" />
+    <path
+        android:fillColor="#0F172A"
+        android:pathData="M48,44l16,9l-16,9z" />
+    <path
+        android:fillColor="#3B82F6"
+        android:pathData="M44,78h20v4h-20z" />
+</vector>

--- a/android/presenter-stage/app/src/main/res/values/strings.xml
+++ b/android/presenter-stage/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Presenter Stage</string>
+</resources>

--- a/android/presenter-stage/build.gradle.kts
+++ b/android/presenter-stage/build.gradle.kts
@@ -1,0 +1,5 @@
+// Top-level build file. Plugin versions are declared here and applied per-module.
+plugins {
+    id("com.android.application") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/android/presenter-stage/gradle.properties
+++ b/android/presenter-stage/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android/presenter-stage/settings.gradle.kts
+++ b/android/presenter-stage/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "PresenterStage"
+include(":app")

--- a/crates/presenter-core/src/android_stage_display.rs
+++ b/crates/presenter-core/src/android_stage_display.rs
@@ -3,14 +3,17 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Default launcher target: the TCL built-in browser PACKAGE.
+/// Default launcher target: our own Presenter Stage app PACKAGE.
 ///
 /// The launcher fires a `VIEW` intent at this package with the configured
-/// `PRESENTER_ANDROID_STAGE_URL` (see `android_stage.rs`). It is a bare package
-/// (no `/activity`), which is the proven-working shape on the prod stage TVs.
-/// Legacy `package/activity` values are still accepted by `validate()` and the
-/// launcher extracts the package from them for backward compatibility.
-pub const DEFAULT_LAUNCH_PACKAGE: &str = "com.tcl.browser";
+/// `PRESENTER_ANDROID_STAGE_URL` (see `android_stage.rs`). When the package is
+/// our own app, the watchdog also auto-installs it via ADB if missing — so the
+/// stage runs on ANY Android TV without a kiosk browser and without depending on
+/// a per-brand browser (e.g. `com.tcl.browser`, absent on Sharp/MediaTek TVs).
+/// It is a bare package (no `/activity`). Legacy `package/activity` values are
+/// still accepted by `validate()` and the launcher extracts the package from
+/// them for backward compatibility.
+pub const DEFAULT_LAUNCH_PACKAGE: &str = "sk.newlevel.presenterstage";
 pub const DEFAULT_ADB_PORT: u16 = 5555;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -153,10 +156,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_launch_component_is_bare_browser_package() {
-        // The launcher fires a VIEW intent at a browser PACKAGE (not a
-        // package/activity component), so the default must be a bare package.
-        assert_eq!(DEFAULT_LAUNCH_PACKAGE, "com.tcl.browser");
+    fn default_launch_component_is_bare_app_package() {
+        // The launcher fires a VIEW intent at a bare PACKAGE (not a
+        // package/activity component); the default is our own Presenter Stage app
+        // so the stage runs on ANY Android TV without a kiosk/per-brand browser.
+        assert_eq!(DEFAULT_LAUNCH_PACKAGE, "sk.newlevel.presenterstage");
     }
 
     #[test]

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -13,6 +13,7 @@ mod m20260506_000001_normalize_text_to_nfc;
 mod m20260517_000001_create_settings_audit;
 mod m20260517_000002_fix_legacy_ableset_defaults;
 mod m20260616_000001_fix_android_stage_launch_package;
+mod m20260624_000001_default_launch_to_presenter_stage;
 
 pub struct Migrator;
 
@@ -30,6 +31,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260517_000001_create_settings_audit::Migration),
             Box::new(m20260517_000002_fix_legacy_ableset_defaults::Migration),
             Box::new(m20260616_000001_fix_android_stage_launch_package::Migration),
+            Box::new(m20260624_000001_default_launch_to_presenter_stage::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260624_000001_default_launch_to_presenter_stage.rs
+++ b/crates/presenter-migration/src/m20260624_000001_default_launch_to_presenter_stage.rs
@@ -1,0 +1,156 @@
+use sea_orm_migration::prelude::*;
+
+/// Previous default launch package: the TCL built-in browser (set by
+/// `m20260616_000001`). It only exists on TCL TVs, so it fails on other brands
+/// (e.g. Sharp/MediaTek, where it is absent) — see #472.
+const OLD_LAUNCH_PACKAGE: &str = "com.tcl.browser";
+
+/// New default launch package: our own Presenter Stage app. The watchdog
+/// auto-installs this APK via ADB on any TV that lacks it, so the stage runs on
+/// EVERY Android TV without a kiosk browser or a per-brand browser dependency.
+const NEW_LAUNCH_PACKAGE: &str = "sk.newlevel.presenterstage";
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Rewrite only rows that still carry the previous default (`com.tcl.browser`)
+/// to our own app package. Operator-customised rows (any other value, e.g. a
+/// deliberately chosen browser) are left untouched. Running twice is a no-op
+/// (the WHERE clause no longer matches after the first run), so this is safe
+/// across redeploys.
+///
+/// Returns the number of rows updated (for test assertions).
+pub(crate) async fn migrate_default_launch_package(
+    conn: &impl sea_orm::ConnectionTrait,
+) -> Result<u64, DbErr> {
+    let backend = conn.get_database_backend();
+
+    // The table is part of the initial schema, but guard defensively: a fresh DB
+    // that has not yet created it (or a future site that dropped it) must not
+    // fail the migration.
+    let table_check = conn
+        .query_one(sea_orm::Statement::from_string(
+            backend,
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='android_stage_displays'"
+                .to_string(),
+        ))
+        .await?;
+    if table_check.is_none() {
+        return Ok(0);
+    }
+
+    let result = conn
+        .execute(sea_orm::Statement::from_sql_and_values(
+            backend,
+            "UPDATE android_stage_displays \
+             SET launch_component = ?1, updated_at = ?2 \
+             WHERE launch_component = ?3",
+            [
+                NEW_LAUNCH_PACKAGE.into(),
+                chrono::Utc::now().to_rfc3339().into(),
+                OLD_LAUNCH_PACKAGE.into(),
+            ],
+        ))
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        migrate_default_launch_package(manager.get_connection()).await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // No-op. Reverting to the TCL-only package would re-break non-TCL TVs.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{Database, DbBackend, Statement};
+
+    async fn setup_db() -> sea_orm::DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE android_stage_displays ( \
+                 id TEXT PRIMARY KEY, label TEXT NOT NULL, host TEXT NOT NULL, \
+                 port INTEGER NOT NULL, launch_component TEXT NOT NULL, \
+                 is_enabled INTEGER NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)"
+                .to_string(),
+        ))
+        .await
+        .expect("ddl");
+        db
+    }
+
+    async fn insert_row(db: &sea_orm::DatabaseConnection, id: &str, launch_component: &str) {
+        db.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO android_stage_displays \
+             (id, label, host, port, launch_component, is_enabled, created_at, updated_at) \
+             VALUES (?1, 'Stage', 'sd1l.lan', 5555, ?2, 1, '2026-06-24T00:00:00Z', '2026-06-24T00:00:00Z')",
+            [id.into(), launch_component.into()],
+        ))
+        .await
+        .expect("insert");
+    }
+
+    async fn fetch_component(db: &sea_orm::DatabaseConnection, id: &str) -> String {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT launch_component FROM android_stage_displays WHERE id = ?1",
+                [id.into()],
+            ))
+            .await
+            .expect("query")
+            .expect("row");
+        row.try_get_by_index::<String>(0).expect("string col")
+    }
+
+    #[tokio::test]
+    async fn migration_replaces_tcl_default_and_is_idempotent() {
+        let db = setup_db().await;
+
+        // old-default row (must be migrated), an operator-customised row (left
+        // alone), and a row already on our app (left alone).
+        insert_row(&db, "tcl", "com.tcl.browser").await;
+        insert_row(&db, "custom", "org.mozilla.firefox").await;
+        insert_row(&db, "ours", "sk.newlevel.presenterstage").await;
+
+        let updated = migrate_default_launch_package(&db).await.expect("up");
+        assert_eq!(
+            updated, 1,
+            "only the com.tcl.browser row should be rewritten"
+        );
+
+        assert_eq!(
+            fetch_component(&db, "tcl").await,
+            "sk.newlevel.presenterstage"
+        );
+        assert_eq!(fetch_component(&db, "custom").await, "org.mozilla.firefox");
+        assert_eq!(
+            fetch_component(&db, "ours").await,
+            "sk.newlevel.presenterstage"
+        );
+
+        // Idempotent: a second run touches nothing.
+        let updated_again = migrate_default_launch_package(&db).await.expect("rerun");
+        assert_eq!(updated_again, 0, "rerun must be a no-op");
+    }
+
+    #[tokio::test]
+    async fn migration_no_op_when_table_missing() {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        let updated = migrate_default_launch_package(&db)
+            .await
+            .expect("missing table must not error");
+        assert_eq!(updated, 0);
+    }
+}

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -860,12 +860,12 @@ async fn seed_migration_populates_four_android_stage_displays_on_empty_table() {
     );
     for d in &displays {
         assert_eq!(d.port, 5555);
-        // The seed (m20260414_000002) inserts the dead Fully Kiosk component,
-        // but the full migration chain run by `connect_in_memory` then applies
-        // m20260616_000001, which rewrites those rows to the TCL browser
-        // package (issue #404). So after migrations the launcher target is the
-        // package, not the dead component.
-        assert_eq!(d.launch_component, "com.tcl.browser");
+        // The seed (m20260414_000002) inserts the dead Fully Kiosk component;
+        // the full migration chain run by `connect_in_memory` then applies
+        // m20260616_000001 (→ com.tcl.browser, #404) and finally m20260624_000001
+        // (→ our own Presenter Stage app, #472), which is the universal launcher
+        // target. So after migrations the launcher target is our app package.
+        assert_eq!(d.launch_component, "sk.newlevel.presenterstage");
         assert!(d.is_enabled, "seeded displays should be enabled");
     }
 }

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -1580,6 +1580,14 @@ mod tests {
         // A message exactly at the cap passes through unchanged (boundary of the
         // len() <= MAX_LEN branch).
         assert_eq!(truncate_error(&"a".repeat(280)), "a".repeat(280));
+        // All single-byte chars: the budget cut lands EXACTLY at MAX_LEN-1 = 279,
+        // so the result is exactly 279 'a's + ellipsis. This pins the budget
+        // comparison precisely — `> → >=` would keep 278, `+ → *` would keep 280.
+        assert_eq!(
+            truncate_error(&"a".repeat(400)),
+            format!("{}…", "a".repeat(279)),
+            "byte budget must keep exactly MAX_LEN-1 single-byte chars",
+        );
     }
 
     // A browser package (e.g. com.tcl.browser) is assumed pre-installed — the

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -880,15 +880,17 @@ fn truncate_error(message: &str) -> String {
     if message.len() <= MAX_LEN {
         message.to_string()
     } else {
-        // Walk down to the nearest UTF-8 char boundary at or below MAX_LEN-1 so
-        // multi-byte codepoints in adb output never panic the byte slice. No
-        // `end > 0` guard is needed: byte 0 is always a char boundary, so the
-        // loop always stops at end >= 0 without underflowing.
-        let mut end = MAX_LEN - 1;
-        while !message.is_char_boundary(end) {
-            end -= 1;
+        // Accumulate whole chars until the next one would exceed the byte budget,
+        // so multi-byte codepoints in adb output are never split (no panic) and
+        // there is no decrement loop to mutate into an infinite loop.
+        let mut truncated = String::new();
+        for c in message.chars() {
+            if truncated.len() + c.len_utf8() > MAX_LEN - 1 {
+                break;
+            }
+            truncated.push(c);
         }
-        format!("{}…", &message[..end])
+        format!("{truncated}…")
     }
 }
 
@@ -1290,6 +1292,13 @@ mod tests {
                 .filter(|c| c.contains("dumpsys activity activities"))
                 .count()
         }
+
+        fn dumpsys_package_calls(&self) -> usize {
+            self.invocations()
+                .iter()
+                .filter(|c| c.contains("dumpsys package"))
+                .count()
+        }
     }
 
     #[async_trait]
@@ -1455,6 +1464,14 @@ mod tests {
             1,
             "the stage must still be launched after install",
         );
+        // The version check (dumpsys package) is ONLY reached when the package is
+        // already present. An absent app must install directly without probing the
+        // version — asserts adb_package_installed actually gates that branch.
+        assert_eq!(
+            runner.dumpsys_package_calls(),
+            0,
+            "an absent app must NOT be version-probed before install",
+        );
     }
 
     // An already-installed app MUST NOT be reinstalled on every launch.
@@ -1513,6 +1530,10 @@ mod tests {
             runner.install_calls(),
             0,
             "an app already at the expected versionCode MUST NOT be reinstalled",
+        );
+        assert!(
+            runner.dumpsys_package_calls() >= 1,
+            "a present app MUST be version-probed (dumpsys package) to decide upgrade",
         );
     }
 

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -90,6 +90,14 @@ const STAGE_URL_ENV: &str = "PRESENTER_ANDROID_STAGE_URL";
 const STAGE_APK_ENV: &str = "PRESENTER_ANDROID_STAGE_APK";
 const DEFAULT_STAGE_APK_PATH: &str = "/opt/presenter/presenter-stage.apk";
 
+/// The `versionCode` of the bundled Presenter Stage APK. MUST be kept in lockstep
+/// with `android/presenter-stage/app/build.gradle.kts` `versionCode`. The watchdog
+/// compares this against the versionCode installed on a TV and reinstalls when the
+/// TV's copy is older — so bumping the app's versionCode (and this constant)
+/// actually ships the new APK to TVs that already have an older one. Without this
+/// comparison, an already-installed (but stale) app would never be upgraded.
+const EXPECTED_STAGE_APK_VERSION_CODE: i64 = 1;
+
 /// Validate that a configured stage URL is a well-formed `http(s)://` URL before
 /// it is spliced into the `am start -a VIEW -d <url>` adb args (which reach the
 /// device's `/system/bin/sh`). Returns the normalized URL string on success, or
@@ -598,11 +606,35 @@ fn adb_install_succeeded(output: &Output) -> bool {
     ensure_success(output).is_ok() && String::from_utf8_lossy(&output.stdout).contains("Success")
 }
 
-/// Ensure our Presenter Stage app is installed on the device. No-op when already
-/// present. Otherwise `adb install -r <apk>`; if that fails (e.g. a signature
-/// mismatch from a rebuilt APK, or a downgrade), fall back to `adb uninstall` +
-/// a clean `adb install`. The app is a stateless WebView shell, so reinstalling
-/// loses nothing.
+/// Read the `versionCode` of `package` installed on the device via
+/// `dumpsys package <pkg>`. Returns `None` when the command fails or no
+/// `versionCode=` line is present (e.g. package absent).
+async fn adb_installed_version_code(
+    runner: &dyn AdbRunner,
+    serial: &str,
+    package: &str,
+) -> Option<i64> {
+    let args = adb_args(["-s", serial, "shell", "dumpsys", "package", package]);
+    let output = runner.run(&args).await.ok()?;
+    parse_version_code(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parse the first `versionCode=<n>` integer out of `dumpsys package` output.
+/// `dumpsys` prints e.g. `    versionCode=7 minSdk=22 targetSdk=34` — we take the
+/// digits immediately after the first `versionCode=`. Returns `None` when no such
+/// field is present. Pure (no I/O) so the parsing is unit-testable.
+fn parse_version_code(dumpsys: &str) -> Option<i64> {
+    let after = dumpsys.split("versionCode=").nth(1)?;
+    let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+/// Ensure our Presenter Stage app is installed AND up to date on the device.
+/// No-op when present at a versionCode >= [`EXPECTED_STAGE_APK_VERSION_CODE`].
+/// Otherwise (absent, stale, or version unreadable) `adb install -r <apk>`; if
+/// that fails (e.g. a signature mismatch from a rebuilt APK, or a downgrade),
+/// fall back to `adb uninstall` + a clean `adb install`. The app is a stateless
+/// WebView shell, so reinstalling loses nothing.
 async fn ensure_app_installed(
     runner: &dyn AdbRunner,
     serial: &str,
@@ -610,9 +642,30 @@ async fn ensure_app_installed(
     apk: &Path,
 ) -> anyhow::Result<()> {
     if adb_package_installed(runner, serial, package).await {
-        return Ok(());
+        match adb_installed_version_code(runner, serial, package).await {
+            // Up to date — nothing to do.
+            Some(installed) if installed >= EXPECTED_STAGE_APK_VERSION_CODE => return Ok(()),
+            // Older than the bundled APK — upgrade in place.
+            Some(installed) => {
+                info!(
+                    serial,
+                    package,
+                    installed,
+                    expected = EXPECTED_STAGE_APK_VERSION_CODE,
+                    "Presenter Stage app is stale — upgrading"
+                );
+            }
+            // Present but versionCode unreadable — reinstall to be safe.
+            None => {
+                warn!(
+                    serial,
+                    package, "Presenter Stage installed but versionCode unreadable — reinstalling"
+                );
+            }
+        }
+    } else {
+        info!(serial, package, apk = %apk.display(), "installing Presenter Stage app on TV");
     }
-    info!(serial, package, apk = %apk.display(), "installing Presenter Stage app on TV");
 
     let mut install_args = adb_args(["-s", serial, "install", "-r"]);
     install_args.push(apk.as_os_str().to_os_string());
@@ -827,7 +880,13 @@ fn truncate_error(message: &str) -> String {
     if message.len() <= MAX_LEN {
         message.to_string()
     } else {
-        format!("{}…", &message[..MAX_LEN - 1])
+        // Slice on a UTF-8 char boundary at or below MAX_LEN-1 so multi-byte
+        // codepoints in adb output never panic the byte slice.
+        let mut end = MAX_LEN - 1;
+        while end > 0 && !message.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &message[..end])
     }
 }
 
@@ -1155,6 +1214,10 @@ mod tests {
         /// Whether `pm path <pkg>` reports the app installed. `false` models a TV
         /// that needs the Presenter Stage APK installed first.
         installed: bool,
+        /// The versionCode `dumpsys package <pkg>` reports for the installed app.
+        /// Defaults to [`EXPECTED_STAGE_APK_VERSION_CODE`] (up to date → no
+        /// reinstall); lower models a stale install the watchdog must upgrade.
+        installed_version: i64,
         calls: Mutex<Vec<String>>,
     }
 
@@ -1164,6 +1227,7 @@ mod tests {
                 foreground,
                 connect_fails: false,
                 installed: true,
+                installed_version: EXPECTED_STAGE_APK_VERSION_CODE,
                 calls: Mutex::new(Vec::new()),
             }
         }
@@ -1173,6 +1237,7 @@ mod tests {
                 foreground,
                 connect_fails: true,
                 installed: true,
+                installed_version: EXPECTED_STAGE_APK_VERSION_CODE,
                 calls: Mutex::new(Vec::new()),
             }
         }
@@ -1181,6 +1246,14 @@ mod tests {
         /// the watchdog must `adb install` the APK).
         fn app_missing(mut self) -> Self {
             self.installed = false;
+            self
+        }
+
+        /// Builder: the app IS installed but at an older versionCode, so the
+        /// watchdog must upgrade it.
+        fn installed_version(mut self, version: i64) -> Self {
+            self.installed = true;
+            self.installed_version = version;
             self
         }
 
@@ -1257,6 +1330,19 @@ mod tests {
                     "package:/data/app/test/base.apk"
                 } else {
                     ""
+                }));
+            }
+
+            // `dumpsys package <pkg>` reports the installed versionCode (empty
+            // when the app is absent).
+            if joined.contains("dumpsys package") {
+                return Ok(ok_output(&if self.installed {
+                    format!(
+                        "    versionCode={} minSdk=22 targetSdk=34",
+                        self.installed_version
+                    )
+                } else {
+                    String::new()
                 }));
             }
 
@@ -1385,6 +1471,82 @@ mod tests {
             0,
             "an already-installed app MUST NOT be reinstalled",
         );
+    }
+
+    // An app present at a versionCode OLDER than the bundled APK MUST be upgraded
+    // (the versionCode comparison the gradle comment promises). Without it, a
+    // bumped APK never reaches a TV that already has an older copy.
+    #[tokio::test]
+    async fn upgrades_our_app_when_installed_version_is_stale() {
+        let runner = FakeAdbRunner::new(Foreground::StagePage)
+            .installed_version(EXPECTED_STAGE_APK_VERSION_CODE - 1);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = our_app_display();
+        let status = test_status();
+
+        let result =
+            connect_and_launch(&runner, &stage_url, &some_apk(), &config, &status, true).await;
+        assert!(result.is_ok(), "upgrade + launch must succeed: {result:?}");
+        assert_eq!(
+            runner.install_calls(),
+            1,
+            "a stale (older versionCode) app MUST be upgraded via adb install",
+        );
+    }
+
+    // A present app at the EXACT expected versionCode must NOT be reinstalled
+    // (boundary: installed == expected → up to date).
+    #[tokio::test]
+    async fn skips_install_when_installed_version_matches_expected() {
+        let runner = FakeAdbRunner::new(Foreground::StagePage)
+            .installed_version(EXPECTED_STAGE_APK_VERSION_CODE);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = our_app_display();
+        let status = test_status();
+
+        let result =
+            connect_and_launch(&runner, &stage_url, &some_apk(), &config, &status, true).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            runner.install_calls(),
+            0,
+            "an app already at the expected versionCode MUST NOT be reinstalled",
+        );
+    }
+
+    #[test]
+    fn parse_version_code_extracts_first_integer_or_none() {
+        assert_eq!(
+            parse_version_code("    versionCode=7 minSdk=22 targetSdk=34"),
+            Some(7),
+            "must parse the integer right after versionCode=",
+        );
+        assert_eq!(
+            parse_version_code("flags=[ DEBUGGABLE ]\n    versionCode=42 ..."),
+            Some(42),
+        );
+        assert_eq!(
+            parse_version_code("no version field here"),
+            None,
+            "absent versionCode must yield None (→ reinstall to be safe)",
+        );
+        assert_eq!(
+            parse_version_code("versionCode= notanumber"),
+            None,
+            "non-numeric versionCode must yield None",
+        );
+    }
+
+    #[test]
+    fn truncate_error_is_utf8_safe_at_boundary() {
+        // A multi-byte codepoint straddling the 279-byte cut must not panic and
+        // must produce valid UTF-8.
+        let message = "x".repeat(278) + "č" + &"y".repeat(20); // 'č' = 2 bytes at 278
+        let out = truncate_error(&message);
+        assert!(out.ends_with('…'), "long message must be ellipsized");
+        assert!(out.len() <= 282, "stays near the cap");
+        // Short messages pass through unchanged.
+        assert_eq!(truncate_error("short"), "short");
     }
 
     // A browser package (e.g. com.tcl.browser) is assumed pre-installed — the

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -880,10 +880,12 @@ fn truncate_error(message: &str) -> String {
     if message.len() <= MAX_LEN {
         message.to_string()
     } else {
-        // Slice on a UTF-8 char boundary at or below MAX_LEN-1 so multi-byte
-        // codepoints in adb output never panic the byte slice.
+        // Walk down to the nearest UTF-8 char boundary at or below MAX_LEN-1 so
+        // multi-byte codepoints in adb output never panic the byte slice. No
+        // `end > 0` guard is needed: byte 0 is always a char boundary, so the
+        // loop always stops at end >= 0 without underflowing.
         let mut end = MAX_LEN - 1;
-        while end > 0 && !message.is_char_boundary(end) {
+        while !message.is_char_boundary(end) {
             end -= 1;
         }
         format!("{}…", &message[..end])
@@ -1539,14 +1541,24 @@ mod tests {
 
     #[test]
     fn truncate_error_is_utf8_safe_at_boundary() {
-        // A multi-byte codepoint straddling the 279-byte cut must not panic and
-        // must produce valid UTF-8.
-        let message = "x".repeat(278) + "č" + &"y".repeat(20); // 'č' = 2 bytes at 278
+        // 'č' (2 bytes) occupies bytes 278-279; the cut index MAX_LEN-1 = 279
+        // lands MID-codepoint. Correct code walks DOWN to byte 278 (the char
+        // boundary at the start of 'č'), so the result is exactly the 278 'x's
+        // plus the ellipsis — 'č' is dropped, never split. Asserting the EXACT
+        // string kills the boundary-walk mutants (end += 1 would instead keep
+        // 'č'; && → || would walk all the way to 0).
+        let message = "x".repeat(278) + "č" + &"y".repeat(20);
         let out = truncate_error(&message);
-        assert!(out.ends_with('…'), "long message must be ellipsized");
-        assert!(out.len() <= 282, "stays near the cap");
+        assert_eq!(
+            out,
+            format!("{}…", "x".repeat(278)),
+            "must cut on the char boundary below the limit (drop the split 'č')",
+        );
         // Short messages pass through unchanged.
         assert_eq!(truncate_error("short"), "short");
+        // A message exactly at the cap passes through unchanged (boundary of the
+        // len() <= MAX_LEN branch).
+        assert_eq!(truncate_error(&"a".repeat(280)), "a".repeat(280));
     }
 
     // A browser package (e.g. com.tcl.browser) is assumed pre-installed — the

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -126,9 +126,13 @@ fn validate_stage_url(raw: &str) -> Option<String> {
 /// Resolve the Presenter Stage APK path from [`STAGE_APK_ENV`] (default
 /// [`DEFAULT_STAGE_APK_PATH`]). Returns `Some(path)` only when the file actually
 /// exists, so the watchdog never attempts an `adb install` of a missing file.
-fn resolve_stage_apk_path() -> Option<PathBuf> {
-    let raw = env::var(STAGE_APK_ENV)
-        .ok()
+/// Resolve the Presenter Stage APK path from the [`STAGE_APK_ENV`] value: fall
+/// back to [`DEFAULT_STAGE_APK_PATH`] when empty/unset, then return the path only
+/// if the file actually exists (so the watchdog never tries to install a missing
+/// file). Kept as a pure function of its argument so it is testable without
+/// touching the process environment; the caller passes `env::var(...).ok()`.
+fn resolve_apk_path_from(raw: Option<String>) -> Option<PathBuf> {
+    let raw = raw
         .filter(|v| !v.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_STAGE_APK_PATH.to_string());
     let path = PathBuf::from(raw);
@@ -223,7 +227,7 @@ impl AndroidStageRegistry {
                 );
             }
         }
-        let apk_path = resolve_stage_apk_path();
+        let apk_path = resolve_apk_path_from(env::var(STAGE_APK_ENV).ok());
         match &apk_path {
             Some(path) => {
                 debug!(env = STAGE_APK_ENV, path = %path.display(), "presenter stage APK available for auto-install");
@@ -1399,6 +1403,50 @@ mod tests {
             runner.install_calls(),
             0,
             "only our own app is auto-installed; a browser package is left alone",
+        );
+    }
+
+    // APK path resolution: an existing configured file resolves to itself; a
+    // missing path (or empty → default, absent in tests) resolves to None so the
+    // watchdog never tries to install a non-existent file.
+    #[test]
+    fn resolve_apk_path_uses_existing_file_and_rejects_missing() {
+        let f =
+            std::env::temp_dir().join(format!("presenter-stage-test-{}.apk", std::process::id()));
+        std::fs::write(&f, b"x").unwrap();
+        assert_eq!(
+            resolve_apk_path_from(Some(f.to_string_lossy().into_owned())),
+            Some(f.clone()),
+            "an existing configured APK path must resolve to itself",
+        );
+        std::fs::remove_file(&f).ok();
+        assert_eq!(
+            resolve_apk_path_from(Some("/no/such/dir/presenter-stage.apk".to_string())),
+            None,
+            "a missing APK path must resolve to None (install skipped)",
+        );
+        assert_eq!(
+            resolve_apk_path_from(Some(String::new())),
+            None,
+            "empty falls back to the default path, which is absent under test → None",
+        );
+    }
+
+    // `adb install` success requires BOTH a success exit AND a `Success` line —
+    // a `Failure [..]` printed on a zero exit must NOT count as installed.
+    #[test]
+    fn adb_install_succeeded_requires_success_exit_and_marker() {
+        assert!(
+            adb_install_succeeded(&ok_output("Success")),
+            "exit 0 + Success ⇒ installed",
+        );
+        assert!(
+            !adb_install_succeeded(&ok_output("Failure [INSTALL_FAILED_VERSION_DOWNGRADE]")),
+            "exit 0 but no Success marker ⇒ NOT installed",
+        );
+        assert!(
+            !adb_install_succeeded(&err_output("Success")),
+            "non-zero exit ⇒ NOT installed",
         );
     }
 

--- a/crates/presenter-server/src/android_stage.rs
+++ b/crates/presenter-server/src/android_stage.rs
@@ -1,12 +1,13 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use presenter_core::{AndroidStageDisplay, AndroidStageDisplayId};
+use presenter_core::{AndroidStageDisplay, AndroidStageDisplayId, DEFAULT_LAUNCH_PACKAGE};
 use serde::Serialize;
 use std::{
     collections::HashMap,
     env,
     ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
     process::Output,
     sync::Arc,
     time::Duration,
@@ -79,6 +80,16 @@ const RETRY_INTERVAL: Duration = Duration::from_secs(20);
 /// in the deploy systemd units. When unset/empty the launcher skips launching.
 const STAGE_URL_ENV: &str = "PRESENTER_ANDROID_STAGE_URL";
 
+/// Server-wide env var pointing at the Presenter Stage APK on disk. The watchdog
+/// installs this APK via ADB on any TV whose configured launch package is our
+/// own app ([`DEFAULT_LAUNCH_PACKAGE`]) but does not have it installed yet — so
+/// the stage runs on ANY Android TV (incl. ones with no browser, e.g. Sharp/
+/// MediaTek) without a third-party kiosk browser. Defaults to
+/// [`DEFAULT_STAGE_APK_PATH`]; when the file is absent, install is skipped (the
+/// TV must already have the app, or a browser package configured).
+const STAGE_APK_ENV: &str = "PRESENTER_ANDROID_STAGE_APK";
+const DEFAULT_STAGE_APK_PATH: &str = "/opt/presenter/presenter-stage.apk";
+
 /// Validate that a configured stage URL is a well-formed `http(s)://` URL before
 /// it is spliced into the `am start -a VIEW -d <url>` adb args (which reach the
 /// device's `/system/bin/sh`). Returns the normalized URL string on success, or
@@ -110,6 +121,18 @@ fn validate_stage_url(raw: &str) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// Resolve the Presenter Stage APK path from [`STAGE_APK_ENV`] (default
+/// [`DEFAULT_STAGE_APK_PATH`]). Returns `Some(path)` only when the file actually
+/// exists, so the watchdog never attempts an `adb install` of a missing file.
+fn resolve_stage_apk_path() -> Option<PathBuf> {
+    let raw = env::var(STAGE_APK_ENV)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_STAGE_APK_PATH.to_string());
+    let path = PathBuf::from(raw);
+    path.is_file().then_some(path)
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -152,6 +175,10 @@ pub struct AndroidStageRegistry {
     /// `PRESENTER_ANDROID_STAGE_URL` at construction. `None` when unset/empty —
     /// the launcher then warns and skips rather than firing a broken intent.
     stage_url: Arc<Option<String>>,
+    /// Path to the Presenter Stage APK to install on TVs that should run our own
+    /// app but don't have it yet. `None` when the configured/default APK file is
+    /// absent (then install is skipped — see [`STAGE_APK_ENV`]).
+    apk_path: Arc<Option<PathBuf>>,
     displays: Arc<RwLock<HashMap<AndroidStageDisplayId, DeviceEntry>>>,
 }
 
@@ -196,9 +223,22 @@ impl AndroidStageRegistry {
                 );
             }
         }
+        let apk_path = resolve_stage_apk_path();
+        match &apk_path {
+            Some(path) => {
+                debug!(env = STAGE_APK_ENV, path = %path.display(), "presenter stage APK available for auto-install");
+            }
+            None => {
+                debug!(
+                    env = STAGE_APK_ENV,
+                    "presenter stage APK not found — TVs must already have the app or a browser package configured"
+                );
+            }
+        }
         Self {
             runner,
             stage_url: Arc::new(stage_url),
+            apk_path: Arc::new(apk_path),
             displays: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -299,11 +339,19 @@ impl AndroidStageRegistry {
         }));
         let runner = Arc::clone(&self.runner);
         let stage_url = Arc::clone(&self.stage_url);
+        let apk_path = Arc::clone(&self.apk_path);
         let status_clone = Arc::clone(&status);
         let config_clone = display.clone();
         let handle = tokio::spawn(async move {
-            if let Err(err) =
-                run_device_worker(runner, stage_url, config_clone, status_clone, command_rx).await
+            if let Err(err) = run_device_worker(
+                runner,
+                stage_url,
+                apk_path,
+                config_clone,
+                status_clone,
+                command_rx,
+            )
+            .await
             {
                 error!(?err, "android stage display worker exited");
             }
@@ -323,6 +371,7 @@ impl AndroidStageRegistry {
 async fn run_device_worker(
     runner: Arc<dyn AdbRunner>,
     stage_url: Arc<Option<String>>,
+    apk_path: Arc<Option<PathBuf>>,
     mut config: AndroidStageDisplay,
     status: Arc<RwLock<AndroidStageDisplayStatusSnapshot>>,
     mut command_rx: mpsc::Receiver<DeviceCommand>,
@@ -336,7 +385,7 @@ async fn run_device_worker(
                 if config.is_enabled {
                     // Periodic keep-alive: foreground-aware (#419) — only
                     // relaunches when the browser is not already up.
-                    if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &config, &status, false).await {
+                    if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &apk_path, &config, &status, false).await {
                         debug!(display = %config.label, ?err, "android stage display launch attempt failed");
                     }
                 } else {
@@ -355,7 +404,7 @@ async fn run_device_worker(
                         if config.is_enabled {
                             // Explicit/forced launch (startup, config change,
                             // launch-now endpoint): always (re)launch (#419).
-                            if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &config, &status, true).await {
+                            if let Err(err) = connect_and_launch(runner.as_ref(), &stage_url, &apk_path, &config, &status, true).await {
                                 debug!(display = %config.label, ?err, "android stage display manual launch failed");
                             }
                         }
@@ -398,6 +447,7 @@ async fn adb_connect(runner: &dyn AdbRunner, serial: &str) -> anyhow::Result<()>
 async fn connect_and_launch(
     runner: &dyn AdbRunner,
     stage_url: &Arc<Option<String>>,
+    apk_path: &Arc<Option<PathBuf>>,
     config: &AndroidStageDisplay,
     status: &Arc<RwLock<AndroidStageDisplayStatusSnapshot>>,
     force_launch: bool,
@@ -433,6 +483,22 @@ async fn connect_and_launch(
         return Err(err);
     }
 
+    let launch_pkg = launch_package(&config.launch_component);
+
+    // Ensure our own Presenter Stage app is installed before we launch it, so the
+    // stage runs on ANY Android TV — including ones with no usable browser (e.g.
+    // Sharp/MediaTek, where com.tcl.browser is absent) — without a kiosk browser.
+    // Only our app ([`DEFAULT_LAUNCH_PACKAGE`]) is auto-installed; a legacy or
+    // operator-set browser package is assumed already present on the device.
+    if launch_pkg == DEFAULT_LAUNCH_PACKAGE {
+        if let Some(apk) = apk_path.as_deref() {
+            if let Err(err) = ensure_app_installed(runner, &serial, launch_pkg, apk).await {
+                record_error(status, err.to_string()).await;
+                return Err(err);
+            }
+        }
+    }
+
     // #419: foreground-aware keep-alive. On the periodic tick (force_launch =
     // false) skip the am-start when the browser is ALREADY the resumed app —
     // re-firing the VIEW intent reloads com.tcl.browser (black blink + spinner)
@@ -440,7 +506,6 @@ async fn connect_and_launch(
     // genuinely-down display still recovers. Explicit/forced launches (config
     // change, launch-now endpoint) bypass the gate and always relaunch.
     if !force_launch {
-        let launch_pkg = launch_package(&config.launch_component);
         let foreground = adb_foreground_component(runner, &serial).await;
         if !should_launch_stage(foreground.as_deref(), launch_pkg) {
             debug!(
@@ -512,6 +577,71 @@ async fn adb_launch(
     Ok(())
 }
 
+/// True when `package` is installed on the device — `pm path <package>` prints a
+/// `package:` line. A missing package prints nothing (or errors) → false.
+async fn adb_package_installed(runner: &dyn AdbRunner, serial: &str, package: &str) -> bool {
+    let args = adb_args(["-s", serial, "shell", "pm", "path", package]);
+    match runner.run(&args).await {
+        Ok(output) => String::from_utf8_lossy(&output.stdout).contains("package:"),
+        Err(_) => false,
+    }
+}
+
+/// `adb install` reports failure on stdout (`Failure [INSTALL_FAILED_…]`) and,
+/// depending on adb version, may still exit 0 — so require BOTH a success exit
+/// AND a `Success` line.
+fn adb_install_succeeded(output: &Output) -> bool {
+    ensure_success(output).is_ok() && String::from_utf8_lossy(&output.stdout).contains("Success")
+}
+
+/// Ensure our Presenter Stage app is installed on the device. No-op when already
+/// present. Otherwise `adb install -r <apk>`; if that fails (e.g. a signature
+/// mismatch from a rebuilt APK, or a downgrade), fall back to `adb uninstall` +
+/// a clean `adb install`. The app is a stateless WebView shell, so reinstalling
+/// loses nothing.
+async fn ensure_app_installed(
+    runner: &dyn AdbRunner,
+    serial: &str,
+    package: &str,
+    apk: &Path,
+) -> anyhow::Result<()> {
+    if adb_package_installed(runner, serial, package).await {
+        return Ok(());
+    }
+    info!(serial, package, apk = %apk.display(), "installing Presenter Stage app on TV");
+
+    let mut install_args = adb_args(["-s", serial, "install", "-r"]);
+    install_args.push(apk.as_os_str().to_os_string());
+    if let Ok(output) = runner.run(&install_args).await {
+        if adb_install_succeeded(&output) {
+            return Ok(());
+        }
+    }
+
+    // Reinstall path: drop any conflicting/old copy, then install clean.
+    warn!(
+        serial,
+        package, "adb install -r failed — retrying with uninstall + install"
+    );
+    let _ = runner
+        .run(&adb_args(["-s", serial, "uninstall", package]))
+        .await;
+    let mut clean_args = adb_args(["-s", serial, "install"]);
+    clean_args.push(apk.as_os_str().to_os_string());
+    let output = runner
+        .run(&clean_args)
+        .await
+        .map_err(|e| anyhow!("failed to execute adb install for {serial}: {e}"))?;
+    if adb_install_succeeded(&output) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "adb install failed for {serial}: {}",
+            format_command_failure(&output)
+        ))
+    }
+}
+
 /// Extract the Android PACKAGE from a stored `launch_component`. New rows store
 /// a bare package (`com.tcl.browser`); legacy rows may store
 /// `package/activity` — in that case we take the substring before the first
@@ -544,14 +674,17 @@ fn build_launch_args(launch_component: &str, stage_url: Option<&str>) -> Option<
     ])
 }
 
-/// The browser's resumed component (`<pkg>/<activity>`) suffix that means the
-/// STAGE PAGE is genuinely showing — `com.tcl.browser`'s content/browse
-/// activity. When the foreground component ends with this, the stage is loaded
-/// and the keep-alive must NOT relaunch (re-firing the VIEW intent would reload
-/// the page — the #419 black blink). Any OTHER activity of the same package
-/// (notably the home portal `.portal.home.activity.StartActivity` the TV opens
-/// to at power-on — #447) is NOT the stage and MUST be (re)launched.
-const STAGE_CONTENT_ACTIVITY_SUFFIX: &str = "BrowsePageActivity";
+/// Resumed-activity suffixes that mean the STAGE PAGE is genuinely showing:
+/// - `StageActivity` — our own Presenter Stage app (its single activity);
+/// - `BrowsePageActivity` — legacy `com.tcl.browser`'s content/browse activity.
+///
+/// When the foreground component ends with one of these AND its package is the
+/// configured launch package, the stage is loaded and the keep-alive must NOT
+/// relaunch (re-firing the VIEW intent would reload the page — the #419 black
+/// blink). Any OTHER activity of the same package (notably com.tcl.browser's
+/// home portal `.portal.home.activity.StartActivity` the TV opens to at
+/// power-on — #447) is NOT the stage and MUST be (re)launched.
+const STAGE_CONTENT_ACTIVITY_SUFFIXES: &[&str] = &["StageActivity", "BrowsePageActivity"];
 
 /// Decide whether the periodic keep-alive should (re)launch the stage browser,
 /// given the device's current foreground/resumed COMPONENT (`<pkg>/<activity>`).
@@ -584,8 +717,10 @@ fn should_launch_stage(foreground_component: Option<&str>, launch_package: &str)
             // its content/browse activity — i.e. the stage page is genuinely
             // showing. The home portal (`…StartActivity`) is the same package
             // but a different activity, so it correctly relaunches (#447).
-            let stage_is_showing =
-                package == launch_package && activity.ends_with(STAGE_CONTENT_ACTIVITY_SUFFIX);
+            let stage_is_showing = package == launch_package
+                && STAGE_CONTENT_ACTIVITY_SUFFIXES
+                    .iter()
+                    .any(|suffix| activity.ends_with(suffix));
             !stage_is_showing
         }
         // Foreground could not be determined → don't suppress a possibly-needed
@@ -1013,6 +1148,9 @@ mod tests {
         /// When true, `adb connect <serial>` returns a failed/non-success
         /// Output so `adb_connect` errors (modeling an unreachable device).
         connect_fails: bool,
+        /// Whether `pm path <pkg>` reports the app installed. `false` models a TV
+        /// that needs the Presenter Stage APK installed first.
+        installed: bool,
         calls: Mutex<Vec<String>>,
     }
 
@@ -1021,6 +1159,7 @@ mod tests {
             Self {
                 foreground,
                 connect_fails: false,
+                installed: true,
                 calls: Mutex::new(Vec::new()),
             }
         }
@@ -1029,8 +1168,23 @@ mod tests {
             Self {
                 foreground,
                 connect_fails: true,
+                installed: true,
                 calls: Mutex::new(Vec::new()),
             }
+        }
+
+        /// Builder: the app is NOT yet installed (so `pm path` reports nothing and
+        /// the watchdog must `adb install` the APK).
+        fn app_missing(mut self) -> Self {
+            self.installed = false;
+            self
+        }
+
+        fn install_calls(&self) -> usize {
+            self.invocations()
+                .iter()
+                .filter(|c| c.contains("install") && !c.contains("uninstall"))
+                .count()
         }
 
         fn invocations(&self) -> Vec<String> {
@@ -1093,12 +1247,27 @@ mod tests {
                 };
             }
 
+            // `pm path <pkg>` reports install state (`package:` line = installed).
+            if joined.contains("shell pm path") {
+                return Ok(ok_output(if self.installed {
+                    "package:/data/app/test/base.apk"
+                } else {
+                    ""
+                }));
+            }
+
+            // `adb install [-r] <apk>` succeeds (prints `Success`); `uninstall`
+            // is handled by the generic clean-success path below.
+            if joined.contains("install") && !joined.contains("uninstall") {
+                return Ok(ok_output("Success"));
+            }
+
             // `adb connect <serial>` fails when the device is unreachable.
             if self.connect_fails && joined.starts_with("connect ") {
                 return Ok(err_output("error: failed to connect to 'host:port'"));
             }
 
-            // connect / disconnect / `am start` all succeed cleanly.
+            // connect / disconnect / uninstall / `am start` all succeed cleanly.
             Ok(ok_output(""))
         }
     }
@@ -1126,6 +1295,113 @@ mod tests {
         }))
     }
 
+    /// No APK configured → the watchdog never attempts an install (the default
+    /// for the keep-alive/foreground tests, which use a browser package).
+    fn no_apk() -> Arc<Option<PathBuf>> {
+        Arc::new(None)
+    }
+
+    /// An APK is available on disk → install-if-missing can fire.
+    fn some_apk() -> Arc<Option<PathBuf>> {
+        Arc::new(Some(PathBuf::from("/opt/presenter/presenter-stage.apk")))
+    }
+
+    /// A display configured to launch our OWN app ([`DEFAULT_LAUNCH_PACKAGE`]),
+    /// which is the only package the watchdog auto-installs.
+    fn our_app_display() -> AndroidStageDisplay {
+        let now = Utc::now();
+        AndroidStageDisplay::new(
+            AndroidStageDisplayId::from_uuid(Uuid::new_v4()),
+            "Stage TV".to_string(),
+            "10.0.0.42".to_string(),
+            5555,
+            DEFAULT_LAUNCH_PACKAGE.to_string(),
+            true,
+            now,
+            now,
+        )
+    }
+
+    // Our own app's single activity IS the stage page → keep-alive must NOT
+    // relaunch when it is foreground; a different app must (re)launch.
+    #[test]
+    fn should_launch_stage_skips_for_our_stage_activity() {
+        assert!(
+            !should_launch_stage(
+                Some("sk.newlevel.presenterstage/sk.newlevel.presenterstage.StageActivity"),
+                "sk.newlevel.presenterstage",
+            ),
+            "our StageActivity foreground IS the stage — must not relaunch",
+        );
+        assert!(
+            should_launch_stage(
+                Some("com.android.tv.settings/.Main"),
+                "sk.newlevel.presenterstage"
+            ),
+            "another app foreground must relaunch our stage",
+        );
+    }
+
+    // A TV missing our app MUST get it installed via adb before the stage launch.
+    #[tokio::test]
+    async fn installs_our_app_when_missing_before_launch() {
+        let runner = FakeAdbRunner::new(Foreground::StagePage).app_missing();
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = our_app_display();
+        let status = test_status();
+
+        let result =
+            connect_and_launch(&runner, &stage_url, &some_apk(), &config, &status, true).await;
+        assert!(result.is_ok(), "install + launch must succeed: {result:?}");
+        assert_eq!(
+            runner.install_calls(),
+            1,
+            "a missing app MUST be installed via adb before launch",
+        );
+        assert_eq!(
+            runner.am_start_calls(),
+            1,
+            "the stage must still be launched after install",
+        );
+    }
+
+    // An already-installed app MUST NOT be reinstalled on every launch.
+    #[tokio::test]
+    async fn skips_install_when_our_app_present() {
+        let runner = FakeAdbRunner::new(Foreground::StagePage);
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = our_app_display();
+        let status = test_status();
+
+        let result =
+            connect_and_launch(&runner, &stage_url, &some_apk(), &config, &status, true).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            runner.install_calls(),
+            0,
+            "an already-installed app MUST NOT be reinstalled",
+        );
+    }
+
+    // A browser package (e.g. com.tcl.browser) is assumed pre-installed — the
+    // watchdog must NOT try to install it even when an APK is available.
+    #[tokio::test]
+    async fn skips_install_for_non_default_package() {
+        let runner = FakeAdbRunner::new(Foreground::StagePage).app_missing();
+        let stage_url = Arc::new(Some(TEST_STAGE_URL.to_string()));
+        let config = test_display();
+        let status = test_status();
+
+        let result =
+            connect_and_launch(&runner, &stage_url, &some_apk(), &config, &status, true).await;
+        assert!(result.is_ok());
+        assert_eq!(
+            runner.install_calls(),
+            0,
+            "only our own app is auto-installed; a browser package is left alone",
+        );
+    }
+
     // (a) Periodic keep-alive, stage page already foreground → NO `am start`.
     #[tokio::test]
     async fn tick_skips_am_start_when_stage_page_foreground() {
@@ -1135,7 +1411,8 @@ mod tests {
         let status = test_status();
 
         // force_launch=false models the periodic tick.
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, false).await;
         assert!(
             result.is_ok(),
             "keep-alive on a healthy display must succeed"
@@ -1173,7 +1450,8 @@ mod tests {
         let config = test_display();
         let status = test_status();
 
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, false).await;
         assert!(
             result.is_ok(),
             "a TV stuck on the home portal must relaunch and succeed (#447)"
@@ -1199,7 +1477,8 @@ mod tests {
         let config = test_display();
         let status = test_status();
 
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, false).await;
         assert!(
             result.is_ok(),
             "a backgrounded display must relaunch and succeed"
@@ -1225,7 +1504,8 @@ mod tests {
         let config = test_display();
         let status = test_status();
 
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, false).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, false).await;
         assert!(result.is_ok());
 
         assert_eq!(runner.dumpsys_calls(), 1, "the gate is consulted on a tick");
@@ -1246,7 +1526,8 @@ mod tests {
         let config = test_display();
         let status = test_status();
 
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, true).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, true).await;
         assert!(result.is_ok(), "a forced launch must succeed");
 
         assert_eq!(
@@ -1273,7 +1554,8 @@ mod tests {
         let config = test_display();
         let status = test_status();
 
-        let result = connect_and_launch(&runner, &stage_url, &config, &status, true).await;
+        let result =
+            connect_and_launch(&runner, &stage_url, &no_apk(), &config, &status, true).await;
         assert!(
             result.is_err(),
             "a failed `adb connect` MUST abort the launch with an error",
@@ -1317,7 +1599,7 @@ mod tests {
         tx.try_send(DeviceCommand::LaunchNow).unwrap();
         tx.try_send(DeviceCommand::Shutdown).unwrap();
 
-        run_device_worker(runner, stage_url, config, status, rx)
+        run_device_worker(runner, stage_url, no_apk(), config, status, rx)
             .await
             .expect("worker should exit cleanly on Shutdown");
 

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.156"
+version = "0.4.157"
 dependencies = [
  "anyhow",
  "chrono",

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -28,6 +28,9 @@ Environment=PRESENTER_LIBRARY_ROOT=/home/newlevel/devel/presenter/presenter-libr
 # #404: stage URL the launcher opens on every Android stage display (see
 # presenter.service). Dev points at its own /stage on port 8080.
 Environment=PRESENTER_ANDROID_STAGE_URL=http://10.77.8.134:8080/stage
+# #472: the Presenter Stage APK the watchdog installs on TVs that need our own
+# app. Dev deploys to /opt/presenter-dev (the default path is /opt/presenter).
+Environment=PRESENTER_ANDROID_STAGE_APK=/opt/presenter-dev/presenter-stage.apk
 Environment=RUST_LOG=info,tower_http=debug
 # Offset integration ports to avoid conflicts with production
 Environment=PRESENTER_COMPANION_ENABLED=0

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -52,6 +52,9 @@ Environment=PRESENTER_LIBRARY_ROOT=/opt/presenter/libraries
 # points at its own /stage. If unset the launcher warns and skips (no broken
 # intent).
 Environment=PRESENTER_ANDROID_STAGE_URL=http://10.77.9.205/stage
+# #472: the Presenter Stage APK the watchdog installs on any TV that needs our
+# own app (so the stage runs on every Android TV without a kiosk browser).
+Environment=PRESENTER_ANDROID_STAGE_APK=/opt/presenter/presenter-stage.apk
 Environment=RUST_LOG=info,tower_http=debug
 
 # Security hardening - allow binding to port 80


### PR DESCRIPTION
## Goal

Closes #472.

The Android stage-display launcher hardcoded `com.tcl.browser`, which only exists on TCL TVs. PP's new Sharp Google TV has no such browser, so the watchdog couldn't launch the stage there (and would fall back to Fully Kiosk — the NDI-stuttering app we deliberately left). This makes the stage run on **EVERY Android TV with no kiosk browser**.

## What changed

- **New minimal WebView TV app** (`android/presenter-stage/`, Kotlin) — `sk.newlevel.presenterstage`. Fullscreen immersive WebView, hardware-accelerated, autoplay-allowed, keep-screen-on, LEANBACK launcher + VIEW http/https intent filter. Loads the stage URL handed to it by the watchdog's VIEW intent.
- **Watchdog auto-installs the app via ADB** (`android_stage.rs`) — when a display's launch package is our default and the app is missing, it `install -r`s the shipped APK (uninstall+reinstall fallback on signature mismatch). Brand-agnostic: no per-TV browser dependency.
- **Default launch package → our app** (`presenter-core`) + idempotent migration `m20260624_000001` rewriting existing `com.tcl.browser` rows to `sk.newlevel.presenterstage` (operator-customised rows untouched).
- **CI builds + ships the APK** — `build-android` (JDK 17 + Gradle `assembleDebug`) in pipeline/deploy/release; APK synced to servers; `PRESENTER_ANDROID_STAGE_APK` set in both deploy units.

## Tests

- Android watchdog unit tests: install-when-missing, skip-when-present, skip-for-non-default-package, our-stage-activity foreground handling.
- Pure `resolve_apk_path_from` + `adb_install_succeeded` tests (kill the diff-scoped mutation survivors).
- Migration tests: rewrites only the TCL default, idempotent, no-op when table missing.
- Persistence seed test asserts new default package.
- Full pipeline green incl. 16-shard mutation gate, clippy, NDI E2E, Playwright.

## Deploy note

Prod deploy switches SNV SD1–4 launch package to our app (migration + watchdog auto-install). NDI visual smoothness on the live wall is verifiable only by eye on-site — I verify install/foreground/stage-load via ADB; final NDI smoothness needs a person at a TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)