### PR TITLE
Bundle: video_sources migration #468 + PP deploy fail-safe & stage URL #469/#470 (v0.4.159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,12 +249,17 @@ jobs:
             sudo apt-get update -qq
             sudo apt-get install -y -qq $MISSING
           fi
-          # Probe that VAAPI H264 encoder is available
+          # Probe that the VAAPI H264 encoder is available. NON-FATAL (#469): PP
+          # is GPU-less (Intel Alder Lake-N, no working VA-API), so vah264enc is
+          # legitimately absent there. A hard `exit 1` here previously aborted the
+          # deploy AFTER the service was stopped + the new binary copied, leaving
+          # PP DOWN. Warn and continue instead — NDI hardware encode is simply
+          # unavailable on such a host; the stage display + software paths work.
           if ! gst-inspect-1.0 vah264enc >/dev/null 2>&1; then
-            echo "::error::vah264enc element not available after install — VA-API driver missing or kernel/firmware mismatch"
-            exit 1
+            echo "::warning::vah264enc not available on this host — VA-API hardware H264 encoding unavailable (expected on the GPU-less PP). Continuing deploy."
+          else
+            echo "vah264enc available: $(gst-inspect-1.0 vah264enc | head -1)"
           fi
-          echo "vah264enc available: $(gst-inspect-1.0 vah264enc | head -1)"
           REMOTE_SCRIPT
 
       - name: Backup database
@@ -350,9 +355,22 @@ jobs:
       - name: Deploy systemd service
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter.service deploy-target:/tmp/presenter.service
-          ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && sudo systemctl daemon-reload"
+          # The shared unit hardcodes SNV's PRESENTER_ANDROID_STAGE_URL. PP needs
+          # its OWN stage URL (its server IP) so the watchdog points PP's TV at PP,
+          # not SNV (#470). Ship a per-env drop-in that overrides it. Override the
+          # default with the PP_STAGE_URL repo variable if PP's IP changes.
+          PP_STAGE_URL="${{ vars.PP_STAGE_URL || 'http://10.77.8.205/stage' }}"
+          ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
+            sudo mkdir -p /etc/systemd/system/presenter.service.d && \
+            printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PP_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
+            sudo systemctl daemon-reload"
 
       - name: Start service
+        # Run even if an earlier step failed (#469): a deploy that stops the
+        # service then hits a later error must never leave PP DOWN — always
+        # bring the service back up. The job still reports failure for the real
+        # error, but PP keeps serving.
+        if: always()
         run: |
           ssh deploy-target "sudo systemctl enable ${{ env.SERVICE_NAME }} && sudo systemctl start ${{ env.SERVICE_NAME }}"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.158"
+version = "0.4.159"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.158"
+version = "0.4.159"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -14,6 +14,7 @@ mod m20260517_000001_create_settings_audit;
 mod m20260517_000002_fix_legacy_ableset_defaults;
 mod m20260616_000001_fix_android_stage_launch_package;
 mod m20260624_000001_default_launch_to_presenter_stage;
+mod m20260625_000001_add_video_sources;
 
 pub struct Migrator;
 
@@ -32,6 +33,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260517_000002_fix_legacy_ableset_defaults::Migration),
             Box::new(m20260616_000001_fix_android_stage_launch_package::Migration),
             Box::new(m20260624_000001_default_launch_to_presenter_stage::Migration),
+            Box::new(m20260625_000001_add_video_sources::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260625_000001_add_video_sources.rs
+++ b/crates/presenter-migration/src/m20260625_000001_add_video_sources.rs
@@ -1,0 +1,154 @@
+use sea_orm_migration::prelude::*;
+
+/// #468: `video_sources` was added to the INITIAL migration
+/// (`m20250927_000001`) on 2026-04-04 rather than as an incremental one. Any DB
+/// created before that (e.g. PP's 0.4.71 install) therefore never got the table
+/// and 500s on the video-sources endpoint. This incremental migration creates it
+/// `IF NOT EXISTS`, so it is a no-op on DBs that already have it (prod/dev, and
+/// PP after its manual patch) and reconciles any older DB.
+///
+/// The column set is identical to the initial migration's `video_sources` table.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Local column identifiers, mirroring the initial migration's `VideoSources`
+/// enum so this incremental `create_table` produces the exact same schema.
+#[derive(DeriveIden)]
+enum VideoSources {
+    Table,
+    Id,
+    Label,
+    NdiName,
+    IsActive,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(VideoSources::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(VideoSources::Id)
+                            .string_len(36)
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(VideoSources::Label).string().not_null())
+                    .col(ColumnDef::new(VideoSources::NdiName).string().not_null())
+                    .col(
+                        ColumnDef::new(VideoSources::IsActive)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(VideoSources::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP"),
+                    )
+                    .col(
+                        ColumnDef::new(VideoSources::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // No-op: dropping video_sources would destroy user-configured NDI
+        // sources. Reverting the reconciliation is never desirable.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
+
+    /// A bare DB that LACKS `video_sources` (simulating an install predating the
+    /// table) must have it created by this migration, after which it is
+    /// queryable. RED before the migration (the SELECT errors), GREEN after.
+    #[tokio::test]
+    async fn creates_video_sources_on_a_db_that_lacks_it() {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+
+        // RED: the table does not exist yet — a query must fail.
+        let before = db
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT id FROM video_sources".to_string(),
+            ))
+            .await;
+        assert!(
+            before.is_err(),
+            "precondition: video_sources must not exist before the migration",
+        );
+
+        // Apply the migration.
+        let manager = SchemaManager::new(&db);
+        Migration.up(&manager).await.expect("migration up");
+
+        // GREEN: the table now exists and is queryable.
+        let after = db
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT id, label, ndi_name, is_active, created_at, updated_at \
+                 FROM video_sources"
+                    .to_string(),
+            ))
+            .await;
+        assert!(
+            after.is_ok(),
+            "video_sources must be queryable after the migration: {after:?}",
+        );
+    }
+
+    /// Running on a DB that ALREADY has the table is a no-op (IF NOT EXISTS), so
+    /// it is safe on prod/dev/PP and on re-run.
+    #[tokio::test]
+    async fn is_idempotent_when_table_already_exists() {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        let manager = SchemaManager::new(&db);
+
+        Migration.up(&manager).await.expect("first up");
+        // Insert a row so we can prove the second run does not drop/recreate it.
+        db.execute(Statement::from_string(
+            DbBackend::Sqlite,
+            "INSERT INTO video_sources (id, label, ndi_name, is_active, created_at, updated_at) \
+             VALUES ('s1', 'Cam 1', 'NDI Cam 1', 0, '2026-06-25T00:00:00Z', '2026-06-25T00:00:00Z')"
+                .to_string(),
+        ))
+        .await
+        .expect("insert");
+
+        Migration
+            .up(&manager)
+            .await
+            .expect("second up must be a no-op");
+
+        let row = db
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS n FROM video_sources".to_string(),
+            ))
+            .await
+            .expect("query")
+            .expect("row");
+        let n: i64 = row.try_get_by("n").expect("count");
+        assert_eq!(
+            n, 1,
+            "re-run must preserve existing rows (no drop/recreate)"
+        );
+    }
+}


### PR DESCRIPTION
Three bundle-safe issues (v0.4.159).

Closes #468
Closes #469
Closes #470

## #468 — Idempotent video_sources migration
`video_sources` lived only in the initial migration (added 2026-04-04), so DBs predating it (PP) 500'd. New `m20260625_000001_add_video_sources` (CREATE TABLE IF NOT EXISTS, identical columns) reconciles old DBs, no-op everywhere else. RED/GREEN + idempotency tests.

## #469 — PP deploy can no longer leave PP down
release.yml deploy-pp VA-API probe `exit 1` always failed on GPU-less PP, AFTER stop+binary-swap → PP DOWN. Probe is now a warning; `Start service` runs `if: always()`.

## #470 — PP gets its own stage URL
deploy-pp writes a per-env systemd drop-in (`PRESENTER_ANDROID_STAGE_URL`, default `http://10.77.8.205/stage`, overridable via `PP_STAGE_URL` repo var) so PP's TV targets PP, not SNV.

## Verify note
#468 is fully tested (migration RED/GREEN). #469/#470 are CI-workflow changes exercised on the next PP GitHub Release — they fix the path the playbook currently flags as "deploy PP by hand".

🤖 Generated with [Claude Code](https://claude.com/claude-code)