### PR TITLE
Fix file-size gate undercount past early mod tests; declaration (#407, v0.4.162)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -360,6 +360,13 @@ jobs:
           # post-actions), so the cache never warms — a permanent deadlock.
           # FAILS if the warm job is removed or the shards stop depending on it.
           bash tests/ci/mutation-warm-bootstrap.test.sh
+          # Regression guard for #407: the file-size gate stopped counting at the
+          # FIRST #[cfg(test)], so a file with an early `#[cfg(test)] mod tests;`
+          # external declaration had its real production code undercounted —
+          # 1100-line files bypassed the 1000-line cap. This proves the corrected
+          # count (count_prod_lines.sh) sees the full size and FAILS if the
+          # undercount regresses.
+          bash tests/ci/file-size-gate.test.sh
 
   # ============================================
   # Mutation Testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.161"
+version = "0.4.162"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/scripts/dev/count_prod_lines.sh
+++ b/scripts/dev/count_prod_lines.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Count PRODUCTION lines of a Rust source file for the file-size gate (#407).
+#
+# Production lines = everything before the file's INLINE `#[cfg(test)]` test
+# module. The boundary is the first `#[cfg(test)]` that is followed by an inline
+# module BODY (`mod <name> {`). A `#[cfg(test)] mod tests;` DECLARATION (the test
+# code lives in a separate, gate-exempt file) is NOT a boundary — older logic
+# stopped at it and silently undercounted everything after, letting 1100-line
+# files bypass the 1000-line cap (#407). A file with no inline test module counts
+# in full.
+#
+# Usage: count_prod_lines.sh <file>   # prints the production line count
+set -euo pipefail
+
+file="$1"
+
+test_line=$(awk '
+  # An attribute line: remember it as a candidate boundary.
+  /^[[:space:]]*#\[cfg\(test\)\]/ { cfg = NR; next }
+  # Skip blank lines between the attribute and the item it annotates.
+  cfg && /^[[:space:]]*$/ { next }
+  # First non-blank line after #[cfg(test)]:
+  cfg {
+    # `mod <name> {` = inline test MODULE body → this is the boundary.
+    if ($0 ~ /^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]].*\{/) { print cfg; exit }
+    # Anything else (e.g. `mod tests;` external decl, `use ...;`, a test fn) is
+    # NOT the inline-module boundary — keep scanning for a later one.
+    cfg = 0
+  }
+' "$file")
+
+if [[ -n "${test_line}" ]]; then
+  echo $(( test_line - 1 ))
+else
+  wc -l < "$file" | tr -d ' '
+fi

--- a/scripts/dev/quality-check.sh
+++ b/scripts/dev/quality-check.sh
@@ -140,14 +140,12 @@ for file in "${target_files[@]}"; do
   for cf in "${changed[@]:-}"; do
     if [[ "$cf" == "$file" ]]; then is_changed=1; break; fi
   done
-  # Count production lines only (exclude inline #[cfg(test)] module and below)
-  test_line=$(awk '/^\s*#\[cfg\(test\)\]/{print NR; exit}' "$file")
-  if [[ -n "${test_line}" ]]; then
-    prod_lines=$(( test_line - 1 ))
-  else
-    prod_lines=$(wc -l < "$file" | tr -d ' ')
-  fi
-  lines=$prod_lines
+  # Count production lines only (exclude the inline #[cfg(test)] module). #407:
+  # delegated to count_prod_lines.sh, which stops ONLY at an inline `mod ... {`
+  # test module — NOT at a `#[cfg(test)] mod tests;` external-file declaration
+  # (the old inline awk stopped there and undercounted, letting 1100-line files
+  # slip past the cap). Self-test: tests/ci/file-size-gate.test.sh.
+  lines=$(bash "$(dirname "${BASH_SOURCE[0]}")/count_prod_lines.sh" "$file")
   if (( lines > 1000 )); then
     if (( is_changed )); then
       fail "${file} exceeds hard cap (1000 lines): ${lines}"

--- a/tests/ci/file-size-gate.test.sh
+++ b/tests/ci/file-size-gate.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Self-test / regression guard for the file-size CI gate (#407).
+#
+# The gate counts a file's PRODUCTION lines as everything before its inline
+# `#[cfg(test)]` test module. The old logic stopped at the FIRST `#[cfg(test)]`
+# of any kind — so a file with an EARLY `#[cfg(test)] mod tests;` declaration
+# (test code in a SEPARATE, exempt file) had ALL its real production code after
+# that line counted as "test" and silently undercounted: 1100-line files slid
+# past the 1000-line hard cap. The fix (scripts/dev/count_prod_lines.sh) stops
+# ONLY at an inline `mod <name> {` module BODY. This script proves it.
+#
+# What it proves:
+#   1. GREEN — count_prod_lines.sh counts a >1000-line file that has an EARLY
+#      `#[cfg(test)] mod tests;` declaration at its FULL size (gate would FIRE).
+#   2. RED   — the OLD buggy awk reports a tiny count on that same fixture (a
+#      silent bypass). Pins the FIX, not just current behavior.
+#   3. Inline test module is still excluded (production count stops at the body).
+# ============================================================================
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COUNTER="$ROOT_DIR/scripts/dev/count_prod_lines.sh"
+
+if [[ ! -f "$COUNTER" ]]; then
+  echo "::error::file-size gate self-test: counter not found at $COUNTER" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+ok()  { echo "  PASS: $*"; pass_count=$((pass_count + 1)); }
+bad() { echo "::error::file-size gate self-test FAILED: $*" >&2; fail_count=$((fail_count + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- Fixture 1: early `mod tests;` declaration + 1100 production lines --------
+FIX_EARLY="$WORK/early_mod_tests.rs"
+{
+  echo '#[cfg(test)]'
+  echo 'mod tests;'
+  echo ''
+  for i in $(seq 1 1100); do echo "pub fn prod_${i}() -> u32 { ${i} }"; done
+} > "$FIX_EARLY"
+
+# (1) GREEN: the fixed counter sees the real production size (>1000).
+got=$(bash "$COUNTER" "$FIX_EARLY")
+if (( got > 1000 )); then
+  ok "early-mod-tests file counted at full prod size ($got > 1000) — gate fires"
+else
+  bad "early-mod-tests file undercounted: got $got, expected > 1000"
+fi
+
+# (2) RED: the OLD buggy awk (stop at first #[cfg(test)]) undercounts → bypass.
+old_test_line=$(awk '/^\s*#\[cfg\(test\)\]/{print NR; exit}' "$FIX_EARLY")
+old_count=$(( old_test_line - 1 ))
+if (( old_count <= 1000 )); then
+  ok "old buggy logic undercounts the same file ($old_count) — confirms the bug the fix closes"
+else
+  bad "old logic unexpectedly counted $old_count — fixture does not reproduce #407"
+fi
+
+# --- Fixture 2: inline `#[cfg(test)] mod tests { ... }` must still be excluded -
+FIX_INLINE="$WORK/inline_mod_tests.rs"
+{
+  for i in $(seq 1 40); do echo "pub fn prod_${i}() -> u32 { ${i} }"; done
+  echo '#[cfg(test)]'
+  echo 'mod tests {'
+  for i in $(seq 1 60); do echo "    #[test] fn t_${i}() { assert_eq!(1, 1); }"; done
+  echo '}'
+} > "$FIX_INLINE"
+got_inline=$(bash "$COUNTER" "$FIX_INLINE")
+# 40 prod fns + the `#[cfg(test)]` boundary at line 41 → 40 production lines.
+if (( got_inline == 40 )); then
+  ok "inline test module excluded (production count = $got_inline)"
+else
+  bad "inline test module mis-counted: got $got_inline, expected 40"
+fi
+
+echo "file-size gate self-test: $pass_count passed, $fail_count failed"
+(( fail_count == 0 )) || exit 1


### PR DESCRIPTION
Closes #407

The file-size gate stopped counting production lines at the FIRST `#[cfg(test)]`, so a file with an early `#[cfg(test)] mod tests;` (test code in a separate, exempt file) had ALL real code after that line counted as "test" — state/mod.rs (1117 real lines) silently bypassed the 1000-line cap.

Fix: extract the count into `scripts/dev/count_prod_lines.sh`, which stops ONLY at an inline `mod <name> {` module body, not an external `mod tests;` declaration. `tests/ci/file-size-gate.test.sh` (wired into the Run-CI-shell-tests step) proves it: GREEN (early-mod-tests file counted at full size → gate fires) + RED (old awk undercounts to 0) + inline module still excluded.

Note: state/mod.rs (1117 lines) is now correctly counted — it WARNS (unchanged in this PR; the gate only fails on changed files). Its decomposition is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)