### PR TITLE
NDI T4: true server→display latency (network RTT/2 + render residual) + honest n/a (#512)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.180"
+version = "0.4.181"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -15,6 +15,7 @@ use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use leptos::web_sys::{HtmlVideoElement, RtcPeerConnection};
 
 use super::ndi_beacon::post_stats_beacon;
+use super::ndi_clock_offset::ClockOffsetEstimator;
 use super::ndi_profile::persist_proven_profile_mode;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
 
@@ -96,32 +97,45 @@ const VIDEO_LATENCY_EMIT_INTERVAL_MS: f64 = 1000.0;
 /// higher = more responsive. 0.2 gives a calm, legible stage readout.
 const VIDEO_LATENCY_SMOOTHING_ALPHA: f64 = 0.2;
 
-/// Derive the stage-side VIDEO latency in milliseconds from one frame's rVFC
-/// metadata fields (#479). "Stage-side video latency" is the time from a
-/// frame's media being RECEIVED to it being DISPLAYED on screen — the user's
-/// decode→render definition, distinct from the WS connection round-trip.
+/// Derive the TRUE server→display video latency in milliseconds (#512, T4).
 ///
-/// Preference order:
-/// 1. received→displayed: `expected_display_time - receive_time`. WebRTC rVFC
-///    exposes both (`receiveTime` = last packet of the frame received,
-///    `expectedDisplayTime` = when the UA expects it visible) — the truest
-///    end-to-end figure.
-/// 2. decode duration: `processing_duration_s * 1000`. When `receiveTime` is
-///    absent (non-WebRTC / older browsers) the decode lag is the closest proxy
-///    rVFC offers.
+/// The number is the time from the frame leaving the server to it being painted
+/// on the stage — the sum of two independently-measured, physically-real hops:
 ///
-/// Returns `None` when neither pair is available. Negatives (clock skew between
-/// the receive and display timestamps) clamp to 0 so the stage never shows a
-/// nonsensical negative latency.
+/// 1. **render residual** = `expected_display_time - receive_time` (rVFC).
+///    `receiveTime` is when the frame's LAST RTP packet arrived in the browser;
+///    `expectedDisplayTime` is when the UA will paint it. The span between them
+///    is jitter-buffer + decode + present — i.e. everything AFTER arrival. (When
+///    the receive/display pair is absent, decode duration `processing_duration_s`
+///    is the closest residual proxy.)
+/// 2. **network one-way** = `network_one_way_ms`, ≈ RTT/2 from the `/ndi/time`
+///    offset handshake (#510). This is the server→browser transit that happens
+///    BEFORE `receiveTime` — the hop the old #479 residual-only number MISSED
+///    entirely (why Tailscale-from-home read the LOWEST latency: its WAN transit
+///    was invisible, leaving only local paint delay).
+///
+/// `network_one_way_ms = None` (no fresh `/ndi/time` round-trip landed, or the
+/// last one aged out) → returns `None` (**n/a**), NOT the residual alone: the
+/// residual-only figure is exactly the misleading number #512 replaces, so it is
+/// never shown as if it were the full latency. Honest n/a beats a plausible lie.
+///
+/// Negatives (clock skew) clamp to 0 so the stage never shows a nonsensical
+/// negative latency; the sum is therefore always ≥ 0, and for a given residual a
+/// higher RTT (e.g. Tailscale) always yields a higher — never lower — number.
 pub(crate) fn derive_video_latency_ms(
     receive_time: Option<f64>,
     expected_display_time: Option<f64>,
     processing_duration_s: Option<f64>,
+    network_one_way_ms: Option<f64>,
 ) -> Option<f64> {
-    if let (Some(recv), Some(disp)) = (receive_time, expected_display_time) {
-        return Some((disp - recv).max(0.0));
-    }
-    processing_duration_s.map(|s| (s * 1000.0).max(0.0))
+    let residual = if let (Some(recv), Some(disp)) = (receive_time, expected_display_time) {
+        (disp - recv).max(0.0)
+    } else {
+        (processing_duration_s? * 1000.0).max(0.0)
+    };
+    // Truthful server→display REQUIRES the network hop. Without it the residual
+    // alone is the old misleading number → report n/a (design §3 trust predicate).
+    Some(residual + network_one_way_ms?.max(0.0))
 }
 
 /// Fold one latency `sample` (ms) into the running EMA. `prev = None` (no
@@ -138,7 +152,7 @@ pub(crate) fn smooth_latency(prev: Option<f64>, sample: f64, alpha: f64) -> f64 
 /// typed binding for it, so the fields are read via `Reflect` (missing/non-numeric
 /// → `None`, never an error/log). Returns `None` when the frame carries no
 /// usable timing metadata.
-fn video_latency_from_meta(meta: &JsValue) -> Option<f64> {
+fn video_latency_from_meta(meta: &JsValue, network_one_way_ms: Option<f64>) -> Option<f64> {
     let get = |k: &str| {
         js_sys::Reflect::get(meta, &JsValue::from_str(k))
             .ok()
@@ -148,6 +162,7 @@ fn video_latency_from_meta(meta: &JsValue) -> Option<f64> {
         get("receiveTime"),
         get("expectedDisplayTime"),
         get("processingDuration"),
+        network_one_way_ms,
     )
 }
 
@@ -157,21 +172,40 @@ fn video_latency_from_meta(meta: &JsValue) -> Option<f64> {
 /// `VIDEO_LATENCY_EMIT_INTERVAL_MS` (#479). No-op when the frame carries no
 /// usable timing metadata, so a browser whose rVFC omits the timing fields
 /// simply never shows the readout (rather than showing a wrong value).
-fn update_video_latency(meta: &JsValue, stats: &FrameStats, setter: &Option<VideoLatencySetter>) {
-    let Some(sample) = video_latency_from_meta(meta) else {
-        return;
-    };
-    let smoothed = smooth_latency(
-        stats.video_latency_ms.get(),
-        sample,
-        VIDEO_LATENCY_SMOOTHING_ALPHA,
-    );
-    stats.video_latency_ms.set(Some(smoothed));
+fn update_video_latency(
+    meta: &JsValue,
+    stats: &FrameStats,
+    setter: &Option<VideoLatencySetter>,
+    network_one_way_ms: Option<f64>,
+) {
     let now = now_ms();
-    if now - stats.last_latency_emit_at.get() >= VIDEO_LATENCY_EMIT_INTERVAL_MS {
-        stats.last_latency_emit_at.set(now);
-        if let Some(setter) = setter {
-            setter(Some(smoothed));
+    let due = now - stats.last_latency_emit_at.get() >= VIDEO_LATENCY_EMIT_INTERVAL_MS;
+    match video_latency_from_meta(meta, network_one_way_ms) {
+        Some(sample) => {
+            let smoothed = smooth_latency(
+                stats.video_latency_ms.get(),
+                sample,
+                VIDEO_LATENCY_SMOOTHING_ALPHA,
+            );
+            stats.video_latency_ms.set(Some(smoothed));
+            if due {
+                stats.last_latency_emit_at.set(now);
+                if let Some(setter) = setter {
+                    setter(Some(smoothed));
+                }
+            }
+        }
+        // No trustworthy figure this frame (no fresh /ndi/time offset yet, or it
+        // aged out): show n/a rather than a stale-but-confident number. Reset the
+        // EMA so a resumed reading starts fresh instead of dragging an old value.
+        None => {
+            stats.video_latency_ms.set(None);
+            if due {
+                stats.last_latency_emit_at.set(now);
+                if let Some(setter) = setter {
+                    setter(None);
+                }
+            }
         }
     }
 }
@@ -366,6 +400,7 @@ pub(crate) fn start_rvfc_frame_observer(
     active: &Rc<Cell<bool>>,
     stats: &Rc<FrameStats>,
     escalation: &Rc<ReloadEscalation>,
+    clock_offset: &Rc<ClockOffsetEstimator>,
     video_latency_setter: Option<VideoLatencySetter>,
     frames_live_setter: Option<FramesLiveSetter>,
 ) -> bool {
@@ -382,6 +417,7 @@ pub(crate) fn start_rvfc_frame_observer(
         let source_id = source_id.to_string();
         let holder = Rc::clone(&holder);
         let escalation = Rc::clone(escalation);
+        let clock_offset = Rc::clone(clock_offset);
         Closure::<dyn FnMut(JsValue, JsValue)>::new(move |_now: JsValue, meta: JsValue| {
             if !active.get() {
                 return;
@@ -393,9 +429,11 @@ pub(crate) fn start_rvfc_frame_observer(
             // #500: frames are presenting → drop the neutral covering placeholder
             // (idempotent: only the false→true transition writes the signal).
             mark_frames_live(&stats, &frames_live_setter);
-            // #479: surface this frame's received→displayed latency to the
-            // stage's separate "video · N ms" readout (throttled + smoothed).
-            update_video_latency(&meta, &stats, &video_latency_setter);
+            // #512: TRUE server→display latency = network one-way (RTT/2 from the
+            // /ndi/time offset handshake, #510) + this frame's render residual.
+            // `None` RTT (no fresh offset yet) → update_video_latency shows n/a.
+            let network_one_way_ms = clock_offset.current().map(|(_offset, rtt)| rtt / 2.0);
+            update_video_latency(&meta, &stats, &video_latency_setter, network_one_way_ms);
             let n = record_presented_frame(&stats);
             if n % Watchdog::RVFC_BEACON_FRAME_PERIOD == 0 {
                 post_stats_beacon(&pc, &source_id, &stats);
@@ -522,44 +560,96 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────
 
     #[test]
-    fn prefers_received_to_displayed_when_both_present() {
-        // receiveTime=1000, expectedDisplayTime=1080 → 80ms received→displayed.
-        // processingDuration is IGNORED when the receive/display pair exists.
+    fn sums_render_residual_and_network_one_way() {
+        // residual = expectedDisplayTime(1080) - receiveTime(1000) = 80ms;
+        // network one-way = 20ms → true server→display = 100ms. processingDuration
+        // is IGNORED when the receive/display pair exists.
         assert_eq!(
-            derive_video_latency_ms(Some(1000.0), Some(1080.0), Some(0.005)),
-            Some(80.0)
+            derive_video_latency_ms(Some(1000.0), Some(1080.0), Some(0.005), Some(20.0)),
+            Some(100.0)
         );
     }
 
     #[test]
-    fn falls_back_to_processing_duration_without_receive_time() {
-        // No receiveTime → decode duration (seconds → ms): 0.012s = 12ms.
+    fn falls_back_to_processing_duration_then_adds_network() {
+        // No receiveTime → decode duration residual (0.012s = 12ms) + 10ms network.
         assert_eq!(
-            derive_video_latency_ms(None, Some(1080.0), Some(0.012)),
-            Some(12.0)
+            derive_video_latency_ms(None, Some(1080.0), Some(0.012), Some(10.0)),
+            Some(22.0)
         );
-        // expectedDisplayTime alone (no receiveTime) also falls back to decode.
-        assert_eq!(derive_video_latency_ms(None, None, Some(0.02)), Some(20.0));
+        // processingDuration alone (no receive/display pair) + network.
+        assert_eq!(
+            derive_video_latency_ms(None, None, Some(0.02), Some(5.0)),
+            Some(25.0)
+        );
     }
 
     #[test]
-    fn none_when_no_usable_metadata() {
-        assert_eq!(derive_video_latency_ms(None, None, None), None);
-        // receiveTime without expectedDisplayTime and no processingDuration
-        // cannot produce a figure.
-        assert_eq!(derive_video_latency_ms(Some(1000.0), None, None), None);
+    fn n_a_without_a_network_sample() {
+        // #512 trust predicate: no fresh /ndi/time offset → n/a, NOT the
+        // residual-only figure (that is exactly the old misleading number).
+        assert_eq!(
+            derive_video_latency_ms(Some(1000.0), Some(1080.0), Some(0.005), None),
+            None
+        );
+        assert_eq!(derive_video_latency_ms(None, None, Some(0.02), None), None);
     }
 
     #[test]
-    fn clamps_negative_skew_to_zero() {
-        // Clock skew making display appear BEFORE receive must never surface a
-        // negative latency on the stage.
+    fn none_when_no_residual_source() {
+        // No residual source at all → n/a regardless of a network sample.
+        assert_eq!(derive_video_latency_ms(None, None, None, Some(10.0)), None);
+        // receiveTime without expectedDisplayTime and no processingDuration.
         assert_eq!(
-            derive_video_latency_ms(Some(1080.0), Some(1000.0), None),
-            Some(0.0)
+            derive_video_latency_ms(Some(1000.0), None, None, Some(10.0)),
+            None
         );
-        // Negative processingDuration (defensive) also clamps.
-        assert_eq!(derive_video_latency_ms(None, None, Some(-0.01)), Some(0.0));
+    }
+
+    #[test]
+    fn clamps_negative_residual_but_keeps_network() {
+        // Clock skew making display appear BEFORE receive clamps the residual to
+        // 0; the (real) network term still contributes. Never negative.
+        assert_eq!(
+            derive_video_latency_ms(Some(1080.0), Some(1000.0), None, Some(10.0)),
+            Some(10.0)
+        );
+        // Negative processingDuration (defensive) also clamps to 0 residual.
+        assert_eq!(
+            derive_video_latency_ms(None, None, Some(-0.01), Some(5.0)),
+            Some(5.0)
+        );
+    }
+
+    #[test]
+    fn tailscale_reading_is_never_lower_than_lan() {
+        // The core #512 regression invariant: for the SAME stream/residual, a
+        // higher network one-way (Tailscale/WAN) must yield a HIGHER — never
+        // lower — latency than LAN. This is the exact bug (Tailscale read the
+        // LOWEST) the redefinition fixes: the old residual-only number ignored
+        // network transit entirely.
+        let lan = derive_video_latency_ms(Some(1000.0), Some(1080.0), None, Some(3.0))
+            .expect("lan reading");
+        let tailscale = derive_video_latency_ms(Some(1000.0), Some(1080.0), None, Some(60.0))
+            .expect("tailscale reading");
+        assert!(
+            tailscale > lan,
+            "tailscale ({tailscale}) must exceed lan ({lan}) for the same residual"
+        );
+    }
+
+    #[test]
+    fn latency_is_always_non_negative() {
+        for (recv, disp, proc, net) in [
+            (Some(1000.0), Some(1080.0), None, Some(0.0)),
+            (Some(1080.0), Some(1000.0), None, Some(0.0)),
+            (None, None, Some(0.0), Some(0.0)),
+            (Some(1000.0), Some(1080.0), None, Some(1000.0)),
+        ] {
+            if let Some(v) = derive_video_latency_ms(recv, disp, proc, net) {
+                assert!(v >= 0.0, "latency must never be negative, got {v}");
+            }
+        }
     }
 
     #[test]

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -346,6 +346,11 @@ impl Watchdog {
         if let Some(setter) = &frames_live_setter {
             setter(false);
         }
+        // #510/#512: the browser<->server pipeline-clock offset estimator. Created
+        // BEFORE the frame observer so the observer can read its current (offset,
+        // RTT) each presented frame — the RTT/2 network-transit term of the TRUE
+        // server→display latency (#512, T4).
+        let clock_offset_estimator = ClockOffsetEstimator::new();
         let rvfc_supported = start_rvfc_frame_observer(
             video,
             pc,
@@ -353,6 +358,7 @@ impl Watchdog {
             &active,
             &stats,
             escalation,
+            &clock_offset_estimator,
             video_latency_setter,
             // #500: the rVFC path marks frames live on each presented frame; the
             // health ticker (below) flips them back to not-live on staleness, so
@@ -368,8 +374,8 @@ impl Watchdog {
         // same `video` element) doing the browser<->server pipeline-clock
         // offset handshake. Independent of the frame-stats observer above —
         // it needs no decode-side counters, just a periodic tick that survives
-        // TV WebView timer throttling the same way.
-        let clock_offset_estimator = ClockOffsetEstimator::new();
+        // TV WebView timer throttling the same way. Feeds the SAME estimator the
+        // observer reads, so the RTT it measures becomes the latency's network term.
         ndi_clock_offset::start(video, &active, &clock_offset_estimator, clock_offset_setter);
         let health_ticker_handle = start_health_ticker(
             video,

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -86,19 +86,19 @@ pub fn StatusBar(
         }
     };
 
-    // #479: stage-side VIDEO latency — shown as a SEPARATE readout next to the
-    // connection one (decode→render lag of the NDI/WHEP video, distinct from
-    // the WS connection round-trip). Sourced from the shared StageContext
-    // signal written by `NdiVideo`'s frame observer. Rendered ONLY when a value
-    // is present (a video layout with frames flowing); non-video layouts leave
-    // the signal None so the readout simply doesn't appear.
+    // #512: the TRUE server→display video latency — network transit (RTT/2 via
+    // /ndi/time) + render residual (buffer+decode+present). A SEPARATE readout
+    // next to the connection one. Sourced from the shared StageContext signal
+    // written by `NdiVideo`'s frame observer. Shown whenever NDI video is LIVE;
+    // the value is the number, or "n/a" when there is no trustworthy measurement
+    // (no fresh /ndi/time offset / it aged out) — never a misleading residual.
+    // Non-video layouts leave frames not-live so the readout doesn't appear.
     let video_latency = ctx.video_latency_ms;
-    let has_video_latency = move || video_latency.get().is_some();
-    let video_latency_text = move || {
-        video_latency
-            .get()
-            .map(|ms| format!("video \u{00b7} {} ms", ms as u32))
-            .unwrap_or_default()
+    let frames_live = ctx.ndi_frames_live;
+    let has_video_latency = move || frames_live.get();
+    let video_latency_text = move || match video_latency.get() {
+        Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
+        None => "server\u{2192}displej \u{00b7} n/a".to_string(),
     };
 
     autofit_effect_tabular(clock_ref, STATUS_MAX_FONT, move || clock_text.get());

--- a/docs/adr/0008-ndi-true-latency.md
+++ b/docs/adr/0008-ndi-true-latency.md
@@ -1,0 +1,69 @@
+# 0008 — NDI stage-display TRUE server→display latency
+
+**Status:** Accepted (2026-07-01)
+
+## Context
+
+The stage display showed a "video · N ms" latency (#479) computed as the rVFC
+`expectedDisplayTime − receiveTime` residual. That value is a **browser-local
+residual** (jitter-buffer + decode + present) measured *after* the frame's last
+packet already arrived. It contains **no network transit and no encode time**,
+which produced physically nonsensical readings the user reported:
+
+- Tailscale-from-home read the **lowest** latency (23 ms) — the WAN transit is
+  spent *before* `receiveTime`, so it was invisible; only local paint delay remained.
+- A weak Hyundai TV read **lower** than the powerful SD1 — the value tracks each
+  WebView's frame scheduler, not real lag.
+
+User decision: **the number must be truthful — a false number is worse than none.**
+
+The originally-designed fix (docs/superpowers/specs/2026-06-30-ndi-true-latency-design.md,
+ticket T4) used `latency = (report.timestamp + offset) − estimatedPlayoutTimestamp`.
+The #509 (T0) probe, run against the **real prod stage TVs**, proved this dead on
+our hardware: every real display — AND a control desktop HeadlessChrome on the
+same stream — reports `estimatedPlayoutTimestamp` **absent** (`playout_class="absent"`)
+after thousands of frames. Our pipeline pins a monotonic `SystemClock` with
+`rtpbin ntp-time-source=clock-time`, and Chrome does not surface
+`estimatedPlayoutTimestamp` from the resulting RTCP SRs. Making it appear is a deep,
+uncertain GStreamer webrtcbin/SR-NTP change and was not worth blocking the metric on.
+
+## Decision
+
+Compute the metric from signals **every real device reliably reports**:
+
+```
+latency_ms = render_residual + network_one_way
+```
+
+- **render_residual** = rVFC `expectedDisplayTime − receiveTime` (jitter-buffer +
+  decode + present), clamped ≥ 0. Falls back to decode duration when the pair is
+  absent. This is what the old #479 number measured — kept, because it is real.
+- **network_one_way** ≈ **RTT/2** from the `/ndi/time` pipeline-clock offset
+  handshake (#510). This is the server→browser transit the old number missed — the
+  reason Tailscale read lowest.
+
+No double-count: the residual already covers everything *after* packet arrival; the
+network term covers everything *before* it.
+
+**Honesty rules:**
+- `network_one_way` unavailable (no fresh `/ndi/time` round-trip, or it aged out per
+  the estimator's staleness/RTT trust predicate) → the readout shows **`n/a`**, never
+  the residual alone (that is the old misleading number).
+- The readout is visible only while NDI video is **live**; non-video layouts hide it.
+- Labelled **"server→displej"** — it measures server→display (network + buffer +
+  decode + present), NOT camera→NDI→server (only the CI clock-strip measures full
+  glass-to-glass), and it is a **video** diagnostic, not a lip-sync guarantee.
+- If `estimatedPlayoutTimestamp` ever becomes available (desktop / a future pipeline
+  change), the SR-anchored value can be preferred with automatic fallback to this sum.
+
+## Consequences
+
+- The metric now rises with real network + buffer + decode delay and satisfies the
+  regression invariants (unit-tested in `ndi_frame_stats.rs`): for the same stream a
+  higher RTT (Tailscale/WAN) yields a **higher — never lower** — number than LAN, and
+  the value is always **non-negative**.
+- It is **honest**: `n/a` when unmeasurable, labelled server→display, presented as a
+  video diagnostic. The old residual is no longer shown as a headline number.
+- It carries a small extra per-frame read of the offset estimator (cheap, in-memory).
+- It does **not** need absolute time sync (dantesync) or `estimatedPlayoutTimestamp`;
+  the `/ndi/time` offset keeps both terms addable in the browser clock domain.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,6 +203,18 @@ The application version is available at runtime:
 - UI footer displays version with channel suffix for non-release builds
 - Logs include version on startup
 
+### Stage video latency (server→display)
+
+The stage's `server→displej · N ms` readout is the TRUE server→display video
+latency: **network one-way (RTT/2 from the `/ndi/time` pipeline-clock handshake) +
+render residual (`expectedDisplayTime − receiveTime` = jitter-buffer + decode +
+present)**. It shows `n/a` — never a misleading number — when there is no fresh
+`/ndi/time` offset, and is labelled server→display (not glass-to-glass, not
+lip-sync). The old residual-only figure ignored network transit (why Tailscale read
+lowest) and is no longer a headline number. `estimatedPlayoutTimestamp` is absent on
+the real Android-TV WebViews (and desktop Chrome) with our monotonic-clock RTCP SRs,
+so the metric deliberately avoids it. See `docs/adr/0008-ndi-true-latency.md`.
+
 ### CI Validation
 
 The `version-check.yml` workflow enforces:

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -8,19 +8,27 @@ import {
 } from "./support";
 
 // ─────────────────────────────────────────────────────────────────────────
-// #479 — the stage shows VIDEO latency (decode→render) as a SEPARATE readout
-// next to the web/connection latency. The connection readout ("CONNECTED · N
-// ms") is the WS heartbeat round-trip; the new readout ("video · N ms") is the
-// stage-side received→displayed lag derived per-frame from rVFC metadata by
-// `NdiVideo`'s frame observer.
+// #512 — the stage shows the TRUE server→display video latency as a SEPARATE
+// readout next to the web/connection latency. The connection readout
+// ("CONNECTED · N ms") is the WS heartbeat round-trip; the video readout
+// ("server→displej · N ms") is the network transit (RTT/2 via /ndi/time) plus
+// the per-frame render residual (buffer+decode+present) — written per frame by
+// `NdiVideo`'s rVFC observer.
+//
+// The readout is shown whenever NDI video is LIVE; its value is the number, or
+// "n/a" when there is no trustworthy measurement (no fresh /ndi/time offset) —
+// never a misleading residual-only figure. Non-video layouts leave frames
+// not-live so the readout is absent.
 //
 // The real per-frame value needs a live NDI/WebRTC stream (the self-hosted
 // `@synthetic-ndi` GPU lane). This deterministic test runs on the standard
-// GitHub-hosted `e2e` lane: it drives the readout via the stage test hook
-// (`__presenterStageSetVideoLatency`) — the same signal the rVFC observer
-// writes — and asserts BOTH readouts render, are distinct, and that clearing
-// the value hides the video readout. The derivation math itself
-// (rVFC metadata → ms) is unit-tested in `ndi_frame_stats.rs`.
+// GitHub-hosted `e2e` lane: it drives the frames-live flag and the latency
+// value via the stage test hooks (`__presenterStageSetNdiFramesLive` /
+// `__presenterStageSetVideoLatency`) — the same signals the rVFC observer
+// writes — and asserts the readout appears when video is live, shows the
+// number when measurable and "n/a" when not, and disappears when video stops.
+// The derivation math (residual + network → ms, n/a-without-network,
+// Tailscale-≥-LAN) is unit-tested in `ndi_frame_stats.rs`.
 // ─────────────────────────────────────────────────────────────────────────
 
 test.describe.configure({ timeout: 120_000 });
@@ -65,8 +73,8 @@ async function openVideoStage(context: BrowserContext): Promise<Page> {
   return stagePage;
 }
 
-/** Drive the stage-side video-latency readout (the same signal the rVFC
- * observer writes). `null` clears it. */
+/** Drive the stage-side video-latency value (the same signal the rVFC observer
+ * writes). `null` clears it → the readout shows "n/a" while video is live. */
 async function setVideoLatency(page: Page, ms: number | null): Promise<void> {
   await page.evaluate((value) => {
     (
@@ -77,7 +85,19 @@ async function setVideoLatency(page: Page, ms: number | null): Promise<void> {
   }, ms);
 }
 
-test("stage shows video latency as a separate readout next to connection latency", async ({
+/** Drive the "NDI frames are presenting" flag (gates the readout's visibility,
+ * the same signal the rVFC observer / proxy write per frame). */
+async function setFramesLive(page: Page, live: boolean): Promise<void> {
+  await page.evaluate((value) => {
+    (
+      window as unknown as {
+        __presenterStageSetNdiFramesLive?: (v: boolean) => void;
+      }
+    ).__presenterStageSetNdiFramesLive?.(value);
+  }, live);
+}
+
+test("stage shows true server→display latency as a separate readout, with honest n/a", async ({
   context,
 }) => {
   const consoleMessages: string[] = [];
@@ -95,28 +115,37 @@ test("stage shows video latency as a separate readout next to connection latency
   await expect(connectionEl).toBeVisible();
   await expect(connectionEl).toContainText("CONNECTED");
 
-  // No video flowing yet → the video readout is absent (not just empty).
+  // No NDI video flowing yet → the video readout is absent (not just empty).
   await expect(videoEl).toHaveCount(0);
 
-  // A frame's derived latency arrives → the SEPARATE "video · N ms" readout
-  // appears with the expected "<number> ms" format.
-  await setVideoLatency(stagePage, 42);
+  // Video goes live but no trustworthy measurement yet → the readout appears
+  // showing "n/a" (honest), NOT a misleading number.
+  await setFramesLive(stagePage, true);
   await expect(videoEl).toBeVisible();
-  await expect(videoEl).toContainText(/video\s*·\s*42\s*ms/);
+  await expect(videoEl).toContainText(/server→displej\s*·\s*n\/a/);
 
-  // The two readouts coexist as DISTINCT elements (the user's decision: video
-  // latency shown SEPARATELY from connection latency, not combined).
+  // A measured server→display latency arrives → the readout shows "<n> ms".
+  await setVideoLatency(stagePage, 42);
+  await expect(videoEl).toContainText(/server→displej\s*·\s*42\s*ms/);
+
+  // The two readouts coexist as DISTINCT elements (video latency shown
+  // SEPARATELY from connection latency, not combined).
   await expect(connectionEl).toContainText("CONNECTED");
-  await expect(connectionEl).not.toContainText("video");
+  await expect(connectionEl).not.toContainText("displej");
   await expect(videoEl).not.toContainText("CONNECTED");
 
   // The value updates live (a later, larger figure).
   await setVideoLatency(stagePage, 137);
-  await expect(videoEl).toContainText(/video\s*·\s*137\s*ms/);
+  await expect(videoEl).toContainText(/server→displej\s*·\s*137\s*ms/);
+
+  // Measurement lost while video still live (offset aged out) → honest n/a,
+  // never a stale-but-confident number.
+  await setVideoLatency(stagePage, null);
+  await expect(videoEl).toContainText(/server→displej\s*·\s*n\/a/);
 
   // Video stops (source deactivated) → the readout disappears; the connection
   // readout remains.
-  await setVideoLatency(stagePage, null);
+  await setFramesLive(stagePage, false);
   await expect(videoEl).toHaveCount(0);
   await expect(connectionEl).toBeVisible();
 


### PR DESCRIPTION
Closes #512

Ticket T4 of the NDI true-latency design. Makes the stage latency number TRUTHFUL.

**Why the old number was nonsense** (#479): it showed the rVFC `expectedDisplayTime − receiveTime` residual — a browser-LOCAL figure measured AFTER the frame's last packet arrived, so it contained NO network transit. That is why Tailscale-from-home read the *lowest* latency (23ms) and a weak Hyundai TV read lower than the strong SD1.

**Why the originally-designed fix was dead:** the #509 probe, run against the real prod TVs AND a control desktop Chrome, proved `estimatedPlayoutTimestamp` is **absent** on our stream (monotonic-clock RTCP SRs). Chasing GStreamer SR/NTP internals is an uncertain rabbit hole.

**The fix (redefined metric):**
`latency = render_residual (buffer+decode+present, rVFC) + network_one_way (RTT/2 from the /ndi/time offset handshake, #510)`
No double-count (residual = after arrival; network = before). Built from signals every real device reports.

- Shows **n/a** — never the misleading residual alone — when there is no fresh `/ndi/time` offset.
- Labelled **server→displej** (not glass-to-glass, not lip-sync); readout visible only while NDI video is live.
- Unit invariants (ndi_frame_stats.rs): **Tailscale ≥ LAN**, non-negative, n/a-without-network, residual+network sum. E2E updated (stage-video-latency.spec.ts) for the new label + honest n/a.
- Docs: ADR 0008 + architecture.md.

Version 0.4.181.