### PR TITLE
fix(ndi): server→display latency readout gates on ndi_active (reliable visibility) [#512 follow-up]

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -502,6 +502,14 @@ jobs:
         env:
           PRESENTER_BUILD_CHANNEL: dev
 
+      - name: Build synthetic NDI sender (test-helpers)
+        # Built HERE (deps hot from the step above) and shipped as an artifact so
+        # the self-hosted e2e-ndi lane never compiles Rust — per the runner
+        # architecture (CLAUDE.md: the local runner only runs pre-built
+        # artifacts). A toolchain bump on dev2 used to force a ~19-min cold
+        # rebuild of the gstreamer tree there, blowing e2e-ndi's 20-min cap.
+        run: cargo build --release -p presenter-ndi --features test-helpers --bin ndi_test_sender
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -511,6 +519,7 @@ jobs:
             target/release/presenter-server
             target/release/import_propresenter
             target/release/ingest_bibles
+            target/release/ndi_test_sender
 
   # ============================================
   # Android Stage APK (the universal stage-display app the server installs on TVs)
@@ -687,20 +696,20 @@ jobs:
           path: _artifacts
 
       - name: Place binaries
-        # ALL three prebuilt binaries are required: the spec's beforeAll runs
-        # refresh-dev-data.sh, which invokes import_propresenter + ingest_bibles.
-        # If they're missing it falls back to `cargo run` (cold compile) and the
-        # 180s beforeAll hook times out before any test runs.
+        # ALL four prebuilt binaries are required: the spec's beforeAll runs
+        # refresh-dev-data.sh, which invokes import_propresenter + ingest_bibles
+        # (missing → `cargo run` cold-compile → 180s beforeAll timeout), and the
+        # synthetic sender is prebuilt in the GH-hosted Build job — this runner
+        # never compiles Rust (a dev2 toolchain bump once forced a ~19-min cold
+        # gstreamer rebuild here, blowing the 20-min job cap).
         run: |
           mkdir -p target/release
           cp _artifacts/presenter-server target/release/
           cp _artifacts/import_propresenter target/release/
           cp _artifacts/ingest_bibles target/release/
-          chmod +x target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles
-          ls -la target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles
-
-      - name: Build synthetic NDI sender (test-helpers)
-        run: cargo build -p presenter-ndi --features test-helpers --bin ndi_test_sender
+          cp _artifacts/ndi_test_sender target/release/
+          chmod +x target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles target/release/ndi_test_sender
+          ls -la target/release/presenter-server target/release/import_propresenter target/release/ingest_bibles target/release/ndi_test_sender
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -719,7 +728,7 @@ jobs:
         # presenter test-server it spawns) can discover + consume it. Runs in
         # the background; stopped in the cleanup step below.
         run: |
-          PRESENTER_NDI_TEST_NAME="PRESENTER-TEST" nohup ./target/debug/ndi_test_sender > /tmp/ndi_test_sender.log 2>&1 &
+          PRESENTER_NDI_TEST_NAME="PRESENTER-TEST" nohup ./target/release/ndi_test_sender > /tmp/ndi_test_sender.log 2>&1 &
           echo $! > /tmp/ndi_test_sender.pid
           # Give NDI discovery a moment to advertise the source.
           sleep 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.181"
+version = "0.4.182"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.180"
+version = "0.4.182"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -89,13 +89,15 @@ pub fn StatusBar(
     // #512: the TRUE server→display video latency — network transit (RTT/2 via
     // /ndi/time) + render residual (buffer+decode+present). A SEPARATE readout
     // next to the connection one. Sourced from the shared StageContext signal
-    // written by `NdiVideo`'s frame observer. Shown whenever NDI video is LIVE;
-    // the value is the number, or "n/a" when there is no trustworthy measurement
-    // (no fresh /ndi/time offset / it aged out) — never a misleading residual.
-    // Non-video layouts leave frames not-live so the readout doesn't appear.
+    // written by `NdiVideo`'s frame observer. Shown whenever NDI is the ACTIVE
+    // source (`ndi_active` — a stable per-layout flag, NOT the flaky per-frame
+    // `frames_live` which throttles on idle/headless and would wrongly hide the
+    // readout); the value is the number, or "n/a" when there is no trustworthy
+    // measurement (no fresh /ndi/time offset / it aged out) — never a misleading
+    // residual. Non-NDI layouts leave `ndi_active` false so the readout is absent.
     let video_latency = ctx.video_latency_ms;
-    let frames_live = ctx.ndi_frames_live;
-    let has_video_latency = move || frames_live.get();
+    let ndi_active = ctx.ndi_active;
+    let has_video_latency = move || ndi_active.get();
     let video_latency_text = move || match video_latency.get() {
         Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
         None => "server\u{2192}displej \u{00b7} n/a".to_string(),

--- a/crates/presenter-ui/src/pages/stage.rs
+++ b/crates/presenter-ui/src/pages/stage.rs
@@ -77,6 +77,24 @@ pub fn StagePage() -> impl IntoView {
         setter.forget();
     }
 
+    // Test hook (#512): drive the "NDI source active" flag deterministically from
+    // the E2E without a real NDI source. `ndi_active` gates the server→display
+    // latency readout's visibility (shown whenever NDI is the active source; the
+    // value is a number or honest "n/a"). Accepts a boolean. Production never calls
+    // this — `ndi_active` is set from the live stage snapshot.
+    {
+        let ndi_active = ctx.ndi_active;
+        let setter = Closure::wrap(Box::new(move |v: JsValue| {
+            ndi_active.set(v.as_bool().unwrap_or(false));
+        }) as Box<dyn Fn(JsValue)>);
+        let _ = js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__presenterStageSetNdiActive"),
+            setter.as_ref(),
+        );
+        setter.forget();
+    }
+
     // Test/diagnostic hook (#510 T3): read-only getter for the browser<->server
     // pipeline-clock offset estimate. Returns `{offsetMs, rttMs}` once a
     // fresh, low-RTT NTP-style round trip against `/ndi/time` has landed, or

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -85,16 +85,16 @@ async function setVideoLatency(page: Page, ms: number | null): Promise<void> {
   }, ms);
 }
 
-/** Drive the "NDI frames are presenting" flag (gates the readout's visibility,
- * the same signal the rVFC observer / proxy write per frame). */
-async function setFramesLive(page: Page, live: boolean): Promise<void> {
+/** Drive the "NDI source active" flag (gates the readout's visibility — the
+ * stable per-layout signal, set from the live snapshot in production). */
+async function setNdiActive(page: Page, active: boolean): Promise<void> {
   await page.evaluate((value) => {
     (
       window as unknown as {
-        __presenterStageSetNdiFramesLive?: (v: boolean) => void;
+        __presenterStageSetNdiActive?: (v: boolean) => void;
       }
-    ).__presenterStageSetNdiFramesLive?.(value);
-  }, live);
+    ).__presenterStageSetNdiActive?.(value);
+  }, active);
 }
 
 test("stage shows true server→display latency as a separate readout, with honest n/a", async ({
@@ -115,12 +115,12 @@ test("stage shows true server→display latency as a separate readout, with hone
   await expect(connectionEl).toBeVisible();
   await expect(connectionEl).toContainText("CONNECTED");
 
-  // No NDI video flowing yet → the video readout is absent (not just empty).
+  // No NDI source active yet → the video readout is absent (not just empty).
   await expect(videoEl).toHaveCount(0);
 
-  // Video goes live but no trustworthy measurement yet → the readout appears
-  // showing "n/a" (honest), NOT a misleading number.
-  await setFramesLive(stagePage, true);
+  // NDI source goes active but no trustworthy measurement yet → the readout
+  // appears showing "n/a" (honest), NOT a misleading number.
+  await setNdiActive(stagePage, true);
   await expect(videoEl).toBeVisible();
   await expect(videoEl).toContainText(/server→displej\s*·\s*n\/a/);
 
@@ -143,9 +143,9 @@ test("stage shows true server→display latency as a separate readout, with hone
   await setVideoLatency(stagePage, null);
   await expect(videoEl).toContainText(/server→displej\s*·\s*n\/a/);
 
-  // Video stops (source deactivated) → the readout disappears; the connection
-  // readout remains.
-  await setFramesLive(stagePage, false);
+  // NDI source deactivated → the readout disappears; the connection readout
+  // remains.
+  await setNdiActive(stagePage, false);
   await expect(videoEl).toHaveCount(0);
   await expect(connectionEl).toBeVisible();
 


### PR DESCRIPTION
Follow-up to #512.

Verified on prod after #512 deploy: the true latency value is CORRECT (`server→displej · 25 ms` = render residual + LAN network one-way; the /ndi/time offset estimator produces rtt≈2ms). But the readout was **hidden** because #512 gated its visibility on the per-frame `frames_live` signal, which throttles on idle/headless WebViews — the number only appeared when `frames_live` was forced true.

Fix: gate the readout on the stable per-layout **`ndi_active`** flag (set from the live snapshot whenever an NDI source is active) — so the number, or honest `n/a`, shows reliably on the real stage TVs and on desktop. Adds `__presenterStageSetNdiActive` test hook; `stage-video-latency.spec.ts` updated to drive it.

Version 0.4.182.