### PR TITLE
NDI latency T3: /ndi/time pipeline-clock endpoint + browser offset estimator (#510)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.179"
+version = "0.4.180"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/clock.rs
+++ b/crates/presenter-ndi/src/clock.rs
@@ -1,0 +1,52 @@
+//! Pipeline-clock time exposure for the `/ndi/time` HTTP endpoint (#510, T3
+//! of the NDI true-latency rework —
+//! `docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md` §3).
+//!
+//! Every encoder pipeline is pinned to `gst::SystemClock::obtain()`
+//! (`pipeline/build.rs`) and every consumer pipeline shares that SAME clock
+//! instance (`pipeline/consumers.rs`). `rtpbin`'s `ntp-time-source` is set to
+//! `clock-time`, so the RTCP Sender Reports encode this exact clock's raw
+//! value — NOT `SystemTime::now()` wall-clock, NOT an NTP-disciplined time.
+//! `pipeline_clock_now_ms()` reads that SAME process-wide clock singleton, so
+//! a browser's NTP-style round trip against `/ndi/time` yields an offset in
+//! the SAME domain the SR timestamps live in — no absolute wall-clock sync
+//! required for the offset to be meaningful (design §3 "why this drops
+//! dantesync off the critical path").
+
+use anyhow::Result;
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+/// Current server pipeline-clock time, in milliseconds, as an `f64` (matching
+/// the browser's `performance.now()` / `DOMHighResTimeStamp` scale so the two
+/// are directly comparable in an NTP-style round-trip calculation).
+///
+/// Calls `presenter_ndi::init()` first (idempotent, cheap after the first
+/// process-wide call — see `lib.rs`) so this works even before any NDI
+/// pipeline has ever been built: `gst::SystemClock::obtain()` requires
+/// `gstreamer::init()` to have run at least once, but needs no pipeline, no
+/// encoder, and no NDI source to return a valid, monotonically advancing time.
+pub fn pipeline_clock_now_ms() -> Result<f64> {
+    crate::init()?;
+    let clock = gst::SystemClock::obtain();
+    Ok(clock.time().nseconds() as f64 / 1_000_000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_clock_now_ms_is_finite_and_monotonic() {
+        let t1 = pipeline_clock_now_ms().expect("first pipeline clock read");
+        assert!(
+            t1.is_finite() && t1 >= 0.0,
+            "pipeline clock must be a finite, non-negative ms value, got {t1}"
+        );
+        let t2 = pipeline_clock_now_ms().expect("second pipeline clock read");
+        assert!(
+            t2 >= t1,
+            "pipeline clock must never go backwards: t1={t1} t2={t2}"
+        );
+    }
+}

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+pub mod clock;
 pub mod discovery;
 pub mod manager;
 pub mod ndi_sdk;
@@ -8,6 +9,7 @@ pub mod pipeline;
 pub mod test_strip;
 pub mod whep_session;
 
+pub use clock::pipeline_clock_now_ms;
 pub use discovery::SourceList;
 pub use manager::NdiManager;
 pub use manager::PipelineStartError;

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -244,6 +244,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ndi/sources", get(integrations::ndi::discover_ndi_sources))
         .route("/ndi/status", get(integrations::ndi::ndi_status))
         .route("/ndi/ice-servers", get(integrations::ndi::ndi_ice_servers))
+        .route("/ndi/time", get(integrations::ndi::ndi_time))
         .route(
             "/ndi/client-stats",
             post(integrations::ndi::ndi_client_stats),

--- a/crates/presenter-server/src/router/integrations/ndi.rs
+++ b/crates/presenter-server/src/router/integrations/ndi.rs
@@ -33,6 +33,37 @@ pub(crate) async fn ndi_status(State(state): State<AppState>) -> Json<serde_json
     Json(serde_json::json!({ "available": state.ndi_manager().is_some() }))
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NdiTimeDto {
+    /// The server's GStreamer PIPELINE-CLOCK time, in milliseconds — NOT
+    /// `SystemTime::now()` wall-clock. See the `ndi_time` doc below.
+    server_time_ms: f64,
+}
+
+/// `GET /ndi/time` (#510, T3 of the NDI true-latency rework) — returns the
+/// server's GStreamer **pipeline-clock** time, the EXACT clock domain the
+/// RTCP Sender Reports encode (`rtpbin ntp-time-source=clock-time`, set in
+/// `consumers.rs`). The browser's clock-offset estimator
+/// (`presenter-ui`'s `ndi_clock_offset` module) does a periodic NTP-style
+/// round trip against this route to compute
+/// `offset_browser→serverPipelineClock`: since both this endpoint and the SR
+/// live in the SAME clock domain, a later metric (#512, T4) can convert
+/// `estimatedPlayoutTimestamp` into that domain without needing an absolute
+/// wall-clock sync (dantesync) on the critical path. See
+/// `docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md` §3.
+///
+/// Deliberately does NOT require an active NDI source/pipeline —
+/// `gst::SystemClock::obtain()` is a process-wide singleton valid as soon as
+/// `gstreamer::init()` has run once (idempotent, lazily triggered here on the
+/// first call if no NDI pipeline has started yet).
+#[instrument(skip_all)]
+pub(crate) async fn ndi_time() -> Result<Json<NdiTimeDto>, AppError> {
+    let server_time_ms = presenter_ndi::pipeline_clock_now_ms()
+        .map_err(|e| AppError::service_unavailable(format!("pipeline clock unavailable: {e}")))?;
+    Ok(Json(NdiTimeDto { server_time_ms }))
+}
+
 /// `GET /ndi/ice-servers` (#502) — returns the browser-ready WebRTC ICE
 /// servers (Cloudflare Realtime TURN). The browser sets these on its
 /// `RTCPeerConnection` so a relay candidate exists when the direct LAN path is
@@ -385,6 +416,26 @@ mod tests {
         assert_eq!(
             classify_playout(Some(report), None),
             PlayoutClass::ValidOtherDomain
+        );
+    }
+
+    #[tokio::test]
+    async fn ndi_time_returns_finite_monotonic_pipeline_clock() {
+        // #510 T3: the offset estimator's NTP-style round trip depends on
+        // /ndi/time returning a sane, ADVANCING value — a stuck or garbage
+        // clock would silently poison every downstream offset sample.
+        let Json(first) = ndi_time().await.expect("first /ndi/time call");
+        assert!(
+            first.server_time_ms.is_finite() && first.server_time_ms >= 0.0,
+            "expected a finite, non-negative pipeline-clock ms value, got {}",
+            first.server_time_ms
+        );
+        let Json(second) = ndi_time().await.expect("second /ndi/time call");
+        assert!(
+            second.server_time_ms >= first.server_time_ms,
+            "pipeline clock must never go backwards: first={} second={}",
+            first.server_time_ms,
+            second.server_time_ms
         );
     }
 

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.179"
+version = "0.4.180"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/mod.rs
+++ b/crates/presenter-ui/src/components/stage/mod.rs
@@ -3,6 +3,7 @@ pub mod bible_layout;
 pub mod bible_overlay;
 pub mod camera_crew;
 mod ndi_beacon;
+mod ndi_clock_offset;
 mod ndi_frame_stats;
 pub mod ndi_fullscreen;
 mod ndi_health_ticker;

--- a/crates/presenter-ui/src/components/stage/ndi_clock_offset.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_clock_offset.rs
@@ -1,0 +1,406 @@
+//! Browser↔server pipeline-clock offset estimator (#510, T3 of the NDI
+//! true-latency rework —
+//! `docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md` §3).
+//!
+//! Periodic NTP-style round trip against `/ndi/time` (the server's
+//! GStreamer pipeline-clock time — the SAME clock domain the RTCP Sender
+//! Reports encode), so a later ticket (#512, T4) can convert a getStats
+//! `report.timestamp` reading into that domain and subtract
+//! `estimatedPlayoutTimestamp` directly, without needing an absolute
+//! wall-clock sync (dantesync) on the critical path.
+//!
+//! Driven by the rVFC callback, NOT `setInterval` — TV WebViews throttle
+//! background/idle timers (the codebase already abandoned `setInterval` for
+//! this reason in `ndi_frame_stats.rs`). `t0`/`t2` use `now_ms()`
+//! (`performance.now()`), the SAME domain WebRTC's `RTCStats.timestamp`
+//! (read as `report.timestamp` in `ndi_beacon.rs`) lives in — so the offset
+//! this estimator produces is directly addable to a `report.timestamp`
+//! reading.
+//!
+//! Split into its own module (not folded into `ndi_frame_stats.rs`, already
+//! 570 lines) per the design's quality-gate note.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
+use leptos::web_sys::{HtmlVideoElement, Response};
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+
+use super::ndi_frame_stats::{
+    schedule_video_frame_callback, video_supports_rvfc, SharedRvfcClosure,
+};
+use super::ndi_watchdog::now_ms;
+
+/// How often to attempt a fresh NTP-style round trip (ms). Evaluated on the
+/// rVFC tick, so actual cadence drifts a little with the presented fps —
+/// close enough for a metric measured in single-digit-to-tens of ms.
+const HANDSHAKE_PERIOD_MS: f64 = 2000.0;
+
+/// Reject a round-trip sample whose RTT exceeds this. A queued/slow round
+/// trip biases the offset by up to `RTT-asymmetry / 2` (design §3) — a
+/// multi-second RTT is not a network we should trust for a ms-scale offset.
+const MAX_ACCEPTABLE_RTT_MS: f64 = 1000.0;
+
+/// Bounded sample history — old samples are stale anyway once a fresher,
+/// lower-RTT one has landed.
+const MAX_SAMPLES: usize = 8;
+
+/// An offset estimate is STALE (report `n/a` via `current()`) once this long
+/// has passed since the last ACCEPTED sample — a confidently-wrong number
+/// during a WAN/Tailscale hiccup is worse than no number (design §3 trust
+/// predicate).
+const STALE_AFTER_MS: f64 = 15_000.0;
+
+/// Callback that publishes the current `(offset_ms, rtt_ms)` estimate (or
+/// `None` when no fresh sample exists) to a shared signal. Boxed behind `Rc`
+/// so it threads cheaply from `NdiVideo` through `Watchdog::install`, mirroring
+/// `VideoLatencySetter` / `FramesLiveSetter` in `ndi_frame_stats.rs`.
+pub(crate) type ClockOffsetSetter = Rc<dyn Fn(Option<(f64, f64)>)>;
+
+/// One NTP-style round-trip sample.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct OffsetSample {
+    /// `server_time_ms − midpoint(t0, t2)` — the browser→server-pipeline-clock
+    /// offset this sample implies.
+    pub(crate) offset_ms: f64,
+    /// `t2 − t0` — total round-trip time for this sample.
+    pub(crate) rtt_ms: f64,
+    /// `now_ms()` this sample was accepted (== `t2`), for staleness/age-out.
+    pub(crate) at_ms: f64,
+}
+
+/// Compute one NTP-style sample from a round trip: `t0_ms` = browser clock
+/// just before sending, `server_ms` = the server's pipeline-clock time
+/// returned by `/ndi/time`, `t2_ms` = browser clock just after the response
+/// arrived. Assumes symmetric transit (the classic SNTP simplification) —
+/// the design's §3 documents the resulting `RTT-asymmetry/2` bias bound.
+pub(crate) fn compute_sample(t0_ms: f64, server_ms: f64, t2_ms: f64) -> OffsetSample {
+    OffsetSample {
+        offset_ms: server_ms - (t0_ms + t2_ms) / 2.0,
+        rtt_ms: t2_ms - t0_ms,
+        at_ms: t2_ms,
+    }
+}
+
+/// Select the best offset from a set of samples: prefer the LOWEST-RTT
+/// samples (least-queued round trip ≈ most symmetric, design §3), then take
+/// the MEDIAN of their offsets to remove jitter within that low-RTT set.
+/// Returns `None` when `samples` is empty or every sample exceeds
+/// `MAX_ACCEPTABLE_RTT_MS` (reject high-RTT — a degraded link must not
+/// produce a confident-looking number).
+pub(crate) fn select_offset(samples: &[OffsetSample]) -> Option<f64> {
+    let mut usable: Vec<&OffsetSample> = samples
+        .iter()
+        .filter(|s| s.rtt_ms.is_finite() && s.rtt_ms >= 0.0 && s.rtt_ms <= MAX_ACCEPTABLE_RTT_MS)
+        .collect();
+    if usable.is_empty() {
+        return None;
+    }
+    usable.sort_by(|a, b| a.rtt_ms.total_cmp(&b.rtt_ms));
+    let min_rtt = usable[0].rtt_ms;
+    // "low-RTT samples" = within 2x the best RTT seen this window — tight
+    // enough to reject a queued outlier, loose enough that a healthy LAN
+    // link (where every sample is already near-minimal) keeps most samples.
+    let low_rtt_cutoff = (min_rtt * 2.0).max(min_rtt + 1.0);
+    let mut low_rtt: Vec<f64> = usable
+        .iter()
+        .filter(|s| s.rtt_ms <= low_rtt_cutoff)
+        .map(|s| s.offset_ms)
+        .collect();
+    low_rtt.sort_by(f64::total_cmp);
+    let mid = low_rtt.len() / 2;
+    Some(if low_rtt.len() % 2 == 0 {
+        (low_rtt[mid - 1] + low_rtt[mid]) / 2.0
+    } else {
+        low_rtt[mid]
+    })
+}
+
+/// Is the most recent accepted sample too old to trust?
+pub(crate) fn is_stale(last_sample_at_ms: f64, now_ms: f64) -> bool {
+    now_ms - last_sample_at_ms > STALE_AFTER_MS
+}
+
+/// Shared, `Rc`-cloneable estimator state. One instance per active NDI WHEP
+/// connection, owned alongside `FrameStats` in `Watchdog::install`.
+pub(crate) struct ClockOffsetEstimator {
+    samples: RefCell<Vec<OffsetSample>>,
+    last_attempt_at_ms: Cell<f64>,
+    in_flight: Cell<bool>,
+}
+
+impl ClockOffsetEstimator {
+    pub(crate) fn new() -> Rc<Self> {
+        Rc::new(Self {
+            samples: RefCell::new(Vec::with_capacity(MAX_SAMPLES)),
+            last_attempt_at_ms: Cell::new(f64::NEG_INFINITY),
+            in_flight: Cell::new(false),
+        })
+    }
+
+    /// Current best `(offset_ms, rtt_ms)` estimate at `now_ms`, or `None`
+    /// when no sample has ever landed OR the freshest one has aged out.
+    /// Takes `now_ms` explicitly (rather than reading the DOM clock itself)
+    /// so this stays a pure, directly unit-testable function.
+    pub(crate) fn current_at(&self, now_ms: f64) -> Option<(f64, f64)> {
+        let samples = self.samples.borrow();
+        let newest_at = samples.last()?.at_ms;
+        if is_stale(newest_at, now_ms) {
+            return None;
+        }
+        let offset = select_offset(&samples)?;
+        // The reported RTT is the best (lowest) sample's own RTT — the most
+        // representative "how good is this measurement" figure.
+        let min_rtt = samples
+            .iter()
+            .map(|s| s.rtt_ms)
+            .fold(f64::INFINITY, f64::min);
+        Some((offset, min_rtt))
+    }
+
+    /// `current_at(now_ms())` — the DOM-clock-reading convenience wrapper
+    /// used by the live handshake loop.
+    pub(crate) fn current(&self) -> Option<(f64, f64)> {
+        self.current_at(now_ms())
+    }
+
+    fn push_sample(&self, sample: OffsetSample) {
+        let mut samples = self.samples.borrow_mut();
+        if samples.len() == MAX_SAMPLES {
+            samples.remove(0);
+        }
+        samples.push(sample);
+    }
+}
+
+/// One NTP-style round trip against `/ndi/time`. Fire-and-forget on failure —
+/// a dropped fetch just means no new sample this round; the estimator will
+/// retry on the next due handshake tick, and `current()` reports `n/a` once
+/// the existing samples age out.
+async fn round_trip(estimator: &Rc<ClockOffsetEstimator>) {
+    let t0 = now_ms();
+    let Some(window) = leptos::web_sys::window() else {
+        return;
+    };
+    let Ok(resp_value) = JsFuture::from(window.fetch_with_str("/ndi/time")).await else {
+        return;
+    };
+    let t2 = now_ms();
+    let Ok(response) = resp_value.dyn_into::<Response>() else {
+        return;
+    };
+    if !response.ok() {
+        return;
+    }
+    let Ok(json_promise) = response.json() else {
+        return;
+    };
+    let Ok(json) = JsFuture::from(json_promise).await else {
+        return;
+    };
+    let server_ms = js_sys::Reflect::get(&json, &JsValue::from_str("serverTimeMs"))
+        .ok()
+        .and_then(|v| v.as_f64());
+    let Some(server_ms) = server_ms else {
+        return;
+    };
+    estimator.push_sample(compute_sample(t0, server_ms, t2));
+}
+
+/// If a handshake is due and none is already in flight, fire one — and once
+/// it completes (success OR failure), publish the resulting `current()`
+/// estimate to `setter` so a run of failures eventually ages the reading out
+/// to `n/a` rather than leaving a stale number displayed forever.
+fn maybe_fire_handshake(estimator: &Rc<ClockOffsetEstimator>, setter: Option<ClockOffsetSetter>) {
+    if estimator.in_flight.get() {
+        return;
+    }
+    let now = now_ms();
+    if now - estimator.last_attempt_at_ms.get() < HANDSHAKE_PERIOD_MS {
+        return;
+    }
+    estimator.last_attempt_at_ms.set(now);
+    estimator.in_flight.set(true);
+    let estimator = Rc::clone(estimator);
+    spawn_local(async move {
+        round_trip(&estimator).await;
+        estimator.in_flight.set(false);
+        if let Some(setter) = setter {
+            setter(estimator.current());
+        }
+    });
+}
+
+/// Start a self-rescheduling rVFC-driven handshake loop on `video`. Ticks
+/// once per PRESENTED frame (never throttled like `setInterval` on TV
+/// WebViews — design §3) but only actually fires a round trip once per
+/// `HANDSHAKE_PERIOD_MS`; every other tick is a cheap no-op check.
+///
+/// Returns `false` when the browser lacks rVFC — same fallback boundary as
+/// `start_rvfc_frame_observer`; the estimator simply never runs there and
+/// `current()` stays `None` (`n/a`), which is honest per the trust predicate.
+pub(crate) fn start(
+    video: &HtmlVideoElement,
+    active: &Rc<Cell<bool>>,
+    estimator: &Rc<ClockOffsetEstimator>,
+    setter: Option<ClockOffsetSetter>,
+) -> bool {
+    if !video_supports_rvfc(video) {
+        return false;
+    }
+
+    let holder: SharedRvfcClosure = Rc::new(RefCell::new(None));
+    let cb = {
+        let active = Rc::clone(active);
+        let estimator = Rc::clone(estimator);
+        let video = video.clone();
+        let holder = Rc::clone(&holder);
+        Closure::<dyn FnMut(JsValue, JsValue)>::new(move |_now: JsValue, _meta: JsValue| {
+            if !active.get() {
+                return;
+            }
+            maybe_fire_handshake(&estimator, setter.clone());
+            schedule_video_frame_callback(&video, &holder);
+        })
+    };
+    *holder.borrow_mut() = Some(cb);
+    schedule_video_frame_callback(video, &holder);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_sample_symmetric_round_trip() {
+        // t0=1000, server=1050, t2=1010 -> offset = 1050 - (1000+1010)/2 = 45; rtt=10.
+        let s = compute_sample(1000.0, 1050.0, 1010.0);
+        assert_eq!(s.rtt_ms, 10.0);
+        assert!((s.offset_ms - 45.0).abs() < 1e-9);
+        assert_eq!(s.at_ms, 1010.0);
+    }
+
+    #[test]
+    fn select_offset_empty_is_none() {
+        assert_eq!(select_offset(&[]), None);
+    }
+
+    #[test]
+    fn select_offset_rejects_all_high_rtt() {
+        let samples = [OffsetSample {
+            offset_ms: 10.0,
+            rtt_ms: 5000.0,
+            at_ms: 0.0,
+        }];
+        assert_eq!(
+            select_offset(&samples),
+            None,
+            "every sample exceeds MAX_ACCEPTABLE_RTT_MS and must be rejected"
+        );
+    }
+
+    #[test]
+    fn select_offset_even_count_averages_middle_two() {
+        let samples = [
+            OffsetSample {
+                offset_ms: 10.0,
+                rtt_ms: 5.0,
+                at_ms: 0.0,
+            },
+            OffsetSample {
+                offset_ms: 20.0,
+                rtt_ms: 5.0,
+                at_ms: 0.0,
+            },
+        ];
+        assert_eq!(select_offset(&samples), Some(15.0));
+    }
+
+    #[test]
+    fn select_offset_prefers_min_rtt_median_and_excludes_far_outlier() {
+        // Three low-RTT samples (median wins) plus one high-RTT outlier whose
+        // wildly different offset must NOT pollute the result: low_rtt_cutoff
+        // = max(min_rtt*2, min_rtt+1) = max(10*2, 11) = 20, so the 40ms-RTT
+        // sample is excluded from the median even though it's under the
+        // absolute MAX_ACCEPTABLE_RTT_MS reject bound.
+        let samples = [
+            OffsetSample {
+                offset_ms: 100.0,
+                rtt_ms: 10.0,
+                at_ms: 0.0,
+            },
+            OffsetSample {
+                offset_ms: 105.0,
+                rtt_ms: 12.0,
+                at_ms: 0.0,
+            },
+            OffsetSample {
+                offset_ms: 102.0,
+                rtt_ms: 11.0,
+                at_ms: 0.0,
+            },
+            OffsetSample {
+                offset_ms: 500.0,
+                rtt_ms: 40.0,
+                at_ms: 0.0,
+            },
+        ];
+        assert_eq!(
+            select_offset(&samples),
+            Some(102.0),
+            "median of the 3 low-RTT samples; the high-RTT outlier must be excluded"
+        );
+    }
+
+    #[test]
+    fn is_stale_within_bound_is_fresh() {
+        assert!(!is_stale(1000.0, 1000.0 + STALE_AFTER_MS - 1.0));
+    }
+
+    #[test]
+    fn is_stale_past_bound_is_stale() {
+        assert!(is_stale(1000.0, 1000.0 + STALE_AFTER_MS + 1.0));
+    }
+
+    #[test]
+    fn estimator_current_at_none_before_any_sample() {
+        let estimator = ClockOffsetEstimator::new();
+        assert_eq!(estimator.current_at(0.0), None);
+    }
+
+    #[test]
+    fn estimator_current_at_reports_fresh_sample() {
+        let estimator = ClockOffsetEstimator::new();
+        estimator.push_sample(compute_sample(1000.0, 1050.0, 1010.0));
+        let (offset, rtt) = estimator
+            .current_at(1010.0)
+            .expect("a single fresh sample must be reported");
+        assert!((offset - 45.0).abs() < 1e-9);
+        assert_eq!(rtt, 10.0);
+    }
+
+    #[test]
+    fn estimator_current_at_none_once_stale() {
+        let estimator = ClockOffsetEstimator::new();
+        estimator.push_sample(compute_sample(1000.0, 1050.0, 1010.0));
+        // Ask "now" far enough past the sample's at_ms (1010.0) to be stale.
+        let far_future = 1010.0 + STALE_AFTER_MS + 1.0;
+        assert_eq!(
+            estimator.current_at(far_future),
+            None,
+            "an aged-out sample must report n/a, never a stale-but-confident number"
+        );
+    }
+
+    #[test]
+    fn estimator_push_sample_bounds_history_to_max_samples() {
+        let estimator = ClockOffsetEstimator::new();
+        for i in 0..(MAX_SAMPLES + 5) {
+            let t = i as f64 * 100.0;
+            estimator.push_sample(compute_sample(t, t + 10.0, t + 5.0));
+        }
+        assert_eq!(estimator.samples.borrow().len(), MAX_SAMPLES);
+    }
+}

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -332,8 +332,10 @@ pub(crate) fn snapshot_present_gaps(stats: &FrameStats) -> (f64, u32, Option<f64
 }
 
 /// Shared holder for the self-rescheduling rVFC closure (the closure needs a
-/// handle to itself to re-register for the next presented frame).
-type SharedRvfcClosure = Rc<RefCell<Option<Closure<dyn FnMut(JsValue, JsValue)>>>>;
+/// handle to itself to re-register for the next presented frame). `pub(crate)`
+/// so `ndi_clock_offset`'s independent rVFC-driven handshake loop (#510) can
+/// reuse the SAME scheduling idiom instead of duplicating it.
+pub(crate) type SharedRvfcClosure = Rc<RefCell<Option<Closure<dyn FnMut(JsValue, JsValue)>>>>;
 
 /// Start a self-rescheduling `requestVideoFrameCallback` loop on `video`,
 /// maintaining `stats.frames_presented` / `stats.last_frame_at`. rVFC fires
@@ -367,13 +369,7 @@ pub(crate) fn start_rvfc_frame_observer(
     video_latency_setter: Option<VideoLatencySetter>,
     frames_live_setter: Option<FramesLiveSetter>,
 ) -> bool {
-    let supported = js_sys::Reflect::get(
-        video.as_ref(),
-        &JsValue::from_str("requestVideoFrameCallback"),
-    )
-    .map(|f| f.is_function())
-    .unwrap_or(false);
-    if !supported {
+    if !video_supports_rvfc(video) {
         return false;
     }
 
@@ -412,9 +408,23 @@ pub(crate) fn start_rvfc_frame_observer(
     true
 }
 
+/// Does `video` support `requestVideoFrameCallback`? `pub(crate)` so
+/// `ndi_clock_offset`'s independent rVFC-driven handshake loop (#510) shares
+/// this same feature check instead of duplicating it.
+pub(crate) fn video_supports_rvfc(video: &HtmlVideoElement) -> bool {
+    js_sys::Reflect::get(
+        video.as_ref(),
+        &JsValue::from_str("requestVideoFrameCallback"),
+    )
+    .map(|f| f.is_function())
+    .unwrap_or(false)
+}
+
 /// Invoke `video.requestVideoFrameCallback(cb)` via Reflect (web_sys has no
 /// stable binding for rVFC). Silent no-op if the method is missing.
-fn schedule_video_frame_callback(video: &HtmlVideoElement, holder: &SharedRvfcClosure) {
+/// `pub(crate)` so `ndi_clock_offset`'s independent rVFC-driven handshake loop
+/// (#510) can reuse the SAME scheduling idiom instead of duplicating it.
+pub(crate) fn schedule_video_frame_callback(video: &HtmlVideoElement, holder: &SharedRvfcClosure) {
     let Ok(f) = js_sys::Reflect::get(
         video.as_ref(),
         &JsValue::from_str("requestVideoFrameCallback"),

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -16,6 +16,7 @@ use leptos::web_sys::{
 };
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
+use super::ndi_clock_offset::ClockOffsetSetter;
 use super::ndi_frame_stats::{FramesLiveSetter, VideoLatencySetter};
 use super::ndi_watchdog::{now_ms, profile_mode_is_compat, ReloadEscalation, Watchdog};
 use crate::state::stage::StageContext;
@@ -74,6 +75,15 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let frames_live_setter: Option<FramesLiveSetter> =
         frames_live_sig.map(|sig| std::rc::Rc::new(move |v: bool| sig.set(v)) as FramesLiveSetter);
 
+    // #510 (T3): same shared-signal pattern for the browser<->server
+    // pipeline-clock offset estimate. Written by the independent rVFC-driven
+    // handshake loop inside `Watchdog::install`, once per completed round
+    // trip (success or failure — so a run of failures also ages the reading
+    // out to `None`/`n/a`). No StageContext → no setter (None), same as above.
+    let clock_offset_sig = use_context::<StageContext>().map(|ctx| ctx.clock_offset);
+    let clock_offset_setter: Option<ClockOffsetSetter> = clock_offset_sig
+        .map(|sig| std::rc::Rc::new(move |v: Option<(f64, f64)>| sig.set(v)) as ClockOffsetSetter);
+
     // Holds the active connection: the WHEP session + the watchdog observing
     // its health. Cleanup must close both — see on_cleanup below.
     struct ActiveConnection {
@@ -105,12 +115,14 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let cancelled_for_effect = Arc::clone(&cancelled);
     let video_latency_setter_for_effect = video_latency_setter;
     let frames_live_setter_for_effect = frames_live_setter;
+    let clock_offset_setter_for_effect = clock_offset_setter;
     Effect::new(move |_| {
         let Some(video) = video_ref.get() else { return };
         let source_id = source_id_for_effect.clone();
         let cancelled = Arc::clone(&cancelled_for_effect);
         let video_latency_setter = video_latency_setter_for_effect.clone();
         let frames_live_setter = frames_live_setter_for_effect.clone();
+        let clock_offset_setter = clock_offset_setter_for_effect.clone();
         spawn_local(async move {
             // The reconnect-trigger flag: when a watchdog fires, it sets this
             // flag; the loop drains it and reconnects.
@@ -184,6 +196,7 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
                             &escalation,
                             video_latency_setter.clone(),
                             frames_live_setter.clone(),
+                            clock_offset_setter.clone(),
                             move || flag.set(true),
                         );
 

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -20,6 +20,7 @@ use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use leptos::web_sys::{HtmlVideoElement, RtcIceConnectionState, RtcPeerConnection};
 use wasm_bindgen_futures::spawn_local;
 
+use super::ndi_clock_offset::{self, ClockOffsetEstimator, ClockOffsetSetter};
 use super::ndi_frame_stats::{
     start_rvfc_frame_observer, FrameStats, FramesLiveSetter, VideoLatencySetter,
 };
@@ -326,6 +327,7 @@ impl Watchdog {
         escalation: &Rc<ReloadEscalation>,
         video_latency_setter: Option<VideoLatencySetter>,
         frames_live_setter: Option<FramesLiveSetter>,
+        clock_offset_setter: Option<ClockOffsetSetter>,
         on_failure: F,
     ) -> Self {
         let active: Rc<Cell<bool>> = Rc::new(Cell::new(true));
@@ -362,6 +364,13 @@ impl Watchdog {
                 "watchdog: requestVideoFrameCallback unsupported — using currentTime frame proxy"
             );
         }
+        // #510 (T3): an INDEPENDENT rVFC-driven loop (own registration on the
+        // same `video` element) doing the browser<->server pipeline-clock
+        // offset handshake. Independent of the frame-stats observer above —
+        // it needs no decode-side counters, just a periodic tick that survives
+        // TV WebView timer throttling the same way.
+        let clock_offset_estimator = ClockOffsetEstimator::new();
+        ndi_clock_offset::start(video, &active, &clock_offset_estimator, clock_offset_setter);
         let health_ticker_handle = start_health_ticker(
             video,
             pc,

--- a/crates/presenter-ui/src/pages/stage.rs
+++ b/crates/presenter-ui/src/pages/stage.rs
@@ -77,6 +77,38 @@ pub fn StagePage() -> impl IntoView {
         setter.forget();
     }
 
+    // Test/diagnostic hook (#510 T3): read-only getter for the browser<->server
+    // pipeline-clock offset estimate. Returns `{offsetMs, rttMs}` once a
+    // fresh, low-RTT NTP-style round trip against `/ndi/time` has landed, or
+    // `null` before the first sample / once it ages out (honest `n/a` — see
+    // `ndi_clock_offset`'s trust predicate). A later ticket (#512, T4) will
+    // read the SAME `ctx.clock_offset` signal to build the true server→display
+    // latency metric; in production this getter is simply never called.
+    {
+        let clock_offset = ctx.clock_offset;
+        let getter = Closure::wrap(Box::new(move || -> JsValue {
+            match clock_offset.get_untracked() {
+                Some((offset_ms, rtt_ms)) => {
+                    let obj = js_sys::Object::new();
+                    let _ = js_sys::Reflect::set(
+                        &obj,
+                        &"offsetMs".into(),
+                        &JsValue::from_f64(offset_ms),
+                    );
+                    let _ = js_sys::Reflect::set(&obj, &"rttMs".into(), &JsValue::from_f64(rtt_ms));
+                    obj.into()
+                }
+                None => JsValue::NULL,
+            }
+        }) as Box<dyn Fn() -> JsValue>);
+        let _ = js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__presenterStageClockOffset"),
+            getter.as_ref(),
+        );
+        getter.forget();
+    }
+
     // Connect stage WebSocket
     let ws_handle = stage::use_stage_websocket(ctx.client_id.clone(), ctx.layout_code);
 

--- a/crates/presenter-ui/src/state/stage.rs
+++ b/crates/presenter-ui/src/state/stage.rs
@@ -32,6 +32,13 @@ pub struct StageContext {
     /// client whose `ndi_status` is still a stale `connecting` does not hide a
     /// video that is already decoding. `false` whenever no frames are flowing.
     pub ndi_frames_live: RwSignal<bool>,
+    /// Browser↔server pipeline-clock offset estimate (#510, T3):
+    /// `Some((offset_ms, rtt_ms))` once a fresh, low-RTT NTP-style round trip
+    /// against `/ndi/time` has landed, `None` before the first sample or once
+    /// the freshest one ages out (design's honest `n/a` trust predicate — see
+    /// `ndi_clock_offset`). A later ticket (#512, T4) reads this to convert a
+    /// `report.timestamp` reading into the server pipeline-clock domain.
+    pub clock_offset: RwSignal<Option<(f64, f64)>>,
 }
 
 impl StageContext {
@@ -47,6 +54,7 @@ impl StageContext {
             ndi_status: RwSignal::new(String::new()),
             video_latency_ms: RwSignal::new(None),
             ndi_frames_live: RwSignal::new(false),
+            clock_offset: RwSignal::new(None),
         }
     }
 }

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -303,3 +303,11 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
 - **Gotchas → ci skill:** stale GStreamer registry cache hides nvh264enc after recovery; dmesg
   retains pre-recovery NV_ERR_RESET_REQUIRED. Both documented in `.claude/skills/ci/SKILL.md`.
 - Solo PR (dev→main, Closes #445), version 0.4.178.
+
+## 2026-07-01 — #509 (NDI latency: device-capability + lag-location probe)
+- Shipped the diagnostic probe measuring device capability + where NDI latency arises on real stage displays; gates the true server→display metric (#512). No user-facing metric change yet — diagnostic surface only.
+- Solo PR #516 (dev→main), merged 0a1b902, version 0.4.179. Deployed prod (0.4.179, NDI streaming healthy) + dev, DOM-verified.
+
+## 2026-07-01 — #510 (NDI latency: /ndi/time pipeline-clock endpoint + browser offset estimator)
+- `/ndi/time` returns the server GStreamer pipeline-clock time (same clock RTCP SR encodes — not wall-clock/dantesync). Browser estimator: NTP-style handshake → offset_browser→serverPipelineClock + RTT, with min-RTT/median selection, outlier rejection, staleness bound. Feeds #512. Pipeline clock untouched (`ntp-time-source=clock-time` preserved — avoids the ~400ms/20s render hitch).
+- Tests: 11 offset-math + endpoint unit tests. Solo PR (dev→main, Closes #510), version 0.4.180.


### PR DESCRIPTION
Closes #510

Implements ticket T3 of the NDI true-latency design (docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md).

- New `/ndi/time` endpoint returns the server GStreamer **pipeline-clock** time (the same clock RTCP Sender Reports encode — not wall-clock, not dantesync).
- Browser-side clock-offset estimator: NTP-style handshake → `offset_browser→serverPipelineClock` + RTT, with min-RTT/median selection, outlier rejection, and a staleness bound. Feeds the true server→display metric (#512).
- Pipeline clock untouched (`ntp-time-source=clock-time` preserved — no ~400ms/20s render hitch).
- Tests: offset-math unit tests (compute/select/staleness) + endpoint tests.

Also logs #509 (already merged) in docs/autopilot-log.md.

Version 0.4.180.