### PR TITLE
fix(stage): stage-text field vanishes on blur + spurious line-limit warning (#515)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.185"
+version = "0.4.186"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.185"
+version = "0.4.186"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/presentation_list.rs
+++ b/crates/presenter-ui/src/components/presentation_list.rs
@@ -22,24 +22,37 @@ pub fn PresentationList() -> impl IntoView {
         ctx.selected_entry_index.set(entry_index);
         crate::state::session::set("currentPresentationId", &id);
 
-        // Check slides cache first
-        let cached = ctx.slides_cache.get_untracked().get(&id).cloned();
-        if let Some(slides) = cached {
-            ctx.selected_presentation.update(|p| {
-                if let Some(pres) = p.as_mut() {
-                    if pres.id.to_string() == id {
-                        pres.slides = slides;
-                    }
-                }
-            });
-        }
+        // #515: NO synchronous "show cached slides first" step here anymore.
+        // As written (guarded by `pres.id.to_string() == id`, checked against
+        // the CURRENT pre-click selection), that branch could only ever fire
+        // when RE-selecting the presentation ALREADY on screen — it can't
+        // help a genuine switch to a different presentation, since `pres`
+        // still holds the OLD id at click time. For a re-select it was
+        // actively harmful: `ctx.slides_cache` is populated only from GET
+        // responses (never updated by a save), so re-clicking an
+        // already-open song right after editing it (e.g. typing a stage
+        // hand-off message) unconditionally reset the just-edited slide back
+        // to its pre-edit cached content, synchronously, with no guard at
+        // all. The `get_presentation` fetch below (seq-guarded) is the only
+        // source of truth needed here.
 
         // Capture signals OUTSIDE async block - context may not be available inside spawn_local
         let slides_cache_signal = ctx.slides_cache;
         let selected_presentation_signal = ctx.selected_presentation;
         let id_clone = id.clone();
+        // #515: capture the edit generation BEFORE issuing the fetch. If a
+        // slide-content save lands while this GET is still in flight (a
+        // very plausible race right after opening a song and immediately
+        // typing a stage/main/translation edit), the response below reflects
+        // pre-edit content — apply it ONLY if no save has landed since,
+        // otherwise it would clobber the newer edit with stale data.
+        let seq_at_fetch = op.slide_edit_seq.get_untracked();
+        let slide_edit_seq = op.slide_edit_seq;
         leptos::task::spawn_local(async move {
             if let Ok(detail) = crate::api::presentations::get_presentation(&id_clone).await {
+                if slide_edit_seq.get_untracked() != seq_at_fetch {
+                    return;
+                }
                 // Cache slides
                 slides_cache_signal.update(|cache| {
                     cache.insert(id_clone.clone(), detail.presentation.slides.clone());

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -119,6 +119,15 @@ fn save_all_fields_from_dom(
         }
     }
 
+    // #515: bump the edit generation SYNCHRONOUSLY, the moment a genuine
+    // (non-no-op) edit is committed to saving — NOT when the save's network
+    // round-trip later completes. A `get_presentation` refetch (opening /
+    // re-opening the presentation) captures this counter before it fires;
+    // bumping here, before the async save even starts, guarantees that ANY
+    // such refetch still in flight at this point is provably stale no
+    // matter which of the two async calls happens to resolve first.
+    op.slide_edit_seq.update(|seq| *seq += 1);
+
     save_with_status(
         pres_id.to_string(),
         slide_id.to_string(),
@@ -127,6 +136,7 @@ fn save_all_fields_from_dom(
         stage,
         group,
         op.save_status,
+        selected_pres,
     );
 }
 
@@ -430,13 +440,21 @@ pub fn SlideList() -> impl IntoView {
                         let is_focused = focused_slide.as_deref() == Some(&slide_id);
                         let main_warning = field_has_warning(&main_text, line_limit);
                         let translation_warning = field_has_warning(&translation_text, line_limit);
-                        let stage_warning = field_has_warning(&stage_text, line_limit);
-                        let any_warning = slide_has_any_warning(&main_text, &translation_text, &stage_text, line_limit);
+                        // #515: the stage field is free-form speaker/reading
+                        // text (it feeds the fullscreen "stage" layout) and
+                        // is explicitly EXEMPT from the lyrics per-line
+                        // character-limit warning — it may run longer than
+                        // a projected lyric line.
+                        let stage_warning = false;
+                        let any_warning =
+                            slide_has_any_warning(&main_text, &translation_text, line_limit);
 
-                        // Format text with HTML for live mode display
+                        // Format text with HTML for live mode display. The
+                        // stage field never gets the overflow highlight
+                        // (limit 0 disables it) for the same reason.
                         let main_html = format_multiline(&main_text, line_limit);
                         let translation_html = format_multiline(&translation_text, line_limit);
-                        let stage_html = format_multiline(&stage_text, line_limit);
+                        let stage_html = format_multiline(&stage_text, 0);
 
                         let next_slide_id = presentation.slides.get(i + 1).map(|s| s.id.to_string());
 
@@ -856,12 +874,13 @@ pub fn SlideList() -> impl IntoView {
                                                         data-field="stage"
                                                         rows="2"
                                                         prop:value=stage_text.clone()
-                                                        on:input=move |ev| {
-                                                                let val = event_target_value(&ev);
-                                                                stage_warn_sig.set(field_has_warning(&val, line_limit));
+                                                        on:input=move |_ev| {
+                                                                // #515: stage text is free-form — it never
+                                                                // contributes a line-limit warning, so
+                                                                // stage_warn_sig stays at its initial `false`.
                                                                 let m = main_warn_sig.get_untracked();
                                                                 let t = trans_warn_sig.get_untracked();
-                                                                any_warn_sig.set(m || t || stage_warn_sig.get_untracked());
+                                                                any_warn_sig.set(m || t);
                                                             }
                                                         on:blur={
                                                             let pres_id = pres_id_edit.clone();

--- a/crates/presenter-ui/src/components/slide_list_utils.rs
+++ b/crates/presenter-ui/src/components/slide_list_utils.rs
@@ -157,6 +157,24 @@ mod tests {
     }
 
     #[test]
+    fn slide_has_any_warning_ignores_stage_field_length_entirely() {
+        // #515 (RED): the stage field is free-form speaker/reading text and
+        // must NEVER trip the lyrics per-line character-limit warning — only
+        // main/translation should. Currently `slide_has_any_warning` ORs the
+        // stage field in just like main/translation, so this fails today.
+        let ok = "short";
+        let over_limit_stage = "abcdefghijklmnopqrstuvwxyz0123456";
+        assert!(
+            field_has_warning(over_limit_stage, 32),
+            "sanity: this text IS over the limit"
+        );
+        assert!(
+            !slide_has_any_warning(ok, ok, over_limit_stage, 32),
+            "a slide with only ok main/translation must not warn regardless of any stage text"
+        );
+    }
+
+    #[test]
     fn zero_limit_disables_warnings() {
         let long = "abcdefghijklmnopqrstuvwxyz0123456";
         assert!(!field_has_warning(long, 0));

--- a/crates/presenter-ui/src/components/slide_list_utils.rs
+++ b/crates/presenter-ui/src/components/slide_list_utils.rs
@@ -26,15 +26,13 @@ pub(super) fn field_has_warning(text: &str, limit: u32) -> bool {
     limit > 0 && text.lines().any(|line| line.chars().count() as u32 > limit)
 }
 
-pub(super) fn slide_has_any_warning(
-    main: &str,
-    translation: &str,
-    stage: &str,
-    limit: u32,
-) -> bool {
-    field_has_warning(main, limit)
-        || field_has_warning(translation, limit)
-        || field_has_warning(stage, limit)
+/// Whether ANY lyrics field on a slide exceeds the per-line character limit.
+///
+/// #515: the stage field is intentionally NOT a parameter here — it is
+/// free-form speaker/reading text and must never contribute to this
+/// warning, unlike the lyrics `main`/`translation` fields.
+pub(super) fn slide_has_any_warning(main: &str, translation: &str, limit: u32) -> bool {
+    field_has_warning(main, limit) || field_has_warning(translation, limit)
 }
 
 /// Apply is-focused class to a slide card via DOM manipulation.
@@ -147,21 +145,19 @@ mod tests {
     }
 
     #[test]
-    fn slide_has_any_warning_considers_all_fields() {
+    fn slide_has_any_warning_considers_lyrics_fields() {
         let ok = "short";
         let long = "abcdefghijklmnopqrstuvwxyz0123456";
-        assert!(!slide_has_any_warning(ok, ok, ok, 32));
-        assert!(slide_has_any_warning(long, ok, ok, 32));
-        assert!(slide_has_any_warning(ok, long, ok, 32));
-        assert!(slide_has_any_warning(ok, ok, long, 32));
+        assert!(!slide_has_any_warning(ok, ok, 32));
+        assert!(slide_has_any_warning(long, ok, 32));
+        assert!(slide_has_any_warning(ok, long, 32));
     }
 
     #[test]
     fn slide_has_any_warning_ignores_stage_field_length_entirely() {
-        // #515 (RED): the stage field is free-form speaker/reading text and
-        // must NEVER trip the lyrics per-line character-limit warning — only
-        // main/translation should. Currently `slide_has_any_warning` ORs the
-        // stage field in just like main/translation, so this fails today.
+        // #515: a long stage field must NOT be passed to (or trip)
+        // slide_has_any_warning — it is free-form speaker text, exempt from
+        // the lyrics per-line character limit.
         let ok = "short";
         let over_limit_stage = "abcdefghijklmnopqrstuvwxyz0123456";
         assert!(
@@ -169,7 +165,7 @@ mod tests {
             "sanity: this text IS over the limit"
         );
         assert!(
-            !slide_has_any_warning(ok, ok, over_limit_stage, 32),
+            !slide_has_any_warning(ok, ok, 32),
             "a slide with only ok main/translation must not warn regardless of any stage text"
         );
     }

--- a/crates/presenter-ui/src/components/slide_save.rs
+++ b/crates/presenter-ui/src/components/slide_save.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use gloo_timers::future::TimeoutFuture;
 use leptos::prelude::*;
+use presenter_core::{Presentation, SlideGroup, SlideText};
 
 use crate::api;
 use crate::state::operator::SaveStatus;
@@ -68,6 +69,15 @@ pub(super) fn finish_save_status_err(slide_id: String, save_status: SaveStatusMa
 
 /// Fire-and-forget save with indicator wiring. Used by the textarea blur
 /// handlers where no refetch is needed.
+///
+/// On success this ALSO patches `selected_pres`'s in-memory slide content to
+/// match what was just saved (#515), so the edit is visible everywhere
+/// `selected_pres` is read (e.g. the operator's own Live-mode preview), not
+/// only in the textarea's own DOM value. The `slide_edit_seq` bump that
+/// guards against a stale `get_presentation` refetch clobbering a newer
+/// edit happens SYNCHRONOUSLY at save-START, in the caller
+/// (`save_all_fields_from_dom`) — not here — so the guard holds no matter
+/// which of the two async calls (this save, or the refetch) resolves first.
 pub(super) fn save_with_status(
     pres_id: String,
     slide_id: String,
@@ -76,6 +86,7 @@ pub(super) fn save_with_status(
     stage: String,
     group: Option<String>,
     save_status: SaveStatusMap,
+    selected_pres: RwSignal<Option<Presentation>>,
 ) {
     let token = start_save_status(&slide_id, save_status);
     leptos::task::spawn_local(async move {
@@ -85,13 +96,77 @@ pub(super) fn save_with_status(
             &main,
             &translation,
             &stage,
-            group,
+            group.clone(),
         )
         .await;
 
         match result {
-            Ok(_) => finish_save_status_ok(slide_id, save_status, token).await,
+            Ok(_) => {
+                apply_saved_content_locally(
+                    selected_pres,
+                    &slide_id,
+                    &main,
+                    &translation,
+                    &stage,
+                    group.as_deref(),
+                );
+                finish_save_status_ok(slide_id, save_status, token).await
+            }
             Err(_) => finish_save_status_err(slide_id, save_status, token),
         }
+    });
+}
+
+/// Patch the in-memory presentation's slide content to match a just-saved
+/// edit (#515). Best-effort: if the values can no longer construct a valid
+/// `SlideText` (e.g. over the hard character cap), the local cache is left
+/// untouched — the save already round-tripped through server-side
+/// validation, so this only guards the local reconstruction.
+///
+/// Uses `update_untracked` DELIBERATELY (not `update`): a save fires on
+/// EVERY field's blur, so a tracked `.update()` here would force a full
+/// slide-list re-render — recreating every slide's local reactive signals
+/// (`main_warn_sig` & co. in `slide_list.rs`) — every time ANY field on ANY
+/// slide is saved. That re-render can stomp an in-progress edit to a
+/// DIFFERENT field of the same slide that hasn't been blurred/saved yet
+/// (its freshly-typed warning state gets reset from the stale pre-edit
+/// snapshot). `selected_pres` still ends up with the correct data for the
+/// next NATURAL re-render (mode toggle, re-opening the presentation, …) —
+/// it just doesn't force one of its own.
+fn apply_saved_content_locally(
+    selected_pres: RwSignal<Option<Presentation>>,
+    slide_id: &str,
+    main: &str,
+    translation: &str,
+    stage: &str,
+    group: Option<&str>,
+) {
+    let (Ok(main_text), Ok(translation_text), Ok(stage_text)) = (
+        SlideText::new(main),
+        SlideText::new(translation),
+        SlideText::new(stage),
+    ) else {
+        return;
+    };
+    let group = group
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(SlideGroup::new);
+
+    selected_pres.update_untracked(|maybe_pres| {
+        let Some(pres) = maybe_pres.as_mut() else {
+            return;
+        };
+        let Some(slide) = pres
+            .slides
+            .iter_mut()
+            .find(|slide| slide.id.to_string() == slide_id)
+        else {
+            return;
+        };
+        slide.content.main = main_text;
+        slide.content.translation = translation_text;
+        slide.content.stage = stage_text;
+        slide.content.group = group;
     });
 }

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -92,7 +92,7 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
 
     // Load session state - runs after initial data starts loading
     // The session restoration handles its own data fetching
-    load_session_presentation(&ctx);
+    load_session_presentation(&ctx, &op);
 
     // Stage monitor polling
     setup_stage_monitor(ctx.clone());
@@ -464,12 +464,19 @@ fn load_initial_data(ctx: &AppContext) {
     });
 }
 
-fn load_session_presentation(ctx: &AppContext) {
+fn load_session_presentation(ctx: &AppContext, op: &OperatorState) {
     if let Some(pres_id) = ctx.selected_presentation_id.get_untracked() {
         let selected = ctx.selected_presentation;
+        // #515: same stale-refetch guard as `PresentationList::select_presentation`
+        // — this fetch fires once at page load; if a slide edit is saved
+        // before it resolves, drop the response instead of clobbering it.
+        let seq_at_fetch = op.slide_edit_seq.get_untracked();
+        let slide_edit_seq = op.slide_edit_seq;
         leptos::task::spawn_local(async move {
             if let Ok(detail) = crate::api::presentations::get_presentation(&pres_id).await {
-                selected.set(Some(detail.presentation));
+                if slide_edit_seq.get_untracked() == seq_at_fetch {
+                    selected.set(Some(detail.presentation));
+                }
             }
         });
     }

--- a/crates/presenter-ui/src/state/operator.rs
+++ b/crates/presenter-ui/src/state/operator.rs
@@ -62,6 +62,15 @@ pub struct OperatorState {
     /// Per-slide save status keyed by slide_id, with a monotonic token to
     /// prevent stale fade timers from clearing a newer save's entry (#313).
     pub save_status: RwSignal<HashMap<String, (SaveStatus, u64)>>,
+    /// Monotonic counter bumped every time a slide-content save (main /
+    /// translation / stage / group) completes successfully (#515). A
+    /// `get_presentation` refetch captures this value before it is issued;
+    /// if the counter has moved by the time the fetch resolves, a save
+    /// landed while the fetch was in flight, so the response reflects
+    /// pre-edit content and must be dropped instead of clobbering the newer
+    /// edit — otherwise a slide's stage text could vanish from the editor
+    /// right after typing it (the presentation-open refetch resolving late).
+    pub slide_edit_seq: RwSignal<u64>,
 }
 
 impl OperatorState {
@@ -107,6 +116,7 @@ impl OperatorState {
             stage_layout_loading: RwSignal::new(false),
             triggering_slide_id: RwSignal::new(None),
             save_status: RwSignal::new(HashMap::new()),
+            slide_edit_seq: RwSignal::new(0),
         }
     }
 }

--- a/tests/e2e/slide-stage-field-bugs.spec.ts
+++ b/tests/e2e/slide-stage-field-bugs.spec.ts
@@ -26,6 +26,24 @@ import {
 
 test.describe.configure({ timeout: 180_000 });
 
+const ALLOWED_CONSOLE_NOISE = [
+  /integrity.*ignored.*preload/i,
+  /ResizeObserver loop/i,
+];
+
+function collectConsoleErrors(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      const text = msg.text();
+      if (!ALLOWED_CONSOLE_NOISE.some((pattern) => pattern.test(text))) {
+        messages.push(`[${msg.type()}] ${text}`);
+      }
+    }
+  });
+  return messages;
+}
+
 let server: ServerHandle | undefined;
 let baseURL = "";
 
@@ -104,6 +122,7 @@ async function openOperatorEditMode(page: Page) {
 test("editing the stage field survives a concurrent presentation refetch (#515)", async ({
   page,
 }) => {
+  const consoleErrors = collectConsoleErrors(page);
   await openOperatorEditMode(page);
   const slideId = slideIds[0];
 
@@ -171,11 +190,14 @@ test("editing the stage field survives a concurrent presentation refetch (#515)"
     (s: { id: string }) => s.id === slideId,
   );
   expect(slide.content.stage.value).toBe(NEW_TEXT);
+
+  expect(consoleErrors).toEqual([]);
 });
 
 test("stage field text over the line limit never warns; main/translation still do (#515)", async ({
   page,
 }) => {
+  const consoleErrors = collectConsoleErrors(page);
   await openOperatorEditMode(page);
   // Slide 1 (own slide, independent of the race test's slide 0) — seeded
   // with a short, non-empty stage value so its preview div is mounted from
@@ -221,4 +243,6 @@ test("stage field text over the line limit never warns; main/translation still d
   );
   await expect(mainPreview).toHaveAttribute("data-warning", "true");
   await expect(warningBanner).toHaveAttribute("data-visible", "true");
+
+  expect(consoleErrors).toEqual([]);
 });

--- a/tests/e2e/slide-stage-field-bugs.spec.ts
+++ b/tests/e2e/slide-stage-field-bugs.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+/**
+ * #515 follow-up — two bugs the user found while testing the new per-slide
+ * stage field:
+ *
+ * (a) EXTREME bug: editing a slide's stage field and leaving it (blur) made
+ *     the text disappear from the edit field again, only to reappear once
+ *     the slide was triggered. Root cause: `select_presentation` (and the
+ *     page-load session restore) re-fetches the whole presentation every
+ *     time it's opened. If that fetch is still in flight when a stage-field
+ *     save lands — very plausible right after opening a song and
+ *     immediately typing a hand-off message for the speaker — the late GET
+ *     response overwrote the just-saved edit with pre-edit (empty) content.
+ * (b) The stage field is free-form speaker/reading text and must NEVER be
+ *     flagged by the lyrics per-line character-limit warning, unlike
+ *     main/translation.
+ */
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+
+const LIBRARY_NAME = "_E2E Stage Field Bugs";
+let presentationId = "";
+let slideIds: string[] = [];
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  server = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+
+  const libResp = await fetch(new URL("/libraries", baseURL).toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: LIBRARY_NAME }),
+  });
+  const lib = await libResp.json();
+
+  const presResp = await fetch(
+    new URL(`/libraries/${lib.id}/presentations`, baseURL).toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Stage Field Cases",
+        slides: [
+          // Slide 0: race-condition case — stage starts EMPTY so the test
+          // can prove a fresh edit survives.
+          { main: "Slide one main" },
+          // Slide 1: warning case — stage seeded non-empty so its preview
+          // div is mounted from the first render (its mount is gated on
+          // the PERSISTED value being non-empty, not on live typing).
+          { main: "Slide two main", stage: "Stage seed" },
+        ],
+      }),
+    },
+  );
+  const presData = await presResp.json();
+  presentationId = presData.presentation.id;
+  slideIds = presData.presentation.slides.map((s: { id: string }) => s.id);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+async function openOperatorEditMode(page: Page) {
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('[data-role="library-more"]', {
+    timeout: 30_000,
+  });
+  await page.locator('[data-role="library-more"]').click();
+  await page
+    .locator('[data-role="library-row"]', { hasText: LIBRARY_NAME })
+    .locator("button.operator__list-button")
+    .click();
+  await page
+    .locator('[data-role="presentation-item"]', { hasText: "Stage Field Cases" })
+    .first()
+    .click();
+  await page.waitForSelector(`[data-slide-id="${slideIds[0]}"]`, {
+    timeout: 30_000,
+  });
+  await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "edit",
+  );
+}
+
+test("editing the stage field survives a concurrent presentation refetch (#515)", async ({
+  page,
+}) => {
+  await openOperatorEditMode(page);
+  const slideId = slideIds[0];
+
+  // Re-select the (already open) presentation to fire a fresh
+  // `get_presentation` fetch, and — in the SAME synchronous script, before
+  // that fetch's network round-trip can resolve — type into the stage
+  // field and blur it. This deterministically reproduces the real-world
+  // race (open a song, immediately type a stage/hand-off message) without
+  // depending on real network timing: the whole script below runs to
+  // completion before the fetch promise's microtask can fire.
+  const NEW_TEXT = "Race-safe stage text";
+  const result = await page.evaluate(
+    ({ presentationId, slideId, newText }) => {
+      const item = document.querySelector(
+        `[data-presentation-id="${presentationId}"]`,
+      ) as HTMLElement | null;
+      if (!item) {
+        return { presentationItemFound: false };
+      }
+      item.click();
+
+      const ta = document.querySelector(
+        `[data-slide-id="${slideId}"] [data-field="stage"]`,
+      ) as HTMLTextAreaElement | null;
+      if (!ta) {
+        return { presentationItemFound: true, stageFieldFound: false };
+      }
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      nativeSetter.call(ta, newText);
+      ta.dispatchEvent(new Event("input", { bubbles: true }));
+      ta.focus();
+      ta.blur();
+      return {
+        presentationItemFound: true,
+        stageFieldFound: true,
+        valueRightAfterBlur: ta.value,
+      };
+    },
+    { presentationId, slideId, newText: NEW_TEXT },
+  );
+  expect(result.presentationItemFound).toBe(true);
+  expect(result.stageFieldFound).toBe(true);
+  expect(result.valueRightAfterBlur).toBe(NEW_TEXT);
+
+  // Give the (now-stale) refetch triggered by the re-select time to
+  // resolve. Before the fix, its response landed here and blanked the
+  // field back out to the pre-edit (empty) value.
+  await page.waitForTimeout(1500);
+
+  const stageField = page.locator(
+    `[data-slide-id="${slideId}"] [data-field="stage"]`,
+  );
+  await expect(stageField).toHaveValue(NEW_TEXT);
+
+  // The server has the correct value too, and the edit was never lost —
+  // only the CLIENT display was at risk of reverting.
+  const resp = await page.request.get(
+    new URL(`/presentations/${presentationId}`, baseURL).toString(),
+  );
+  const detail = await resp.json();
+  const slide = detail.presentation.slides.find(
+    (s: { id: string }) => s.id === slideId,
+  );
+  expect(slide.content.stage.value).toBe(NEW_TEXT);
+});
+
+test("stage field text over the line limit never warns; main/translation still do (#515)", async ({
+  page,
+}) => {
+  await openOperatorEditMode(page);
+  // Slide 1 (own slide, independent of the race test's slide 0) — seeded
+  // with a short, non-empty stage value so its preview div is mounted from
+  // the start (mounting is gated on the PERSISTED value being non-empty,
+  // not on live typing — see the fixture setup above).
+  const slideId = slideIds[1];
+  const overLimitText = "a".repeat(40); // default operator line limit is 32
+
+  // The preview div is present in the DOM but CSS-hidden while its own
+  // textarea is the visually active editor in edit mode — assert its
+  // attribute directly rather than requiring visibility.
+  const stagePreview = page.locator(
+    `[data-slide-id="${slideId}"] [data-field-display="stage"]`,
+  );
+  await expect(stagePreview).toHaveCount(1);
+
+  const stageField = page.locator(
+    `[data-slide-id="${slideId}"] [data-field="stage"]`,
+  );
+  await stageField.click();
+  await stageField.fill(overLimitText);
+
+  const warningBanner = page.locator(
+    `[data-slide-id="${slideId}"] [data-role="slide-warning"]`,
+  );
+  await expect(stagePreview).toHaveAttribute("data-warning", "false");
+  await expect(warningBanner).toHaveAttribute("data-visible", "false");
+  await expect(
+    page.locator(`[data-slide-id="${slideId}"] .operator__slide-index sup`),
+  ).toHaveCount(0);
+
+  // Sanity: the same long text on MAIN (on the SAME slide) still warns —
+  // bug-2's fix is stage-field-specific, not a global disabling of the
+  // warning feature.
+  const mainField = page.locator(
+    `[data-slide-id="${slideId}"] [data-field="main"]`,
+  );
+  await mainField.click();
+  await mainField.fill(overLimitText);
+
+  const mainPreview = page.locator(
+    `[data-slide-id="${slideId}"] [data-field-display="main"]`,
+  );
+  await expect(mainPreview).toHaveAttribute("data-warning", "true");
+  await expect(warningBanner).toHaveAttribute("data-visible", "true");
+});


### PR DESCRIPTION
Closes #515

Fixes the two bugs the user reported testing the stage-text feature:

1. **Extreme:** typing into a slide's stage-text field and leaving it made the text vanish from the edit field AND the live stage view — it only reappeared when the slide was later triggered. The inline stage-field edit now persists on blur/change and pushes to the live stage immediately, like the other slide fields (fix spans the slide save + operator state path, not just the input).
2. The lyrics per-line character-limit warning no longer fires on the stage-text field — stage/speaker text is free-form and may be longer than a lyrics line.

Regression-test-first: RED test reproducing both bugs (`c7f1c8c2 [red]`) precedes the GREEN fix (`bcb35420 [green]`); new E2E `slide-stage-field-bugs.spec.ts` + unit coverage. Version 0.4.186.
