### PR TITLE
feat(resolume): push-audit read endpoint, capture failed pushes, retention (#489)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.165"
+version = "0.4.166"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.165"
+version = "0.4.166"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/audit.rs
+++ b/crates/presenter-persistence/src/repository/audit.rs
@@ -83,12 +83,15 @@ impl Repository {
         Ok(())
     }
 
-    /// #483: most-recent push-audit rows (newest first), optionally scoped to a
-    /// host and/or a `since` cutoff. For post-event latency analysis.
+    /// #483/#489: most-recent push-audit rows (newest first), optionally scoped
+    /// to a host, an `outcome` prefix (e.g. `error` to list every failed push —
+    /// the outcome column is `ok` or `error: <reason>`), and/or a `since` cutoff.
+    /// For post-event latency + failure analysis.
     #[instrument(skip(self))]
     pub async fn list_resolume_push_audit(
         &self,
         host: Option<&str>,
+        outcome: Option<&str>,
         since: Option<chrono::DateTime<chrono::Utc>>,
         limit: u64,
     ) -> anyhow::Result<Vec<ResolumePushAuditEntry>> {
@@ -99,6 +102,11 @@ impl Repository {
             .limit(limit);
         if let Some(h) = host {
             q = q.filter(resolume_push_audit::Column::Host.eq(h));
+        }
+        if let Some(o) = outcome {
+            // Prefix match so `error` matches `error: <reason>` rows while `ok`
+            // matches the plain success rows.
+            q = q.filter(resolume_push_audit::Column::Outcome.starts_with(o));
         }
         if let Some(t) = since {
             let stamp: chrono::DateTime<chrono::FixedOffset> = t.into();
@@ -118,6 +126,56 @@ impl Repository {
                 created_at: m.created_at.into(),
             })
             .collect())
+    }
+
+    /// #489: bound the `resolume_push_audit` table so months of services don't
+    /// grow it without limit. Deletes rows older than `retain`, then — if the
+    /// table is still over `max_rows` — drops the oldest rows beyond that cap
+    /// (newest `max_rows` kept). `max_rows == 0` disables the count cap. Returns
+    /// the number of rows deleted. Idempotent and cheap (indexed on created_at);
+    /// safe to call on a timer and at startup.
+    #[instrument(skip(self))]
+    pub async fn prune_resolume_push_audit(
+        &self,
+        retain: chrono::Duration,
+        max_rows: u64,
+    ) -> anyhow::Result<u64> {
+        use crate::entities::resolume_push_audit;
+        use sea_orm::{PaginatorTrait, QuerySelect};
+
+        let mut deleted = 0u64;
+
+        // Age-based prune: drop everything older than the retention window.
+        let cutoff: chrono::DateTime<chrono::FixedOffset> = (Utc::now() - retain).into();
+        let res = resolume_push_audit::Entity::delete_many()
+            .filter(resolume_push_audit::Column::CreatedAt.lt(cutoff))
+            .exec(&self.db)
+            .await?;
+        deleted += res.rows_affected;
+
+        // Count-cap prune: if still over the cap, delete the oldest rows beyond
+        // the newest `max_rows`. The boundary is the created_at of the first row
+        // that should be dropped (offset `max_rows` in newest-first order).
+        if max_rows > 0 {
+            let total = resolume_push_audit::Entity::find().count(&self.db).await?;
+            if total > max_rows {
+                if let Some(boundary) = resolume_push_audit::Entity::find()
+                    .order_by_desc(resolume_push_audit::Column::CreatedAt)
+                    .offset(max_rows)
+                    .limit(1)
+                    .one(&self.db)
+                    .await?
+                {
+                    let res = resolume_push_audit::Entity::delete_many()
+                        .filter(resolume_push_audit::Column::CreatedAt.lte(boundary.created_at))
+                        .exec(&self.db)
+                        .await?;
+                    deleted += res.rows_affected;
+                }
+            }
+        }
+
+        Ok(deleted)
     }
 
     #[instrument(skip(self))]

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -1548,12 +1548,15 @@ async fn resolume_push_audit_round_trip() {
     repo.record_resolume_push_audit(&other_host).await.unwrap();
 
     // All rows.
-    let all = repo.list_resolume_push_audit(None, None, 50).await.unwrap();
+    let all = repo
+        .list_resolume_push_audit(None, None, None, 50)
+        .await
+        .unwrap();
     assert_eq!(all.len(), 2);
 
     // Host filter returns only the matching host, fields intact.
     let only_cg = repo
-        .list_resolume_push_audit(Some("cg-resolume.lan"), None, 50)
+        .list_resolume_push_audit(Some("cg-resolume.lan"), None, None, 50)
         .await
         .unwrap();
     assert_eq!(only_cg.len(), 1);
@@ -1568,8 +1571,153 @@ async fn resolume_push_audit_round_trip() {
     // `since` cutoff in the future excludes everything.
     let future = now + Duration::seconds(3600);
     let none = repo
-        .list_resolume_push_audit(None, Some(future), 50)
+        .list_resolume_push_audit(None, None, Some(future), 50)
         .await
         .unwrap();
     assert!(none.is_empty());
+}
+
+/// #489: the outcome prefix filter lists failed pushes (`error: <reason>`) and
+/// successful pushes separately — the key read-side query for the audit table.
+#[tokio::test]
+async fn list_resolume_push_audit_filters_by_outcome_prefix() {
+    let repo = Repository::connect_in_memory().await.unwrap();
+    let now = Utc::now();
+
+    let ok_row = crate::audit::ResolumePushAuditEntry {
+        correlation_id: None,
+        host: "cg-resolume.lan".to_string(),
+        t_queue_wait_ms: 1.0,
+        t_ensure_mapping_ms: 0.0,
+        t_total_ms: 20.0,
+        refetched: false,
+        outcome: "ok".to_string(),
+        created_at: now,
+    };
+    let err_row = crate::audit::ResolumePushAuditEntry {
+        correlation_id: None,
+        host: "cg-resolume.lan".to_string(),
+        t_queue_wait_ms: 0.0,
+        t_ensure_mapping_ms: 5000.0,
+        t_total_ms: 5000.0,
+        refetched: false,
+        outcome: "error: composition request failed with status 500".to_string(),
+        created_at: now,
+    };
+    repo.record_resolume_push_audit(&ok_row).await.unwrap();
+    repo.record_resolume_push_audit(&err_row).await.unwrap();
+
+    let errors = repo
+        .list_resolume_push_audit(None, Some("error"), None, 50)
+        .await
+        .unwrap();
+    assert_eq!(
+        errors.len(),
+        1,
+        "outcome=error must return only failed pushes"
+    );
+    assert!(errors[0].outcome.starts_with("error: "));
+
+    let oks = repo
+        .list_resolume_push_audit(None, Some("ok"), None, 50)
+        .await
+        .unwrap();
+    assert_eq!(
+        oks.len(),
+        1,
+        "outcome=ok must return only successful pushes"
+    );
+    assert_eq!(oks[0].outcome, "ok");
+}
+
+/// #489: retention prune drops rows older than the retention window.
+#[tokio::test]
+async fn prune_resolume_push_audit_removes_rows_older_than_retention() {
+    let repo = Repository::connect_in_memory().await.unwrap();
+    let now = Utc::now();
+
+    let insert = |created_at: chrono::DateTime<Utc>| {
+        let repo = &repo;
+        async move {
+            repo.record_resolume_push_audit(&crate::audit::ResolumePushAuditEntry {
+                correlation_id: None,
+                host: "h".to_string(),
+                t_queue_wait_ms: 0.0,
+                t_ensure_mapping_ms: 0.0,
+                t_total_ms: 1.0,
+                refetched: false,
+                outcome: "ok".to_string(),
+                created_at,
+            })
+            .await
+            .unwrap();
+        }
+    };
+
+    // 3 rows older than 30 days, 2 recent.
+    for i in 0..3 {
+        insert(now - Duration::days(40) - Duration::seconds(i)).await;
+    }
+    for i in 0..2 {
+        insert(now - Duration::seconds(i)).await;
+    }
+
+    // Age-only prune (count cap disabled): exactly the 3 old rows go.
+    let deleted = repo
+        .prune_resolume_push_audit(Duration::days(30), 0)
+        .await
+        .unwrap();
+    assert_eq!(deleted, 3, "the 3 rows older than 30 days must be pruned");
+
+    let remaining = repo
+        .list_resolume_push_audit(None, None, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(remaining.len(), 2, "the 2 recent rows must remain");
+
+    // Idempotent: a second prune deletes nothing.
+    let again = repo
+        .prune_resolume_push_audit(Duration::days(30), 0)
+        .await
+        .unwrap();
+    assert_eq!(again, 0, "prune must be idempotent");
+}
+
+/// #489: retention prune caps the row count, keeping the newest `max_rows`.
+#[tokio::test]
+async fn prune_resolume_push_audit_caps_row_count_keeping_newest() {
+    let repo = Repository::connect_in_memory().await.unwrap();
+    let now = Utc::now();
+
+    // 5 rows with distinct, recent timestamps (newest = i==0).
+    for i in 0..5i64 {
+        repo.record_resolume_push_audit(&crate::audit::ResolumePushAuditEntry {
+            correlation_id: Some(format!("c{i}")),
+            host: "h".to_string(),
+            t_queue_wait_ms: 0.0,
+            t_ensure_mapping_ms: 0.0,
+            t_total_ms: 1.0,
+            refetched: false,
+            outcome: "ok".to_string(),
+            created_at: now - Duration::seconds(i),
+        })
+        .await
+        .unwrap();
+    }
+
+    // Cap at 2 (no age prune in play): drop the 3 oldest.
+    let deleted = repo
+        .prune_resolume_push_audit(Duration::days(365), 2)
+        .await
+        .unwrap();
+    assert_eq!(deleted, 3, "rows beyond the newest 2 must be pruned");
+
+    let remaining = repo
+        .list_resolume_push_audit(None, None, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(remaining.len(), 2, "exactly max_rows must remain");
+    // Newest two kept: c0 (now) and c1 (now-1s), newest-first.
+    assert_eq!(remaining[0].correlation_id.as_deref(), Some("c0"));
+    assert_eq!(remaining[1].correlation_id.as_deref(), Some("c1"));
 }

--- a/crates/presenter-server/src/resolume/handlers.rs
+++ b/crates/presenter-server/src/resolume/handlers.rs
@@ -22,6 +22,18 @@ struct StageStepTimings {
     t_trigger_ms: f64,
 }
 
+/// Telemetry captured while a stage push runs, populated incrementally so the
+/// audit row + timing log can be emitted on BOTH the success and the error path
+/// (#489). On an early error (e.g. the composition fetch timing out) the
+/// progress recorded so far — most importantly `t_ensure_mapping_ms` — is still
+/// reported, so a failed push leaves an honest audit row.
+#[derive(Default)]
+struct StagePushMetrics {
+    t_ensure_mapping_ms: f64,
+    refetched: bool,
+    steps: StageStepTimings,
+}
+
 use super::driver::TRIGGER_DELAY;
 
 pub(super) fn translation_short_code(code: &str) -> String {
@@ -56,48 +68,81 @@ impl HostDriver {
             .unwrap_or(0.0);
         let correlation_id = update.correlation_id;
 
+        // #489: run the fallible push, then emit the timing log + audit row on
+        // BOTH outcomes. A failed push (e.g. Resolume unreachable → the 5 s
+        // COMPOSITION_TIMEOUT) now records an `outcome=error` row instead of
+        // vanishing, so it shows in the audit table and the latency aggregate.
+        let mut metrics = StagePushMetrics::default();
+        let result = self.handle_stage_push(&update, status, &mut metrics).await;
+        let t_total_ms = elapsed_ms(pickup_at);
+        let correlation_str = correlation_id.map(|u| u.to_string()).unwrap_or_default();
+
+        let outcome = match &result {
+            Ok(()) => "ok".to_string(),
+            Err(err) => audit_failure_outcome(err),
+        };
+        tracing::info!(
+            target: "presenter::resolume::timing",
+            correlation_id = correlation_str,
+            host = %self.config.host,
+            t_queue_wait_ms,
+            t_ensure_mapping_ms = metrics.t_ensure_mapping_ms,
+            t_main_ms = metrics.steps.t_main_ms,
+            t_trans_ms = metrics.steps.t_trans_ms,
+            t_song_ms = metrics.steps.t_song_ms,
+            t_band_ms = metrics.steps.t_band_ms,
+            t_trigger_delay_ms = TRIGGER_DELAY.as_secs_f64() * 1000.0,
+            t_trigger_ms = metrics.steps.t_trigger_ms,
+            t_total_ms,
+            refetched = metrics.refetched,
+            outcome = %outcome,
+            "resolume stage timing"
+        );
+
+        // #483/#489: persist a per-push audit row (non-blocking) on both paths,
+        // so post-event latency + failure analysis is a SQL/HTTP query, and the
+        // cross-host perceived-latency line is emitted by the writer task. The
+        // audit emit never blocks or fails the push (`try_send`, errors dropped).
+        self.record_push_audit(
+            correlation_id,
+            t_queue_wait_ms,
+            metrics.t_ensure_mapping_ms,
+            t_total_ms,
+            metrics.refetched,
+            &outcome,
+        );
+
+        // Propagate the error so the worker still records it (#484 backoff +
+        // dedup'd ERROR log) — the audit row is in ADDITION, not a replacement.
+        result
+    }
+
+    /// The fallible body of a stage push, separated so [`handle_stage`] can
+    /// record an audit row on both success and failure (#489). Populates
+    /// `metrics` as it progresses; on an early error the timings recorded so far
+    /// (notably `t_ensure_mapping_ms`) are kept for the audit row.
+    async fn handle_stage_push(
+        &mut self,
+        update: &StageUpdate,
+        status: &Arc<RwLock<ResolumeConnectionSnapshot>>,
+        metrics: &mut StagePushMetrics,
+    ) -> anyhow::Result<()> {
         let mapping_start = Instant::now();
         // #483: serves from cache on the push path; `refetched` is true only on
-        // a cold/invalidated cache (NOT on staleness anymore).
-        let fetch = self.ensure_mapping().await?;
-        let t_ensure_mapping_ms = elapsed_ms(mapping_start);
+        // a cold/invalidated cache (NOT on staleness anymore). Capture the
+        // elapsed mapping time even if the fetch errors (the COMPOSITION_TIMEOUT
+        // spike is the failure we most want recorded) BEFORE propagating.
+        let fetch = self.ensure_mapping().await;
+        metrics.t_ensure_mapping_ms = elapsed_ms(mapping_start);
+        let fetch = fetch?;
+        metrics.refetched = fetch.refetched;
 
-        let steps = if let Some(mapping) = self.mapping.clone() {
-            self.apply_stage_mapping(&update, &mapping, status).await?
+        metrics.steps = if let Some(mapping) = self.mapping.clone() {
+            self.apply_stage_mapping(update, &mapping, status).await?
         } else {
             StageStepTimings::default()
         };
         self.mark_connected(status).await;
-
-        let t_total_ms = elapsed_ms(pickup_at);
-        tracing::info!(
-            target: "presenter::resolume::timing",
-            correlation_id = correlation_id.map(|u| u.to_string()).unwrap_or_default(),
-            host = %self.config.host,
-            t_queue_wait_ms,
-            t_ensure_mapping_ms,
-            t_main_ms = steps.t_main_ms,
-            t_trans_ms = steps.t_trans_ms,
-            t_song_ms = steps.t_song_ms,
-            t_band_ms = steps.t_band_ms,
-            t_trigger_delay_ms = TRIGGER_DELAY.as_secs_f64() * 1000.0,
-            t_trigger_ms = steps.t_trigger_ms,
-            t_total_ms,
-            refetched = fetch.refetched,
-            "resolume stage timing"
-        );
-
-        // #483: persist a per-push audit row (non-blocking) so post-event
-        // latency analysis is a SQL query, and so the cross-host perceived
-        // latency line can be emitted by the writer task.
-        self.record_push_audit(
-            correlation_id,
-            t_queue_wait_ms,
-            t_ensure_mapping_ms,
-            t_total_ms,
-            fetch.refetched,
-            "ok",
-        );
         Ok(())
     }
 
@@ -781,4 +826,47 @@ fn put_text_param_future(
 
 fn elapsed_ms(start: Instant) -> f64 {
     start.elapsed().as_secs_f64() * 1000.0
+}
+
+/// #489: a compact, single-line audit `outcome` for a FAILED push, stored in the
+/// `outcome` column as `error: <reason>`. The full error (with its `?` chain)
+/// still goes to the dedup'd ERROR log via `record_error`; the audit row just
+/// needs a greppable reason, so the reason is flattened to one line and capped.
+fn audit_failure_outcome(err: &anyhow::Error) -> String {
+    const MAX_REASON: usize = 160;
+    let reason: String = err
+        .to_string()
+        .replace('\n', " ")
+        .chars()
+        .take(MAX_REASON)
+        .collect();
+    format!("error: {reason}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::audit_failure_outcome;
+
+    #[test]
+    fn audit_failure_outcome_prefixes_error_and_flattens_reason() {
+        let err = anyhow::anyhow!("composition request failed with status 500");
+        assert_eq!(
+            audit_failure_outcome(&err),
+            "error: composition request failed with status 500"
+        );
+        // outcome=error prefix filter must match.
+        assert!(audit_failure_outcome(&err).starts_with("error"));
+    }
+
+    #[test]
+    fn audit_failure_outcome_flattens_newlines_and_caps_length() {
+        let err = anyhow::anyhow!("line one\nline two");
+        let out = audit_failure_outcome(&err);
+        assert!(!out.contains('\n'), "newlines must be flattened");
+
+        let long = anyhow::anyhow!("{}", "x".repeat(500));
+        let out = audit_failure_outcome(&long);
+        // "error: " (7) + 160 capped reason chars.
+        assert_eq!(out.chars().count(), 7 + 160);
+    }
 }

--- a/crates/presenter-server/src/resolume/latency_tests.rs
+++ b/crates/presenter-server/src/resolume/latency_tests.rs
@@ -280,7 +280,7 @@ async fn stage_push_persists_audit_row_through_registry() {
     let mut found = None;
     for _ in 0..60 {
         let rows = repo
-            .list_resolume_push_audit(None, None, 10)
+            .list_resolume_push_audit(None, None, None, 10)
             .await
             .expect("list audit");
         if let Some(row) = rows.into_iter().next() {
@@ -300,6 +300,55 @@ async fn stage_push_persists_audit_row_through_registry() {
     assert!(
         row.refetched,
         "the first push fetches the composition inline"
+    );
+}
+
+#[tokio::test]
+async fn failed_stage_push_persists_error_audit_row_through_registry() {
+    // #489: a push that FAILS (Resolume returns a non-2xx on /composition) must
+    // still leave an audit row with outcome starting `error`, so the failures
+    // that hurt most — a down Resolume → COMPOSITION_TIMEOUT — are visible in
+    // the audit table instead of being silently dropped (the gap #489 fixes).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/composition"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let repo = Repository::connect_in_memory().await.expect("repo");
+    let registry = ResolumeRegistry::new().expect("registry");
+    registry.attach_audit_writer(repo.clone());
+    registry.set_hosts(vec![mock_host(&server)]).await;
+
+    let correlation_id = uuid::Uuid::new_v4();
+    let mut update = stage_main("Line 1");
+    update.correlation_id = Some(correlation_id);
+    registry.stage_update(update).await;
+
+    // Retry-with-assert: the worker + writer run on background tasks.
+    let mut found = None;
+    for _ in 0..60 {
+        let rows = repo
+            .list_resolume_push_audit(None, Some("error"), None, 10)
+            .await
+            .expect("list audit");
+        if let Some(row) = rows.into_iter().next() {
+            found = Some(row);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let row = found.expect("a failed push must persist an outcome=error audit row");
+    assert_eq!(
+        row.correlation_id.as_deref(),
+        Some(correlation_id.to_string().as_str())
+    );
+    assert_eq!(row.host, server.address().ip().to_string());
+    assert!(
+        row.outcome.starts_with("error"),
+        "failed push outcome must start with `error`, got {:?}",
+        row.outcome
     );
 }
 

--- a/crates/presenter-server/src/resolume/mod.rs
+++ b/crates/presenter-server/src/resolume/mod.rs
@@ -36,6 +36,14 @@ const AUDIT_CHANNEL_CAPACITY: usize = 512;
 /// with the next slide's correlation id.
 const PERCEIVED_FLUSH_AFTER: Duration = Duration::from_secs(2);
 const PERCEIVED_SWEEP_INTERVAL: Duration = Duration::from_millis(500);
+/// #489: retention for the append-only `resolume_push_audit` table. The writer
+/// task prunes on this cadence (and once at startup): rows older than
+/// `AUDIT_RETENTION_DAYS` go, and if still over `AUDIT_RETENTION_MAX_ROWS` the
+/// oldest beyond the cap are dropped. Both bounds keep the table from growing
+/// unbounded over months of services without losing recent diagnostics.
+const AUDIT_PRUNE_INTERVAL: Duration = Duration::from_secs(3600);
+const AUDIT_RETENTION_DAYS: i64 = 30;
+const AUDIT_RETENTION_MAX_ROWS: u64 = 10_000;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -323,6 +331,9 @@ fn spawn_audit_writer(repo: Repository, mut rx: mpsc::Receiver<ResolumePushAudit
     tokio::spawn(async move {
         let mut pending: HashMap<String, PerceivedAgg> = HashMap::new();
         let mut sweep = tokio::time::interval(PERCEIVED_SWEEP_INTERVAL);
+        // #489: prune the audit table on a slow cadence (first tick fires
+        // immediately → a startup prune), keeping it bounded by age + row count.
+        let mut prune = tokio::time::interval(AUDIT_PRUNE_INTERVAL);
         loop {
             tokio::select! {
                 maybe = rx.recv() => {
@@ -354,6 +365,17 @@ fn spawn_audit_writer(repo: Repository, mut rx: mpsc::Receiver<ResolumePushAudit
                     }
                 }
                 _ = sweep.tick() => flush_perceived(&mut pending, false),
+                _ = prune.tick() => {
+                    if let Err(err) = repo
+                        .prune_resolume_push_audit(
+                            chrono::Duration::days(AUDIT_RETENTION_DAYS),
+                            AUDIT_RETENTION_MAX_ROWS,
+                        )
+                        .await
+                    {
+                        tracing::warn!(?err, "failed to prune resolume push audit table");
+                    }
+                }
             }
         }
         flush_perceived(&mut pending, true);

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -237,6 +237,10 @@ pub fn build_router(state: AppState) -> Router {
             "/integrations/audit",
             get(integrations::audit::list_settings_audit),
         )
+        .route(
+            "/integrations/resolume-push-audit",
+            get(integrations::resolume_push_audit::list_resolume_push_audit),
+        )
         .route("/ndi/sources", get(integrations::ndi::discover_ndi_sources))
         .route("/ndi/status", get(integrations::ndi::ndi_status))
         .route(

--- a/crates/presenter-server/src/router/integrations/mod.rs
+++ b/crates/presenter-server/src/router/integrations/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod ndi;
 pub(super) mod ndi_whep;
 pub(super) mod osc;
 pub(super) mod resolume;
+pub(super) mod resolume_push_audit;
 pub(super) mod video_source;
 
 use axum::http::HeaderMap;

--- a/crates/presenter-server/src/router/integrations/resolume_push_audit.rs
+++ b/crates/presenter-server/src/router/integrations/resolume_push_audit.rs
@@ -1,0 +1,136 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::Deserialize;
+use tracing::instrument;
+
+use super::super::AppError;
+use crate::state::AppState;
+use presenter_persistence::ResolumePushAuditEntry;
+
+/// #489: query for `GET /integrations/resolume-push-audit`. Mirrors the
+/// settings-audit endpoint (`/integrations/audit`). All filters are optional;
+/// `outcome` is a prefix (`error` lists every failed push, `ok` the successes).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResolumePushAuditQuery {
+    pub host: Option<String>,
+    pub outcome: Option<String>,
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
+    pub limit: Option<u64>,
+}
+
+/// #489: expose the `resolume_push_audit` rows over HTTP so post-event latency +
+/// failure analysis is an API call (prod has no sqlite3 — project memory: "use
+/// API to query data"). Newest rows first, capped at 1000 per request.
+#[instrument(skip_all)]
+pub(crate) async fn list_resolume_push_audit(
+    State(state): State<AppState>,
+    Query(q): Query<ResolumePushAuditQuery>,
+) -> Result<Json<Vec<ResolumePushAuditEntry>>, AppError> {
+    let limit = q.limit.unwrap_or(100).min(1000);
+    let rows = state
+        .repository()
+        .list_resolume_push_audit(q.host.as_deref(), q.outcome.as_deref(), q.since, limit)
+        .await?;
+    Ok(Json(rows))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(host: &str, outcome: &str) -> ResolumePushAuditEntry {
+        ResolumePushAuditEntry {
+            correlation_id: Some("cid-1".to_string()),
+            host: host.to_string(),
+            t_queue_wait_ms: 1.0,
+            t_ensure_mapping_ms: 0.0,
+            t_total_ms: 20.0,
+            refetched: false,
+            outcome: outcome.to_string(),
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn endpoint_round_trips_rows_with_host_and_outcome_filters() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        state
+            .repository()
+            .record_resolume_push_audit(&entry("cg-resolume.lan", "ok"))
+            .await
+            .unwrap();
+        state
+            .repository()
+            .record_resolume_push_audit(&entry(
+                "cg-resolume.lan",
+                "error: composition request failed with status 500",
+            ))
+            .await
+            .unwrap();
+        state
+            .repository()
+            .record_resolume_push_audit(&entry("other.lan", "ok"))
+            .await
+            .unwrap();
+
+        // No filter: all three rows round-trip through the endpoint.
+        let Json(all) = list_resolume_push_audit(
+            State(state.clone()),
+            Query(ResolumePushAuditQuery {
+                host: None,
+                outcome: None,
+                since: None,
+                limit: None,
+            }),
+        )
+        .await
+        .expect("list all");
+        assert_eq!(all.len(), 3);
+
+        // Outcome prefix filter returns only the failed push.
+        let Json(errors) = list_resolume_push_audit(
+            State(state.clone()),
+            Query(ResolumePushAuditQuery {
+                host: None,
+                outcome: Some("error".to_string()),
+                since: None,
+                limit: None,
+            }),
+        )
+        .await
+        .expect("list errors");
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].outcome.starts_with("error: "));
+
+        // Host filter scopes to one host.
+        let Json(cg) = list_resolume_push_audit(
+            State(state.clone()),
+            Query(ResolumePushAuditQuery {
+                host: Some("cg-resolume.lan".to_string()),
+                outcome: None,
+                since: None,
+                limit: None,
+            }),
+        )
+        .await
+        .expect("list host");
+        assert_eq!(cg.len(), 2);
+
+        // Limit is honoured.
+        let Json(limited) = list_resolume_push_audit(
+            State(state),
+            Query(ResolumePushAuditQuery {
+                host: None,
+                outcome: None,
+                since: None,
+                limit: Some(1),
+            }),
+        )
+        .await
+        .expect("list limited");
+        assert_eq!(limited.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Observability follow-up to #483's `resolume_push_audit` table. Three deliverables:

1. **Read endpoint** — `GET /integrations/resolume-push-audit` (filters: `host`, `outcome` prefix, `since` rfc3339, `limit`), mirroring the settings-audit endpoint `/integrations/audit`. Prod has no `sqlite3`, so the rows are now readable over HTTP/API instead of copying the DB off-box.
2. **Capture failed pushes** — `handle_stage` now records an audit row on BOTH the success and the error path. A failed push (e.g. Resolume unreachable → up to the 5 s `COMPOSITION_TIMEOUT`) writes `outcome="error: <reason>"` instead of vanishing, so the pushes that hurt most appear in the audit table and the cross-host latency aggregate. The audit emit stays non-blocking (`try_send`, dropped on full), and the error still propagates so the #484 backoff + dedup'd ERROR log are unchanged.
3. **Retention** — the writer task prunes `resolume_push_audit` on a 1 h cadence (and once at startup): rows older than 30 days go, and if still over 10 000 rows the oldest beyond the cap are dropped (newest kept). Idempotent, indexed on `created_at`.

No schema change (the table + entity already exist from #483).

## Tests
- `failed_stage_push_persists_error_audit_row_through_registry` — a failing `/composition` push leaves an `outcome=error` row (the key behavioral guarantee).
- `endpoint_round_trips_rows_with_host_and_outcome_filters` — read endpoint round-trips with host / outcome / limit filters.
- `prune_resolume_push_audit_removes_rows_older_than_retention` + `prune_resolume_push_audit_caps_row_count_keeping_newest` — retention age-prune + count-cap.
- `list_resolume_push_audit_filters_by_outcome_prefix`, `audit_failure_outcome_*` — outcome filter + reason formatting.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiNVo8Sa67MNggNrEajhdq