### PR TITLE
Stage: per-TV dropped-frame readout (#523) + de-emphasize diagnostic text (#524) + SD1 decoder diagnostic (#525 step 1)

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -15,6 +15,28 @@ triggers:
 
 # Presenter CI Skill
 
+## e2e-ndi lane NEVER compiles Rust — prebuild artifacts in the GH Build job (#519 lesson)
+
+The self-hosted `e2e-ndi` lane (`timeout-minutes: 20`) must only RUN pre-built artifacts,
+never `cargo build` on the runner (matches the runner architecture: the local runner doesn't
+compile Rust). A **toolchain bump on dev2** (e.g. `rustc` stable auto-updated) invalidates the
+runner-workspace Rust cache → a `cargo build … ndi_test_sender` step then cold-rebuilds the whole
+gstreamer tree (~19 min) → blows the 20-min cap → GitHub cancels the job → deploys skipped → ALL
+PRs blocked. This looks like a mystery cancellation with green logs. Fix (already in `pipeline.yml`):
+the `Build` job (GH-hosted, deps hot) builds `cargo build --release -p presenter-ndi --features
+test-helpers --bin ndi_test_sender` and ships it in `build-artifacts`; `e2e-ndi` just `cp`s
+`_artifacts/ndi_test_sender target/release/` and runs it. If e2e-ndi ever cold-builds again, check
+whether a new Rust-compiling step crept into that lane — don't raise the timeout.
+
+## `quality-check.sh --strict` IS the CI "Quality Checks" gate — run it locally before push
+
+CI runs `./scripts/dev/quality-check.sh --strict --against origin/main` (not just `fn_length_check.py`).
+Run that EXACT command locally before pushing. Hard-fails: file >1000 prod lines, **fn >120 lines
+(tests NOT exempt; >80 is only a warn)**, `continue-on-error` in workflows, and cargo-deny/cargo-audit
+policy. Note: cargo-deny/cargo-audit can transiently FAIL then PASS on an immediate re-run (advisory
+DB / lock timing) — re-run once before treating a deny/audit failure as real. A >120 fn added by a
+feature → split a helper out (e.g. #514 split `extract_inbound_video` out of `post_client_stats`).
+
 ## Runner Management
 
 Local runner host: `10.77.8.134` (same machine as dev server), label `self-hosted`/`local`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.184"
+version = "0.4.185"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router/integrations/ndi.rs
+++ b/crates/presenter-server/src/router/integrations/ndi.rs
@@ -186,6 +186,19 @@ pub(crate) struct NdiClientStatsBeacon {
     /// (#514) The min round-trip time (ms) behind that offset — the network
     /// half of the displayed latency (one-way ≈ RTT/2) and its quality bound.
     pub clock_rtt_ms: Option<f64>,
+    /// (#525 step 1 probe) `decoderImplementation` from the SAME inbound-rtp
+    /// getStats snapshot — the exact decoder backend the browser picked
+    /// ("ffmpeg" software, or a hardware backend name like "MediaCodec" on
+    /// Android). `None` when the WebView doesn't expose the field at all.
+    /// This is the field that answers "is this display's ~90ms decode+present
+    /// residual a software-decode cost, or something else?" before any
+    /// playback change is made.
+    pub decoder_implementation: Option<String>,
+    /// (#525 step 1 probe) `powerEfficientDecoder` from the same snapshot —
+    /// true when the browser reports the decode path as power-efficient
+    /// (typically hardware-accelerated). `None` when unsupported by the
+    /// WebView.
+    pub power_efficient_decoder: Option<bool>,
 }
 
 /// Classification of a display's `estimatedPlayoutTimestamp` for the #509 (T0)
@@ -293,6 +306,8 @@ pub(crate) async fn ndi_client_stats(Json(beacon): Json<NdiClientStatsBeacon>) -
         video_latency_ms = beacon.video_latency_ms,
         clock_offset_ms = beacon.clock_offset_ms,
         clock_rtt_ms = beacon.clock_rtt_ms,
+        decoder_implementation = beacon.decoder_implementation.as_deref(),
+        power_efficient_decoder = beacon.power_efficient_decoder,
         user_agent = beacon.user_agent.as_deref(),
         "NDI stage-display client stats beacon"
     );
@@ -418,6 +433,42 @@ mod tests {
         assert_eq!(bare.video_latency_ms, None);
         assert_eq!(bare.clock_offset_ms, None);
         assert_eq!(bare.clock_rtt_ms, None);
+    }
+
+    #[test]
+    fn client_stats_beacon_parses_decoder_probe_fields() {
+        // #525 step 1: the decoder-implementation probe fields the stage now
+        // sends — locates whether a display's decode+present residual is a
+        // software-decode cost before any playback change is made.
+        let beacon: NdiClientStatsBeacon = serde_json::from_str(
+            r#"{
+                "sourceId":"src-1",
+                "decoderImplementation":"ffmpeg",
+                "powerEfficientDecoder":false
+            }"#,
+        )
+        .expect("beacon JSON with decoder-probe fields parses");
+        assert_eq!(beacon.decoder_implementation.as_deref(), Some("ffmpeg"));
+        assert_eq!(beacon.power_efficient_decoder, Some(false));
+
+        // A hardware-backed display reports a HW decoder name + true.
+        let hw: NdiClientStatsBeacon = serde_json::from_str(
+            r#"{
+                "sourceId":"src-1",
+                "decoderImplementation":"MediaCodec",
+                "powerEfficientDecoder":true
+            }"#,
+        )
+        .expect("beacon JSON with hardware decoder-probe fields parses");
+        assert_eq!(hw.decoder_implementation.as_deref(), Some("MediaCodec"));
+        assert_eq!(hw.power_efficient_decoder, Some(true));
+
+        // Older clients / unsupported WebViews omit them entirely → optional
+        // (back-compat) — this must never break beacon parsing.
+        let bare: NdiClientStatsBeacon =
+            serde_json::from_str(r#"{"sourceId":"src-1"}"#).expect("bare beacon parses");
+        assert_eq!(bare.decoder_implementation, None);
+        assert_eq!(bare.power_efficient_decoder, None);
     }
 
     #[test]

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.184"
+version = "0.4.185"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -187,8 +187,11 @@ fn extract_inbound_video(report: &JsValue) -> InboundVideoStats {
 /// stats extension, never one without the other). If a future WebView ever
 /// violated that pairing, the worst case is a momentarily-optimistic "0" on
 /// this purely diagnostic overlay, not a functional regression. Split out of
-/// `post_client_stats` to keep that function under the 80-line size-warning
-/// threshold.
+/// `post_client_stats` as its own concern (keeps the size-warning threshold
+/// creep down; the exact line count isn't pinned here since it will keep
+/// moving as fields are added — `scripts/dev/quality-check.sh` is the source
+/// of truth for whether it's still just a warning or has crossed the 120-line
+/// hard cap).
 fn notify_dropped_frames(inbound: &InboundVideoStats, setter: &Option<DroppedFramesSetter>) {
     let Some(setter) = setter else { return };
     let counts = match (inbound.frames_dropped, inbound.freeze_count) {

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -180,11 +180,15 @@ fn extract_inbound_video(report: &JsValue) -> InboundVideoStats {
 /// #523: push this beacon's dropped-frame + freeze counts to the on-screen
 /// readout. `None` only when the browser's getStats reports NEITHER field
 /// (honest "no data" rather than a misleading 0); a report with at least one
-/// of the two fields present treats the other as 0 (freezeCount and
-/// framesDropped are both cumulative counters that start at 0, so an absent
-/// sibling field alongside a present one is "not yet incremented", not
-/// "unknown"). Split out of `post_client_stats` to keep that function under
-/// the 80-line size-warning threshold.
+/// of the two fields present treats the other as 0. This assumes the two
+/// fields are supported TOGETHER or not at all — true on every real target
+/// here (all stage displays are Chromium/WebView, and Chromium has always
+/// shipped `framesDropped` + `freezeCount` as part of the same inbound-rtp
+/// stats extension, never one without the other). If a future WebView ever
+/// violated that pairing, the worst case is a momentarily-optimistic "0" on
+/// this purely diagnostic overlay, not a functional regression. Split out of
+/// `post_client_stats` to keep that function under the 80-line size-warning
+/// threshold.
 fn notify_dropped_frames(inbound: &InboundVideoStats, setter: &Option<DroppedFramesSetter>) {
     let Some(setter) = setter else { return };
     let counts = match (inbound.frames_dropped, inbound.freeze_count) {

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -177,6 +177,26 @@ fn extract_inbound_video(report: &JsValue) -> InboundVideoStats {
     out
 }
 
+/// #523: push this beacon's dropped-frame + freeze counts to the on-screen
+/// readout. `None` only when the browser's getStats reports NEITHER field
+/// (honest "no data" rather than a misleading 0); a report with at least one
+/// of the two fields present treats the other as 0 (freezeCount and
+/// framesDropped are both cumulative counters that start at 0, so an absent
+/// sibling field alongside a present one is "not yet incremented", not
+/// "unknown"). Split out of `post_client_stats` to keep that function under
+/// the 80-line size-warning threshold.
+fn notify_dropped_frames(inbound: &InboundVideoStats, setter: &Option<DroppedFramesSetter>) {
+    let Some(setter) = setter else { return };
+    let counts = match (inbound.frames_dropped, inbound.freeze_count) {
+        (None, None) => None,
+        (dropped, freeze) => Some((
+            dropped.unwrap_or(0.0).round() as u32,
+            freeze.unwrap_or(0.0).round() as u32,
+        )),
+    };
+    setter(counts);
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn post_client_stats(
     source_id: &str,
@@ -189,24 +209,7 @@ async fn post_client_stats(
     dropped_frames_setter: Option<DroppedFramesSetter>,
 ) {
     let inbound = extract_inbound_video(report);
-
-    // #523: push this beacon's dropped-frame + freeze counts to the on-screen
-    // readout. `None` only when the browser's getStats reports NEITHER field
-    // (honest "no data" rather than a misleading 0); a report with at least
-    // one of the two fields present treats the other as 0 (freezeCount and
-    // framesDropped are both cumulative counters that start at 0, so an
-    // absent sibling field alongside a present one is "not yet incremented",
-    // not "unknown").
-    if let Some(setter) = &dropped_frames_setter {
-        let counts = match (inbound.frames_dropped, inbound.freeze_count) {
-            (None, None) => None,
-            (dropped, freeze) => Some((
-                dropped.unwrap_or(0.0).round() as u32,
-                freeze.unwrap_or(0.0).round() as u32,
-            )),
-        };
-        setter(counts);
-    }
+    notify_dropped_frames(&inbound, &dropped_frames_setter);
 
     // #509 (T0): full userAgent — the exact WebView/Chrome version per real
     // stage TV, which decides whether the playout field is available there.
@@ -276,5 +279,56 @@ async fn post_client_stats(
     };
     if let Some(window) = leptos::web_sys::window() {
         let _ = JsFuture::from(window.fetch_with_request(&request)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{notify_dropped_frames, DroppedFramesSetter, InboundVideoStats};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    type CapturedCounts = Rc<Cell<Option<(u32, u32)>>>;
+
+    fn capturing_setter() -> (DroppedFramesSetter, CapturedCounts) {
+        let captured = Rc::new(Cell::new(None));
+        let setter = {
+            let captured = Rc::clone(&captured);
+            Rc::new(move |v: Option<(u32, u32)>| captured.set(v)) as DroppedFramesSetter
+        };
+        (setter, captured)
+    }
+
+    #[test]
+    fn no_data_from_getstats_reports_none_not_a_fabricated_zero() {
+        let (setter, captured) = capturing_setter();
+        let inbound = InboundVideoStats::default();
+        notify_dropped_frames(&inbound, &Some(setter));
+        assert_eq!(captured.get(), None);
+    }
+
+    #[test]
+    fn dropped_present_freeze_absent_treats_freeze_as_zero() {
+        // Both counters are cumulative and start at 0 — a present dropped-count
+        // with no freeze field yet means "0 freezes so far", not "unknown".
+        let (setter, captured) = capturing_setter();
+        let inbound = InboundVideoStats {
+            frames_dropped: Some(128.0),
+            ..Default::default()
+        };
+        notify_dropped_frames(&inbound, &Some(setter));
+        assert_eq!(captured.get(), Some((128, 0)));
+    }
+
+    #[test]
+    fn both_present_round_to_nearest_integer() {
+        let (setter, captured) = capturing_setter();
+        let inbound = InboundVideoStats {
+            frames_dropped: Some(128.0),
+            freeze_count: Some(2.0),
+            ..Default::default()
+        };
+        notify_dropped_frames(&inbound, &Some(setter));
+        assert_eq!(captured.get(), Some((128, 2)));
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -15,7 +15,7 @@ use leptos::wasm_bindgen::{JsCast, JsValue};
 use leptos::web_sys::RtcPeerConnection;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
-use super::ndi_frame_stats::{snapshot_present_gaps, FrameStats};
+use super::ndi_frame_stats::{snapshot_present_gaps, DroppedFramesSetter, FrameStats};
 use super::ndi_profile::{local_storage, profile_mode_is_compat, profile_mode_name};
 
 /// localStorage key for the persistent per-display identity used in stats
@@ -55,6 +55,7 @@ pub(crate) fn post_stats_beacon(
     source_id: &str,
     stats: &FrameStats,
     clock_offset: Option<(f64, f64)>,
+    dropped_frames_setter: Option<DroppedFramesSetter>,
 ) {
     let (max_gap, over100, fps) = snapshot_present_gaps(stats);
     let video_latency_ms = stats.video_latency_ms.get();
@@ -70,6 +71,7 @@ pub(crate) fn post_stats_beacon(
                 fps,
                 video_latency_ms,
                 clock_offset,
+                dropped_frames_setter,
             )
             .await;
         }
@@ -85,12 +87,13 @@ pub(crate) fn maybe_post_beacon(
     source_id: &str,
     stats: &FrameStats,
     clock_offset: Option<(f64, f64)>,
+    dropped_frames_setter: Option<DroppedFramesSetter>,
 ) {
     tick_count.set(tick_count.get().wrapping_add(1));
     if tick_count.get() % 15 != 0 {
         return;
     }
-    post_stats_beacon(pc, source_id, stats, clock_offset);
+    post_stats_beacon(pc, source_id, stats, clock_offset, dropped_frames_setter);
 }
 
 /// Extract inbound-video stats from an RtcStatsReport (a JS Map) and POST a
@@ -121,6 +124,12 @@ struct InboundVideoStats {
     // pre-first-SR gotcha), distinguished server-side.
     estimated_playout: Option<f64>,
     report_ts: Option<f64>,
+    // #525 (step 1) device-decode probe: is this display decoding H264 in
+    // HARDWARE or falling back to SOFTWARE? A software decode on a "smart TV"
+    // box is the prime suspect for a large decode+present residual (SD1 read
+    // ~90ms above sd2-4). Purely diagnostic — read-only, no playback change.
+    decoder_implementation: Option<String>,
+    power_efficient_decoder: Option<bool>,
 }
 
 /// One pass over the RtcStatsReport map: the inbound-rtp video entry's fields,
@@ -150,6 +159,8 @@ fn extract_inbound_video(report: &JsValue) -> InboundVideoStats {
                 codec_id = get("codecId").as_string();
                 out.estimated_playout = get("estimatedPlayoutTimestamp").as_f64();
                 out.report_ts = get("timestamp").as_f64();
+                out.decoder_implementation = get("decoderImplementation").as_string();
+                out.power_efficient_decoder = get("powerEfficientDecoder").as_bool();
             }
         }
     }
@@ -175,8 +186,27 @@ async fn post_client_stats(
     presented_fps: Option<f64>,
     video_latency_ms: Option<f64>,
     clock_offset: Option<(f64, f64)>,
+    dropped_frames_setter: Option<DroppedFramesSetter>,
 ) {
     let inbound = extract_inbound_video(report);
+
+    // #523: push this beacon's dropped-frame + freeze counts to the on-screen
+    // readout. `None` only when the browser's getStats reports NEITHER field
+    // (honest "no data" rather than a misleading 0); a report with at least
+    // one of the two fields present treats the other as 0 (freezeCount and
+    // framesDropped are both cumulative counters that start at 0, so an
+    // absent sibling field alongside a present one is "not yet incremented",
+    // not "unknown").
+    if let Some(setter) = &dropped_frames_setter {
+        let counts = match (inbound.frames_dropped, inbound.freeze_count) {
+            (None, None) => None,
+            (dropped, freeze) => Some((
+                dropped.unwrap_or(0.0).round() as u32,
+                freeze.unwrap_or(0.0).round() as u32,
+            )),
+        };
+        setter(counts);
+    }
 
     // #509 (T0): full userAgent — the exact WebView/Chrome version per real
     // stage TV, which decides whether the playout field is available there.
@@ -216,6 +246,11 @@ async fn post_client_stats(
         // #509 (T0) device-capability probe fields.
         "estimatedPlayoutTimestamp": inbound.estimated_playout,
         "reportTimestamp": inbound.report_ts,
+        // #525 (step 1) device-decode probe — is this display's H264 decode
+        // HARDWARE or SOFTWARE? Diagnostic only; read live to find where SD1's
+        // decode+present residual actually lives before any playback change.
+        "decoderImplementation": inbound.decoder_implementation,
+        "powerEfficientDecoder": inbound.power_efficient_decoder,
         "userAgent": user_agent,
         // #514 observability: the smoothed TRUE server→display latency this
         // display currently SHOWS (#512; null = n/a) plus the /ndi/time clock

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -98,8 +98,9 @@ pub(crate) fn refresh_frames_live_staleness(stats: &FrameStats, setter: &Option<
 
 /// Cadence (ms) at which the smoothed video latency is pushed to the on-screen
 /// signal. rVFC fires ~30×/s; writing the reactive signal that often would
-/// re-run the StatusBar autofit every frame. ~1 update/s keeps the readout
-/// live without churning the render.
+/// re-run the StatusBar's reactive text (and, before #524, the autofit reflow
+/// search it drove) every frame. ~1 update/s keeps the readout live without
+/// churning the render.
 const VIDEO_LATENCY_EMIT_INTERVAL_MS: f64 = 1000.0;
 
 /// EMA responsiveness for the on-screen video-latency figure. Lower = smoother
@@ -259,8 +260,9 @@ pub(crate) struct FrameStats {
     pub(crate) video_latency_ms: Cell<Option<f64>>,
     /// `now_ms()` of the last push of `video_latency_ms` to the on-screen
     /// signal. The rVFC callback fires ~30×/s; the readout is updated at most
-    /// once per `VIDEO_LATENCY_EMIT_INTERVAL_MS` so the StatusBar autofit does
-    /// not re-run every frame. Seeded to 0.0 so the first sample emits at once.
+    /// once per `VIDEO_LATENCY_EMIT_INTERVAL_MS` so the StatusBar's reactive
+    /// text does not re-run every frame. Seeded to 0.0 so the first sample
+    /// emits at once.
     pub(crate) last_latency_emit_at: Cell<f64>,
     /// Last-EMITTED frames-live state for THIS session (#500). Tracks what was
     /// last pushed to `StageContext::ndi_frames_live` via the `FramesLiveSetter`

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -36,6 +36,16 @@ pub(crate) type VideoLatencySetter = Rc<dyn Fn(Option<f64>)>;
 /// gate entirely (e.g. a video element with no StageContext).
 pub(crate) type FramesLiveSetter = Rc<dyn Fn(bool)>;
 
+/// Callback that publishes per-display dropped-frame + freeze counts (#523) to
+/// the shared `StageContext::dropped_frames` signal driving the stage's
+/// "⬇N" (and "❄N") health readout beside the latency figure. Fed
+/// `(frames_dropped, freeze_count)` from the SAME getStats inbound-rtp sample
+/// the health beacon already reads (`ndi_beacon::extract_inbound_video`) —
+/// this updates on the BEACON cadence (getStats is async and only sampled
+/// there), not the 1s video-latency cadence. `None` (no setter) disables the
+/// readout entirely (e.g. a video element with no StageContext).
+pub(crate) type DroppedFramesSetter = Rc<dyn Fn(Option<(u32, u32)>)>;
+
 /// How long after the last presented frame the video is considered no longer
 /// "live" (#500). Once `now - last_frame_at` exceeds this, the 1s health ticker
 /// flips `ndi_frames_live` back to `false` so a genuinely silent/stopped source
@@ -403,6 +413,7 @@ pub(crate) fn start_rvfc_frame_observer(
     clock_offset: &Rc<ClockOffsetEstimator>,
     video_latency_setter: Option<VideoLatencySetter>,
     frames_live_setter: Option<FramesLiveSetter>,
+    dropped_frames_setter: Option<DroppedFramesSetter>,
 ) -> bool {
     if !video_supports_rvfc(video) {
         return false;
@@ -436,7 +447,13 @@ pub(crate) fn start_rvfc_frame_observer(
             update_video_latency(&meta, &stats, &video_latency_setter, network_one_way_ms);
             let n = record_presented_frame(&stats);
             if n % Watchdog::RVFC_BEACON_FRAME_PERIOD == 0 {
-                post_stats_beacon(&pc, &source_id, &stats, clock_offset.current());
+                post_stats_beacon(
+                    &pc,
+                    &source_id,
+                    &stats,
+                    clock_offset.current(),
+                    dropped_frames_setter.clone(),
+                );
             }
             schedule_video_frame_callback(&video, &holder);
         })

--- a/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
@@ -17,8 +17,8 @@ use leptos::web_sys::{HtmlVideoElement, RtcPeerConnection};
 use super::ndi_beacon::maybe_post_beacon;
 use super::ndi_clock_offset::ClockOffsetEstimator;
 use super::ndi_frame_stats::{
-    mark_frames_live, record_presented_frame, refresh_frames_live_staleness, FrameStats,
-    FramesLiveSetter,
+    mark_frames_live, record_presented_frame, refresh_frames_live_staleness, DroppedFramesSetter,
+    FrameStats, FramesLiveSetter,
 };
 use super::ndi_profile::maybe_profile_fallback;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
@@ -45,6 +45,7 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
     escalation: &Rc<ReloadEscalation>,
     clock_offset: &Rc<ClockOffsetEstimator>,
     frames_live_setter: Option<FramesLiveSetter>,
+    dropped_frames_setter: Option<DroppedFramesSetter>,
     on_failure: Rc<F>,
 ) -> i32 {
     let active = Rc::clone(active);
@@ -71,7 +72,14 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
         }
         // Beacon first: the healthy-path early returns below must not
         // starve it during normal playback.
-        maybe_post_beacon(&tick_count, &pc, &source_id, &stats, clock_offset.current());
+        maybe_post_beacon(
+            &tick_count,
+            &pc,
+            &source_id,
+            &stats,
+            clock_offset.current(),
+            dropped_frames_setter.clone(),
+        );
         if !rvfc_supported
             && approximate_frame_from_current_time(&video, &stats, &last_current_time)
         {

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -17,7 +17,7 @@ use leptos::web_sys::{
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use super::ndi_clock_offset::ClockOffsetSetter;
-use super::ndi_frame_stats::{FramesLiveSetter, VideoLatencySetter};
+use super::ndi_frame_stats::{DroppedFramesSetter, FramesLiveSetter, VideoLatencySetter};
 use super::ndi_watchdog::{now_ms, profile_mode_is_compat, ReloadEscalation, Watchdog};
 use crate::state::stage::StageContext;
 
@@ -84,6 +84,17 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let clock_offset_setter: Option<ClockOffsetSetter> = clock_offset_sig
         .map(|sig| std::rc::Rc::new(move |v: Option<(f64, f64)>| sig.set(v)) as ClockOffsetSetter);
 
+    // #523: same shared-signal pattern for the per-display dropped-frame +
+    // freeze counts shown beside the latency figure. Written from the getStats
+    // beacon path (both the rVFC frame-count-driven beacon and the 1s ticker's
+    // beacon share this setter — see `Watchdog::install`). Owned by the parent
+    // StagePage, so it survives this mount/unmount. No StageContext → no
+    // setter (None).
+    let dropped_frames_sig = use_context::<StageContext>().map(|ctx| ctx.dropped_frames);
+    let dropped_frames_setter: Option<DroppedFramesSetter> = dropped_frames_sig.map(|sig| {
+        std::rc::Rc::new(move |v: Option<(u32, u32)>| sig.set(v)) as DroppedFramesSetter
+    });
+
     // Holds the active connection: the WHEP session + the watchdog observing
     // its health. Cleanup must close both — see on_cleanup below.
     struct ActiveConnection {
@@ -116,6 +127,7 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let video_latency_setter_for_effect = video_latency_setter;
     let frames_live_setter_for_effect = frames_live_setter;
     let clock_offset_setter_for_effect = clock_offset_setter;
+    let dropped_frames_setter_for_effect = dropped_frames_setter;
     Effect::new(move |_| {
         let Some(video) = video_ref.get() else { return };
         let source_id = source_id_for_effect.clone();
@@ -123,6 +135,7 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
         let video_latency_setter = video_latency_setter_for_effect.clone();
         let frames_live_setter = frames_live_setter_for_effect.clone();
         let clock_offset_setter = clock_offset_setter_for_effect.clone();
+        let dropped_frames_setter = dropped_frames_setter_for_effect.clone();
         spawn_local(async move {
             // The reconnect-trigger flag: when a watchdog fires, it sets this
             // flag; the loop drains it and reconnects.
@@ -197,6 +210,7 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
                             video_latency_setter.clone(),
                             frames_live_setter.clone(),
                             clock_offset_setter.clone(),
+                            dropped_frames_setter.clone(),
                             move || flag.set(true),
                         );
 

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -90,9 +90,24 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     // beacon share this setter — see `Watchdog::install`). Owned by the parent
     // StagePage, so it survives this mount/unmount. No StageContext → no
     // setter (None).
+    //
+    // #523 (review follow-up): the two beacon-trigger paths can each call
+    // `pc.get_stats()` concurrently (~every 15s); their async resolutions are
+    // NOT guaranteed to land in the order they started. Without a guard, an
+    // older-but-later-resolving result could overwrite a fresher one and make
+    // the readout visibly jump BACKWARD for one beacon interval. Guarded via
+    // `should_apply_dropped_frames_update` (pure, unit-tested below): these
+    // are cumulative session counters that only ever increase, so a genuine
+    // update is never smaller than what's already shown — except the
+    // intentional reconnect reset to `None` (`Watchdog::install`), which this
+    // check always lets through.
     let dropped_frames_sig = use_context::<StageContext>().map(|ctx| ctx.dropped_frames);
     let dropped_frames_setter: Option<DroppedFramesSetter> = dropped_frames_sig.map(|sig| {
-        std::rc::Rc::new(move |v: Option<(u32, u32)>| sig.set(v)) as DroppedFramesSetter
+        std::rc::Rc::new(move |v: Option<(u32, u32)>| {
+            if should_apply_dropped_frames_update(v, sig.get_untracked()) {
+                sig.set(v);
+            }
+        }) as DroppedFramesSetter
     });
 
     // Holds the active connection: the WHEP session + the watchdog observing
@@ -379,6 +394,33 @@ pub(crate) const HEALTHY_SESSION_MS: f64 = 20_000.0;
 /// was healthy enough to reset the reconnect backoff (#369). Pure + unit-tested.
 pub(crate) fn should_reset_backoff(session_lifetime_ms: f64) -> bool {
     session_lifetime_ms >= HEALTHY_SESSION_MS
+}
+
+/// #523 (review follow-up): should an incoming dropped-frame+freeze reading
+/// actually be applied to the on-screen signal? The two beacon-trigger paths
+/// (rVFC frame-count-driven + the 1s health ticker) can each call
+/// `pc.get_stats()` concurrently roughly every 15s; their async resolutions
+/// are NOT guaranteed to land in start order, so without this guard an
+/// older-but-later-resolving reading could overwrite a fresher one and make
+/// the readout visibly jump BACKWARD for one interval.
+///
+/// `framesDropped`/`freezeCount` are cumulative WebRTC counters that only
+/// ever increase within one RTCPeerConnection session, so a genuine update
+/// is never smaller than what's already shown — reject one that is (it must
+/// be a stale, out-of-order resolution). The ONE deliberate exception: a
+/// `None` incoming value (or `None` currently shown) always applies — that
+/// is the reconnect reset (`Watchdog::install`) or the first reading of a
+/// fresh session, never a stale in-order regression. Pure + unit-tested.
+pub(crate) fn should_apply_dropped_frames_update(
+    incoming: Option<(u32, u32)>,
+    current: Option<(u32, u32)>,
+) -> bool {
+    match (incoming, current) {
+        (None, _) | (Some(_), None) => true,
+        (Some((dropped, freeze)), Some((prev_dropped, prev_freeze))) => {
+            dropped >= prev_dropped && freeze >= prev_freeze
+        }
+    }
 }
 
 /// Sleep for this instance's next capped-exponential backoff duration, then
@@ -796,5 +838,43 @@ mod tests {
         // A long-lived session that blipped — reset (prompt reconnect).
         assert!(should_reset_backoff(HEALTHY_SESSION_MS));
         assert!(should_reset_backoff(300_000.0));
+    }
+
+    /// #523 (review follow-up): two concurrent beacon-trigger paths' getStats()
+    /// resolutions can land out of order; the guard must reject a stale
+    /// (smaller) reading while still accepting the reconnect reset and the
+    /// first reading of a fresh session.
+    mod dropped_frames_monotonic_guard {
+        use super::super::should_apply_dropped_frames_update as should_apply;
+
+        #[test]
+        fn accepts_the_first_reading_of_a_fresh_session() {
+            assert!(should_apply(Some((0, 0)), None));
+            assert!(should_apply(Some((128, 2)), None));
+        }
+
+        #[test]
+        fn accepts_the_reconnect_reset_to_none() {
+            assert!(should_apply(None, Some((128, 2))));
+        }
+
+        #[test]
+        fn accepts_a_monotonically_increasing_update() {
+            assert!(should_apply(Some((129, 2)), Some((128, 2))));
+            assert!(should_apply(Some((128, 3)), Some((128, 2))));
+            assert!(
+                should_apply(Some((128, 2)), Some((128, 2))),
+                "equal counts still apply"
+            );
+        }
+
+        #[test]
+        fn rejects_an_out_of_order_stale_resolution() {
+            // The classic race: an older-but-later-resolving getStats() call
+            // would regress either counter visibly backward — reject it.
+            assert!(!should_apply(Some((100, 2)), Some((128, 2))));
+            assert!(!should_apply(Some((128, 1)), Some((128, 2))));
+            assert!(!should_apply(Some((100, 1)), Some((128, 2))));
+        }
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -22,7 +22,8 @@ use wasm_bindgen_futures::spawn_local;
 
 use super::ndi_clock_offset::{self, ClockOffsetEstimator, ClockOffsetSetter};
 use super::ndi_frame_stats::{
-    start_rvfc_frame_observer, FrameStats, FramesLiveSetter, VideoLatencySetter,
+    start_rvfc_frame_observer, DroppedFramesSetter, FrameStats, FramesLiveSetter,
+    VideoLatencySetter,
 };
 use super::ndi_health_ticker::start_health_ticker;
 
@@ -328,6 +329,7 @@ impl Watchdog {
         video_latency_setter: Option<VideoLatencySetter>,
         frames_live_setter: Option<FramesLiveSetter>,
         clock_offset_setter: Option<ClockOffsetSetter>,
+        dropped_frames_setter: Option<DroppedFramesSetter>,
         on_failure: F,
     ) -> Self {
         let active: Rc<Cell<bool>> = Rc::new(Cell::new(true));
@@ -345,6 +347,13 @@ impl Watchdog {
         // (no cover) so this never flashes the cover.
         if let Some(setter) = &frames_live_setter {
             setter(false);
+        }
+        // #523: a freshly-installed session hasn't posted a beacon yet, so any
+        // dropped/freeze count still on screen is from the prior (torn-down)
+        // session. Clear it rather than show a stale figure — the next beacon
+        // (up to ~15s away) repopulates it honestly.
+        if let Some(setter) = &dropped_frames_setter {
+            setter(None);
         }
         // #510/#512: the browser<->server pipeline-clock offset estimator. Created
         // BEFORE the frame observer so the observer can read its current (offset,
@@ -364,6 +373,9 @@ impl Watchdog {
             // health ticker (below) flips them back to not-live on staleness, so
             // BOTH share the same per-session setter.
             frames_live_setter.clone(),
+            // #523: BOTH beacon paths (rVFC frame-count-driven and the 1s
+            // ticker) can post a stats beacon, so both share the same setter.
+            dropped_frames_setter.clone(),
         );
         if !rvfc_supported {
             leptos::logging::warn!(
@@ -387,6 +399,7 @@ impl Watchdog {
             escalation,
             &clock_offset_estimator,
             frames_live_setter,
+            dropped_frames_setter,
             on_failure,
         );
 

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -348,6 +348,17 @@ impl Watchdog {
         if let Some(setter) = &frames_live_setter {
             setter(false);
         }
+        // #523 (review follow-up): a freshly-installed session hasn't decoded a
+        // frame yet, so any server→display ms figure still on screen belongs to
+        // the prior (torn-down) session. Clear it for the SAME reason
+        // `frames_live_setter` is cleared above — the first presented frame's
+        // `update_video_latency` call repopulates it honestly within ~1s. (This
+        // reset was missing before #523 added the analogous one for
+        // `dropped_frames_setter` below; both readouts now clear consistently on
+        // every reconnect instead of only one of the two.)
+        if let Some(setter) = &video_latency_setter {
+            setter(None);
+        }
         // #523: a freshly-installed session hasn't posted a beacon yet, so any
         // dropped/freeze count still on screen is from the prior (torn-down)
         // session. Clear it rather than show a stale figure — the next beacon

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -224,6 +224,13 @@ mod tests {
             format_video_latency_line(Some(84.0), Some((128, 2))),
             "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}128 \u{2744}2"
         );
+        // Freezes with zero dropped frames is a real combination too (a
+        // display can freeze without the decoder ever reporting a drop) —
+        // both figures show together, symmetric with the dropped-only case.
+        assert_eq!(
+            format_video_latency_line(Some(84.0), Some((0, 3))),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}0 \u{2744}3"
+        );
     }
 
     #[test]

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -98,20 +98,25 @@ pub fn StatusBar(
     let video_latency = ctx.video_latency_ms;
     let ndi_active = ctx.ndi_active;
     let has_video_latency = move || ndi_active.get();
-    let video_latency_text = move || match video_latency.get() {
-        Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
-        None => "server\u{2192}displej \u{00b7} n/a".to_string(),
-    };
+    // #523: per-display dropped-frame + freeze count from the getStats beacon,
+    // shown appended to the latency figure — see `format_video_latency_line`.
+    let dropped_frames = ctx.dropped_frames;
+    let video_latency_text =
+        move || format_video_latency_line(video_latency.get(), dropped_frames.get());
 
     autofit_effect_tabular(clock_ref, STATUS_MAX_FONT, move || clock_text.get());
     if !hide_live {
         autofit_effect_tabular(live_ref, STATUS_MAX_FONT, live_text);
     }
-    autofit_effect_tabular(connection_ref, STATUS_MAX_FONT, connection_text);
     if !hide_song_number {
         autofit_effect_tabular(song_number_ref, STATUS_MAX_FONT, song_number);
     }
-    autofit_effect_tabular(video_latency_ref, STATUS_MAX_FONT, video_latency_text);
+    // #524: `.stage__connection` and `.stage__video-latency` are diagnostic-only
+    // readouts (close-up info for the operator, not primary content) — they
+    // deliberately do NOT autofit to fill their box (that's why they used to
+    // look too prominent). `stage.css` gives them a small fixed font-size +
+    // low opacity instead; the clock/live/song-number readouts above keep
+    // autofit since they ARE primary content.
 
     view! {
         <div node_ref=clock_ref class="stage__clock">
@@ -155,4 +160,79 @@ fn current_time_string() -> String {
         now.get_minutes(),
         now.get_seconds()
     )
+}
+
+/// Pure format helper for the `.stage__video-latency` readout text (#523):
+/// appends the per-display dropped-frame (+ freeze, when nonzero) count from
+/// the getStats beacon to the existing "server→displej · N ms" figure.
+/// Extracted so the formatting is host-unit-testable without a live
+/// Leptos/WASM render — the reactive closure in `StatusBar` is a thin wrapper
+/// over this.
+fn format_video_latency_line(
+    latency_ms: Option<f64>,
+    dropped_frames: Option<(u32, u32)>,
+) -> String {
+    let base = match latency_ms {
+        Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
+        None => "server\u{2192}displej \u{00b7} n/a".to_string(),
+    };
+    match dropped_frames {
+        // Freeze count is shown too, but only when it's actually nonzero —
+        // keeps the common case (dropped frames with no freeze) to ONE short
+        // extra token, per the issue's "ONE short line" format.
+        Some((dropped, freeze)) if freeze > 0 => {
+            format!("{base} \u{00b7} \u{2b07}{dropped} \u{2744}{freeze}")
+        }
+        Some((dropped, _)) => format!("{base} \u{00b7} \u{2b07}{dropped}"),
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_video_latency_line;
+
+    #[test]
+    fn shows_latency_alone_when_no_drop_data_yet() {
+        // No beacon has landed yet (fresh session / reconnect) — the readout
+        // must not show a stale/fabricated drop count.
+        assert_eq!(
+            format_video_latency_line(Some(112.0), None),
+            "server\u{2192}displej \u{00b7} 112 ms"
+        );
+        assert_eq!(
+            format_video_latency_line(None, None),
+            "server\u{2192}displej \u{00b7} n/a"
+        );
+    }
+
+    #[test]
+    fn appends_dropped_count_with_no_freeze() {
+        assert_eq!(
+            format_video_latency_line(Some(112.0), Some((0, 0))),
+            "server\u{2192}displej \u{00b7} 112 ms \u{00b7} \u{2b07}0"
+        );
+        assert_eq!(
+            format_video_latency_line(Some(84.0), Some((128, 0))),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}128"
+        );
+    }
+
+    #[test]
+    fn appends_freeze_count_only_when_nonzero() {
+        assert_eq!(
+            format_video_latency_line(Some(84.0), Some((128, 2))),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}128 \u{2744}2"
+        );
+    }
+
+    #[test]
+    fn n_a_latency_still_shows_drop_count() {
+        // A dropped-frame count is meaningful even without a trustworthy
+        // latency reading — never suppress it just because latency is n/a.
+        assert_eq!(
+            format_video_latency_line(None, Some((5, 0))),
+            "server\u{2192}displej \u{00b7} n/a \u{00b7} \u{2b07}5"
+        );
+    }
 }

--- a/crates/presenter-ui/src/pages/stage.rs
+++ b/crates/presenter-ui/src/pages/stage.rs
@@ -58,6 +58,27 @@ pub fn StagePage() -> impl IntoView {
         setter.forget();
     }
 
+    // Test hook (#523): drive the per-display dropped-frame + freeze counters
+    // deterministically from the E2E without a live NDI/GPU pipeline (getStats
+    // beacons need a real WebRTC connection). Accepts two numbers (dropped,
+    // freeze) — the SAME pair the getStats beacon writes — or null/null to
+    // clear. In production this global is simply never called.
+    {
+        let dropped_frames = ctx.dropped_frames;
+        let setter = Closure::wrap(Box::new(move |dropped: JsValue, freeze: JsValue| {
+            match (dropped.as_f64(), freeze.as_f64()) {
+                (Some(d), Some(f)) => dropped_frames.set(Some((d as u32, f as u32))),
+                _ => dropped_frames.set(None),
+            }
+        }) as Box<dyn Fn(JsValue, JsValue)>);
+        let _ = js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__presenterStageSetDroppedFrames"),
+            setter.as_ref(),
+        );
+        setter.forget();
+    }
+
     // Test hook (#500): drive the "frames are presenting" flag deterministically
     // from the E2E without a live NDI/GPU pipeline (the GitHub-hosted e2e lane
     // has neither). Accepts a boolean — the SAME signal the rVFC observer /

--- a/crates/presenter-ui/src/state/stage.rs
+++ b/crates/presenter-ui/src/state/stage.rs
@@ -39,6 +39,16 @@ pub struct StageContext {
     /// `ndi_clock_offset`). A later ticket (#512, T4) reads this to convert a
     /// `report.timestamp` reading into the server pipeline-clock domain.
     pub clock_offset: RwSignal<Option<(f64, f64)>>,
+    /// Per-display dropped-frame + freeze counts (#523): `Some((frames_dropped,
+    /// freeze_count))` from the SAME getStats inbound-rtp sample the health
+    /// beacon already reads (`ndi_beacon::extract_inbound_video`), pushed to
+    /// this signal each time a beacon is posted (~every
+    /// `Watchdog::RVFC_BEACON_FRAME_PERIOD` frames or every 15th health tick —
+    /// getStats is async, so this updates on the BEACON cadence, not the 1s
+    /// video-latency cadence). Shown beside `video_latency_ms` in the stage's
+    /// "server→displej · N ms · ⬇N" readout. `None` when no beacon has landed
+    /// yet, or the browser's getStats reports neither field.
+    pub dropped_frames: RwSignal<Option<(u32, u32)>>,
 }
 
 impl StageContext {
@@ -55,6 +65,7 @@ impl StageContext {
             video_latency_ms: RwSignal::new(None),
             ndi_frames_live: RwSignal::new(false),
             clock_offset: RwSignal::new(None),
+            dropped_frames: RwSignal::new(None),
         }
     }
 }

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -179,6 +179,13 @@ body.stage {
     50% { opacity: 0.7; }
 }
 
+/* #524: `.stage__connection` and `.stage__video-latency` are DIAGNOSTIC-ONLY
+   readouts — close-up info for the operator, not primary stage content. They
+   used to `autofit_effect_tabular` (scale font to FILL the box), which is
+   exactly why they looked too prominent. Fixed instead: a small fixed
+   font-size + low opacity, still legible up close. Rust no longer calls
+   autofit for these two elements (see `status_bar.rs`); the box's
+   width/height/position are otherwise unchanged. */
 .stage__connection {
     position: absolute;
     right: 2%;
@@ -186,6 +193,8 @@ body.stage {
     width: 24%;
     height: 2.5%;
     color: #38bdf8;
+    opacity: 0.45;
+    font-size: 1vw;
     font-family: "Courier New", Courier, monospace;
     font-weight: 600;
     letter-spacing: 0.05em;
@@ -199,9 +208,9 @@ body.stage {
 
 /* #479: stage-side VIDEO latency — a SEPARATE compact readout sitting just
    ABOVE the connection readout (same right corner). Distinguished from the
-   connection figure by a dimmer teal. tabular-nums is REQUIRED by the
-   autofit_effect_tabular coupling (equal char-length ⇒ equal width). Only
-   rendered when video frames are flowing. */
+   connection figure by a dimmer teal. Only rendered when video frames are
+   flowing. #524: small fixed font-size + low opacity — see the comment on
+   `.stage__connection` above. */
 .stage__video-latency {
     position: absolute;
     right: 2%;
@@ -209,7 +218,8 @@ body.stage {
     width: 24%;
     height: 2.5%;
     color: #7dd3fc;
-    opacity: 0.85;
+    opacity: 0.45;
+    font-size: 1vw;
     font-family: "Courier New", Courier, monospace;
     font-weight: 600;
     letter-spacing: 0.05em;

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -185,7 +185,21 @@ body.stage {
    exactly why they looked too prominent. Fixed instead: a small fixed
    font-size + low opacity, still legible up close. Rust no longer calls
    autofit for these two elements (see `status_bar.rs`); the box's
-   width/height/position are otherwise unchanged. */
+   width/height/position are otherwise unchanged. Shared here (one rule,
+   not copy-pasted per element) since both belong to the same "diagnostic,
+   de-emphasized" category — a future diagnostic readout should join this
+   selector list rather than duplicate the values. `text-overflow: ellipsis`
+   is new safety: with autofit gone, a long-uptime session accumulating a
+   large #523 dropped/freeze count is no longer auto-shrunk to fit — it now
+   truncates visibly (…) instead of being silently clipped by
+   `overflow: hidden` with no indication anything is missing. */
+.stage__connection,
+.stage__video-latency {
+    opacity: 0.45;
+    font-size: 1vw;
+    text-overflow: ellipsis;
+}
+
 .stage__connection {
     position: absolute;
     right: 2%;
@@ -193,8 +207,6 @@ body.stage {
     width: 24%;
     height: 2.5%;
     color: #38bdf8;
-    opacity: 0.45;
-    font-size: 1vw;
     font-family: "Courier New", Courier, monospace;
     font-weight: 600;
     letter-spacing: 0.05em;
@@ -209,8 +221,8 @@ body.stage {
 /* #479: stage-side VIDEO latency — a SEPARATE compact readout sitting just
    ABOVE the connection readout (same right corner). Distinguished from the
    connection figure by a dimmer teal. Only rendered when video frames are
-   flowing. #524: small fixed font-size + low opacity — see the comment on
-   `.stage__connection` above. */
+   flowing. #524: small fixed font-size + low opacity — see the shared rule
+   above `.stage__connection`. */
 .stage__video-latency {
     position: absolute;
     right: 2%;
@@ -218,8 +230,6 @@ body.stage {
     width: 24%;
     height: 2.5%;
     color: #7dd3fc;
-    opacity: 0.45;
-    font-size: 1vw;
     font-family: "Courier New", Courier, monospace;
     font-weight: 600;
     letter-spacing: 0.05em;

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -234,3 +234,48 @@ test("stage shows dropped-frame + freeze count beside the video latency", async 
 
   await stagePage.close();
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// #524 — the diagnostic readouts (`.stage__connection`, `.stage__video-latency`)
+// must render SMALL + FAINT (close-up info for the operator, not primary
+// content) rather than autofit-scaled to fill their box (which is why they
+// used to look too prominent). Verified by reading the COMPUTED style —
+// asserting a fixed small font-size + low opacity, not just visual guessing.
+// ─────────────────────────────────────────────────────────────────────────
+
+test("diagnostic readouts render small and faint (de-emphasized, not autofit)", async ({
+  context,
+}) => {
+  const stagePage = await openVideoStage(context);
+  await setNdiActive(stagePage, true);
+  await setVideoLatency(stagePage, 84);
+
+  const connectionEl = stagePage.locator(".stage__connection");
+  const videoEl = stagePage.locator(".stage__video-latency");
+  await expect(videoEl).toBeVisible();
+
+  const readComputed = async (locator: typeof connectionEl) =>
+    locator.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return { fontSize: parseFloat(style.fontSize), opacity: parseFloat(style.opacity) };
+    });
+
+  const connectionStyle = await readComputed(connectionEl);
+  const videoStyle = await readComputed(videoEl);
+
+  // Faint: low opacity (~0.4-0.5), never full-strength like primary content.
+  expect(connectionStyle.opacity).toBeGreaterThan(0);
+  expect(connectionStyle.opacity).toBeLessThanOrEqual(0.5);
+  expect(videoStyle.opacity).toBeGreaterThan(0);
+  expect(videoStyle.opacity).toBeLessThanOrEqual(0.5);
+
+  // Small: a fixed vw-scaled size, not autofit-to-fill-the-box (which would
+  // scale toward the STATUS_MAX_FONT ceiling). Comfortably below any autofit
+  // result, but still nonzero (readable up close, per the issue).
+  expect(connectionStyle.fontSize).toBeGreaterThan(0);
+  expect(connectionStyle.fontSize).toBeLessThan(40);
+  expect(videoStyle.fontSize).toBeGreaterThan(0);
+  expect(videoStyle.fontSize).toBeLessThan(40);
+
+  await stagePage.close();
+});

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -97,6 +97,27 @@ async function setNdiActive(page: Page, active: boolean): Promise<void> {
   }, active);
 }
 
+/** Drive the per-display dropped-frame + freeze counters (#523) — the SAME
+ * pair the getStats beacon writes. `null` clears them. */
+async function setDroppedFrames(
+  page: Page,
+  counts: { dropped: number; freeze: number } | null,
+): Promise<void> {
+  await page.evaluate((value) => {
+    (
+      window as unknown as {
+        __presenterStageSetDroppedFrames?: (
+          dropped: number | null,
+          freeze: number | null,
+        ) => void;
+      }
+    ).__presenterStageSetDroppedFrames?.(
+      value ? value.dropped : null,
+      value ? value.freeze : null,
+    );
+  }, counts);
+}
+
 test("stage shows true server→display latency as a separate readout, with honest n/a", async ({
   context,
 }) => {
@@ -148,6 +169,65 @@ test("stage shows true server→display latency as a separate readout, with hone
   await setNdiActive(stagePage, false);
   await expect(videoEl).toHaveCount(0);
   await expect(connectionEl).toBeVisible();
+
+  // browser-console-zero-errors: no errors/warnings the whole time.
+  expect(consoleMessages).toEqual([]);
+
+  await stagePage.close();
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #523 — the stage shows per-display dropped-frame (+freeze) counts beside
+// the latency figure, so "how is this TV doing" is visible at a glance (a
+// low latency reading can otherwise hide a TV that is dropping frames to
+// achieve it). Sourced from the SAME getStats inbound-rtp sample the health
+// beacon already reads; this test drives it via the deterministic test hook
+// (`__presenterStageSetDroppedFrames`), the same signal the beacon path
+// writes. The append-format math (⬇N, +❄N only when nonzero) is unit-tested
+// in `status_bar.rs`.
+// ─────────────────────────────────────────────────────────────────────────
+
+test("stage shows dropped-frame + freeze count beside the video latency", async ({
+  context,
+}) => {
+  const consoleMessages: string[] = [];
+  const stagePage = await openVideoStage(context);
+  stagePage.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  const videoEl = stagePage.locator(".stage__video-latency");
+
+  await setNdiActive(stagePage, true);
+  await setVideoLatency(stagePage, 84);
+  await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
+
+  // No beacon has landed yet → the readout shows the latency ALONE, no
+  // fabricated drop count.
+  await expect(videoEl).not.toContainText("⬇");
+
+  // A beacon lands with zero drops/freezes → shown as "⬇0" (honest zero, not
+  // hidden — the whole point is a per-TV health signal at a glance).
+  await setDroppedFrames(stagePage, { dropped: 0, freeze: 0 });
+  await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms\s*·\s*⬇0/);
+  await expect(videoEl).not.toContainText("❄");
+
+  // Drops accumulate → the count updates live.
+  await setDroppedFrames(stagePage, { dropped: 128, freeze: 0 });
+  await expect(videoEl).toContainText(/⬇128/);
+  await expect(videoEl).not.toContainText("❄");
+
+  // A freeze count is present too → shown alongside the drop count.
+  await setDroppedFrames(stagePage, { dropped: 128, freeze: 2 });
+  await expect(videoEl).toContainText(/⬇128\s*❄2/);
+
+  // Reconnect (or no getStats data) clears it → readout falls back to the
+  // latency alone, never a stale count.
+  await setDroppedFrames(stagePage, null);
+  await expect(videoEl).not.toContainText("⬇");
+  await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
 
   // browser-console-zero-errors: no errors/warnings the whole time.
   expect(consoleMessages).toEqual([]);


### PR DESCRIPTION
Closes #523
Closes #524

Salvaged + finished from a session-limited worker. Three additive stage pieces (display + observability only — NO playback/buffer change):

- **#523** — the stage TV shows its per-display **dropped-frame + freeze count** beside the latency (`server→displej · N ms · ⬇D` / `❄F`), sourced from the same getStats inbound-rtp sample the beacon reads. A low latency can hide a TV dropping frames to achieve it — now that trade-off is visible. Test hook `__presenterStageSetDroppedFrames` + E2E.
- **#524** — the diagnostic readouts (latency / drops / connection) are now **smaller + more transparent** — secondary info for a close look, not competing with stage content. Dropped the autofit-to-fill for these; small fixed size + lower opacity.
- **#525 step-1 diagnostic** (does NOT close #525) — beacon now also reports `decoderImplementation` + `powerEfficientDecoder` so we can read, live from prod, whether SD1 hardware- or software-decodes (the prime suspect for its ~90 ms decode+present residual). Server struct + log + serde tests.

**Hard constraint honored (user directive):** no jitter-buffer / playout / playback behavior changed — `jitterBufferTarget=0` / `playoutDelayHint=0` left exactly as-is; no buffer raised on any TV. The SD1 playback FIX (#525 step 2) is a later separate PR, gated on the decoder reading.

Version 0.4.185.
