### PR TITLE
refactor(stage): bundle NdiVideo signal setters into StageSignalSetters (#527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.186"
+version = "0.4.187"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.186"
+version = "0.4.187"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/ndi_clock_offset.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_clock_offset.rs
@@ -28,7 +28,7 @@ use leptos::web_sys::{HtmlVideoElement, Response};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use super::ndi_frame_stats::{
-    schedule_video_frame_callback, video_supports_rvfc, SharedRvfcClosure,
+    schedule_video_frame_callback, video_supports_rvfc, SharedRvfcClosure, StageSignalSetters,
 };
 use super::ndi_watchdog::now_ms;
 
@@ -240,15 +240,21 @@ fn maybe_fire_handshake(estimator: &Rc<ClockOffsetEstimator>, setter: Option<Clo
 /// Returns `false` when the browser lacks rVFC — same fallback boundary as
 /// `start_rvfc_frame_observer`; the estimator simply never runs there and
 /// `current()` stays `None` (`n/a`), which is honest per the trust predicate.
+///
+/// Takes the SAME `StageSignalSetters` bundle threaded through the rest of
+/// the `Watchdog::install` chain (#527) and plucks just its `clock_offset`
+/// field — the other fields are unused here (this loop owns only the
+/// browser<->server clock handshake).
 pub(crate) fn start(
     video: &HtmlVideoElement,
     active: &Rc<Cell<bool>>,
     estimator: &Rc<ClockOffsetEstimator>,
-    setter: Option<ClockOffsetSetter>,
+    setters: &StageSignalSetters,
 ) -> bool {
     if !video_supports_rvfc(video) {
         return false;
     }
+    let setter: Option<ClockOffsetSetter> = setters.clock_offset.clone();
 
     let holder: SharedRvfcClosure = Rc::new(RefCell::new(None));
     let cb = {

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -516,10 +516,53 @@ pub(crate) fn schedule_video_frame_callback(video: &HtmlVideoElement, holder: &S
 mod tests {
     use super::{
         derive_video_latency_ms, frames_are_stale, mark_frames_live, smooth_latency, FrameStats,
-        FramesLiveSetter, FRAMES_LIVE_STALENESS_MS, VIDEO_LATENCY_SMOOTHING_ALPHA,
+        FramesLiveSetter, StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS,
+        VIDEO_LATENCY_SMOOTHING_ALPHA,
     };
     use std::cell::Cell;
     use std::rc::Rc;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #527 refactor: the four stage-diagnostic signal setters are bundled into
+    // ONE `StageSignalSetters` struct threaded through the watchdog chain. This
+    // guards that the struct actually carries + exposes each optional setter and
+    // that a held setter still fires (the refactor must not drop a signal).
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn stage_signal_setters_defaults_all_none() {
+        let setters = StageSignalSetters::default();
+        assert!(setters.video_latency.is_none());
+        assert!(setters.frames_live.is_none());
+        assert!(setters.clock_offset.is_none());
+        assert!(setters.dropped_frames.is_none());
+    }
+
+    #[test]
+    fn stage_signal_setters_hold_and_fire_each_signal() {
+        let latency_seen = Rc::new(Cell::new(None::<f64>));
+        let live_seen = Rc::new(Cell::new(false));
+        let video_latency: VideoLatencySetter = {
+            let latency_seen = Rc::clone(&latency_seen);
+            Rc::new(move |v: Option<f64>| latency_seen.set(v))
+        };
+        let frames_live: FramesLiveSetter = {
+            let live_seen = Rc::clone(&live_seen);
+            Rc::new(move |v: bool| live_seen.set(v))
+        };
+        let setters = StageSignalSetters {
+            video_latency: Some(video_latency),
+            frames_live: Some(frames_live),
+            clock_offset: None,
+            dropped_frames: None,
+        };
+        // The bundled setters still reach their targets (no signal dropped by
+        // the struct-bundling refactor).
+        (setters.video_latency.as_ref().expect("video_latency setter"))(Some(42.0));
+        (setters.frames_live.as_ref().expect("frames_live setter"))(true);
+        assert_eq!(latency_seen.get(), Some(42.0));
+        assert!(live_seen.get());
+    }
 
     // ─────────────────────────────────────────────────────────────────────
     // #500 frames-live gate: the neutral covering placeholder must reflect

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -15,7 +15,7 @@ use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use leptos::web_sys::{HtmlVideoElement, RtcPeerConnection};
 
 use super::ndi_beacon::post_stats_beacon;
-use super::ndi_clock_offset::ClockOffsetEstimator;
+use super::ndi_clock_offset::{ClockOffsetEstimator, ClockOffsetSetter};
 use super::ndi_profile::persist_proven_profile_mode;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
 
@@ -45,6 +45,22 @@ pub(crate) type FramesLiveSetter = Rc<dyn Fn(bool)>;
 /// there), not the 1s video-latency cadence. `None` (no setter) disables the
 /// readout entirely (e.g. a video element with no StageContext).
 pub(crate) type DroppedFramesSetter = Rc<dyn Fn(Option<(u32, u32)>)>;
+
+/// Bundles the per-session stage-diagnostic signal setters that are threaded,
+/// as a SINGLE unit, through the `NdiVideo` → `Watchdog::install` →
+/// `start_rvfc_frame_observer` / `ndi_clock_offset::start` /
+/// `start_health_ticker` call chain (#527). Each field is `None` under the
+/// same "no `StageContext` → no setter → readout disabled" contract each
+/// setter carried individually before this refactor. Adding a new stage
+/// diagnostic signal now costs ONE new field here instead of a new positional
+/// parameter threaded through every function in the chain.
+#[derive(Clone, Default)]
+pub(crate) struct StageSignalSetters {
+    pub(crate) video_latency: Option<VideoLatencySetter>,
+    pub(crate) frames_live: Option<FramesLiveSetter>,
+    pub(crate) clock_offset: Option<ClockOffsetSetter>,
+    pub(crate) dropped_frames: Option<DroppedFramesSetter>,
+}
 
 /// How long after the last presented frame the video is considered no longer
 /// "live" (#500). Once `now - last_frame_at` exceeds this, the 1s health ticker
@@ -404,7 +420,6 @@ pub(crate) type SharedRvfcClosure = Rc<RefCell<Option<Closure<dyn FnMut(JsValue,
 /// The closure is gated by `active`: once cleared it returns WITHOUT
 /// rescheduling, ending the chain (the leaked holder cycle goes inert —
 /// same bounded-leak idiom as the rest of this file).
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn start_rvfc_frame_observer(
     video: &HtmlVideoElement,
     pc: &RtcPeerConnection,
@@ -413,13 +428,14 @@ pub(crate) fn start_rvfc_frame_observer(
     stats: &Rc<FrameStats>,
     escalation: &Rc<ReloadEscalation>,
     clock_offset: &Rc<ClockOffsetEstimator>,
-    video_latency_setter: Option<VideoLatencySetter>,
-    frames_live_setter: Option<FramesLiveSetter>,
-    dropped_frames_setter: Option<DroppedFramesSetter>,
+    setters: &StageSignalSetters,
 ) -> bool {
     if !video_supports_rvfc(video) {
         return false;
     }
+    let video_latency_setter = setters.video_latency.clone();
+    let frames_live_setter = setters.frames_live.clone();
+    let dropped_frames_setter = setters.dropped_frames.clone();
 
     let holder: SharedRvfcClosure = Rc::new(RefCell::new(None));
     let cb = {

--- a/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
@@ -17,8 +17,8 @@ use leptos::web_sys::{HtmlVideoElement, RtcPeerConnection};
 use super::ndi_beacon::maybe_post_beacon;
 use super::ndi_clock_offset::ClockOffsetEstimator;
 use super::ndi_frame_stats::{
-    mark_frames_live, record_presented_frame, refresh_frames_live_staleness, DroppedFramesSetter,
-    FrameStats, FramesLiveSetter,
+    mark_frames_live, record_presented_frame, refresh_frames_live_staleness, FrameStats,
+    StageSignalSetters,
 };
 use super::ndi_profile::maybe_profile_fallback;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
@@ -44,8 +44,7 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
     rvfc_supported: bool,
     escalation: &Rc<ReloadEscalation>,
     clock_offset: &Rc<ClockOffsetEstimator>,
-    frames_live_setter: Option<FramesLiveSetter>,
-    dropped_frames_setter: Option<DroppedFramesSetter>,
+    setters: &StageSignalSetters,
     on_failure: Rc<F>,
 ) -> i32 {
     let active = Rc::clone(active);
@@ -55,6 +54,10 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
     let source_id = source_id.to_string();
     let escalation = Rc::clone(escalation);
     let clock_offset = Rc::clone(clock_offset);
+    // #527: only the two fields this ticker needs, plucked once out of the
+    // shared bundle before they're moved into the `move` closure below.
+    let frames_live_setter = setters.frames_live.clone();
+    let dropped_frames_setter = setters.dropped_frames.clone();
     let tick_count = Cell::new(0u32);
     let last_current_time = Cell::new(0.0f64);
     let cb = Closure::<dyn FnMut()>::new(move || {

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -17,7 +17,9 @@ use leptos::web_sys::{
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use super::ndi_clock_offset::ClockOffsetSetter;
-use super::ndi_frame_stats::{DroppedFramesSetter, FramesLiveSetter, VideoLatencySetter};
+use super::ndi_frame_stats::{
+    DroppedFramesSetter, FramesLiveSetter, StageSignalSetters, VideoLatencySetter,
+};
 use super::ndi_watchdog::{now_ms, profile_mode_is_compat, ReloadEscalation, Watchdog};
 use crate::state::stage::StageContext;
 
@@ -110,6 +112,17 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
         }) as DroppedFramesSetter
     });
 
+    // #527: bundle the four per-session setters into ONE struct threaded
+    // through the effect below and into `Watchdog::install` — a new stage
+    // diagnostic signal now costs one struct field instead of a new
+    // positional parameter in every function of the chain.
+    let stage_signal_setters = StageSignalSetters {
+        video_latency: video_latency_setter,
+        frames_live: frames_live_setter,
+        clock_offset: clock_offset_setter,
+        dropped_frames: dropped_frames_setter,
+    };
+
     // Holds the active connection: the WHEP session + the watchdog observing
     // its health. Cleanup must close both — see on_cleanup below.
     struct ActiveConnection {
@@ -139,18 +152,12 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
         StoredValue::new_local(Some(ReloadEscalation::new()));
 
     let cancelled_for_effect = Arc::clone(&cancelled);
-    let video_latency_setter_for_effect = video_latency_setter;
-    let frames_live_setter_for_effect = frames_live_setter;
-    let clock_offset_setter_for_effect = clock_offset_setter;
-    let dropped_frames_setter_for_effect = dropped_frames_setter;
+    let stage_signal_setters_for_effect = stage_signal_setters;
     Effect::new(move |_| {
         let Some(video) = video_ref.get() else { return };
         let source_id = source_id_for_effect.clone();
         let cancelled = Arc::clone(&cancelled_for_effect);
-        let video_latency_setter = video_latency_setter_for_effect.clone();
-        let frames_live_setter = frames_live_setter_for_effect.clone();
-        let clock_offset_setter = clock_offset_setter_for_effect.clone();
-        let dropped_frames_setter = dropped_frames_setter_for_effect.clone();
+        let stage_signal_setters = stage_signal_setters_for_effect.clone();
         spawn_local(async move {
             // The reconnect-trigger flag: when a watchdog fires, it sets this
             // flag; the loop drains it and reconnects.
@@ -222,10 +229,7 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
                             &session.pc,
                             &source_id,
                             &escalation,
-                            video_latency_setter.clone(),
-                            frames_live_setter.clone(),
-                            clock_offset_setter.clone(),
-                            dropped_frames_setter.clone(),
+                            stage_signal_setters.clone(),
                             move || flag.set(true),
                         );
 

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -20,11 +20,8 @@ use leptos::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use leptos::web_sys::{HtmlVideoElement, RtcIceConnectionState, RtcPeerConnection};
 use wasm_bindgen_futures::spawn_local;
 
-use super::ndi_clock_offset::{self, ClockOffsetEstimator, ClockOffsetSetter};
-use super::ndi_frame_stats::{
-    start_rvfc_frame_observer, DroppedFramesSetter, FrameStats, FramesLiveSetter,
-    VideoLatencySetter,
-};
+use super::ndi_clock_offset::{self, ClockOffsetEstimator};
+use super::ndi_frame_stats::{start_rvfc_frame_observer, FrameStats, StageSignalSetters};
 use super::ndi_health_ticker::start_health_ticker;
 
 // Re-export the profile-mode query so `ndi_video.rs` keeps importing it from
@@ -320,16 +317,12 @@ impl Watchdog {
     /// when video has been dead long enough that reconnect has demonstrably
     /// failed. It is passed in (not created here) precisely so it survives the
     /// Watchdog being recreated on every reconnect.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn install<F: Fn() + 'static>(
         video: &HtmlVideoElement,
         pc: &RtcPeerConnection,
         source_id: &str,
         escalation: &Rc<ReloadEscalation>,
-        video_latency_setter: Option<VideoLatencySetter>,
-        frames_live_setter: Option<FramesLiveSetter>,
-        clock_offset_setter: Option<ClockOffsetSetter>,
-        dropped_frames_setter: Option<DroppedFramesSetter>,
+        setters: StageSignalSetters,
         on_failure: F,
     ) -> Self {
         let active: Rc<Cell<bool>> = Rc::new(Cell::new(true));
@@ -345,25 +338,25 @@ impl Watchdog {
         // wrongly hide the neutral cover. The first presented frame re-marks it
         // true; on a healthy mid-stream reconnect the status is `connected`
         // (no cover) so this never flashes the cover.
-        if let Some(setter) = &frames_live_setter {
+        if let Some(setter) = &setters.frames_live {
             setter(false);
         }
         // #523 (review follow-up): a freshly-installed session hasn't decoded a
         // frame yet, so any server→display ms figure still on screen belongs to
         // the prior (torn-down) session. Clear it for the SAME reason
-        // `frames_live_setter` is cleared above — the first presented frame's
+        // `frames_live` is cleared above — the first presented frame's
         // `update_video_latency` call repopulates it honestly within ~1s. (This
         // reset was missing before #523 added the analogous one for
-        // `dropped_frames_setter` below; both readouts now clear consistently on
+        // `dropped_frames` below; both readouts now clear consistently on
         // every reconnect instead of only one of the two.)
-        if let Some(setter) = &video_latency_setter {
+        if let Some(setter) = &setters.video_latency {
             setter(None);
         }
         // #523: a freshly-installed session hasn't posted a beacon yet, so any
         // dropped/freeze count still on screen is from the prior (torn-down)
         // session. Clear it rather than show a stale figure — the next beacon
         // (up to ~15s away) repopulates it honestly.
-        if let Some(setter) = &dropped_frames_setter {
+        if let Some(setter) = &setters.dropped_frames {
             setter(None);
         }
         // #510/#512: the browser<->server pipeline-clock offset estimator. Created
@@ -379,14 +372,11 @@ impl Watchdog {
             &stats,
             escalation,
             &clock_offset_estimator,
-            video_latency_setter,
-            // #500: the rVFC path marks frames live on each presented frame; the
-            // health ticker (below) flips them back to not-live on staleness, so
-            // BOTH share the same per-session setter.
-            frames_live_setter.clone(),
-            // #523: BOTH beacon paths (rVFC frame-count-driven and the 1s
-            // ticker) can post a stats beacon, so both share the same setter.
-            dropped_frames_setter.clone(),
+            // #527: the rVFC path plucks the video-latency/frames-live/dropped-
+            // frames fields it needs out of the SAME bundle the health ticker
+            // (below) also receives — a new stage diagnostic signal is now one
+            // struct field, not a new positional parameter in both places.
+            &setters,
         );
         if !rvfc_supported {
             leptos::logging::warn!(
@@ -399,7 +389,7 @@ impl Watchdog {
         // it needs no decode-side counters, just a periodic tick that survives
         // TV WebView timer throttling the same way. Feeds the SAME estimator the
         // observer reads, so the RTT it measures becomes the latency's network term.
-        ndi_clock_offset::start(video, &active, &clock_offset_estimator, clock_offset_setter);
+        ndi_clock_offset::start(video, &active, &clock_offset_estimator, &setters);
         let health_ticker_handle = start_health_ticker(
             video,
             pc,
@@ -409,8 +399,7 @@ impl Watchdog {
             rvfc_supported,
             escalation,
             &clock_offset_estimator,
-            frames_live_setter,
-            dropped_frames_setter,
+            &setters,
             on_failure,
         );
 


### PR DESCRIPTION
Closes #527

Pure internal refactor (no behavior change): bundles the four stage-diagnostic `Rc<dyn Fn(...)>` signal setters — video-latency, frames-live, clock-offset, dropped-frames — into one `StageSignalSetters` struct threaded through `NdiVideo` → `Watchdog::install` → the rVFC observer / health ticker, instead of one positional parameter each. Adds unit tests (`stage_signal_setters_defaults_all_none`, `stage_signal_setters_hold_and_fire_each_signal`) guarding that the struct carries + fires each signal (no signal dropped). Existing 203 ui tests pass unchanged. Version 0.4.187.
