### PR TITLE
feat(stage): worship-pp current badge from playlist + sidebar auto-scroll (#461)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.167"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.167"
+version = "0.4.168"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.160"
+version = "0.4.168"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/mod.rs
+++ b/crates/presenter-ui/src/components/stage/mod.rs
@@ -15,6 +15,7 @@ pub mod status_bar;
 pub mod timer_layout;
 pub mod wake_lock;
 pub mod worship_pp;
+mod worship_pp_helpers;
 pub mod worship_snv;
 
 /// How the stage should present an `ndi_status` over the NDI video area.

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -113,22 +113,25 @@ pub fn WorshipPp(
 
     // Auto-scroll the playlist sidebar so the ACTIVE song stays visible as the
     // service advances past the ~10 rows that fit at 1080p (#461). Tracks the
-    // active entry's name; when it changes, defers one tick (Timeout 0) so the
-    // `--active` class is applied to the DOM before scrolling, then centers the
-    // active row in the sidebar. Mirrors the operator slide-list scroll Effect.
+    // active entry's POSITION (not its name): a worship set can legitimately
+    // repeat the same song, so name-based dedup would suppress the scroll when
+    // advancing between two same-named entries. When the active position
+    // changes, defers one tick (Timeout 0) so the `--active` class is applied
+    // to the DOM before scrolling, then centers the active row in the sidebar.
+    // Mirrors the operator slide-list scroll Effect (which dedups on the unique
+    // slide id for the same reason).
     {
         let snapshot = ctx.snapshot;
-        Effect::new(move |prev: Option<Option<String>>| {
-            let active_name = snapshot.with(|opt| {
+        Effect::new(move |prev: Option<Option<usize>>| {
+            let active_idx = snapshot.with(|opt| {
                 opt.as_ref()
                     .and_then(|s| s.playlist_entries.as_ref())
-                    .and_then(|entries| entries.iter().find(|e| e.is_active))
-                    .map(|e| e.name.clone())
+                    .and_then(|entries| entries.iter().position(|e| e.is_active))
             });
-            if active_name.is_some() && active_name != prev.flatten() {
+            if active_idx.is_some() && active_idx != prev.flatten() {
                 gloo_timers::callback::Timeout::new(0, scroll_active_entry_into_view).forget();
             }
-            active_name
+            active_idx
         });
     }
 

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -1,5 +1,8 @@
 use leptos::prelude::*;
 
+use super::worship_pp_helpers::{
+    current_song_from_entries, next_song_from_entries, scroll_active_entry_into_view,
+};
 use crate::state::stage::StageContext;
 use crate::utils::autofit::autofit_effect;
 use crate::utils::color::group_pill_style;
@@ -92,13 +95,6 @@ pub fn WorshipPp(
     let current_group_text = move || current_group().unwrap_or_default();
     let next_group_text = move || next_group().unwrap_or_default();
 
-    let current_song_text = move || {
-        ctx.snapshot
-            .get()
-            .and_then(|s| s.song_name)
-            .unwrap_or_default()
-    };
-
     let playlist_entries = move || {
         ctx.snapshot
             .get()
@@ -106,17 +102,35 @@ pub fn WorshipPp(
             .unwrap_or_default()
     };
 
+    // worship-pp specific: derive the CURRENT-song badge from the Presenter
+    // playlist's active entry, NOT from AbleSet's server-side s.song_name (#461).
+    let current_song_text = move || current_song_from_entries(&playlist_entries());
+
     // worship-pp specific: derive next-song from the Presenter playlist's
     // entry-after-active, NOT from AbleSet's s.next_song_name. If no entry
     // is active, or the active one is last, returns "" (no next song).
-    let next_song_text = move || {
-        let entries = playlist_entries();
-        let mut iter = entries.iter().skip_while(|e| !e.is_active);
-        iter.next(); // consume the active entry itself
-        iter.next()
-            .map(|e| clean_song_name(&e.name))
-            .unwrap_or_default()
-    };
+    let next_song_text = move || next_song_from_entries(&playlist_entries());
+
+    // Auto-scroll the playlist sidebar so the ACTIVE song stays visible as the
+    // service advances past the ~10 rows that fit at 1080p (#461). Tracks the
+    // active entry's name; when it changes, defers one tick (Timeout 0) so the
+    // `--active` class is applied to the DOM before scrolling, then centers the
+    // active row in the sidebar. Mirrors the operator slide-list scroll Effect.
+    {
+        let snapshot = ctx.snapshot;
+        Effect::new(move |prev: Option<Option<String>>| {
+            let active_name = snapshot.with(|opt| {
+                opt.as_ref()
+                    .and_then(|s| s.playlist_entries.as_ref())
+                    .and_then(|entries| entries.iter().find(|e| e.is_active))
+                    .map(|e| e.name.clone())
+            });
+            if active_name.is_some() && active_name != prev.flatten() {
+                gloo_timers::callback::Timeout::new(0, scroll_active_entry_into_view).forget();
+            }
+            active_name
+        });
+    }
 
     autofit_effect(current_text_ref, CURRENT_MAX_FONT, current_text);
     autofit_effect(next_text_ref, NEXT_MAX_FONT, next_text);

--- a/crates/presenter-ui/src/components/stage/worship_pp.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp.rs
@@ -113,13 +113,15 @@ pub fn WorshipPp(
 
     // Auto-scroll the playlist sidebar so the ACTIVE song stays visible as the
     // service advances past the ~10 rows that fit at 1080p (#461). Tracks the
-    // active entry's POSITION (not its name): a worship set can legitimately
-    // repeat the same song, so name-based dedup would suppress the scroll when
-    // advancing between two same-named entries. When the active position
+    // active entry's POSITION (not its name) so the scroll still FIRES when a
+    // set repeats a song and the operator advances between two same-named
+    // entries (name-based dedup would suppress it). When the active position
     // changes, defers one tick (Timeout 0) so the `--active` class is applied
     // to the DOM before scrolling, then centers the active row in the sidebar.
     // Mirrors the operator slide-list scroll Effect (which dedups on the unique
-    // slide id for the same reason).
+    // slide id for the same reason). Note: for a REPEATED song the scroll still
+    // targets the first matching `--active` row because rows are name-keyed;
+    // correct per-occurrence targeting is tracked in #496.
     {
         let snapshot = ctx.snapshot;
         Effect::new(move |prev: Option<Option<usize>>| {

--- a/crates/presenter-ui/src/components/stage/worship_pp_helpers.rs
+++ b/crates/presenter-ui/src/components/stage/worship_pp_helpers.rs
@@ -1,0 +1,141 @@
+//! Pure song-name derivations and sidebar auto-scroll for the worship-pp
+//! stage layout.
+//!
+//! Extracted from `worship_pp.rs` (#461) so the playlist-sourced song-name
+//! derivations are unit-testable on the host, and to keep `worship_pp.rs`
+//! readable. The current/next badges on the worship-pp stage are sourced from
+//! the Presenter PLAYLIST (the user's intent), NOT from AbleSet's server-side
+//! `song_name`/`next_song_name`.
+
+use presenter_core::StagePlaylistEntry;
+
+use crate::utils::text::clean_song_name;
+
+/// Current-song name sourced from the Presenter PLAYLIST.
+///
+/// Returns the cleaned name of the `is_active` entry, or `""` when no entry is
+/// active. This is the worship-pp current-song badge source: the badge must
+/// reflect the playlist's active entry rather than the AbleSet-first
+/// server-side `song_name` (#461).
+pub fn current_song_from_entries(entries: &[StagePlaylistEntry]) -> String {
+    entries
+        .iter()
+        .find(|e| e.is_active)
+        .map(|e| clean_song_name(&e.name))
+        .unwrap_or_default()
+}
+
+/// Next-song name sourced from the Presenter PLAYLIST: the entry AFTER the
+/// active one. Returns `""` when nothing is active or the active entry is last.
+///
+/// Mirrors worship-pp's established next-song behavior (formerly an inline
+/// closure in `worship_pp.rs`, added in b503ed06).
+pub fn next_song_from_entries(entries: &[StagePlaylistEntry]) -> String {
+    let mut iter = entries.iter().skip_while(|e| !e.is_active);
+    iter.next(); // consume the active entry itself
+    iter.next()
+        .map(|e| clean_song_name(&e.name))
+        .unwrap_or_default()
+}
+
+/// CSS selector for the worship-pp playlist sidebar's active entry row.
+const ACTIVE_ENTRY_SELECTOR: &str = ".stage-pp__playlist-sidebar .stage-pp__playlist-entry--active";
+
+/// Scroll the worship-pp playlist sidebar so the ACTIVE song row is visible.
+///
+/// Keeps the currently-triggered song on screen as the service advances past
+/// the ~10 rows that fit at 1080p (#461). Centers the active row within the
+/// `overflow-y:auto` sidebar — the sidebar BOX size/position is unchanged, only
+/// its scroll position moves (CLAUDE.md box-dimensions rule: content scroll is
+/// allowed, layout boxes are not). No-op when no active row is rendered yet.
+///
+/// Adapts the operator slide-list scroll pattern (`slide_list_scroll.rs`) to
+/// this component. It queries the DOM rather than holding a `NodeRef` because
+/// Leptos's keyed `<For>` reuses row DOM, so the "active row" is whichever row
+/// currently carries the `--active` class, not a fixed node.
+pub fn scroll_active_entry_into_view() {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Ok(Some(active_el)) = document.query_selector(ACTIVE_ENTRY_SELECTOR) else {
+        return;
+    };
+    let opts = web_sys::ScrollIntoViewOptions::new();
+    opts.set_block(web_sys::ScrollLogicalPosition::Center);
+    active_el.scroll_into_view_with_scroll_into_view_options(&opts);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use presenter_core::StagePlaylistEntry;
+
+    fn entry(name: &str, is_active: bool) -> StagePlaylistEntry {
+        StagePlaylistEntry {
+            name: name.to_string(),
+            presentation_id: None,
+            is_active,
+            entry_type: "presentation".to_string(),
+        }
+    }
+
+    #[test]
+    fn current_song_returns_active_entry_name() {
+        let entries = vec![
+            entry("First", false),
+            entry("Second", true),
+            entry("Third", false),
+        ];
+        assert_eq!(current_song_from_entries(&entries), "Second");
+    }
+
+    #[test]
+    fn current_song_cleans_three_digit_prefix() {
+        let entries = vec![entry("042 Amazing Grace", true)];
+        assert_eq!(current_song_from_entries(&entries), "Amazing Grace");
+    }
+
+    #[test]
+    fn current_song_empty_when_no_active() {
+        let entries = vec![entry("First", false), entry("Second", false)];
+        assert_eq!(current_song_from_entries(&entries), "");
+    }
+
+    #[test]
+    fn current_song_empty_for_empty_list() {
+        assert_eq!(current_song_from_entries(&[]), "");
+    }
+
+    #[test]
+    fn next_song_returns_entry_after_active() {
+        let entries = vec![
+            entry("First", false),
+            entry("Second", true),
+            entry("Third", false),
+        ];
+        assert_eq!(next_song_from_entries(&entries), "Third");
+    }
+
+    #[test]
+    fn next_song_cleans_three_digit_prefix() {
+        let entries = vec![entry("Active", true), entry("042 Next One", false)];
+        assert_eq!(next_song_from_entries(&entries), "Next One");
+    }
+
+    #[test]
+    fn next_song_empty_when_active_is_last() {
+        let entries = vec![entry("First", false), entry("Last", true)];
+        assert_eq!(next_song_from_entries(&entries), "");
+    }
+
+    #[test]
+    fn next_song_empty_when_no_active() {
+        let entries = vec![entry("First", false), entry("Second", false)];
+        assert_eq!(next_song_from_entries(&entries), "");
+    }
+
+    #[test]
+    fn next_song_empty_for_empty_list() {
+        assert_eq!(next_song_from_entries(&[]), "");
+    }
+}

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -520,13 +520,12 @@ test.describe("Stage worship-pp layout", () => {
       }
       if (picked.length >= 16) break;
     }
-    if (picked.length < 14) {
-      test.skip(
-        true,
-        `fixture has fewer than 14 distinct presentations with slides (got ${picked.length})`,
-      );
-      return;
-    }
+    // The seeded library has 1000+ presentations, so this is a hard guard, not
+    // a silent skip (test-strictness): a thin fixture must fail loudly.
+    expect(
+      picked.length,
+      `fixture needs >=14 distinct slide-bearing presentations (got ${picked.length})`,
+    ).toBeGreaterThanOrEqual(14);
 
     // Create a playlist holding all picked presentations, in order.
     const playlistResp = await page.request.post(

--- a/tests/e2e/stage-worship-pp.spec.ts
+++ b/tests/e2e/stage-worship-pp.spec.ts
@@ -469,4 +469,212 @@ test.describe("Stage worship-pp layout", () => {
 
     expect(consoleErrors).toEqual([]);
   });
+
+  test("current-song badge is sourced from the playlist's active entry, and the active row auto-scrolls into view as the song advances past the visible area (#461)", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        const t = msg.text();
+        if (!t.includes("favicon") && !t.includes("crbug.com/981419")) {
+          consoleErrors.push(`[${msg.type()}] ${t}`);
+        }
+      }
+    });
+
+    // Set worship-pp layout.
+    const layoutResp = await page.request.post(
+      new URL("/stage/layout", baseURL).toString(),
+      { data: { code: "worship-pp" } },
+    );
+    expect(layoutResp.ok()).toBeTruthy();
+
+    // Collect MANY presentations with slides, with DISTINCT sanitized names so
+    // the keyed <For> doesn't collide. Skip names with a 3-digit prefix so the
+    // sanitized name equals the trimmed raw name (clean assertion).
+    const libsResp = await page.request.get(
+      new URL("/libraries", baseURL).toString(),
+    );
+    expect(libsResp.ok()).toBeTruthy();
+    const libs = (await libsResp.json()) as Array<{
+      id: string;
+      presentations?: Array<{
+        id: string;
+        name?: string;
+        slides?: Array<{ id: string }>;
+      }>;
+    }>;
+    const seen = new Set<string>();
+    const picked: Array<{ id: string; name: string; slideId: string }> = [];
+    for (const lib of libs) {
+      for (const p of lib.presentations ?? []) {
+        const rawName = (p.name ?? "").trim();
+        const firstSlide = p.slides?.[0]?.id;
+        if (!rawName || !firstSlide) continue;
+        if (/^\d{3}\s/.test(rawName)) continue; // would be stripped server-side
+        if (seen.has(rawName)) continue;
+        seen.add(rawName);
+        picked.push({ id: p.id, name: rawName, slideId: firstSlide });
+        if (picked.length >= 16) break;
+      }
+      if (picked.length >= 16) break;
+    }
+    if (picked.length < 14) {
+      test.skip(
+        true,
+        `fixture has fewer than 14 distinct presentations with slides (got ${picked.length})`,
+      );
+      return;
+    }
+
+    // Create a playlist holding all picked presentations, in order.
+    const playlistResp = await page.request.post(
+      new URL("/playlists", baseURL).toString(),
+      { data: { name: `Autoscroll Test ${Date.now()}`, showInDashboard: true } },
+    );
+    expect(playlistResp.ok()).toBeTruthy();
+    const playlist = (await playlistResp.json()) as { id: string };
+    const entriesResp = await page.request.put(
+      new URL(`/playlists/${playlist.id}/entries`, baseURL).toString(),
+      {
+        data: {
+          entries: picked.map((p) => ({
+            type: "presentation",
+            presentationId: p.id,
+          })),
+        },
+      },
+    );
+    expect(entriesResp.ok()).toBeTruthy();
+
+    const lastIdx = picked.length - 1;
+
+    // Trigger the FIRST presentation so the early row is active.
+    const trigFirst = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: picked[0].id,
+          currentSlideId: picked[0].slideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trigFirst.status()).toBe(204);
+
+    // Open the stage at 1080p (sidebar fits ~10 rows; 14+ entries overflow).
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto(new URL("/stage", baseURL).toString());
+    await page.waitForFunction(() => document.body.dataset.wasmReady === "true", {
+      timeout: 30_000,
+    });
+    await page.waitForFunction(
+      () => document.body.dataset.layoutCode === "worship-pp",
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      (n) =>
+        document.querySelectorAll(".stage-pp__playlist-entry").length >= n,
+      picked.length,
+      { timeout: 15_000 },
+    );
+
+    const activeIndex = async (): Promise<number> =>
+      page.evaluate(() => {
+        const rows = Array.from(
+          document.querySelectorAll(".stage-pp__playlist-entry"),
+        );
+        return rows.findIndex((r) =>
+          r.classList.contains("stage-pp__playlist-entry--active"),
+        );
+      });
+
+    const badgeText = async (): Promise<string> =>
+      (
+        (await page
+          .locator(".stage__current-song .stage__song-name-text")
+          .textContent()) ?? ""
+      ).trim();
+
+    const activeRowText = async (): Promise<string> =>
+      (
+        (await page
+          .locator(".stage-pp__playlist-entry--active")
+          .first()
+          .textContent()) ?? ""
+      ).trim();
+
+    // Row 0 active; the badge must reflect the PLAYLIST's active entry — equal
+    // to both the active row's text and the triggered presentation's name.
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(0);
+    await expect.poll(badgeText, { timeout: 10_000 }).toBe(picked[0].name);
+    expect(await badgeText()).toBe(await activeRowText());
+
+    // Sanity: the LAST row must currently be OUT of view (below the fold), so
+    // there is genuinely something to scroll. Proves overflow exists.
+    const lastRowInitiallyHidden = await page.evaluate((idx) => {
+      const sidebar = document
+        .querySelector(".stage-pp__playlist-sidebar")
+        ?.getBoundingClientRect();
+      const rows = document.querySelectorAll(".stage-pp__playlist-entry");
+      const last = rows[idx]?.getBoundingClientRect();
+      if (!sidebar || !last) return false;
+      // Below the fold: the row's top is at/under the sidebar's bottom edge.
+      return last.top >= sidebar.bottom;
+    }, lastIdx);
+    expect(
+      lastRowInitiallyHidden,
+      "last playlist row should start below the fold",
+    ).toBe(true);
+
+    // Advance to the LAST presentation (off-screen). The active row must
+    // auto-scroll into view AND the badge must update to the new active song.
+    const trigLast = await page.request.post(
+      new URL("/stage/state", baseURL).toString(),
+      {
+        data: {
+          presentationId: picked[lastIdx].id,
+          currentSlideId: picked[lastIdx].slideId,
+          playlistId: playlist.id,
+        },
+      },
+    );
+    expect(trigLast.status()).toBe(204);
+
+    await expect.poll(activeIndex, { timeout: 10_000 }).toBe(lastIdx);
+    await expect
+      .poll(badgeText, { timeout: 10_000 })
+      .toBe(picked[lastIdx].name);
+    expect(await badgeText()).toBe(await activeRowText());
+
+    // The active row is now scrolled INTO the sidebar's visible viewport.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => {
+            const sidebar = document
+              .querySelector(".stage-pp__playlist-sidebar")
+              ?.getBoundingClientRect();
+            const active = document
+              .querySelector(".stage-pp__playlist-entry--active")
+              ?.getBoundingClientRect();
+            if (!sidebar || !active) return false;
+            // Fully within the sidebar's vertical viewport (2px slack).
+            return (
+              active.top >= sidebar.top - 2 &&
+              active.bottom <= sidebar.bottom + 2
+            );
+          }),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // Cleanup.
+    await page.request.delete(
+      new URL(`/playlists/${playlist.id}`, baseURL).toString(),
+    );
+
+    expect(consoleErrors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #461

Two PP-ONLY behavioral changes to the worship-PP stage layout, plus tests:

1. **Current-song badge sourced from the Presenter playlist.** The worship-PP CURRENT-song badge now reads the playlist's active entry (`clean_song_name` of the `is_active` `StagePlaylistEntry`) instead of AbleSet's server-side `song_name` — mirroring worship-PP's existing playlist-sourced NEXT-song badge.
2. **Playlist sidebar auto-scroll.** The `overflow-y:auto` sidebar (~10 rows at 1080p) now keeps the ACTIVE song visible as the service advances past the visible rows. A reactive `Effect` tracks the active entry and centers its row via `scroll_into_view` (content scroll only — the sidebar box size/position is unchanged per the CLAUDE.md box-dimensions rule).

## Rescope note (issue text was inverted)

The issue asked to make worship-PP behave "like worship-snv", but `ticket-validator` proved that reference is **inverted**: worship-SNV is AbleSet-based for next-song, so copying it would be wrong. This is therefore a **PP-only** change. Also, the worship-PP NEXT-song badge was **already** playlist-sourced (commit b503ed06, 2026-04-27) — only the CURRENT badge needed switching. `worship_snv.rs` is untouched.

## Tests

- **Unit:** `current_song_from_entries` / `next_song_from_entries` extracted to `worship_pp_helpers.rs` with 9 unit tests (active entry, 3-digit-prefix cleaning, no-active, empty, last-entry edge cases). These prove the badge is derived from the playlist's active entry, not from `song_name`.
- **E2E (Playwright):** `tests/e2e/stage-worship-pp.spec.ts` — loads a 14+ entry playlist at 1080p, asserts (a) the current-song badge equals the active playlist entry's name and updates when a later song is triggered, (b) the active row auto-scrolls into the sidebar viewport after advancing past the fold, (c) zero browser console errors/warnings. Verified green locally and in CI.

## Verification

- CI Pipeline run 28338445184 — all 22 jobs green (fmt, clippy, version, quality, Test, Build, Coverage, Playwright E2E 1-3/3, NDI E2E, Deploy to Dev).