### PR TITLE
NDI T0: device-capability + lag-location probe (gates true-latency metric) (#509)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.178"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.178"
+version = "0.4.179"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/pipeline.rs
+++ b/crates/presenter-ndi/src/pipeline.rs
@@ -56,6 +56,7 @@ use crate::whep_session::{IceCandidate, WhepConnectionState, WhepSession};
 
 mod build;
 mod consumers;
+mod ingest_timing;
 mod lifecycle;
 mod negotiation;
 mod reaper;

--- a/crates/presenter-ndi/src/pipeline/build.rs
+++ b/crates/presenter-ndi/src/pipeline/build.rs
@@ -110,6 +110,15 @@ impl NdiPipeline {
 
         connect_demux_pads(&ndisrcdemux, &videoconvert, &audio_fakesink);
 
+        // #509 (T0): read-only ingest-timing probe on the raw NDI frames
+        // (videoconvert's static sink pad, fed by the demux video pad). With
+        // ndisrc timestamp-mode=receive-time, buffer PTS = this server's clock
+        // at frame arrival, so the probe logs the camera→NDI→server delivery
+        // cadence — the signal that localizes the "lags/jumps after a while".
+        if let Some(sink) = videoconvert.static_pad("sink") {
+            super::ingest_timing::install_probe(&sink, ndi_name);
+        }
+
         tracing::info!(
             encoder = encoder_name,
             %ndi_name,

--- a/crates/presenter-ndi/src/pipeline/ingest_timing.rs
+++ b/crates/presenter-ndi/src/pipeline/ingest_timing.rs
@@ -1,0 +1,164 @@
+//! Server-side NDI ingest-timing probe (#509 / T0 of the true-latency design
+//! `docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md`).
+//!
+//! A read-only buffer pad probe on the raw NDI frames entering the encoder
+//! (post-demux, pre-scale) that periodically logs the frame-ARRIVAL cadence at
+//! the server. `ndisrc` runs `timestamp-mode=receive-time` (see
+//! `build::build_ndi_source`), so each buffer's PTS IS this server's clock at
+//! the instant the NDI frame arrived — the inter-frame PTS gap is exactly the
+//! camera→NDI→server delivery cadence.
+//!
+//! T0 must LOCATE where the recurring "lags/jumps after a while" lives: a smooth
+//! ingest cadence here (steady ~33 ms gaps, no large gaps) proves the drift is
+//! downstream — server→display (encode/network/jitter-buffer/decode) — while
+//! jumpy ingest gaps localize it upstream (camera→NDI→server). T4's metric is a
+//! server→display number; this probe is what tells us whether such a number can
+//! even explain the complaint.
+//!
+//! The accounting is a pure, unit-tested accumulator; the pad probe is thin glue
+//! that never mutates the buffer and always returns `Ok`.
+
+use std::time::Duration;
+
+/// Emitted once per interval by [`IngestTimingAccumulator::record`].
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct IngestTimingReport {
+    /// Frames observed in this interval (both with and without a PTS).
+    pub frames: u64,
+    /// Subset of `frames` that carried no PTS. `receive-time` mode should make
+    /// this 0; a non-zero value is itself a finding (ndisrc not stamping).
+    pub frames_no_pts: u64,
+    /// Wall span of the interval, from the first→last PTS delta (ms).
+    pub span_ms: f64,
+    /// Mean arrival rate over the interval (frames / span).
+    pub fps: f64,
+    /// Largest inter-arrival gap seen this interval (ms). A big value = an
+    /// ingest-side stall/jump → the drift is upstream (camera→NDI→server).
+    pub max_gap_ms: f64,
+    /// Count of inter-arrival gaps over the threshold (perceptible ingest hitches).
+    pub gaps_over_threshold: u64,
+    /// The gap threshold in effect (ms), for interpreting `gaps_over_threshold`.
+    pub gap_threshold_ms: f64,
+}
+
+/// Pure accumulator for NDI frame-arrival cadence. Fed one PTS per buffer by the
+/// pad probe; returns `Some(report)` (and resets) once an interval's worth of
+/// media time has elapsed since the interval's first frame.
+pub(super) struct IngestTimingAccumulator {
+    interval_ns: u64,
+    gap_threshold_ns: u64,
+    // --- per-interval state ---
+    first_pts: Option<u64>,
+    last_pts: Option<u64>,
+    frames: u64,
+    frames_no_pts: u64,
+    max_gap_ns: u64,
+    gaps_over_threshold: u64,
+}
+
+impl IngestTimingAccumulator {
+    pub(super) fn new(interval: Duration, gap_threshold: Duration) -> Self {
+        Self {
+            interval_ns: interval.as_nanos() as u64,
+            gap_threshold_ns: gap_threshold.as_nanos() as u64,
+            first_pts: None,
+            last_pts: None,
+            frames: 0,
+            frames_no_pts: 0,
+            max_gap_ns: 0,
+            gaps_over_threshold: 0,
+        }
+    }
+
+    /// Record one buffer's PTS (nanoseconds on the server's receive clock).
+    /// Returns `Some(report)` once `interval` of media time has elapsed since
+    /// the interval's first frame, resetting for the next interval.
+    pub(super) fn record(&mut self, pts_ns: Option<u64>) -> Option<IngestTimingReport> {
+        // RED stub — real accounting lands in the [green] commit.
+        let _ = pts_ns;
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acc_5s_100ms() -> IngestTimingAccumulator {
+        IngestTimingAccumulator::new(Duration::from_secs(5), Duration::from_millis(100))
+    }
+
+    const NS_PER_MS: u64 = 1_000_000;
+
+    #[test]
+    fn steady_30fps_reports_smooth_cadence_no_large_gaps() {
+        let mut acc = acc_5s_100ms();
+        let mut report = None;
+        // 6 seconds of steady 30fps frames (33ms apart) — one interval must fire.
+        for i in 0..180u64 {
+            let pts = i * 33 * NS_PER_MS;
+            if let Some(r) = acc.record(Some(pts)) {
+                report = Some(r);
+                break;
+            }
+        }
+        let r = report.expect("a 5s interval must emit within 6s of frames");
+        assert!(r.span_ms >= 5000.0, "span {} should reach the interval", r.span_ms);
+        assert!(
+            (r.fps - 30.0).abs() < 2.0,
+            "arrival fps {} should be ~30",
+            r.fps
+        );
+        assert!(
+            r.max_gap_ms < 100.0,
+            "steady cadence must have no gap over threshold, got max {}",
+            r.max_gap_ms
+        );
+        assert_eq!(r.gaps_over_threshold, 0);
+        assert_eq!(r.frames_no_pts, 0);
+    }
+
+    #[test]
+    fn a_large_arrival_gap_is_flagged() {
+        let mut acc = acc_5s_100ms();
+        let mut pts = 0u64;
+        let mut report = None;
+        // Steady frames, but inject one 400ms stall partway through.
+        for i in 0..180u64 {
+            let step = if i == 60 { 400 } else { 33 };
+            pts += step * NS_PER_MS;
+            if let Some(r) = acc.record(Some(pts)) {
+                report = Some(r);
+                break;
+            }
+        }
+        let r = report.expect("interval emits");
+        assert!(
+            r.max_gap_ms >= 399.0,
+            "the 400ms stall must surface as max gap, got {}",
+            r.max_gap_ms
+        );
+        assert!(
+            r.gaps_over_threshold >= 1,
+            "the stall must count as a gap over the 100ms threshold"
+        );
+    }
+
+    #[test]
+    fn frames_without_pts_are_counted_not_timed() {
+        let mut acc = acc_5s_100ms();
+        // A frame with no PTS must not panic, must be counted, and must not
+        // seed/advance the interval timing.
+        assert_eq!(acc.record(None), None);
+        let mut report = None;
+        for i in 0..180u64 {
+            let pts = i * 33 * NS_PER_MS;
+            if let Some(r) = acc.record(Some(pts)) {
+                report = Some(r);
+                break;
+            }
+        }
+        let r = report.expect("interval emits after PTS frames start");
+        assert_eq!(r.frames_no_pts, 1, "the single no-PTS frame is counted once");
+    }
+}

--- a/crates/presenter-ndi/src/pipeline/ingest_timing.rs
+++ b/crates/presenter-ndi/src/pipeline/ingest_timing.rs
@@ -18,7 +18,16 @@
 //! The accounting is a pure, unit-tested accumulator; the pad probe is thin glue
 //! that never mutates the buffer and always returns `Ok`.
 
+use std::sync::Mutex;
 use std::time::Duration;
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Interval between ingest-cadence log lines (media time).
+const REPORT_INTERVAL: Duration = Duration::from_secs(5);
+/// An inter-arrival gap over this counts as a perceptible ingest hitch.
+const GAP_THRESHOLD: Duration = Duration::from_millis(100);
 
 /// Emitted once per interval by [`IngestTimingAccumulator::record`].
 #[derive(Debug, Clone, PartialEq)]
@@ -74,10 +83,77 @@ impl IngestTimingAccumulator {
     /// Returns `Some(report)` once `interval` of media time has elapsed since
     /// the interval's first frame, resetting for the next interval.
     pub(super) fn record(&mut self, pts_ns: Option<u64>) -> Option<IngestTimingReport> {
-        // RED stub — real accounting lands in the [green] commit.
-        let _ = pts_ns;
-        None
+        self.frames += 1;
+        let Some(pts) = pts_ns else {
+            // A frame with no PTS can't contribute to timing; count it (a
+            // finding in itself) and leave the interval state untouched.
+            self.frames_no_pts += 1;
+            return None;
+        };
+        if let Some(last) = self.last_pts {
+            let gap = pts.saturating_sub(last);
+            self.max_gap_ns = self.max_gap_ns.max(gap);
+            if gap > self.gap_threshold_ns {
+                self.gaps_over_threshold += 1;
+            }
+        }
+        self.last_pts = Some(pts);
+        let first = *self.first_pts.get_or_insert(pts);
+        let span = pts.saturating_sub(first);
+        if span < self.interval_ns {
+            return None;
+        }
+        let report = IngestTimingReport {
+            frames: self.frames,
+            frames_no_pts: self.frames_no_pts,
+            span_ms: span as f64 / 1_000_000.0,
+            fps: if span > 0 {
+                self.frames as f64 / (span as f64 / 1_000_000_000.0)
+            } else {
+                0.0
+            },
+            max_gap_ms: self.max_gap_ns as f64 / 1_000_000.0,
+            gaps_over_threshold: self.gaps_over_threshold,
+            gap_threshold_ms: self.gap_threshold_ns as f64 / 1_000_000.0,
+        };
+        // Reset: the current frame seeds the next interval.
+        self.first_pts = Some(pts);
+        self.frames = 0;
+        self.frames_no_pts = 0;
+        self.max_gap_ns = 0;
+        self.gaps_over_threshold = 0;
+        Some(report)
     }
+}
+
+/// Install the read-only ingest-timing pad probe on `pad` (the raw-video pad
+/// feeding the encoder). `label` identifies the NDI source in the logs. The
+/// probe never mutates the buffer and always returns `Ok` — it must never
+/// disturb the live pipeline.
+pub(super) fn install_probe(pad: &gst::Pad, label: &str) {
+    let acc = Mutex::new(IngestTimingAccumulator::new(REPORT_INTERVAL, GAP_THRESHOLD));
+    let label = label.to_string();
+    pad.add_probe(gst::PadProbeType::BUFFER, move |_pad, info| {
+        if let Some(gst::PadProbeData::Buffer(buffer)) = &info.data {
+            let pts_ns = buffer.pts().map(|c| c.nseconds());
+            if let Ok(mut acc) = acc.lock() {
+                if let Some(report) = acc.record(pts_ns) {
+                    tracing::info!(
+                        ndi_source = %label,
+                        frames = report.frames,
+                        frames_no_pts = report.frames_no_pts,
+                        span_ms = report.span_ms,
+                        arrival_fps = report.fps,
+                        max_arrival_gap_ms = report.max_gap_ms,
+                        arrival_gaps_over_threshold = report.gaps_over_threshold,
+                        gap_threshold_ms = report.gap_threshold_ms,
+                        "NDI ingest receive-time cadence (server-side; PTS=receive-time)"
+                    );
+                }
+            }
+        }
+        gst::PadProbeReturn::Ok
+    });
 }
 
 #[cfg(test)]
@@ -103,7 +179,11 @@ mod tests {
             }
         }
         let r = report.expect("a 5s interval must emit within 6s of frames");
-        assert!(r.span_ms >= 5000.0, "span {} should reach the interval", r.span_ms);
+        assert!(
+            r.span_ms >= 5000.0,
+            "span {} should reach the interval",
+            r.span_ms
+        );
         assert!(
             (r.fps - 30.0).abs() < 2.0,
             "arrival fps {} should be ~30",
@@ -159,6 +239,9 @@ mod tests {
             }
         }
         let r = report.expect("interval emits after PTS frames start");
-        assert_eq!(r.frames_no_pts, 1, "the single no-PTS frame is counted once");
+        assert_eq!(
+            r.frames_no_pts, 1,
+            "the single no-PTS frame is counted once"
+        );
     }
 }

--- a/crates/presenter-server/src/router/integrations/ndi.rs
+++ b/crates/presenter-server/src/router/integrations/ndi.rs
@@ -131,6 +131,60 @@ pub(crate) struct NdiClientStatsBeacon {
     pub lite: Option<bool>,
 }
 
+/// Classification of a display's `estimatedPlayoutTimestamp` for the #509 (T0)
+/// device-capability probe: which real TVs expose a trustworthy value — the
+/// field T4's true server→display metric would be defined on. `report_timestamp`
+/// is the SAME inbound-rtp getStats snapshot's own Unix-epoch `.timestamp` (ms),
+/// the epoch reference the playout value is compared against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlayoutClass {
+    /// Field absent (the WebView doesn't expose `estimatedPlayoutTimestamp`) →
+    /// the metric would be permanently `n/a` on this device (repeats #479).
+    Absent,
+    /// Present but non-finite (NaN / ±Inf) → unusable.
+    NonFinite,
+    /// Present but a literal `0` — pre-first-RTCP-SR. `Reflect::get(...).as_f64()`
+    /// returns `Some(0.0)` for a literal 0, so a naive check would read it as a
+    /// real timestamp and surface a bogus huge latency; classified separately.
+    Zero,
+    /// Finite, non-zero, and in the SAME Unix-epoch domain as the report's
+    /// `.timestamp` → trustworthy (T4's metric can be built on it here).
+    ValidUnixEpoch,
+    /// Finite, non-zero, but a different domain than the report's `.timestamp`
+    /// (or no report to compare against) → present but domain-suspect.
+    ValidOtherDomain,
+}
+
+impl PlayoutClass {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            PlayoutClass::Absent => "absent",
+            PlayoutClass::NonFinite => "nonfinite",
+            PlayoutClass::Zero => "zero",
+            PlayoutClass::ValidUnixEpoch => "valid-unix-epoch",
+            PlayoutClass::ValidOtherDomain => "valid-other-domain",
+        }
+    }
+}
+
+/// Max |playout − report| (ms) for the two to count as the same epoch domain.
+/// `estimatedPlayoutTimestamp` leads the report time only by the buffer depth
+/// (tens of ms); an epoch mismatch (NTP-1900 vs Unix-1970, or the TV's own
+/// unsynced clock) is off by years, so a generous 5-minute window cleanly
+/// separates "same domain" from "wrong domain".
+const PLAYOUT_EPOCH_MATCH_WINDOW_MS: f64 = 300_000.0;
+
+/// Classify a display's `estimatedPlayoutTimestamp` for the T0 probe. Pure so it
+/// is unit-tested directly (RED→GREEN) and reused by T4's trust predicate.
+pub(crate) fn classify_playout(
+    estimated_playout_ms: Option<f64>,
+    report_timestamp_ms: Option<f64>,
+) -> PlayoutClass {
+    // RED stub — real classification lands in the [green] commit.
+    let _ = (estimated_playout_ms, report_timestamp_ms);
+    PlayoutClass::Absent
+}
+
 /// Stage displays POST a compact getStats summary every 15s. Log-only (MVP):
 /// journald keeps the history, so "the stage was laggy at 19:40" is
 /// answerable from data (fps, jitter buffer, freezes per display).
@@ -217,6 +271,51 @@ mod tests {
         assert_eq!(no_gap.max_present_gap_ms, None);
         assert_eq!(no_gap.present_gaps_over100, None);
         assert_eq!(no_gap.presented_fps, None);
+    }
+
+    #[test]
+    fn classify_playout_absent_when_field_missing() {
+        // The WebView doesn't expose estimatedPlayoutTimestamp → permanently n/a.
+        assert_eq!(classify_playout(None, Some(1.75e12)), PlayoutClass::Absent);
+    }
+
+    #[test]
+    fn classify_playout_zero_is_not_a_real_timestamp() {
+        // The Some(0.0) gotcha: pre-first-SR literal 0 must NOT read as valid.
+        assert_eq!(classify_playout(Some(0.0), Some(1.75e12)), PlayoutClass::Zero);
+    }
+
+    #[test]
+    fn classify_playout_nonfinite_is_unusable() {
+        assert_eq!(
+            classify_playout(Some(f64::NAN), Some(1.75e12)),
+            PlayoutClass::NonFinite
+        );
+    }
+
+    #[test]
+    fn classify_playout_valid_when_in_report_epoch() {
+        // Playout leads the report by the buffer depth (tens of ms) → same domain.
+        let report = 1_750_000_000_000.0;
+        assert_eq!(
+            classify_playout(Some(report + 80.0), Some(report)),
+            PlayoutClass::ValidUnixEpoch
+        );
+    }
+
+    #[test]
+    fn classify_playout_other_domain_when_far_from_report_or_no_report() {
+        let report = 1_750_000_000_000.0;
+        // A tiny monotonic-ms value is finite+nonzero but a different domain.
+        assert_eq!(
+            classify_playout(Some(1000.0), Some(report)),
+            PlayoutClass::ValidOtherDomain
+        );
+        // No report to compare against → domain unconfirmable.
+        assert_eq!(
+            classify_playout(Some(report), None),
+            PlayoutClass::ValidOtherDomain
+        );
     }
 
     #[tokio::test]

--- a/crates/presenter-server/src/router/integrations/ndi.rs
+++ b/crates/presenter-server/src/router/integrations/ndi.rs
@@ -129,6 +129,21 @@ pub(crate) struct NdiClientStatsBeacon {
     /// (#379). The standard WASM stage never sets it, so it is always absent
     /// (`None`); retained for backward-compatible beacon parsing.
     pub lite: Option<bool>,
+    /// (#509 T0 probe) `estimatedPlayoutTimestamp` from the SAME inbound-rtp
+    /// getStats snapshot — the field T4's true server→display metric would read.
+    /// `null` = the WebView doesn't expose it (metric permanently n/a there);
+    /// `0.0` = present but pre-first-SR (must not be read as a real timestamp).
+    /// Logged raw every beacon so advancement across consecutive beacons is
+    /// readable server-side; also classified via `classify_playout`.
+    pub estimated_playout_timestamp: Option<f64>,
+    /// (#509 T0 probe) The inbound-rtp stat's OWN Unix-epoch `.timestamp` (ms)
+    /// from the same snapshot — the epoch reference `estimatedPlayoutTimestamp`
+    /// is checked against to prove it shares the Unix-epoch domain.
+    pub report_timestamp: Option<f64>,
+    /// (#509 T0 probe) Full browser `navigator.userAgent` — records the exact
+    /// WebView/Chrome version per real stage TV (SD1, Hyundai), which decides
+    /// whether the playout field is available on the devices that matter.
+    pub user_agent: Option<String>,
 }
 
 /// Classification of a display's `estimatedPlayoutTimestamp` for the #509 (T0)
@@ -180,9 +195,21 @@ pub(crate) fn classify_playout(
     estimated_playout_ms: Option<f64>,
     report_timestamp_ms: Option<f64>,
 ) -> PlayoutClass {
-    // RED stub — real classification lands in the [green] commit.
-    let _ = (estimated_playout_ms, report_timestamp_ms);
-    PlayoutClass::Absent
+    let Some(v) = estimated_playout_ms else {
+        return PlayoutClass::Absent;
+    };
+    if !v.is_finite() {
+        return PlayoutClass::NonFinite;
+    }
+    if v == 0.0 {
+        return PlayoutClass::Zero;
+    }
+    match report_timestamp_ms {
+        Some(r) if r.is_finite() && (v - r).abs() <= PLAYOUT_EPOCH_MATCH_WINDOW_MS => {
+            PlayoutClass::ValidUnixEpoch
+        }
+        _ => PlayoutClass::ValidOtherDomain,
+    }
 }
 
 /// Stage displays POST a compact getStats summary every 15s. Log-only (MVP):
@@ -190,6 +217,8 @@ pub(crate) fn classify_playout(
 /// answerable from data (fps, jitter buffer, freezes per display).
 #[instrument(skip_all)]
 pub(crate) async fn ndi_client_stats(Json(beacon): Json<NdiClientStatsBeacon>) -> StatusCode {
+    let playout_class =
+        classify_playout(beacon.estimated_playout_timestamp, beacon.report_timestamp).as_str();
     tracing::info!(
         display_id = beacon.display_id.as_deref(),
         source_id = %beacon.source_id,
@@ -216,6 +245,10 @@ pub(crate) async fn ndi_client_stats(Json(beacon): Json<NdiClientStatsBeacon>) -
         total_freezes_duration = beacon.total_freezes_duration,
         key_frames_decoded = beacon.key_frames_decoded,
         lite = beacon.lite,
+        estimated_playout_timestamp = beacon.estimated_playout_timestamp,
+        report_timestamp = beacon.report_timestamp,
+        playout_class,
+        user_agent = beacon.user_agent.as_deref(),
         "NDI stage-display client stats beacon"
     );
     StatusCode::NO_CONTENT
@@ -274,6 +307,40 @@ mod tests {
     }
 
     #[test]
+    fn client_stats_beacon_parses_t0_probe_fields() {
+        // #509 T0: the device-capability probe fields the stage now sends.
+        let beacon: NdiClientStatsBeacon = serde_json::from_str(
+            r#"{
+                "sourceId":"src-1",
+                "estimatedPlayoutTimestamp":1750000000080.0,
+                "reportTimestamp":1750000000000.0,
+                "userAgent":"Mozilla/5.0 (Linux; Android 11; SmartTV) Chrome/90"
+            }"#,
+        )
+        .expect("beacon JSON with T0 probe fields parses");
+        assert_eq!(
+            beacon.estimated_playout_timestamp,
+            Some(1_750_000_000_080.0)
+        );
+        assert_eq!(beacon.report_timestamp, Some(1_750_000_000_000.0));
+        assert_eq!(
+            beacon.user_agent.as_deref(),
+            Some("Mozilla/5.0 (Linux; Android 11; SmartTV) Chrome/90")
+        );
+        // A literal 0 playout (pre-first-SR) must round-trip as Some(0.0), not None.
+        let zero: NdiClientStatsBeacon =
+            serde_json::from_str(r#"{"sourceId":"src-1","estimatedPlayoutTimestamp":0.0}"#)
+                .expect("beacon with zero playout parses");
+        assert_eq!(zero.estimated_playout_timestamp, Some(0.0));
+        // Older clients omit them → all optional.
+        let bare: NdiClientStatsBeacon =
+            serde_json::from_str(r#"{"sourceId":"src-1"}"#).expect("bare beacon parses");
+        assert_eq!(bare.estimated_playout_timestamp, None);
+        assert_eq!(bare.report_timestamp, None);
+        assert_eq!(bare.user_agent, None);
+    }
+
+    #[test]
     fn classify_playout_absent_when_field_missing() {
         // The WebView doesn't expose estimatedPlayoutTimestamp → permanently n/a.
         assert_eq!(classify_playout(None, Some(1.75e12)), PlayoutClass::Absent);
@@ -282,7 +349,10 @@ mod tests {
     #[test]
     fn classify_playout_zero_is_not_a_real_timestamp() {
         // The Some(0.0) gotcha: pre-first-SR literal 0 must NOT read as valid.
-        assert_eq!(classify_playout(Some(0.0), Some(1.75e12)), PlayoutClass::Zero);
+        assert_eq!(
+            classify_playout(Some(0.0), Some(1.75e12)),
+            PlayoutClass::Zero
+        );
     }
 
     #[test]

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.177"
+version = "0.4.179"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -98,6 +98,12 @@ async fn post_client_stats(
     let mut freeze_count = JsValue::NULL;
     let mut frames_dropped = JsValue::NULL;
     let mut codec_id = JsValue::NULL;
+    // #509 (T0) device-capability probe: the field T4's true server→display
+    // metric would read, plus the inbound-rtp report's OWN Unix-epoch timestamp
+    // from the SAME snapshot (the epoch reference the playout value is checked
+    // against server-side via `classify_playout`).
+    let mut estimated_playout = JsValue::NULL;
+    let mut report_ts = JsValue::NULL;
 
     let map: &js_sys::Map = report.unchecked_ref();
     let entries = js_sys::try_iter(&map.values()).ok().flatten();
@@ -116,6 +122,11 @@ async fn post_client_stats(
                 freeze_count = get("freezeCount");
                 frames_dropped = get("framesDropped");
                 codec_id = get("codecId");
+                // Read from the same inbound-rtp snapshot: absent → undefined →
+                // `as_f64()` None → null on the wire; a literal 0 → Some(0.0)
+                // (the pre-first-SR gotcha), distinguished server-side.
+                estimated_playout = get("estimatedPlayoutTimestamp");
+                report_ts = get("timestamp");
             }
         }
     }
@@ -127,6 +138,12 @@ async fn post_client_stats(
         .map(|id| map.get(&JsValue::from_str(&id)))
         .and_then(|entry| js_sys::Reflect::get(&entry, &JsValue::from_str("mimeType")).ok())
         .and_then(|v| v.as_string());
+
+    // #509 (T0): full userAgent — the exact WebView/Chrome version per real
+    // stage TV, which decides whether the playout field is available there.
+    let user_agent = leptos::web_sys::window()
+        .map(|w| w.navigator())
+        .and_then(|n| n.user_agent().ok());
 
     // Physical screen size, for telling TV models apart in the logs.
     let screen = leptos::web_sys::window()
@@ -163,6 +180,10 @@ async fn post_client_stats(
         "maxPresentGapMs": max_present_gap_ms,
         "presentGapsOver100": present_gaps_over100,
         "presentedFps": presented_fps,
+        // #509 (T0) device-capability probe fields.
+        "estimatedPlayoutTimestamp": estimated_playout.as_f64(),
+        "reportTimestamp": report_ts.as_f64(),
+        "userAgent": user_agent,
     })
     .to_string();
 

--- a/docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md
+++ b/docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md
@@ -1,0 +1,222 @@
+# NDI Stage-Display TRUE Latency — Analysis & Design
+
+> **Status:** Reviewed (5-lens adversarial review applied) — ready to file as tickets
+> **Date:** 2026-06-30
+> **Context:** The stage display shows a "video · N ms" latency that does not reflect reality
+> (Tailscale-from-home read the *lowest* 23 ms; a weak Hyundai TV read lower than the powerful
+> SD1). This doc explains why, and designs a trustworthy replacement.
+
+---
+
+## 1. The bug — what the current number actually measures
+
+`crates/presenter-ui/src/components/stage/ndi_frame_stats.rs:121` (feature #479) computes:
+
+```
+latency = expectedDisplayTime − receiveTime        (WebRTC requestVideoFrameCallback metadata)
+```
+
+- `receiveTime` = when the frame's **last RTP packet already arrived** in the browser.
+- `expectedDisplayTime` = when the browser plans to paint it.
+
+So it is a **browser-local residual** (jitter-buffer + decode + present) measured *after* the packet
+lands. It contains **no network transit and no sender/encode time.** Consequences that match the
+user's observations exactly:
+
+- **Tailscale-from-home = 23 ms (lowest):** WAN transit is spent *before* `receiveTime`, so it is
+  invisible. 23 ms is just local paint delay.
+- **Weak Hyundai < powerful SD1:** the value is set by each WebView's frame scheduler + buffer
+  depth, not real lag. A cheap TV can report a smaller *residual* while being laggier.
+- **"Lags/jumps after a while":** real — but this metric cannot see it, **and (see §3) it may live
+  upstream of where this metric measures at all.**
+
+User decision (this session): **make the number truthful** — a false number is worse than none.
+
+---
+
+## 2. Infrastructure — the network's time sync (dantesync)
+
+- **dantesync** (`github.com/zbynekdrlik/dantesync`, v1.8.17) = custom Rust daemon: PTPv1 (Dante
+  grandmaster) for *frequency* + NTP (strih.lan) for *UTC phase*. Target precision **< 50 µs**.
+- **strih.lan (10.77.9.202)** = the network NTP master, locked to the Dante PTP grandmaster. All
+  clients point NTP at it.
+- **Install** (Linux): `curl -sSL …/install.sh | sudo bash` — disables chrony/timesyncd, installs a
+  FIFO systemd service. **Targets: Linux + Windows x86_64 only.**
+- Presenter prod (10.77.9.205) + dev (10.77.8.134) are **not** in dantesync `TARGETS.md` / not
+  installed.
+
+### Android TV reality (SD1, Hyundai) — cannot be grandmaster-synced
+
+- No Android/ARM build; Android forbids user-space NTP override + `settimeofday`; PTP unavailable.
+- The TV **has** a clock (Android auto-time, ±tens-of-ms…seconds, drifts) — just not disciplinable.
+- **The design must not trust the TV's absolute clock** (handled in §3 via the offset handshake).
+
+### Mikrotik NTP redirect — the only Android-friendly path to point the TVs at our grandmaster
+
+dantesync cannot run on the TV, but the **router can transparently redirect the TV's own NTP
+traffic to strih.lan** so the TV syncs against our grandmaster-disciplined master instead of Google:
+
+- **DST-NAT UDP/123 → 10.77.9.202** on the Mikrotik, scoped to the stage-TV IPs
+  (`chain=dstnat protocol=udp dst-port=123 src-address-list=stage_tvs action=dst-nat
+  to-addresses=10.77.9.202`). Hostname/DNS-agnostic — works no matter which NTP server the TV is
+  configured for. **Preferred** over a DNS override of `time.android.com` (Android can hardcode an IP
+  or use its own resolver, so DNS override is fragile unless you also DNAT :53).
+- **What it buys:** the TV gets *roughly* correct UTC from our grandmaster (good for logs, TLS,
+  scheduling, and a smaller app-layer offset). **What it does NOT buy:** grandmaster precision —
+  Android's SNTP is a coarse one-shot client (syncs ~daily, then free-runs on the crystal → ±tens of
+  ms right after a sync, drifting toward ±seconds before the next; it *steps*, not slews). That is the
+  **same order of magnitude as the latency we measure**, so it **cannot replace the §3 app-layer
+  offset handshake** (which is continuous + precise). It is a worthwhile **complementary** infra
+  improvement and the right tool for the user's broader "all devices on the grandmaster" goal — filed
+  as **T8** — but the latency metric (T3/T4) does **not** depend on it.
+
+---
+
+## 3. The measurement — robust to an unsynced TV
+
+### Formula (corrected)
+
+```
+latency_ms = (report.timestamp + offset_browser→serverPipelineClock) − estimatedPlayoutTimestamp
+```
+
+- **`report.timestamp`** = the inbound-rtp stat's **own** timestamp, read from the **same
+  `getStats()` snapshot** as `estimatedPlayoutTimestamp`. **Not** a separate post-`await`
+  `Date.now()` — that injects the getStats-resolution latency (10–20 ms on a frozen TV WebView) as a
+  systematic always-positive bias.
+- **`estimatedPlayoutTimestamp`** (inbound-rtp) = playout point of the currently-shown frame, derived
+  by Chrome from RTCP Sender Reports. Stock `webrtcbin` sends SRs by default. **No custom GStreamer
+  code; getStats path since Chrome M70.** SR cadence ~0.5–5 s → the term *steps* at each SR (must be
+  smoothed — see below).
+- **`offset_browser→serverPipelineClock`** = a periodic NTP-style round-trip to a new **`/ndi/time`**
+  endpoint that returns the server's **GStreamer pipeline-clock** time — *the exact clock the RTCP SR
+  encodes* — **not** `SystemTime::now()`. This is the decisive unifier: both terms of the subtraction
+  then live in **one clock domain** (the server pipeline clock), so the monotonic-vs-wall and
+  NTP-1900-vs-Unix-1970 epoch differences are **absorbed into the offset constant**.
+
+### Why this drops dantesync + wall-clock anchoring off the critical path
+
+Because `/ndi/time` serves the **same** clock domain the SR uses, the latency is a difference *within
+one domain* — the server clock's absolute value cancels. So the working metric needs **no** absolute
+sync: **the MVP (T3 + T4) ships on today's clock config.** dantesync (T1) and the disciplined-clock
+swap (T2) become *enhancements*, not preconditions.
+
+### The TV-sync cancellation — and its limit
+
+The TV's absolute clock error cancels because the offset is measured browser↔server. **But the
+cancellation is only as good as RTT *symmetry*:** the offset is biased by `RTT-asymmetry / 2`.
+Median filtering removes *jitter*, not a *stable* one-leg-longer bias. Therefore:
+
+- Prefer **min-RTT** sample selection (least-queued round trip ≈ most symmetric), with a median over
+  the low-RTT samples.
+- **Reject** high-RTT samples; **age out** a stale offset → `n/a`.
+- Drive the handshake from the **rVFC callback, not `setInterval`** — TV WebViews throttle
+  background/idle timers (the codebase already abandoned `setInterval` for this reason).
+- **Tailscale caveat:** subnet-route traffic to 10.77.x can hairpin via a DERP relay with
+  loss/asymmetry (project memory `project_cloudflare_turn.md`) → offset bias of *tens* of ms. Over
+  WAN the number is **low-confidence**, not exact — flag it, never present it as precise.
+
+### Trust predicate (concrete) — never a plausible-but-wrong number
+
+Show a number **only** when ALL hold; otherwise **`n/a`**:
+
+1. `estimatedPlayoutTimestamp` present + finite + **non-zero** + in a sane range + **strictly
+   advancing** across N samples (it is 0/absent until the first SR; `Reflect::get(...).as_f64()`
+   returns `Some(0.0)` for a literal 0 — a naive check surfaces a bogus huge latency in the first
+   seconds);
+2. offset **fresh** (age + RTT under bounds) from ≥1 successful `/ndi/time` round-trip;
+3. ≥1 RTCP SR observed;
+4. offset **dispersion** under a bound (degraded WAN → `n/a` / low-confidence).
+
+Negative handling (replace the current blanket clamp-to-0 in `derive_video_latency_ms`): small
+negative within budget → `0` / "<N ms"; large or persistent negative → **`n/a` + log** (a sign/domain
+regression must surface, not be hidden).
+
+### Smoothing
+
+Smooth the **final** latency (EMA/median over a multi-second window) — not only the offset — so the
+SR-step in `estimatedPlayoutTimestamp` doesn't sawtooth the readout (the reused `smooth_latency` EMA
+helper). Hold the last good value across the first SR-less window; show `n/a` only before the first SR.
+
+### Server clock anchoring (T2 — enhancement, NOT `ntp-time-source=ntp`)
+
+Today `build.rs:49-62` pins the **monotonic** `SystemClock` and `consumers.rs:~720` sets `rtpbin
+ntp-time-source=clock-time` — **deliberately**, to stop a ~400 ms render pause every ~20 s on all TVs
+at once. **Do NOT set `ntp-time-source=ntp`** (it makes RTP(monotonic) and SR-NTP(realtime) drift; a
+dantesync-disciplined `CLOCK_REALTIME` makes that drift *worse*). Instead, *if* a human-readable
+wall-clock value is wanted, **replace the pipeline clock** with a disciplined `gstreamer_net::NtpClock`
+(→strih.lan) or `PtpClock`, force-pinned via `use_clock()` (so `ndisrc` slaving stays off), **keeping
+`ntp-time-source=clock-time`** so RTP and SR-NTP stay on ONE clock. Ship with a regression guard
+asserting the ~400 ms/~20 s "naraz" hitch does not return. `gstreamer-net 0.25.0` is already in
+Cargo.lock.
+
+### GStreamer abs-capture-time (T6 — stretch)
+
+GStreamer ships **no** `abs-capture-time` extension (only RFC-6051 `rtphdrextntp64`, which Chrome
+**ignores** for `captureTimestamp`). The high-fidelity `getSynchronizationSources().captureTimestamp`
+path needs a **full custom `GstRTPHeaderExtension` subclass** (NTP-64 wire read/write +
+`set_attributes`/`set_caps_from_attributes`) **plus SDP `extmap` negotiation** via webrtcbin — not a
+single `add-extension` call. It depends on T2 (the value must be wall-clock NTP from the disciplined
+clock), is feature-detected, and is **strictly additive — must never override** the
+`estimatedPlayoutTimestamp`/`n/a` fallback (almost certainly absent on frozen Android-11 WebViews).
+
+### Scope honesty — what this is, and is NOT
+
+- It measures **server → display** (network + jitter buffer + decode + present). The
+  **camera → NDI → server** hop is **not** included; only the synthetic CI clock-strip measures full
+  glass-to-glass. UI label: **"server→displej"**, never "glass-to-glass".
+- It is a **video** latency diagnostic, **NOT a lip-sync meter** — it carries no audio-path
+  information, so it cannot by itself tell the user whether lips match sound. §5 must not over-promise.
+- The recurring "lags/jumps after a while" may live in the **unmeasured NDI ingest** hop — T0 must
+  locate it before T4 trusts a server→display number to explain it.
+
+---
+
+## 4. Ticket decomposition (corrected backlog)
+
+| # | Title | Repo | Depends | Bundle-safe |
+|---|---|---|---|---|
+| **T0** | Device-capability + lag-location probe (gates T4) | presenter | — | no |
+| **T1** | Deploy dantesync to presenter prod + dev (off critical path) | dantesync | — | no |
+| **T8** | Mikrotik: DST-NAT TV NTP → strih.lan (Android-friendly grandmaster sync) | dantesync/infra | — | no |
+| **T2** | Replace pipeline clock with a disciplined network clock (enhancement) | presenter | T1 | no |
+| **T3** | `/ndi/time` (pipeline-clock) endpoint + browser offset estimator | presenter | — | no |
+| **T4** | True server→display metric + honest display + docs/ADR | presenter | T0, T3 | no |
+| **T6** | (Stretch) `abs-capture-time` `GstRTPHeaderExtension` + `captureTimestamp` | presenter | T2, T4 | no |
+| **T7** | Extend `/ndi/client-stats` beacon with latency + offset + RTT | presenter | T3, T4 | yes (fold into T4 unless over ceiling) |
+
+- **T0 is the mandatory first work item.** Prove on the real SD1 + Hyundai WebViews that
+  `estimatedPlayoutTimestamp` is present/finite/advancing/in-epoch (vs the report's own Unix-epoch
+  `.timestamp`), via the existing `/ndi/client-stats` beacon; AND add server-side NDI receive-time
+  logging to locate whether the drift is server→display or upstream. The metric is defined **only**
+  on fields the real devices prove correct.
+- **No standalone tests ticket.** Tests ship with the code they cover (TDD / regression-test-first /
+  single-feature-single-PR): clock-strip-agreement + n/a-never-fake + Tailscale-≥-LAN + non-negative
+  E2E → **T4**; estimator min-RTT/median/age-out unit tests → **T3**; the ~400 ms/~20 s hitch
+  regression guard → **T2**.
+- **Docs are a T4 deliverable** (the metric's user-visible semantics change + a new route/env):
+  `docs/architecture.md` metric section + `docs/adr/NNNN-ndi-true-latency.md` + `CLAUDE.md` notes.
+
+### Quality-gate landmines (re-measured)
+
+- `consumers.rs` = **842** prod lines (cap 1000) **and** `build_consumer_pipeline_blocking` =
+  **115/120** lines (fn cap, not exempt) → T2/T6 clock edits must go in a **helper / new
+  `pipeline/timestamp.rs`**, never grow that function.
+- `ndi_frame_stats.rs` = **570** (not 431), server `ndi.rs` = **251** (not 169), `status_bar.rs` =
+  156 — all under the file cap; T4's new logic lands in a **new presenter-ui module** to keep the diff
+  clean and files under cap.
+
+---
+
+## 5. Acceptance — does it answer the complaint?
+
+- The number rises with real network/buffer/decode delay and **changes correctly** LAN vs Tailscale
+  and across device decode speed — locked by a **regression invariant**: for the same stream the
+  Tailscale reading must **never** be lower than the LAN reading, and the LAN clock-strip path must
+  assert it is **non-negative**.
+- It is **honest**: labelled server→display, shows `n/a` (not a lie) when the trust predicate fails,
+  and is presented as a **video diagnostic, not a lip-sync guarantee**. The old residual is
+  demoted to a debug-only overlay (accurately labelled), never a second headline number.
+- It is **validated** against the clock-strip ground truth in CI.
+- T0 first answers the open question — whether the metric even works on the real TVs, and where the
+  "lags after a while" actually lives — before T4 builds the headline number on it.


### PR DESCRIPTION
## What & why

**T0** of the NDI true-latency design (`docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md`) — a read-only **device-capability + lag-location probe** that GATES the true server→display metric (T4). It answers two questions before T4 builds a headline number:

1. **Does the metric even work on the real stage TVs?** — is `estimatedPlayoutTimestamp` present / finite / non-zero / advancing / in the Unix-epoch domain on the frozen Android-11 WebViews (SD1, Hyundai)? If it's `0`/absent/static there, any metric is permanently `n/a` on the very TVs that matter (repeating #479).
2. **Where does the "lags/jumps after a while" actually live** — upstream `camera→NDI→server`, or downstream `server→display`?

## Changes (all under the file/fn caps; `consumers.rs` untouched)

- **Client beacon** (`presenter-ui/.../ndi_beacon.rs`): harvest from the SAME inbound-rtp getStats snapshot the field T4 would read — `estimatedPlayoutTimestamp` + the report's own Unix-epoch `.timestamp` — plus `navigator.userAgent` (exact WebView/Chrome version per TV). Absent → `null`; literal `0` → `Some(0.0)` preserved on the wire (the pre-first-SR gotcha).
- **Server beacon** (`presenter-server/.../ndi.rs`): parse + log the three fields and `classify_playout()` the device capability (`absent` / `zero` / `nonfinite` / `valid-unix-epoch` / `valid-other-domain`) so "which fields are trustworthy on the real devices" is answerable from journald. Advancement is read across consecutive beacons (same pattern as the existing DIAG counters).
- **Server ingest probe** (`presenter-ndi/pipeline/ingest_timing.rs`, NEW): read-only pad probe on the raw NDI frames (PTS = receive-time) logging arrival cadence every 5 s (fps / max inter-arrival gap / gaps>100 ms). A smooth cadence here proves the drift is downstream (server→display); jumpy ingest localizes it upstream (camera→NDI→server). Wired on the videoconvert sink pad in `build.rs`.

## Tests (TDD, RED→GREEN)

- `IngestTimingAccumulator` — steady-30fps cadence, large-gap flag, no-PTS counting.
- `classify_playout` — absent / zero(`Some(0.0)`) / nonfinite / valid-unix / other-domain.
- Beacon wire-contract test for the three new fields (incl. `0.0` round-trip + all-optional).

## Findings
Recorded as a comment on #509 and in `docs/autopilot-log.md` after the deploy verification.

Closes #509
