### PR TITLE
feat(stage): fulltext layout + per-slide stage-layout markers (#515)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -23,4 +23,12 @@ ignore = [
   # tracked separately as #367 (blocked: proc-macro-error2 still transitive).
   # (Moved here from the CI --ignore flags, #366.)
   "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained (transitive)
+  # quick-xml 0.39.4 DoS-class advisories (quadratic duplicate-attribute check
+  # + unbounded NsReader namespace allocation), fixed only in >=0.41.0. Pinned
+  # transitively by gst-plugin-ndi (^0.39; even 0.15.3 pins ^0.40) — no upgrade
+  # path until upstream bumps. NDI XML comes only from sources on the trusted
+  # LAN, so exposure is low. Tracked in #522 — remove BOTH ids (and the same
+  # pair in deny.toml) once gst-plugin-ndi allows quick-xml >=0.41.
+  "RUSTSEC-2026-0194", # quick-xml quadratic attr check (transitive, #522)
+  "RUSTSEC-2026-0195", # quick-xml NsReader allocation DoS (transitive, #522)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.183"
+version = "0.4.184"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/stage_display.rs
+++ b/crates/presenter-core/src/stage_display.rs
@@ -72,6 +72,25 @@ impl StageDisplayLayout {
         Self::new("api", "API", "External API-driven stage display")
     }
 
+    /// The single source of truth for which layouts the OPERATOR may select —
+    /// the layout picker, `POST /stage/layout` validation, and per-slide
+    /// stage-layout markers (#515) all share this set. `camera-crew` is
+    /// internal-only (served at /ui/camera) and excluded.
+    pub fn operator_selectable() -> Vec<Self> {
+        Self::built_in()
+            .into_iter()
+            .filter(|layout| layout.code != "camera-crew")
+            .collect()
+    }
+
+    /// Look up an operator-selectable layout by code (`None` for unknown
+    /// codes AND for internal-only layouts like `camera-crew`).
+    pub fn find_operator_selectable(code: &str) -> Option<Self> {
+        Self::operator_selectable()
+            .into_iter()
+            .find(|layout| layout.code == code)
+    }
+
     fn new(code: &str, name: &str, description: &str) -> Self {
         Self {
             code: code.to_string(),
@@ -279,6 +298,21 @@ impl StageDisplaySnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn operator_selectable_excludes_only_camera_crew() {
+        let selectable = StageDisplayLayout::operator_selectable();
+        assert_eq!(selectable.len(), StageDisplayLayout::built_in().len() - 1);
+        assert!(!selectable.iter().any(|layout| layout.code == "camera-crew"));
+        assert!(selectable.iter().any(|layout| layout.code == "fulltext"));
+    }
+
+    #[test]
+    fn find_operator_selectable_rejects_camera_crew_and_unknown() {
+        assert!(StageDisplayLayout::find_operator_selectable("fulltext").is_some());
+        assert!(StageDisplayLayout::find_operator_selectable("camera-crew").is_none());
+        assert!(StageDisplayLayout::find_operator_selectable("nope").is_none());
+    }
 
     #[test]
     fn built_in_layouts_cover_expected_variants() {

--- a/crates/presenter-core/src/stage_display.rs
+++ b/crates/presenter-core/src/stage_display.rs
@@ -51,6 +51,11 @@ impl StageDisplayLayout {
                 "Full viewport NDI video stream",
             ),
             Self::new("bible", "BIBLE", "Full-screen Bible passage display"),
+            Self::new(
+                "fulltext",
+                "FULL TEXT",
+                "Current slide's stage text auto-scaled across the whole screen",
+            ),
             Self::api(),
             Self::new(
                 "camera-crew",
@@ -278,7 +283,7 @@ mod tests {
     #[test]
     fn built_in_layouts_cover_expected_variants() {
         let layouts = StageDisplayLayout::built_in();
-        assert_eq!(layouts.len(), 8);
+        assert_eq!(layouts.len(), 9);
         let codes: Vec<_> = layouts.iter().map(|layout| layout.code.as_str()).collect();
         assert!(codes.contains(&DEFAULT_STAGE_LAYOUT_CODE));
         assert!(codes.contains(&"worship-pp"));
@@ -286,6 +291,7 @@ mod tests {
         assert!(codes.contains(&"preach"));
         assert!(codes.contains(&"ndi-fullscreen"));
         assert!(codes.contains(&"bible"));
+        assert!(codes.contains(&"fulltext"));
         assert!(codes.contains(&"api"));
         assert!(codes.contains(&"camera-crew"));
     }

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -17,6 +17,7 @@ mod m20260624_000001_default_launch_to_presenter_stage;
 mod m20260625_000001_add_video_sources;
 mod m20260628_000001_create_resolume_push_audit;
 mod m20260629_000001_add_stage_active_entry_index;
+mod m20260702_000001_create_slide_stage_layouts;
 
 pub struct Migrator;
 
@@ -38,6 +39,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260625_000001_add_video_sources::Migration),
             Box::new(m20260628_000001_create_resolume_push_audit::Migration),
             Box::new(m20260629_000001_add_stage_active_entry_index::Migration),
+            Box::new(m20260702_000001_create_slide_stage_layouts::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260702_000001_create_slide_stage_layouts.rs
+++ b/crates/presenter-migration/src/m20260702_000001_create_slide_stage_layouts.rs
@@ -1,0 +1,51 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// #515: per-slide stage-layout markers. When the operator triggers a slide
+/// that carries a marker, the server switches the stage display to that
+/// layout (exactly like `POST /stage/layout`). One row per marked slide;
+/// slides without a row leave the layout untouched.
+///
+/// `slide_id` is the primary key (slide UUIDs are globally unique);
+/// `presentation_id` is stored so all markers of a presentation can be listed
+/// for the operator UI and cleaned up when the presentation is deleted.
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Idempotent: CREATE TABLE IF NOT EXISTS makes re-running safe.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "CREATE TABLE IF NOT EXISTS slide_stage_layouts (\
+                slide_id        TEXT NOT NULL PRIMARY KEY,\
+                presentation_id TEXT NOT NULL,\
+                layout_code     TEXT NOT NULL\
+            )",
+        ))
+        .await?;
+
+        // Listing markers for the operator UI filters by presentation.
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "CREATE INDEX IF NOT EXISTS idx_slide_stage_layouts_presentation \
+             ON slide_stage_layouts (presentation_id)",
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "DROP TABLE IF EXISTS slide_stage_layouts",
+            ))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/presenter-persistence/src/entities.rs
+++ b/crates/presenter-persistence/src/entities.rs
@@ -654,3 +654,23 @@ pub mod resolume_push_audit {
 
     impl ActiveModelBehavior for ActiveModel {}
 }
+
+pub mod slide_stage_layout {
+    use sea_orm::entity::prelude::*;
+
+    /// #515: per-slide stage-layout marker. Triggering a slide that carries a
+    /// marker switches the stage display to `layout_code`.
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "slide_stage_layouts")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub slide_id: String,
+        pub presentation_id: String,
+        pub layout_code: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/crates/presenter-persistence/src/repository/library.rs
+++ b/crates/presenter-persistence/src/repository/library.rs
@@ -81,6 +81,11 @@ impl Repository {
         }
 
         txn.commit().await?;
+
+        // #515: a name-colliding re-import cascade-deleted the old library's
+        // slides and recreated them under fresh UUIDs — sweep the marker rows
+        // that now point at dead slide ids so they never accumulate.
+        self.prune_orphan_slide_stage_layouts().await?;
         Ok(())
     }
 
@@ -124,6 +129,9 @@ impl Repository {
         if result.rows_affected == 0 {
             return Err(anyhow!("library not found"));
         }
+        // #515: the FK cascade removed the library's slides — sweep their
+        // stage-layout marker rows (no FK on slide_stage_layouts).
+        self.prune_orphan_slide_stage_layouts().await?;
         Ok(())
     }
 

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -5,6 +5,7 @@ mod library;
 mod playlist;
 mod presentation;
 mod search;
+mod slide_stage_layout;
 mod stage_state;
 #[cfg(test)]
 mod tests;

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -90,16 +90,24 @@ impl Repository {
     #[instrument(skip_all)]
     pub async fn delete_presentation(&self, presentation_id: PresentationId) -> anyhow::Result<()> {
         let id = presentation_id.to_string();
+        // #515: one transaction — the presentation delete and its stage-layout
+        // marker cleanup commit (or fail) together, so a cleanup error can
+        // never report a failed delete that actually happened.
+        let txn = self.db.begin().await?;
         let result = presentation_entity::Entity::delete_by_id(id)
-            .exec(&self.db)
+            .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
             return Err(anyhow!("presentation not found"));
         }
-        // #515: drop any per-slide stage-layout markers of the deleted
-        // presentation so they don't accumulate as orphan rows.
-        self.clear_slide_stage_layouts_for_presentation(presentation_id)
+        crate::entities::slide_stage_layout::Entity::delete_many()
+            .filter(
+                crate::entities::slide_stage_layout::Column::PresentationId
+                    .eq(presentation_id.to_string()),
+            )
+            .exec(&txn)
             .await?;
+        txn.commit().await?;
         Ok(())
     }
 
@@ -108,6 +116,10 @@ impl Repository {
         let txn = self.db.begin().await?;
 
         slide_entity::Entity::delete_many().exec(&txn).await?;
+        // #515: purging every slide purges every stage-layout marker with it.
+        crate::entities::slide_stage_layout::Entity::delete_many()
+            .exec(&txn)
+            .await?;
         presentation_entity::Entity::delete_many()
             .exec(&txn)
             .await?;

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -96,6 +96,10 @@ impl Repository {
         if result.rows_affected == 0 {
             return Err(anyhow!("presentation not found"));
         }
+        // #515: drop any per-slide stage-layout markers of the deleted
+        // presentation so they don't accumulate as orphan rows.
+        self.clear_slide_stage_layouts_for_presentation(presentation_id)
+            .await?;
         Ok(())
     }
 

--- a/crates/presenter-persistence/src/repository/slide_stage_layout.rs
+++ b/crates/presenter-persistence/src/repository/slide_stage_layout.rs
@@ -1,0 +1,204 @@
+//! Per-slide stage-layout marker persistence (#515).
+//!
+//! One row per marked slide: triggering that slide switches the stage display
+//! to the stored layout code. Slides without a row leave the layout untouched.
+
+use crate::entities::slide_stage_layout;
+use anyhow::Context;
+use presenter_core::{PresentationId, SlideId};
+use sea_orm::{sea_query::OnConflict, ColumnTrait, EntityTrait, QueryFilter, Set};
+use std::collections::HashMap;
+use tracing::instrument;
+
+use super::Repository;
+
+impl Repository {
+    /// Layout marker for one slide, if any.
+    #[instrument(skip_all)]
+    pub async fn get_slide_stage_layout(
+        &self,
+        slide_id: SlideId,
+    ) -> anyhow::Result<Option<String>> {
+        let row = slide_stage_layout::Entity::find_by_id(slide_id.to_string())
+            .one(&self.db)
+            .await
+            .context("failed to load slide stage layout")?;
+        Ok(row.map(|r| r.layout_code))
+    }
+
+    /// Upsert the layout marker for a slide.
+    #[instrument(skip_all)]
+    pub async fn set_slide_stage_layout(
+        &self,
+        presentation_id: PresentationId,
+        slide_id: SlideId,
+        layout_code: &str,
+    ) -> anyhow::Result<()> {
+        let model = slide_stage_layout::ActiveModel {
+            slide_id: Set(slide_id.to_string()),
+            presentation_id: Set(presentation_id.to_string()),
+            layout_code: Set(layout_code.to_string()),
+        };
+        slide_stage_layout::Entity::insert(model)
+            .on_conflict(
+                OnConflict::column(slide_stage_layout::Column::SlideId)
+                    .update_columns([
+                        slide_stage_layout::Column::PresentationId,
+                        slide_stage_layout::Column::LayoutCode,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await
+            .context("failed to upsert slide stage layout")?;
+        Ok(())
+    }
+
+    /// Remove a slide's layout marker (no-op when none exists).
+    #[instrument(skip_all)]
+    pub async fn clear_slide_stage_layout(&self, slide_id: SlideId) -> anyhow::Result<()> {
+        slide_stage_layout::Entity::delete_by_id(slide_id.to_string())
+            .exec(&self.db)
+            .await
+            .context("failed to clear slide stage layout")?;
+        Ok(())
+    }
+
+    /// All layout markers of a presentation as `slide_id → layout_code`
+    /// (for the operator UI's per-slide indicators).
+    #[instrument(skip_all)]
+    pub async fn list_slide_stage_layouts(
+        &self,
+        presentation_id: PresentationId,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        let rows = slide_stage_layout::Entity::find()
+            .filter(slide_stage_layout::Column::PresentationId.eq(presentation_id.to_string()))
+            .all(&self.db)
+            .await
+            .context("failed to list slide stage layouts")?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.slide_id, r.layout_code))
+            .collect())
+    }
+
+    /// Remove all markers of a presentation (called when it is deleted).
+    #[instrument(skip_all)]
+    pub async fn clear_slide_stage_layouts_for_presentation(
+        &self,
+        presentation_id: PresentationId,
+    ) -> anyhow::Result<()> {
+        slide_stage_layout::Entity::delete_many()
+            .filter(slide_stage_layout::Column::PresentationId.eq(presentation_id.to_string()))
+            .exec(&self.db)
+            .await
+            .context("failed to clear presentation slide stage layouts")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::Repository;
+    use presenter_core::{PresentationId, SlideId};
+
+    fn ids() -> (PresentationId, SlideId) {
+        (PresentationId::new(), SlideId::new())
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_without_marker() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (_, slide) = ids();
+        assert_eq!(repo.get_slide_stage_layout(slide).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn set_then_get_roundtrips() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (pres, slide) = ids();
+        repo.set_slide_stage_layout(pres, slide, "fulltext")
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.get_slide_stage_layout(slide).await.unwrap(),
+            Some("fulltext".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn set_overwrites_existing_marker() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (pres, slide) = ids();
+        repo.set_slide_stage_layout(pres, slide, "fulltext")
+            .await
+            .unwrap();
+        repo.set_slide_stage_layout(pres, slide, "timer")
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.get_slide_stage_layout(slide).await.unwrap(),
+            Some("timer".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_removes_marker_and_is_idempotent() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (pres, slide) = ids();
+        repo.set_slide_stage_layout(pres, slide, "fulltext")
+            .await
+            .unwrap();
+        repo.clear_slide_stage_layout(slide).await.unwrap();
+        assert_eq!(repo.get_slide_stage_layout(slide).await.unwrap(), None);
+        // Clearing again must not error.
+        repo.clear_slide_stage_layout(slide).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_returns_only_presentation_markers() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (pres_a, slide_a) = ids();
+        let (pres_b, slide_b) = ids();
+        repo.set_slide_stage_layout(pres_a, slide_a, "fulltext")
+            .await
+            .unwrap();
+        repo.set_slide_stage_layout(pres_b, slide_b, "timer")
+            .await
+            .unwrap();
+
+        let map = repo.list_slide_stage_layouts(pres_a).await.unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get(&slide_a.to_string()).map(String::as_str),
+            Some("fulltext")
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_for_presentation_removes_all_its_markers() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let (pres_a, slide_a) = ids();
+        let (pres_b, slide_b) = ids();
+        repo.set_slide_stage_layout(pres_a, slide_a, "fulltext")
+            .await
+            .unwrap();
+        repo.set_slide_stage_layout(pres_b, slide_b, "timer")
+            .await
+            .unwrap();
+
+        repo.clear_slide_stage_layouts_for_presentation(pres_a)
+            .await
+            .unwrap();
+        assert!(repo
+            .list_slide_stage_layouts(pres_a)
+            .await
+            .unwrap()
+            .is_empty());
+        // Other presentations' markers are untouched.
+        assert_eq!(
+            repo.get_slide_stage_layout(slide_b).await.unwrap(),
+            Some("timer".to_string())
+        );
+    }
+}

--- a/crates/presenter-persistence/src/repository/slide_stage_layout.rs
+++ b/crates/presenter-persistence/src/repository/slide_stage_layout.rs
@@ -6,7 +6,7 @@
 use crate::entities::slide_stage_layout;
 use anyhow::Context;
 use presenter_core::{PresentationId, SlideId};
-use sea_orm::{sea_query::OnConflict, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{sea_query::OnConflict, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
 use std::collections::HashMap;
 use tracing::instrument;
 
@@ -82,6 +82,25 @@ impl Repository {
             .collect())
     }
 
+    /// Sweep marker rows whose slide no longer exists — library deletes
+    /// cascade slides away without touching this table, and library
+    /// re-imports assign fresh slide UUIDs. Called after library delete /
+    /// re-import so orphan rows never accumulate (#515).
+    #[instrument(skip_all)]
+    pub async fn prune_orphan_slide_stage_layouts(&self) -> anyhow::Result<u64> {
+        let backend = self.db.get_database_backend();
+        let result = self
+            .db
+            .execute(sea_orm::Statement::from_string(
+                backend,
+                "DELETE FROM slide_stage_layouts \
+                 WHERE slide_id NOT IN (SELECT id FROM slides)",
+            ))
+            .await
+            .context("failed to prune orphan slide stage layouts")?;
+        Ok(result.rows_affected())
+    }
+
     /// Remove all markers of a presentation (called when it is deleted).
     #[instrument(skip_all)]
     pub async fn clear_slide_stage_layouts_for_presentation(
@@ -100,7 +119,20 @@ impl Repository {
 #[cfg(test)]
 mod tests {
     use crate::repository::Repository;
-    use presenter_core::{PresentationId, SlideId};
+    use presenter_core::{PresentationId, Slide, SlideContent, SlideGroup, SlideId, SlideText};
+
+    fn sample_slide(order: u32) -> Slide {
+        Slide::new(
+            order,
+            SlideContent::new(
+                SlideText::new("Main").unwrap(),
+                SlideText::new("Translation").unwrap(),
+                SlideText::new("Stage").unwrap(),
+                Some(SlideGroup::new("Intro")),
+            ),
+        )
+        .with_id(SlideId::new())
+    }
 
     fn ids() -> (PresentationId, SlideId) {
         (PresentationId::new(), SlideId::new())
@@ -173,6 +205,64 @@ mod tests {
             map.get(&slide_a.to_string()).map(String::as_str),
             Some("fulltext")
         );
+    }
+
+    /// #515 review finding: markers must not survive as orphans on the
+    /// library-delete path (FK cascade removes the slides; nothing else
+    /// touches slide_stage_layouts) …
+    #[tokio::test]
+    async fn delete_library_prunes_its_slide_markers() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let library = repo.create_library("Marker Lib").await.unwrap();
+        let slides = [sample_slide(0)];
+        let (_, _, presentation) = repo
+            .create_presentation(library.id, "Marked", Some(&slides))
+            .await
+            .unwrap();
+        let slide_id = presentation.slides[0].id;
+        repo.set_slide_stage_layout(presentation.id, slide_id, "fulltext")
+            .await
+            .unwrap();
+
+        repo.delete_library(library.id).await.unwrap();
+
+        assert_eq!(repo.get_slide_stage_layout(slide_id).await.unwrap(), None);
+    }
+
+    /// … and the Import-Data --purge path clears the whole marker table
+    /// inside the same transaction that purges the slides.
+    #[tokio::test]
+    async fn purge_presentation_content_clears_all_markers() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        let library = repo.create_library("Purge Lib").await.unwrap();
+        let slides = [sample_slide(0)];
+        let (_, _, presentation) = repo
+            .create_presentation(library.id, "Marked", Some(&slides))
+            .await
+            .unwrap();
+        let slide_id = presentation.slides[0].id;
+        repo.set_slide_stage_layout(presentation.id, slide_id, "timer")
+            .await
+            .unwrap();
+
+        repo.purge_presentation_content().await.unwrap();
+
+        assert_eq!(repo.get_slide_stage_layout(slide_id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn prune_removes_rows_whose_slide_no_longer_exists() {
+        let repo = Repository::connect_in_memory().await.expect("db");
+        // A marker pointing at a slide id that exists in NO slides row (the
+        // in-memory DB seeds no slides) is an orphan by definition.
+        let (pres, slide) = ids();
+        repo.set_slide_stage_layout(pres, slide, "fulltext")
+            .await
+            .unwrap();
+
+        let pruned = repo.prune_orphan_slide_stage_layouts().await.unwrap();
+        assert_eq!(pruned, 1);
+        assert_eq!(repo.get_slide_stage_layout(slide).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -8,6 +8,7 @@ pub mod network_mode;
 mod playlists;
 mod presentations;
 mod search;
+mod slide_stage_layout;
 pub(crate) mod stage;
 mod stage_shell;
 mod tablet_pwa;
@@ -279,6 +280,14 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/presentations/{presentation_id}/slides",
             post(presentations::insert_slide),
+        )
+        .route(
+            "/presentations/{presentation_id}/slides/{slide_id}/stage-layout",
+            put(slide_stage_layout::set_slide_stage_layout),
+        )
+        .route(
+            "/presentations/{presentation_id}/slide-stage-layouts",
+            get(slide_stage_layout::list_slide_stage_layouts),
         )
         .route(
             "/presentations/{presentation_id}/slides/{slide_id}/duplicate",

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -1,0 +1,134 @@
+//! Per-slide stage-layout marker endpoints (#515).
+//!
+//! `PUT  /presentations/{presentation_id}/slides/{slide_id}/stage-layout`
+//!     body `{"layoutCode": "fulltext"}` assigns, `{"layoutCode": null}` clears.
+//! `GET  /presentations/{presentation_id}/slide-stage-layouts`
+//!     returns `{ "<slide_id>": "<layout_code>", … }` for the operator UI.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use presenter_core::{PresentationId, SlideId};
+use serde::Deserialize;
+use std::collections::HashMap;
+use tracing::instrument;
+
+use super::AppError;
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SlideStageLayoutRequest {
+    /// `Some(code)` assigns the marker; `None` (JSON `null` / omitted) clears it.
+    #[serde(default)]
+    pub(super) layout_code: Option<String>,
+}
+
+#[instrument(skip_all)]
+pub(super) async fn set_slide_stage_layout(
+    State(state): State<AppState>,
+    Path((presentation_id, slide_id)): Path<(String, String)>,
+    Json(payload): Json<SlideStageLayoutRequest>,
+) -> Result<StatusCode, AppError> {
+    let presentation_uuid = super::parse_uuid("presentationId", &presentation_id)?;
+    let slide_uuid = super::parse_uuid("slideId", &slide_id)?;
+    let code = payload
+        .layout_code
+        .as_deref()
+        .map(str::trim)
+        .filter(|code| !code.is_empty());
+    state
+        .assign_slide_stage_layout(
+            PresentationId::from_uuid(presentation_uuid),
+            SlideId::from_uuid(slide_uuid),
+            code,
+        )
+        .await
+        .map_err(AppError::bad_request)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[instrument(skip_all)]
+pub(super) async fn list_slide_stage_layouts(
+    State(state): State<AppState>,
+    Path(presentation_id): Path<String>,
+) -> Result<Json<HashMap<String, String>>, AppError> {
+    let presentation_uuid = super::parse_uuid("presentationId", &presentation_id)?;
+    let map = state
+        .slide_stage_layouts(PresentationId::from_uuid(presentation_uuid))
+        .await?;
+    Ok(Json(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::{Path, State};
+
+    async fn seeded_state() -> (crate::state::AppState, presenter_core::Presentation) {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        crate::state::seed_sample_library(&state).await.unwrap();
+        let libraries = state.libraries().await.unwrap();
+        let presentation = libraries[0].presentations[0].clone();
+        (state, presentation)
+    }
+
+    #[tokio::test]
+    async fn put_assigns_and_null_clears() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let status = set_slide_stage_layout(
+            State(state.clone()),
+            Path((presentation.id.to_string(), slide_id.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("fulltext".to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let Json(map) =
+            list_slide_stage_layouts(State(state.clone()), Path(presentation.id.to_string()))
+                .await
+                .unwrap();
+        assert_eq!(
+            map.get(&slide_id.to_string()).map(String::as_str),
+            Some("fulltext")
+        );
+
+        // null layoutCode clears the marker.
+        let status = set_slide_stage_layout(
+            State(state.clone()),
+            Path((presentation.id.to_string(), slide_id.to_string())),
+            Json(SlideStageLayoutRequest { layout_code: None }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let Json(map) = list_slide_stage_layouts(State(state), Path(presentation.id.to_string()))
+            .await
+            .unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn put_rejects_unknown_layout() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let result = set_slide_stage_layout(
+            State(state),
+            Path((presentation.id.to_string(), slide_id.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("no-such-layout".to_string()),
+            }),
+        )
+        .await;
+        assert!(result.is_err(), "unknown layout must be rejected");
+    }
+}

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -1193,13 +1193,14 @@ async fn stage_displays_endpoint_returns_builtins() {
         .unwrap();
     let payload: Vec<StageDisplayLayout> = serde_json::from_slice(&bytes).unwrap();
     // camera-crew is excluded from the operator layout picker (Issue 1 fix).
-    // Count is built_in() minus camera-crew = 7.
-    assert_eq!(payload.len(), 7);
+    // Count is built_in() minus camera-crew = 8.
+    assert_eq!(payload.len(), 8);
     assert!(payload
         .iter()
         .any(|layout| layout.code == DEFAULT_STAGE_LAYOUT_CODE));
     assert!(payload.iter().any(|layout| layout.code == "ndi-fullscreen"));
     assert!(payload.iter().any(|layout| layout.code == "bible"));
+    assert!(payload.iter().any(|layout| layout.code == "fulltext"));
     assert!(payload.iter().any(|layout| layout.code == "api"));
     assert!(
         !payload.iter().any(|layout| layout.code == "camera-crew"),

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -113,6 +113,12 @@ pub struct AppState {
     /// In-memory caches: presentation / group-color / ableset (see [`CacheManager`]).
     caches: CacheManager,
     stage_layout: Arc<RwLock<String>>,
+    /// Serializes slide triggers (`update_stage_state`) so the stage-state
+    /// write, the per-slide layout-marker switch (#515) and the resolution
+    /// broadcast of one trigger can never interleave with another trigger's
+    /// (concurrent sources: operator HTTP, tablet, Companion, OSC, AI tools).
+    /// Only `update_stage_state` locks it — no nesting, no deadlock.
+    stage_trigger_lock: Arc<tokio::sync::Mutex<()>>,
     osc_bridge: OscBridge,
     ableset_bridge: AbleSetBridge,
     broadcast_live: Arc<AtomicBool>,
@@ -203,6 +209,7 @@ impl AppState {
             heartbeat_config,
             caches: CacheManager::new(),
             stage_layout: Arc::new(RwLock::new(default_layout)),
+            stage_trigger_lock: Arc::new(tokio::sync::Mutex::new(())),
             osc_bridge,
             ableset_bridge,
             broadcast_live: Arc::new(AtomicBool::new(false)),

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -33,6 +33,7 @@ mod ndi_control;
 mod osc;
 mod presentations;
 mod seed;
+mod slide_stage_layout;
 pub(crate) mod slides;
 pub(crate) mod stage;
 mod stage_display;

--- a/crates/presenter-server/src/state/slide_stage_layout.rs
+++ b/crates/presenter-server/src/state/slide_stage_layout.rs
@@ -1,0 +1,291 @@
+//! Per-slide stage-layout markers (#515) — `AppState` methods.
+//!
+//! The operator can mark a slide with a stage layout; when that slide becomes
+//! current (`POST /stage/state`), the server switches the stage display to the
+//! marked layout exactly like `POST /stage/layout` does (persist + broadcast
+//! over /live/ws). Slides without a marker leave the layout untouched.
+
+use super::AppState;
+use presenter_core::{PresentationId, SlideId, StageDisplayLayout};
+use std::collections::HashMap;
+
+impl AppState {
+    /// Assign (`Some(code)`) or clear (`None`) the stage-layout marker of a
+    /// slide. The assignable set matches the operator layout picker
+    /// (`set_stage_layout_code`): built-in layouts only, minus `camera-crew`.
+    pub async fn assign_slide_stage_layout(
+        &self,
+        presentation_id: PresentationId,
+        slide_id: SlideId,
+        layout_code: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let Some((_, _, presentation)) = self.presentation_detail(presentation_id).await? else {
+            anyhow::bail!("presentation not found");
+        };
+        if !presentation.slides.iter().any(|slide| slide.id == slide_id) {
+            anyhow::bail!("slide not found in presentation");
+        }
+
+        match layout_code {
+            Some(code) => {
+                if code == "camera-crew" {
+                    anyhow::bail!(
+                        "'camera-crew' is not an operator-selectable layout; it cannot be assigned to a slide"
+                    );
+                }
+                if !StageDisplayLayout::built_in()
+                    .into_iter()
+                    .any(|layout| layout.code == code)
+                {
+                    anyhow::bail!("unknown stage layout: {code}");
+                }
+                self.repository
+                    .set_slide_stage_layout(presentation_id, slide_id, code)
+                    .await?;
+                tracing::info!(
+                    target: "presenter::stage::slide_layout",
+                    presentation_id = %presentation_id,
+                    slide_id = %slide_id,
+                    layout_code = %code,
+                    "slide stage-layout marker assigned"
+                );
+            }
+            None => {
+                self.repository.clear_slide_stage_layout(slide_id).await?;
+                tracing::info!(
+                    target: "presenter::stage::slide_layout",
+                    presentation_id = %presentation_id,
+                    slide_id = %slide_id,
+                    "slide stage-layout marker cleared"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// All markers of a presentation as `slide_id → layout_code` (operator UI
+    /// indicators).
+    pub async fn slide_stage_layouts(
+        &self,
+        presentation_id: PresentationId,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        self.repository
+            .list_slide_stage_layouts(presentation_id)
+            .await
+    }
+
+    /// Trigger hook (#515): when the now-current slide carries a marker and
+    /// the stage is on a different layout, switch — same path as
+    /// `POST /stage/layout` (persist + `LiveEvent::StageLayout` + snapshot
+    /// broadcast). A stale marker (layout removed in a later release) must
+    /// NEVER fail the slide trigger: log and continue.
+    pub(super) async fn apply_slide_stage_layout_marker(&self, slide_id: SlideId) {
+        let code = match self.repository.get_slide_stage_layout(slide_id).await {
+            Ok(Some(code)) => code,
+            Ok(None) => return,
+            Err(err) => {
+                tracing::warn!(
+                    target: "presenter::stage::slide_layout",
+                    ?err,
+                    slide_id = %slide_id,
+                    "failed to look up slide stage-layout marker — leaving layout unchanged"
+                );
+                return;
+            }
+        };
+        if self.stage_layout_code().await == code {
+            return;
+        }
+        match self.set_stage_layout_code(&code).await {
+            Ok(layout) => {
+                tracing::info!(
+                    target: "presenter::stage::slide_layout",
+                    slide_id = %slide_id,
+                    layout_code = %layout.code,
+                    "stage layout switched by slide marker"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "presenter::stage::slide_layout",
+                    ?err,
+                    slide_id = %slide_id,
+                    layout_code = %code,
+                    "slide stage-layout marker points at an unusable layout — leaving layout unchanged"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::state::AppState;
+    use presenter_core::{Presentation, SlideId, DEFAULT_STAGE_LAYOUT_CODE};
+
+    async fn seeded_state() -> (AppState, Presentation) {
+        let state = AppState::in_memory().await.unwrap();
+        crate::state::seed_sample_library(&state).await.unwrap();
+        let libraries = state.libraries().await.unwrap();
+        let presentation = libraries[0].presentations[0].clone();
+        (state, presentation)
+    }
+
+    #[tokio::test]
+    async fn assign_then_list_roundtrips() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        state
+            .assign_slide_stage_layout(presentation.id, slide_id, Some("fulltext"))
+            .await
+            .unwrap();
+
+        let map = state.slide_stage_layouts(presentation.id).await.unwrap();
+        assert_eq!(
+            map.get(&slide_id.to_string()).map(String::as_str),
+            Some("fulltext")
+        );
+    }
+
+    #[tokio::test]
+    async fn assign_none_clears_marker() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        state
+            .assign_slide_stage_layout(presentation.id, slide_id, Some("timer"))
+            .await
+            .unwrap();
+        state
+            .assign_slide_stage_layout(presentation.id, slide_id, None)
+            .await
+            .unwrap();
+
+        assert!(state
+            .slide_stage_layouts(presentation.id)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn assign_rejects_unknown_layout() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let err = state
+            .assign_slide_stage_layout(presentation.id, slide_id, Some("no-such-layout"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown stage layout"));
+    }
+
+    #[tokio::test]
+    async fn assign_rejects_camera_crew() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let err = state
+            .assign_slide_stage_layout(presentation.id, slide_id, Some("camera-crew"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("camera-crew"));
+    }
+
+    #[tokio::test]
+    async fn assign_rejects_unknown_slide() {
+        let (state, presentation) = seeded_state().await;
+
+        let err = state
+            .assign_slide_stage_layout(presentation.id, SlideId::new(), Some("fulltext"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("slide not found"));
+    }
+
+    /// The core #515 behavior: triggering a slide that carries a marker
+    /// switches the stage layout, exactly like `POST /stage/layout` would.
+    #[tokio::test]
+    async fn triggering_marked_slide_switches_stage_layout() {
+        let (state, presentation) = seeded_state().await;
+        let current = presentation.slides[0].id;
+        let next = presentation.slides.get(1).map(|slide| slide.id);
+
+        state
+            .set_stage_layout_code(DEFAULT_STAGE_LAYOUT_CODE)
+            .await
+            .unwrap();
+        state
+            .assign_slide_stage_layout(presentation.id, current, Some("fulltext"))
+            .await
+            .unwrap();
+
+        state
+            .update_stage_state(presentation.id, current, next, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(state.stage_layout_code().await, "fulltext");
+    }
+
+    /// A slide WITHOUT a marker leaves the operator-chosen layout untouched —
+    /// markers switch, absence never reverts.
+    #[tokio::test]
+    async fn triggering_unmarked_slide_keeps_current_layout() {
+        let (state, presentation) = seeded_state().await;
+        let marked = presentation.slides[0].id;
+        let unmarked = presentation.slides[1].id;
+
+        state
+            .set_stage_layout_code(DEFAULT_STAGE_LAYOUT_CODE)
+            .await
+            .unwrap();
+        state
+            .assign_slide_stage_layout(presentation.id, marked, Some("fulltext"))
+            .await
+            .unwrap();
+
+        // Marked slide switches …
+        state
+            .update_stage_state(presentation.id, marked, Some(unmarked), None, None)
+            .await
+            .unwrap();
+        assert_eq!(state.stage_layout_code().await, "fulltext");
+
+        // … the following unmarked slide does NOT revert.
+        state
+            .update_stage_state(presentation.id, unmarked, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(state.stage_layout_code().await, "fulltext");
+    }
+
+    /// A stale marker (its layout no longer usable) must never fail the slide
+    /// trigger — the trigger succeeds and the layout stays unchanged.
+    #[tokio::test]
+    async fn stale_marker_does_not_fail_slide_trigger() {
+        let (state, presentation) = seeded_state().await;
+        let current = presentation.slides[0].id;
+
+        // Write an invalid marker directly through the repository, bypassing
+        // the assignment validation (simulates a layout removed in a later
+        // release while the DB row survived).
+        state
+            .repository()
+            .set_slide_stage_layout(presentation.id, current, "removed-layout")
+            .await
+            .unwrap();
+        state
+            .set_stage_layout_code(DEFAULT_STAGE_LAYOUT_CODE)
+            .await
+            .unwrap();
+
+        state
+            .update_stage_state(presentation.id, current, None, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(state.stage_layout_code().await, DEFAULT_STAGE_LAYOUT_CODE);
+    }
+}

--- a/crates/presenter-server/src/state/slide_stage_layout.rs
+++ b/crates/presenter-server/src/state/slide_stage_layout.rs
@@ -6,7 +6,7 @@
 //! over /live/ws). Slides without a marker leave the layout untouched.
 
 use super::AppState;
-use presenter_core::{PresentationId, SlideId, StageDisplayLayout};
+use presenter_core::{PresentationId, SlideId};
 use std::collections::HashMap;
 
 impl AppState {
@@ -28,17 +28,9 @@ impl AppState {
 
         match layout_code {
             Some(code) => {
-                if code == "camera-crew" {
-                    anyhow::bail!(
-                        "'camera-crew' is not an operator-selectable layout; it cannot be assigned to a slide"
-                    );
-                }
-                if !StageDisplayLayout::built_in()
-                    .into_iter()
-                    .any(|layout| layout.code == code)
-                {
-                    anyhow::bail!("unknown stage layout: {code}");
-                }
+                // Same validation as POST /stage/layout — the two paths share
+                // one operator-selectable source of truth and cannot drift.
+                Self::validate_operator_selectable(code)?;
                 self.repository
                     .set_slide_stage_layout(presentation_id, slide_id, code)
                     .await?;
@@ -96,7 +88,10 @@ impl AppState {
         if self.stage_layout_code().await == code {
             return;
         }
-        match self.set_stage_layout_code(&code).await {
+        // publish_snapshots = false: update_stage_state broadcasts the fresh
+        // resolution right after this call, so the full-context snapshot fan-
+        // out inside the switch would reach every /live/ws client twice.
+        match self.switch_stage_layout(&code, false).await {
             Ok(layout) => {
                 tracing::info!(
                     target: "presenter::stage::slide_layout",
@@ -106,12 +101,16 @@ impl AppState {
                 );
             }
             Err(err) => {
+                // Two failure modes share this arm: an unusable marker code
+                // (validation failed — layout genuinely unchanged) and a
+                // broadcast error AFTER the switch was committed (clients
+                // already received StageLayout). Do not claim "unchanged".
                 tracing::warn!(
                     target: "presenter::stage::slide_layout",
                     ?err,
                     slide_id = %slide_id,
                     layout_code = %code,
-                    "slide stage-layout marker points at an unusable layout — leaving layout unchanged"
+                    "slide stage-layout marker switch failed — invalid marker, or the switch committed but its broadcast errored"
                 );
             }
         }
@@ -259,6 +258,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(state.stage_layout_code().await, "fulltext");
+    }
+
+    /// Duplicating a marked slide copies the marker to the duplicate (#515
+    /// review finding) — the copy behaves identically when triggered.
+    #[tokio::test]
+    async fn duplicating_marked_slide_copies_marker() {
+        let (state, presentation) = seeded_state().await;
+        let source = presentation.slides[0].id;
+        state
+            .assign_slide_stage_layout(presentation.id, source, Some("fulltext"))
+            .await
+            .unwrap();
+
+        let slides = state
+            .duplicate_slide(presentation.id, source)
+            .await
+            .unwrap();
+        let duplicate = slides[1].id; // inserted right after the source
+        assert_ne!(duplicate, source);
+
+        let map = state.slide_stage_layouts(presentation.id).await.unwrap();
+        assert_eq!(
+            map.get(&duplicate.to_string()).map(String::as_str),
+            Some("fulltext"),
+            "duplicate must carry the source slide's marker"
+        );
+        // The source keeps its own marker too.
+        assert_eq!(
+            map.get(&source.to_string()).map(String::as_str),
+            Some("fulltext")
+        );
     }
 
     /// A stale marker (its layout no longer usable) must never fail the slide

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -124,11 +124,30 @@ impl AppState {
             .position(|slide| slide.id == slide_id)
             .ok_or_else(|| anyhow::anyhow!("slide not found"))?;
         let source = slides[index].clone();
-        slides.insert(index + 1, Slide::new(0, source.content.clone()));
+        let duplicate = Slide::new(0, source.content.clone());
+        let duplicate_id = duplicate.id;
+        slides.insert(index + 1, duplicate);
         Self::reindex_slides(&mut slides);
         self.repository
             .replace_presentation_slides(presentation_id, &slides)
             .await?;
+        // #515: a duplicate copies ALL slide content — including the stage-
+        // layout marker. Non-fatal: the duplicate itself already succeeded.
+        match self.repository.get_slide_stage_layout(slide_id).await {
+            Ok(Some(code)) => {
+                if let Err(err) = self
+                    .repository
+                    .set_slide_stage_layout(presentation_id, duplicate_id, &code)
+                    .await
+                {
+                    tracing::warn!(?err, %slide_id, "failed to copy stage-layout marker to duplicated slide");
+                }
+            }
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(?err, %slide_id, "failed to read stage-layout marker while duplicating slide");
+            }
+        }
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
         let mut updated_presentation = presentation.clone();
@@ -161,8 +180,12 @@ impl AppState {
         self.repository
             .replace_presentation_slides(presentation_id, &slides)
             .await?;
-        // #515: a deleted slide's stage-layout marker goes with it.
-        self.repository.clear_slide_stage_layout(slide_id).await?;
+        // #515: a deleted slide's stage-layout marker goes with it. Non-fatal
+        // — the slide deletion already committed; a missed row is swept by
+        // prune_orphan_slide_stage_layouts on the next library change.
+        if let Err(err) = self.repository.clear_slide_stage_layout(slide_id).await {
+            tracing::warn!(?err, %slide_id, "failed to clear stage-layout marker of deleted slide");
+        }
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
         let mut updated_presentation = presentation.clone();

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -161,6 +161,8 @@ impl AppState {
         self.repository
             .replace_presentation_slides(presentation_id, &slides)
             .await?;
+        // #515: a deleted slide's stage-layout marker goes with it.
+        self.repository.clear_slide_stage_layout(slide_id).await?;
         self.reconcile_stage_state_after_edit(presentation_id, &slides)
             .await?;
         let mut updated_presentation = presentation.clone();

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -100,16 +100,36 @@ impl AppState {
         self.stage_layout.read().await.clone()
     }
 
-    pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {
+    /// Validate a layout code against the operator-selectable set (#515:
+    /// shared by `POST /stage/layout` AND per-slide marker assignment, so the
+    /// two paths can never drift apart).
+    pub(super) fn validate_operator_selectable(code: &str) -> anyhow::Result<StageDisplayLayout> {
         if code == "camera-crew" {
             return Err(anyhow::anyhow!(
                 "'camera-crew' is not an operator-selectable layout; it is served only at /ui/camera"
             ));
         }
-        let layout = StageDisplayLayout::built_in()
-            .into_iter()
-            .find(|layout| layout.code == code)
-            .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))?;
+        StageDisplayLayout::find_operator_selectable(code)
+            .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))
+    }
+
+    pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {
+        self.switch_stage_layout(code, true).await
+    }
+
+    /// Switch the stage layout. `publish_snapshots = false` skips the
+    /// full-context snapshot broadcast for callers that immediately broadcast
+    /// a fresh resolution themselves (the per-slide marker path inside
+    /// `update_stage_state`, #515) — otherwise every marker-driven switch
+    /// would fan the full snapshot to every /live/ws client twice. The
+    /// `LiveEvent::StageLayout` publish and the api-layout snapshot publish
+    /// always happen (the resolution broadcast skips the api layout).
+    pub(super) async fn switch_stage_layout(
+        &self,
+        code: &str,
+        publish_snapshots: bool,
+    ) -> anyhow::Result<StageDisplayLayout> {
+        let layout = Self::validate_operator_selectable(code)?;
         {
             let mut guard = self.stage_layout.write().await;
             if *guard == layout.code {
@@ -141,10 +161,12 @@ impl AppState {
             // most recent PUT instead of waiting for the next one.
             // `broadcast_stage_snapshots` short-circuits on api layout
             // anyway (see broadcasting.rs::publish_stage_context), so we
-            // replace it with the api snapshot publish here.
+            // replace it with the api snapshot publish here. This publish is
+            // NOT skippable — the resolution broadcast that follows on the
+            // marker path also short-circuits on the api layout.
             let snapshot = self.api_stage_snapshot().await;
             self.live_hub.publish(LiveEvent::Stage { snapshot });
-        } else {
+        } else if publish_snapshots {
             self.broadcast_stage_snapshots().await?;
         }
         Ok(layout)
@@ -152,12 +174,9 @@ impl AppState {
 
     pub async fn stage_displays(&self) -> anyhow::Result<Vec<StageDisplayLayout>> {
         // camera-crew is published always but is not user-selectable from the
-        // operator UI — it's accessed via /ui/camera only. Hide it from the
-        // layout picker.
-        Ok(StageDisplayLayout::built_in()
-            .into_iter()
-            .filter(|l| l.code != "camera-crew")
-            .collect())
+        // operator UI — it's accessed via /ui/camera only. Hidden from the
+        // layout picker via the shared operator-selectable set.
+        Ok(StageDisplayLayout::operator_selectable())
     }
 }
 

--- a/crates/presenter-server/src/state/stage_state.rs
+++ b/crates/presenter-server/src/state/stage_state.rs
@@ -57,6 +57,13 @@ impl AppState {
             playlist_id,
         )
         .with_active_entry_index(entry_index);
+
+        // #515: serialize triggers — without this, two near-simultaneous
+        // triggers from independent sources (operator + Companion pedal)
+        // could interleave state-write / marker-switch / broadcast so the
+        // stage ends on the LOSING trigger's layout or snapshot.
+        let _trigger_guard = self.stage_trigger_lock.lock().await;
+
         let db_start = Instant::now();
         self.repository.upsert_stage_state(&stage_state).await?;
         let t_db_write_ms = db_start.elapsed().as_secs_f64() * 1000.0;
@@ -64,7 +71,9 @@ impl AppState {
         // #515: a slide carrying a stage-layout marker switches the stage
         // display BEFORE the resolution broadcast, so the snapshot below is
         // already published for the new layout. Never fails the trigger.
+        let marker_start = Instant::now();
         self.apply_slide_stage_layout_marker(current_slide_id).await;
+        let t_marker_ms = marker_start.elapsed().as_secs_f64() * 1000.0;
 
         let mut resolution = stage_resolution_from_presentation(
             &presentation,
@@ -101,6 +110,7 @@ impl AppState {
             correlation_id = %correlation_id,
             t_validate_ms,
             t_db_write_ms,
+            t_marker_ms,
             t_broadcast_ms,
             t_total_ms,
             "stage handler timing"

--- a/crates/presenter-server/src/state/stage_state.rs
+++ b/crates/presenter-server/src/state/stage_state.rs
@@ -61,6 +61,11 @@ impl AppState {
         self.repository.upsert_stage_state(&stage_state).await?;
         let t_db_write_ms = db_start.elapsed().as_secs_f64() * 1000.0;
 
+        // #515: a slide carrying a stage-layout marker switches the stage
+        // display BEFORE the resolution broadcast, so the snapshot below is
+        // already published for the new layout. Never fails the trigger.
+        self.apply_slide_stage_layout_marker(current_slide_id).await;
+
         let mut resolution = stage_resolution_from_presentation(
             &presentation,
             Some(library_name),

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.183"
+version = "0.4.184"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/api/presentations.rs
+++ b/crates/presenter-ui/src/api/presentations.rs
@@ -194,3 +194,29 @@ pub async fn reorder_slides(pres_id: &str, slide_ids: Vec<String>) -> Result<Vec
 pub async fn fetch_group_colors() -> Result<HashMap<String, String>, ApiError> {
     get_json("/group-colors").await
 }
+
+// ── Per-slide stage-layout markers (#515) ────────────────────────────────────
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SlideStageLayoutRequest {
+    layout_code: Option<String>,
+}
+
+/// Assign (`Some(code)`) or clear (`None`) a slide's stage-layout marker.
+pub async fn set_slide_stage_layout(
+    pres_id: &str,
+    slide_id: &str,
+    layout_code: Option<String>,
+) -> Result<(), ApiError> {
+    super::put_no_content(
+        &format!("/presentations/{pres_id}/slides/{slide_id}/stage-layout"),
+        &SlideStageLayoutRequest { layout_code },
+    )
+    .await
+}
+
+/// All markers of a presentation as `slide_id → layout_code`.
+pub async fn fetch_slide_stage_layouts(pres_id: &str) -> Result<HashMap<String, String>, ApiError> {
+    get_json(&format!("/presentations/{pres_id}/slide-stage-layouts")).await
+}

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -13,6 +13,7 @@ pub mod slide_list;
 mod slide_list_scroll;
 mod slide_list_utils;
 mod slide_save;
+pub mod slide_stage_layout_picker;
 pub mod stage;
 pub mod stage_preview;
 pub mod surface_nav;

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -11,8 +11,8 @@ use crate::utils::color::group_pill_style;
 
 use super::slide_list_scroll::{handle_wheel_event, scroll_slide_into_view, scroll_slides_to_top};
 use super::slide_list_utils::{
-    apply_focused_class, field_has_warning, format_multiline, reorder_slide_ids,
-    slide_has_any_warning,
+    apply_focused_class, field_has_warning, format_multiline, is_interactive_tag,
+    reorder_slide_ids, slide_has_any_warning,
 };
 use super::slide_save::{
     finish_save_status_err, finish_save_status_ok, save_with_status, start_save_status,
@@ -204,23 +204,10 @@ pub fn SlideList() -> impl IntoView {
     }
 
     // #515: per-slide stage-layout markers of the open presentation
-    // (slide_id → layout_code), refetched whenever the presentation changes.
-    let slide_stage_markers = RwSignal::new(HashMap::<String, String>::new());
-    {
-        let selected_presentation_id = ctx.selected_presentation_id;
-        Effect::new(move |_| {
-            let Some(pres_id) = selected_presentation_id.get() else {
-                slide_stage_markers.set(HashMap::new());
-                return;
-            };
-            leptos::task::spawn_local(async move {
-                match api::presentations::fetch_slide_stage_layouts(&pres_id).await {
-                    Ok(map) => slide_stage_markers.set(map),
-                    Err(_) => slide_stage_markers.set(HashMap::new()),
-                }
-            });
-        });
-    }
+    // (slide_id → layout_code), maintained by the picker module (clears on
+    // presentation switch + stale-response guard).
+    let slide_stage_markers =
+        crate::components::slide_stage_layout_picker::use_slide_stage_markers(&ctx);
 
     // Scroll active slide into view when stage's current slide changes.
     {
@@ -520,7 +507,7 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(target) = ev.target() {
                                             if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                                 let tag = el.tag_name().to_lowercase();
-                                                if tag == "button" || tag == "textarea" || tag == "input" || tag == "select" || tag == "option" {
+                                                if is_interactive_tag(&tag) {
                                                     return;
                                                 }
                                                 if el.get_attribute("data-action").is_some() {
@@ -557,7 +544,7 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(target) = ev.target() {
                                             if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                                 let tag = el.tag_name().to_lowercase();
-                                                if tag == "button" || tag == "textarea" || tag == "input" || tag == "select" || tag == "option" {
+                                                if is_interactive_tag(&tag) {
                                                     return;
                                                 }
                                             }

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -203,6 +203,25 @@ pub fn SlideList() -> impl IntoView {
         });
     }
 
+    // #515: per-slide stage-layout markers of the open presentation
+    // (slide_id → layout_code), refetched whenever the presentation changes.
+    let slide_stage_markers = RwSignal::new(HashMap::<String, String>::new());
+    {
+        let selected_presentation_id = ctx.selected_presentation_id;
+        Effect::new(move |_| {
+            let Some(pres_id) = selected_presentation_id.get() else {
+                slide_stage_markers.set(HashMap::new());
+                return;
+            };
+            leptos::task::spawn_local(async move {
+                match api::presentations::fetch_slide_stage_layouts(&pres_id).await {
+                    Ok(map) => slide_stage_markers.set(map),
+                    Err(_) => slide_stage_markers.set(HashMap::new()),
+                }
+            });
+        });
+    }
+
     // Scroll active slide into view when stage's current slide changes.
     {
         let stage_snapshot = ctx.stage_snapshot;
@@ -464,6 +483,10 @@ pub fn SlideList() -> impl IntoView {
                         // Clone for save-status badge in slide header
                         let slide_id_for_badge = slide_id.clone();
 
+                        // Clones for the per-slide stage-layout control (#515)
+                        let pres_id_for_marker = pres_id.clone();
+                        let slide_id_for_marker = slide_id.clone();
+
                         view! {
                             <article
                                 class=move || {
@@ -497,7 +520,7 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(target) = ev.target() {
                                             if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                                 let tag = el.tag_name().to_lowercase();
-                                                if tag == "button" || tag == "textarea" || tag == "input" {
+                                                if tag == "button" || tag == "textarea" || tag == "input" || tag == "select" || tag == "option" {
                                                     return;
                                                 }
                                                 if el.get_attribute("data-action").is_some() {
@@ -534,7 +557,7 @@ pub fn SlideList() -> impl IntoView {
                                         if let Some(target) = ev.target() {
                                             if let Ok(el) = target.dyn_into::<web_sys::Element>() {
                                                 let tag = el.tag_name().to_lowercase();
-                                                if tag == "button" || tag == "textarea" || tag == "input" {
+                                                if tag == "button" || tag == "textarea" || tag == "input" || tag == "select" || tag == "option" {
                                                     return;
                                                 }
                                             }
@@ -600,6 +623,14 @@ pub fn SlideList() -> impl IntoView {
                                             <span class=class style=color_style data-role="slide-group">{g}</span>
                                         }
                                     })}
+                                    // #515: per-slide stage-layout marker —
+                                    // selector in edit mode, badge in live mode.
+                                    <crate::components::slide_stage_layout_picker::SlideStageLayoutControl
+                                        pres_id=pres_id_for_marker
+                                        slide_id=slide_id_for_marker
+                                        is_edit=is_edit
+                                        markers=slide_stage_markers
+                                    />
                                     {
                                         // Memo: derives this slide's status from the shared map.
                                         // The body runs whenever any slide saves, but the Memo

--- a/crates/presenter-ui/src/components/slide_list_utils.rs
+++ b/crates/presenter-ui/src/components/slide_list_utils.rs
@@ -215,3 +215,26 @@ mod tests {
         assert_eq!(result.len(), 5);
     }
 }
+
+/// Tags whose clicks/pointerdowns must NOT trigger/focus the slide card —
+/// the card's own interactive controls (#515: one predicate shared by the
+/// click AND pointerdown guards so a new control can't be wired into only
+/// one of them).
+pub fn is_interactive_tag(tag: &str) -> bool {
+    matches!(tag, "button" | "textarea" | "input" | "select" | "option")
+}
+
+#[cfg(test)]
+mod interactive_tag_tests {
+    use super::is_interactive_tag;
+
+    #[test]
+    fn interactive_tags_are_skipped_and_plain_tags_are_not() {
+        for tag in ["button", "textarea", "input", "select", "option"] {
+            assert!(is_interactive_tag(tag), "{tag} must be interactive");
+        }
+        for tag in ["div", "span", "article", "header"] {
+            assert!(!is_interactive_tag(tag), "{tag} must not be interactive");
+        }
+    }
+}

--- a/crates/presenter-ui/src/components/slide_stage_layout_picker.rs
+++ b/crates/presenter-ui/src/components/slide_stage_layout_picker.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
 
 use crate::api;
 use crate::state::AppContext;
@@ -20,6 +21,39 @@ pub fn marker_label(code: &str, layouts: &[presenter_core::StageDisplayLayout]) 
         .find(|layout| layout.code == code)
         .map(|layout| layout.name.clone())
         .unwrap_or_else(|| code.to_uppercase())
+}
+
+/// Fetch + maintain the stage-layout marker map (`slide_id → layout_code`)
+/// of the currently selected presentation.
+///
+/// The map is cleared IMMEDIATELY on every presentation switch so the
+/// previous presentation's badges never show on the new one, and a resolved
+/// fetch is applied only when its presentation is STILL the selected one —
+/// otherwise a slow response for presentation A could clobber the map after
+/// the operator already switched to presentation B (out-of-order responses).
+/// A failed fetch leaves the map empty — the honest pessimistic state.
+pub fn use_slide_stage_markers(ctx: &AppContext) -> RwSignal<HashMap<String, String>> {
+    let markers = RwSignal::new(HashMap::<String, String>::new());
+    let selected_presentation_id = ctx.selected_presentation_id;
+    Effect::new(move |_| {
+        let Some(pres_id) = selected_presentation_id.get() else {
+            markers.set(HashMap::new());
+            return;
+        };
+        markers.set(HashMap::new());
+        leptos::task::spawn_local(async move {
+            let result = api::presentations::fetch_slide_stage_layouts(&pres_id).await;
+            // Stale-response guard: only the still-open presentation may
+            // populate the map.
+            if selected_presentation_id.get_untracked().as_deref() != Some(pres_id.as_str()) {
+                return;
+            }
+            if let Ok(map) = result {
+                markers.set(map);
+            }
+        });
+    });
+    markers
 }
 
 #[component]
@@ -38,53 +72,82 @@ pub fn SlideStageLayoutControl(
     if is_edit {
         let pres_id_change = pres_id.clone();
         let slide_id_change = slide_id.clone();
+        // Options carry per-<option> prop:selected (the header layout picker's
+        // pattern) instead of prop:value on the <select>: a select's value can
+        // only stick when a matching <option> already exists, and this
+        // component's options (from /stage-displays) and marker value (per-
+        // presentation fetch) arrive from independent async fetches in either
+        // order. prop:selected re-renders WITH the options themselves, so the
+        // marked layout is selected no matter which response lands first.
+        let options = move || {
+            let selected = current_code.get().unwrap_or_default();
+            let layout_options = layouts
+                .get()
+                .into_iter()
+                .map(|layout| {
+                    let code = layout.code.clone();
+                    let is_selected = code == selected;
+                    view! {
+                        <option value=code prop:selected=is_selected>
+                            {format!("Stage: {}", layout.name)}
+                        </option>
+                    }
+                })
+                .collect_view();
+            view! {
+                <option value="" prop:selected=selected.is_empty()>"Stage: —"</option>
+                {layout_options}
+            }
+        };
+        let on_change = move |ev: leptos::ev::Event| {
+            let value = event_target_value(&ev);
+            let code = if value.is_empty() { None } else { Some(value) };
+            let pres_id = pres_id_change.clone();
+            let slide_id = slide_id_change.clone();
+            let select = ev
+                .target()
+                .and_then(|t| t.dyn_into::<web_sys::HtmlSelectElement>().ok());
+            let code_for_map = code.clone();
+            leptos::task::spawn_local(async move {
+                match api::presentations::set_slide_stage_layout(&pres_id, &slide_id, code).await {
+                    Ok(()) => {
+                        markers.update(|map| match code_for_map {
+                            Some(code) => {
+                                map.insert(slide_id.clone(), code);
+                            }
+                            None => {
+                                map.remove(&slide_id);
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        // The browser already applied the pick to the DOM
+                        // select — snap it back to the server truth so a
+                        // failed save can't silently look saved (the marker
+                        // map did not change, so no re-render fixes it).
+                        let server_code = markers
+                            .get_untracked()
+                            .get(&slide_id)
+                            .cloned()
+                            .unwrap_or_default();
+                        if let Some(select) = select {
+                            select.set_value(&server_code);
+                        }
+                        leptos::logging::warn!(
+                            "stage-layout marker save failed for slide {slide_id}: {err:?}"
+                        );
+                    }
+                }
+            });
+        };
         view! {
             <select
                 class="operator__slide-stage-layout-select"
                 data-role="slide-stage-layout-select"
                 title="Stage layout for this slide (switches when triggered)"
-                prop:value=move || current_code.get().unwrap_or_default()
-                on:change=move |ev| {
-                    let value = event_target_value(&ev);
-                    let code = if value.is_empty() { None } else { Some(value) };
-                    let pres_id = pres_id_change.clone();
-                    let slide_id = slide_id_change.clone();
-                    let code_for_map = code.clone();
-                    leptos::task::spawn_local(async move {
-                        if api::presentations::set_slide_stage_layout(
-                            &pres_id,
-                            &slide_id,
-                            code.clone(),
-                        )
-                        .await
-                        .is_ok()
-                        {
-                            markers.update(|map| match code_for_map {
-                                Some(code) => {
-                                    map.insert(slide_id.clone(), code);
-                                }
-                                None => {
-                                    map.remove(&slide_id);
-                                }
-                            });
-                        }
-                    });
-                }
+                on:change=on_change
             >
-                <option value="">"Stage: —"</option>
-                {move || {
-                    layouts
-                        .get()
-                        .into_iter()
-                        .map(|layout| {
-                            view! {
-                                <option value=layout.code.clone()>
-                                    {format!("Stage: {}", layout.name)}
-                                </option>
-                            }
-                        })
-                        .collect_view()
-                }}
+                {options}
             </select>
         }
         .into_any()

--- a/crates/presenter-ui/src/components/slide_stage_layout_picker.rs
+++ b/crates/presenter-ui/src/components/slide_stage_layout_picker.rs
@@ -1,0 +1,129 @@
+//! Per-slide stage-layout marker control for the operator slide grid (#515).
+//!
+//! Edit mode: a compact selector in the slide-card header assigning/clearing
+//! the marker. Live mode: a small badge on slides that carry one, so the
+//! operator sees which slide will flip the stage layout when triggered.
+
+use std::collections::HashMap;
+
+use leptos::prelude::*;
+
+use crate::api;
+use crate::state::AppContext;
+
+/// Badge / option label for a layout code: the layout's display name when the
+/// picker list knows it, otherwise the uppercased code (stale marker whose
+/// layout disappeared — still shown honestly rather than hidden).
+pub fn marker_label(code: &str, layouts: &[presenter_core::StageDisplayLayout]) -> String {
+    layouts
+        .iter()
+        .find(|layout| layout.code == code)
+        .map(|layout| layout.name.clone())
+        .unwrap_or_else(|| code.to_uppercase())
+}
+
+#[component]
+pub fn SlideStageLayoutControl(
+    pres_id: String,
+    slide_id: String,
+    is_edit: bool,
+    markers: RwSignal<HashMap<String, String>>,
+) -> impl IntoView {
+    let ctx = use_ctx!(AppContext);
+    let layouts = ctx.stage_layouts;
+
+    let sid_for_memo = slide_id.clone();
+    let current_code = Memo::new(move |_| markers.get().get(&sid_for_memo).cloned());
+
+    if is_edit {
+        let pres_id_change = pres_id.clone();
+        let slide_id_change = slide_id.clone();
+        view! {
+            <select
+                class="operator__slide-stage-layout-select"
+                data-role="slide-stage-layout-select"
+                title="Stage layout for this slide (switches when triggered)"
+                prop:value=move || current_code.get().unwrap_or_default()
+                on:change=move |ev| {
+                    let value = event_target_value(&ev);
+                    let code = if value.is_empty() { None } else { Some(value) };
+                    let pres_id = pres_id_change.clone();
+                    let slide_id = slide_id_change.clone();
+                    let code_for_map = code.clone();
+                    leptos::task::spawn_local(async move {
+                        if api::presentations::set_slide_stage_layout(
+                            &pres_id,
+                            &slide_id,
+                            code.clone(),
+                        )
+                        .await
+                        .is_ok()
+                        {
+                            markers.update(|map| match code_for_map {
+                                Some(code) => {
+                                    map.insert(slide_id.clone(), code);
+                                }
+                                None => {
+                                    map.remove(&slide_id);
+                                }
+                            });
+                        }
+                    });
+                }
+            >
+                <option value="">"Stage: —"</option>
+                {move || {
+                    layouts
+                        .get()
+                        .into_iter()
+                        .map(|layout| {
+                            view! {
+                                <option value=layout.code.clone()>
+                                    {format!("Stage: {}", layout.name)}
+                                </option>
+                            }
+                        })
+                        .collect_view()
+                }}
+            </select>
+        }
+        .into_any()
+    } else {
+        view! {
+            <Show when=move || current_code.get().is_some()>
+                <span
+                    class="operator__slide-stage-layout-badge"
+                    data-role="slide-stage-layout-badge"
+                    title="Triggering this slide switches the stage layout"
+                >
+                    {move || {
+                        current_code
+                            .get()
+                            .map(|code| format!("⤢ {}", marker_label(&code, &layouts.get())))
+                            .unwrap_or_default()
+                    }}
+                </span>
+            </Show>
+        }
+        .into_any()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::marker_label;
+    use presenter_core::StageDisplayLayout;
+
+    #[test]
+    fn marker_label_uses_layout_name_when_known() {
+        let layouts = StageDisplayLayout::built_in();
+        assert_eq!(marker_label("fulltext", &layouts), "FULL TEXT");
+        assert_eq!(marker_label("timer", &layouts), "TIMER");
+    }
+
+    #[test]
+    fn marker_label_falls_back_to_uppercased_code() {
+        let layouts = StageDisplayLayout::built_in();
+        assert_eq!(marker_label("removed-layout", &layouts), "REMOVED-LAYOUT");
+    }
+}

--- a/crates/presenter-ui/src/components/stage/fulltext_layout.rs
+++ b/crates/presenter-ui/src/components/stage/fulltext_layout.rs
@@ -1,0 +1,79 @@
+//! Full-screen stage-text layout (#515).
+//!
+//! Renders ONLY the current slide's stage text, auto-scaled up/down to fill
+//! the entire stage screen — for handing the speaker a long text to read or a
+//! short message. Follows the timer layout's minimal pattern: the text area
+//! plus the standard status bar every layout keeps, nothing else.
+
+use leptos::prelude::*;
+
+use crate::state::stage::StageContext;
+use crate::utils::autofit::autofit_effect;
+use crate::ws::stage::StageWsState;
+
+const FULLTEXT_MAX_FONT: f64 = 800.0;
+
+/// Text the fulltext layout shows for a snapshot's current slide: the stage
+/// field when present, falling back to the main lyrics text — the same
+/// precedence the worship layouts use for their current-slide line.
+pub fn fulltext_display_text(stage: &str, main: &str) -> String {
+    if stage.is_empty() {
+        main.to_string()
+    } else {
+        stage.to_string()
+    }
+}
+
+#[component]
+pub fn FulltextLayout(
+    ws_state: ReadSignal<StageWsState>,
+    latency_ms: ReadSignal<Option<f64>>,
+) -> impl IntoView {
+    let ctx = use_context::<StageContext>().expect("StageContext not provided");
+
+    let text_ref = NodeRef::<leptos::html::Div>::new();
+
+    let current_text = move || {
+        ctx.snapshot
+            .get()
+            .and_then(|s| {
+                s.current
+                    .map(|slide| fulltext_display_text(&slide.stage, &slide.main))
+            })
+            .unwrap_or_default()
+    };
+
+    autofit_effect(text_ref, FULLTEXT_MAX_FONT, current_text);
+
+    view! {
+        <div class="stage-container" data-layout="fulltext">
+            <div class="stage-fulltext__display">
+                <span class="stage__debug-label">"fulltext-display"</span>
+                <div node_ref=text_ref class="stage-fulltext__text" data-role="fulltext-text">
+                    {current_text}
+                </div>
+            </div>
+            <super::status_bar::StatusBar ws_state=ws_state latency_ms=latency_ms />
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fulltext_display_text;
+
+    #[test]
+    fn prefers_stage_field_when_present() {
+        assert_eq!(fulltext_display_text("read this", "lyrics"), "read this");
+    }
+
+    #[test]
+    fn falls_back_to_main_when_stage_empty() {
+        assert_eq!(fulltext_display_text("", "lyrics"), "lyrics");
+    }
+
+    #[test]
+    fn empty_slide_renders_empty_text() {
+        assert_eq!(fulltext_display_text("", ""), "");
+    }
+}

--- a/crates/presenter-ui/src/components/stage/mod.rs
+++ b/crates/presenter-ui/src/components/stage/mod.rs
@@ -2,6 +2,7 @@ pub mod api_stage;
 pub mod bible_layout;
 pub mod bible_overlay;
 pub mod camera_crew;
+pub mod fulltext_layout;
 mod ndi_beacon;
 mod ndi_clock_offset;
 mod ndi_frame_stats;

--- a/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
@@ -71,13 +71,7 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
         }
         // Beacon first: the healthy-path early returns below must not
         // starve it during normal playback.
-        maybe_post_beacon(
-            &tick_count,
-            &pc,
-            &source_id,
-            &stats,
-            clock_offset.current(),
-        );
+        maybe_post_beacon(&tick_count, &pc, &source_id, &stats, clock_offset.current());
         if !rvfc_supported
             && approximate_frame_from_current_time(&video, &stats, &last_current_time)
         {

--- a/crates/presenter-ui/src/pages/stage.rs
+++ b/crates/presenter-ui/src/pages/stage.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 
 use crate::api;
 use crate::components::stage::{
-    api_stage::ApiStage, bible_layout::BibleLayout, ndi_fullscreen::NdiFullscreen,
-    preach_layout::PreachLayout, timer_layout::TimerLayout, worship_pp::WorshipPp,
-    worship_snv::WorshipSnv,
+    api_stage::ApiStage, bible_layout::BibleLayout, fulltext_layout::FulltextLayout,
+    ndi_fullscreen::NdiFullscreen, preach_layout::PreachLayout, timer_layout::TimerLayout,
+    worship_pp::WorshipPp, worship_snv::WorshipSnv,
 };
 use crate::state::stage::StageContext;
 use crate::ws::stage::{self, StageWsState};
@@ -287,6 +287,9 @@ pub fn StagePage() -> impl IntoView {
                 }
                 "bible" => {
                     view! { <BibleLayout ws_state=ws_state latency_ms=latency_ms /> }.into_any()
+                }
+                "fulltext" => {
+                    view! { <FulltextLayout ws_state=ws_state latency_ms=latency_ms /> }.into_any()
                 }
                 "api" => {
                     view! { <ApiStage ws_state=ws_state latency_ms=latency_ms /> }.into_any()

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1322,6 +1322,33 @@ body.operator[data-mode="live"] .operator__slide-handle {
   opacity: 0.8;
 }
 
+/* ===== Per-slide stage-layout marker (#515) ===== */
+
+.operator__slide-stage-layout-select {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.25rem;
+  border-radius: 4px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.9);
+  color: #334155;
+  max-width: 9rem;
+}
+
+.operator__slide-stage-layout-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(14, 165, 233, 0.16);
+  color: #0369a1;
+  border: 1px solid rgba(14, 165, 233, 0.4);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  white-space: nowrap;
+}
+
 /* Worship slide card variant — make edit textareas grow like bible */
 .operator__slide-card--worship .operator__slide-editor textarea {
   field-sizing: content;

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -429,6 +429,39 @@ body.stage {
         0 2px 4px rgba(0, 0, 0, 0.7);
 }
 
+/* ===== fulltext layout (#515) ===== */
+
+/* Whole-screen stage text: the display area spans nearly the full viewport
+   (only the status bar strip at the bottom is kept, like every layout), and
+   the text auto-fits inside it via the shared autofit binary search. */
+.stage-fulltext__display {
+    position: absolute;
+    left: 2%;
+    top: 2%;
+    width: 96%;
+    height: 88%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    z-index: 2;
+}
+
+.stage-fulltext__text {
+    color: #f8fafc;
+    font-weight: 700;
+    text-align: center;
+    line-height: 1.12;
+    /* Long hand-off texts are paragraphs: preserve the author's line breaks
+       AND wrap long lines so autofit scales to the screen instead of shrinking
+       a single unwrappable line into unreadability. */
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
 /* ===== NDI background for timer layout (#306) ===== */
 .stage-timer__ndi {
     position: absolute;

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,14 @@ ignore = [
     # no upgrade path until those frameworks migrate (dependency-refresh #343).
     # https://rustsec.org/advisories/RUSTSEC-2026-0173
     "RUSTSEC-2026-0173",
+    # quick-xml 0.39.4 DoS-class advisories, fixed only in >=0.41.0 — pinned
+    # transitively by gst-plugin-ndi (^0.39; 0.15.3 still pins ^0.40). NDI XML
+    # comes only from trusted-LAN sources. Tracked in #522 — remove both here
+    # AND in .cargo/audit.toml once gst-plugin-ndi allows quick-xml >=0.41.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0194
+    "RUSTSEC-2026-0194",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0195
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -316,3 +316,26 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
 - **#512:** the stage latency number is now TRUTHFUL: `latency = render residual (rVFC buffer+decode+present) + network one-way (RTT/2 from /ndi/time, #510)`; labelled `server→displej`; honest `n/a` when no fresh offset. The #509 probe had proven the designed `estimatedPlayoutTimestamp` formula dead on ALL real TVs AND desktop Chrome (`playout_class="absent"` — monotonic-clock RTCP SRs), so the metric was redefined on fields every device reports. Unit invariants: Tailscale ≥ LAN, non-negative, n/a-without-network. ADR 0008 + architecture.md. PR #518, merged 34dcf5dd, v0.4.181.
 - **Visibility fix:** readout gated on stable `ndi_active` (per-frame `frames_live` throttles on idle/headless and hid the correct number). Verified live on prod: `SERVER→DISPLEJ · 21 ms` appears unforced, offset RTT 2.1ms, 0 console errors. PR #519, merged 48083c74, v0.4.182.
 - **CI fix (rode PR #519):** dev2 toolchain bump (rustc 1.96.1) forced a 19-min cold gstreamer rebuild in the e2e-ndi lane → 20-min cap → 2× cancelled. `ndi_test_sender` is now prebuilt in the GH-hosted Build job and shipped as an artifact — the self-hosted runner never compiles Rust again (matches the documented runner architecture).
+
+## 2026-07-02 — #515 (fulltext stage layout + per-slide stage-layout markers)
+- **Part 1:** new `fulltext` built-in layout — the current slide's STAGE text (fallback: main)
+  auto-scaled across the whole screen via the shared `autofit_effect` (max 800px, `pre-wrap` so
+  long hand-off paragraphs wrap instead of shrinking a single line). Minimal per the timer-layout
+  pattern: text area + StatusBar, nothing else. `components/stage/fulltext_layout.rs`.
+- **Part 2:** per-slide stage-layout markers in a NEW `slide_stage_layouts` table
+  (slide_id PK, presentation_id, layout_code; idempotent `m20260702_000001` migration).
+  Trigger flow is fully SERVER-side (tablet rule preserved): `update_stage_state` looks up the
+  marker of the now-current slide BEFORE the resolution broadcast and, if present+different,
+  switches via the same `set_stage_layout_code` path as `POST /stage/layout`. Unmarked slides
+  never revert; a stale marker (layout removed later) logs a warning and never fails the trigger.
+  Endpoints: `PUT /presentations/{pid}/slides/{sid}/stage-layout` (`{"layoutCode": code|null}`),
+  `GET /presentations/{pid}/slide-stage-layouts`. Markers are cleaned up on slide delete +
+  presentation delete. Operator UI: compact select in the slide-card header (edit mode), badge
+  "⤢ <NAME>" (live mode) — new module `components/slide_stage_layout_picker.rs` to keep
+  `slide_list.rs` under the 1000-line cap (now 989 prod lines).
+- **Tests:** repo CRUD (6, `repository/slide_stage_layout.rs`), state assign/validate/trigger-switch
+  (8, `state/slide_stage_layout.rs` — incl. marked-slide-switches, unmarked-keeps, stale-marker-safe),
+  router handler tests, core built_in updates, UI `fulltext_display_text` + `marker_label` units,
+  E2E `tests/e2e/stage-fulltext-layout.spec.ts` (3: fullscreen render + autoscale short-vs-long font
+  assertion, API marker → trigger switches live stage DOM, operator select→badge flow; 0 console errors).
+- Solo PR (dev→main, Closes #515), version 0.4.184.

--- a/ops/companion/presenter/companion/manifest.json
+++ b/ops/companion/presenter/companion/manifest.json
@@ -3,7 +3,7 @@
   "name": "Presenter Companion WS",
   "shortname": "presenter",
   "description": "Control Presenter via the /companion/ws API",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "MIT",
   "repository": "https://git.newleveltech/presenter",
   "bugs": "https://git.newleveltech/presenter/issues",

--- a/ops/companion/presenter/index.js
+++ b/ops/companion/presenter/index.js
@@ -76,6 +76,7 @@ const STAGE_LAYOUT_CHOICES = [
   { id: "preach", label: "PREACH" },
   { id: "ndi-fullscreen", label: "NDI FULLSCREEN" },
   { id: "bible", label: "BIBLE" },
+  { id: "fulltext", label: "FULL TEXT" },
 ];
 
 class PresenterInstance extends InstanceBase {

--- a/ops/companion/presenter/package.json
+++ b/ops/companion/presenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@companion-module/presenter",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Control Presenter via /companion/ws",
   "main": "index.js",
   "type": "commonjs",

--- a/tests/e2e/stage-fulltext-layout.spec.ts
+++ b/tests/e2e/stage-fulltext-layout.spec.ts
@@ -299,6 +299,20 @@ test("operator assigns a marker from the slide card and sees the badge in live m
   await expect(badge).toBeVisible({ timeout: 15_000 });
   await expect(badge).toContainText("FULL TEXT");
 
+  // Back in edit mode the selector must PRE-SELECT the existing marker
+  // (regression guard: prop:value on <select> was applied before the options
+  // mounted, so an assigned marker displayed as "Stage: —" — fixed with
+  // per-<option> prop:selected, the header layout picker's pattern).
+  await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "edit",
+  );
+  const selectAgain = page
+    .locator(`[data-slide-id="${slideIds[1]}"]`)
+    .locator('[data-role="slide-stage-layout-select"]');
+  await expect(selectAgain).toBeVisible({ timeout: 15_000 });
+  await expect(selectAgain).toHaveValue("fulltext", { timeout: 15_000 });
+
   expect(consoleErrors).toEqual([]);
   await page.close();
 });

--- a/tests/e2e/stage-fulltext-layout.spec.ts
+++ b/tests/e2e/stage-fulltext-layout.spec.ts
@@ -1,0 +1,304 @@
+import { test, expect, BrowserContext, Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+/**
+ * #515 — fulltext stage layout + per-slide stage-layout markers.
+ *
+ * (a) The `fulltext` layout renders ONLY the current slide's stage text,
+ *     auto-scaled to the whole screen (short text ⇒ larger font than long).
+ * (b) A slide carrying a stage-layout marker switches the stage layout when
+ *     triggered (server-side, like POST /stage/layout); unmarked slides
+ *     leave the layout untouched.
+ * (c) The operator can assign a marker from the slide card (edit mode) and
+ *     sees a badge on marked slides (live mode).
+ * All tests assert a clean browser console.
+ */
+
+test.describe.configure({ timeout: 180_000 });
+
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!ALLOWED_CONSOLE_NOISE.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+const LIBRARY_NAME = "_E2E Fulltext";
+const SHORT_STAGE_TEXT = "Read this short message";
+const LONG_STAGE_TEXT = [
+  "This is a deliberately long hand-off text for the speaker to read from",
+  "the stage display. It spans multiple sentences so the autofit binary",
+  "search has to shrink the font significantly below the size it picks for",
+  "a short message, which is exactly what this end-to-end test asserts.",
+  "The text keeps going for a while to make the contrast unmistakable and",
+  "the assertion robust against small rendering differences between runs.",
+].join(" ");
+const FALLBACK_MAIN_TEXT = "Fallback main text";
+
+let presentationId = "";
+let slideIds: string[] = [];
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+
+  const libResp = await fetch(new URL("/libraries", baseURL).toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: LIBRARY_NAME }),
+  });
+  const lib = await libResp.json();
+
+  const presResp = await fetch(
+    new URL(`/libraries/${lib.id}/presentations`, baseURL).toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Fulltext Cases",
+        slides: [
+          { main: "Slide one main", stage: SHORT_STAGE_TEXT },
+          { main: "Slide two main", stage: LONG_STAGE_TEXT },
+          { main: FALLBACK_MAIN_TEXT },
+        ],
+      }),
+    },
+  );
+  const presData = await presResp.json();
+  presentationId = presData.presentation.id;
+  slideIds = presData.presentation.slides.map((s: { id: string }) => s.id);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+async function setLayout(context: BrowserContext, code: string) {
+  const resp = await context.request.post(
+    new URL("/stage/layout", baseURL).toString(),
+    { data: { code } },
+  );
+  expect(resp.status()).toBe(200);
+}
+
+async function triggerSlide(context: BrowserContext, idx: number) {
+  const resp = await context.request.post(
+    new URL("/stage/state", baseURL).toString(),
+    {
+      data: {
+        presentationId,
+        currentSlideId: slideIds[idx],
+        nextSlideId: slideIds[idx + 1] ?? null,
+      },
+    },
+  );
+  expect(resp.status()).toBe(204);
+}
+
+async function openStage(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(new URL("/stage", baseURL).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  return page;
+}
+
+async function fulltextFontPx(page: Page): Promise<number> {
+  return page
+    .locator('[data-role="fulltext-text"]')
+    .evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+}
+
+test("fulltext layout shows the stage text fullscreen and auto-scales it", async ({
+  context,
+}) => {
+  await setLayout(context, "fulltext");
+  const stagePage = await openStage(context);
+  const consoleErrors = collectConsoleErrors(stagePage);
+
+  await stagePage.waitForSelector('body[data-layout-code="fulltext"]', {
+    timeout: 15_000,
+  });
+
+  // Short stage text renders verbatim in the fulltext area.
+  await triggerSlide(context, 0);
+  const text = stagePage.locator('[data-role="fulltext-text"]');
+  await expect(text).toHaveText(SHORT_STAGE_TEXT, { timeout: 15_000 });
+  await expect(text).toBeVisible();
+
+  // Autofit picked a real font size (non-trivially large for a short text).
+  await expect
+    .poll(() => fulltextFontPx(stagePage), { timeout: 15_000 })
+    .toBeGreaterThan(60);
+  const shortFont = await fulltextFontPx(stagePage);
+
+  // The long hand-off text must scale DOWN substantially to fit the screen.
+  await triggerSlide(context, 1);
+  await expect(text).toHaveText(LONG_STAGE_TEXT, { timeout: 15_000 });
+  await expect
+    .poll(() => fulltextFontPx(stagePage), { timeout: 15_000 })
+    .toBeLessThan(shortFont * 0.6);
+  const longFont = await fulltextFontPx(stagePage);
+  expect(longFont).toBeGreaterThan(1);
+
+  // A slide with an empty stage field falls back to its main text.
+  await triggerSlide(context, 2);
+  await expect(text).toHaveText(FALLBACK_MAIN_TEXT, { timeout: 15_000 });
+
+  expect(consoleErrors).toEqual([]);
+  await stagePage.close();
+});
+
+test("triggering a marked slide switches the stage layout; unmarked slides keep it", async ({
+  context,
+}) => {
+  await setLayout(context, "worship-snv");
+  const stagePage = await openStage(context);
+  const consoleErrors = collectConsoleErrors(stagePage);
+
+  await stagePage.waitForSelector('body[data-layout-code="worship-snv"]', {
+    timeout: 15_000,
+  });
+
+  // Assign the fulltext marker to slide 0 via the API.
+  const putResp = await context.request.put(
+    new URL(
+      `/presentations/${presentationId}/slides/${slideIds[0]}/stage-layout`,
+      baseURL,
+    ).toString(),
+    { data: { layoutCode: "fulltext" } },
+  );
+  expect(putResp.status()).toBe(204);
+
+  // Triggering the marked slide flips the live stage to fulltext.
+  await triggerSlide(context, 0);
+  await stagePage.waitForSelector('body[data-layout-code="fulltext"]', {
+    timeout: 15_000,
+  });
+  await expect(
+    stagePage.locator('[data-role="fulltext-text"]'),
+  ).toHaveText(SHORT_STAGE_TEXT, { timeout: 15_000 });
+
+  // Triggering an UNMARKED slide keeps the layout (content still updates).
+  await triggerSlide(context, 2);
+  await expect(
+    stagePage.locator('[data-role="fulltext-text"]'),
+  ).toHaveText(FALLBACK_MAIN_TEXT, { timeout: 15_000 });
+  await expect(stagePage.locator("body")).toHaveAttribute(
+    "data-layout-code",
+    "fulltext",
+  );
+
+  // An unknown layout code is rejected outright.
+  const badResp = await context.request.put(
+    new URL(
+      `/presentations/${presentationId}/slides/${slideIds[0]}/stage-layout`,
+      baseURL,
+    ).toString(),
+    { data: { layoutCode: "no-such-layout" } },
+  );
+  expect(badResp.status()).toBe(400);
+
+  expect(consoleErrors).toEqual([]);
+  await stagePage.close();
+});
+
+test("operator assigns a marker from the slide card and sees the badge in live mode", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  const consoleErrors = collectConsoleErrors(page);
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  // Open the test library (created after seeding, so it is not in the
+  // favorites sidebar — go through the "Show all libraries" modal) and the
+  // test presentation.
+  await page.waitForSelector('[data-role="library-more"]', {
+    timeout: 30_000,
+  });
+  await page.locator('[data-role="library-more"]').click();
+  await page
+    .locator('[data-role="library-row"]', { hasText: LIBRARY_NAME })
+    .locator("button.operator__list-button")
+    .click();
+  await page
+    .locator('[data-role="presentation-item"]', { hasText: "Fulltext Cases" })
+    .first()
+    .click();
+  await page.waitForSelector(`[data-slide-id="${slideIds[1]}"]`, {
+    timeout: 30_000,
+  });
+
+  // Edit mode exposes the per-slide stage-layout selector.
+  await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "edit",
+  );
+  const select = page
+    .locator(`[data-slide-id="${slideIds[1]}"]`)
+    .locator('[data-role="slide-stage-layout-select"]');
+  await expect(select).toBeVisible({ timeout: 15_000 });
+  await select.selectOption("fulltext");
+
+  // The marker lands on the server.
+  await expect
+    .poll(async () => {
+      const resp = await context.request.get(
+        new URL(
+          `/presentations/${presentationId}/slide-stage-layouts`,
+          baseURL,
+        ).toString(),
+      );
+      const map = (await resp.json()) as Record<string, string>;
+      return map[slideIds[1]];
+    })
+    .toBe("fulltext");
+
+  // Live mode shows the badge on the marked slide.
+  await page.locator('[data-role="mode-toggle"][data-mode="live"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "live",
+  );
+  const badge = page
+    .locator(`[data-slide-id="${slideIds[1]}"]`)
+    .locator('[data-role="slide-stage-layout-badge"]');
+  await expect(badge).toBeVisible({ timeout: 15_000 });
+  await expect(badge).toContainText("FULL TEXT");
+
+  expect(consoleErrors).toEqual([]);
+  await page.close();
+});


### PR DESCRIPTION
Closes #515

## Two features, one PR (per the issue "2 feature requests")

### 1. `fulltext` stage layout
A new built-in stage layout that renders ONLY the current slide's **stage** text (fallback: main), auto-scaled up/down to fill the entire stage screen — for handing the speaker a long text to read or a short message. Uses the shared `autofit_effect` binary search (max 800px) with `pre-wrap` so long paragraphs wrap. Keeps the standard status bar (timer-layout minimal pattern). Appears automatically in the operator layout picker.

### 2. Per-slide stage-layout markers
The operator can mark any slide with a stage layout; when that slide is triggered (operator click or tablet — lookup is fully **server-side**, tablet rule preserved), the server switches the stage display exactly like `POST /stage/layout` (persist + `LiveEvent::StageLayout` + snapshot broadcast). Unmarked slides never revert the layout; a stale marker logs a warning and never fails the trigger.

- New `slide_stage_layouts` table (idempotent `m20260702_000001` migration, `slide_id` PK; cleaned up on slide/presentation delete)
- `PUT /presentations/{pid}/slides/{sid}/stage-layout` (`{"layoutCode": code|null}`), `GET /presentations/{pid}/slide-stage-layouts`
- Operator UI: compact selector in the slide-card header (edit mode), `⤢ <LAYOUT>` badge (live mode) — new `slide_stage_layout_picker` module keeps `slide_list.rs` under the file cap (989 prod lines)

## Tests
- Repository CRUD (6) — `repository/slide_stage_layout.rs`
- State: assign/validate (incl. camera-crew + unknown-layout rejection), **marked-slide-switches**, **unmarked-keeps**, **stale-marker-never-fails-trigger** (8) — `state/slide_stage_layout.rs`
- Router handler tests; core `built_in()` updates; UI unit tests (`fulltext_display_text`, `marker_label`)
- Playwright E2E `tests/e2e/stage-fulltext-layout.spec.ts` (3 tests, all passing locally):
  1. fulltext renders the stage text fullscreen + **autoscale asserted** (long text font < 0.6× short text font; fallback-to-main covered)
  2. API-assigned marker + `POST /stage/state` trigger switches the live stage DOM to `fulltext`; unmarked slide keeps it; unknown layout → 400
  3. operator assigns via the slide-card selector, badge visible in live mode
  All with the zero-console-errors assertion.

Version: 0.4.184.
