### PR TITLE
feat(stage): recent-window health indicator (🟢/🟡/🔴) on stage TV readout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.188"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.188"
+version = "0.4.189"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.187"
+version = "0.4.189"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/ndi_beacon.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_beacon.rs
@@ -15,7 +15,9 @@ use leptos::wasm_bindgen::{JsCast, JsValue};
 use leptos::web_sys::RtcPeerConnection;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
-use super::ndi_frame_stats::{snapshot_present_gaps, DroppedFramesSetter, FrameStats};
+use super::ndi_frame_stats::{
+    notify_stage_health, snapshot_present_gaps, DroppedFramesSetter, FrameStats, HealthSetter,
+};
 use super::ndi_profile::{local_storage, profile_mode_is_compat, profile_mode_name};
 
 /// localStorage key for the persistent per-display identity used in stats
@@ -50,14 +52,21 @@ fn display_id() -> Option<String> {
 /// the spawned task. The smoothed true latency and the clock offset/RTT
 /// (#514) are likewise sampled synchronously so they describe THIS beacon's
 /// moment, not the post-await one.
+///
+/// #532: the stage-health verdict is classified from this SAME synchronous
+/// snapshot (`max_gap`/`over100`/`fps` need no getStats data at all), so it
+/// is pushed to the readout right here — independent of whether the async
+/// getStats round-trip below succeeds.
 pub(crate) fn post_stats_beacon(
     pc: &RtcPeerConnection,
     source_id: &str,
     stats: &FrameStats,
     clock_offset: Option<(f64, f64)>,
     dropped_frames_setter: Option<DroppedFramesSetter>,
+    health_setter: Option<HealthSetter>,
 ) {
     let (max_gap, over100, fps) = snapshot_present_gaps(stats);
+    notify_stage_health(fps, max_gap, over100, &health_setter);
     let video_latency_ms = stats.video_latency_ms.get();
     let pc = pc.clone();
     let source_id = source_id.to_string();
@@ -88,12 +97,20 @@ pub(crate) fn maybe_post_beacon(
     stats: &FrameStats,
     clock_offset: Option<(f64, f64)>,
     dropped_frames_setter: Option<DroppedFramesSetter>,
+    health_setter: Option<HealthSetter>,
 ) {
     tick_count.set(tick_count.get().wrapping_add(1));
     if tick_count.get() % 15 != 0 {
         return;
     }
-    post_stats_beacon(pc, source_id, stats, clock_offset, dropped_frames_setter);
+    post_stats_beacon(
+        pc,
+        source_id,
+        stats,
+        clock_offset,
+        dropped_frames_setter,
+        health_setter,
+    );
 }
 
 /// Extract inbound-video stats from an RtcStatsReport (a JS Map) and POST a

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -18,6 +18,7 @@ use super::ndi_beacon::post_stats_beacon;
 use super::ndi_clock_offset::{ClockOffsetEstimator, ClockOffsetSetter};
 use super::ndi_profile::persist_proven_profile_mode;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
+use crate::state::stage::{StageHealth, StageHealthReading};
 
 /// Callback that publishes the smoothed stage-side video latency (ms) to the
 /// on-screen readout signal (`StageContext::video_latency_ms`). `Some(ms)`
@@ -46,6 +47,17 @@ pub(crate) type FramesLiveSetter = Rc<dyn Fn(bool)>;
 /// readout entirely (e.g. a video element with no StageContext).
 pub(crate) type DroppedFramesSetter = Rc<dyn Fn(Option<(u32, u32)>)>;
 
+/// Callback that publishes the recent-window stage-health verdict (#532) to
+/// the shared `StageContext::stage_health` signal driving the stage's
+/// "🟢/🟡/🔴" readout beside the latency figure — replacing the CUMULATIVE
+/// ⬇N/❄N suffix `DroppedFramesSetter` used to drive on-screen (that plumbing
+/// is kept for its own sake; only the readout moved to this signal). Fed from
+/// the SAME per-interval accumulators `snapshot_present_gaps` already resets
+/// each beacon, so the reading is inherently RECENT, never cumulative.
+/// `None` (no setter) disables the readout entirely (e.g. a video element
+/// with no StageContext).
+pub(crate) type HealthSetter = Rc<dyn Fn(Option<StageHealthReading>)>;
+
 /// Bundles the per-session stage-diagnostic signal setters that are threaded,
 /// as a SINGLE unit, through the `NdiVideo` → `Watchdog::install` →
 /// `start_rvfc_frame_observer` / `ndi_clock_offset::start` /
@@ -60,6 +72,7 @@ pub(crate) struct StageSignalSetters {
     pub(crate) frames_live: Option<FramesLiveSetter>,
     pub(crate) clock_offset: Option<ClockOffsetSetter>,
     pub(crate) dropped_frames: Option<DroppedFramesSetter>,
+    pub(crate) stage_health: Option<HealthSetter>,
 }
 
 /// How long after the last presented frame the video is considered no longer
@@ -393,6 +406,67 @@ pub(crate) fn snapshot_present_gaps(stats: &FrameStats) -> (f64, u32, Option<f64
     (max_gap, over100, fps)
 }
 
+/// fps at/above this (out of a 30fps NDI source), with a clean recent window,
+/// classifies as 🟢 (#532). A shade under the nominal 30fps so a single
+/// dropped frame in the window doesn't flip a genuinely smooth TV to yellow.
+const HEALTH_FPS_GOOD_MIN: f64 = 27.0;
+/// fps below this classifies as 🔴 regardless of gap count — the decode/
+/// render path is badly starved, not just occasionally hitching.
+const HEALTH_FPS_BAD_MAX: f64 = 15.0;
+/// An inter-present gap at/above this many ms is the "big freeze" bar for the
+/// health verdict — stricter than `PRESENT_GAP_HITCH_MS`'s 100ms perceptible-
+/// hitch threshold (a single ~100-149ms gap alone doesn't sink the verdict to
+/// 🟡, but it does count toward `present_gaps_over100`'s repeated-hitch total
+/// below, since that accumulator is keyed on the 100ms threshold).
+const HEALTH_GAP_HITCH_MS: f64 = 150.0;
+/// This many (or more) >100ms presentation gaps in one recent window is
+/// "repeated" stutter (as opposed to one isolated hitch) — escalates straight
+/// to 🔴 even when fps looks fine (an average can hide a hitch burst).
+const HEALTH_REPEATED_GAPS_MIN: u32 = 2;
+
+/// Pure classifier (#532): recent-window presented-fps + presentation-gap
+/// stats → a health verdict answering "is this stage TV usable right now?".
+/// Unlike getStats' cumulative freeze/drop counters, every input here resets
+/// each beacon interval (`snapshot_present_gaps`), so the verdict reflects
+/// only the LAST ~15-20s, never a stale blip from an hour ago. Thresholds are
+/// the named constants above — tune there, never inline.
+pub(crate) fn stage_health(
+    presented_fps: f64,
+    max_present_gap_ms: f64,
+    present_gaps_over100: u32,
+) -> StageHealth {
+    if presented_fps < HEALTH_FPS_BAD_MAX || present_gaps_over100 >= HEALTH_REPEATED_GAPS_MIN {
+        StageHealth::Bad
+    } else if presented_fps >= HEALTH_FPS_GOOD_MIN
+        && present_gaps_over100 == 0
+        && max_present_gap_ms < HEALTH_GAP_HITCH_MS
+    {
+        StageHealth::Good
+    } else {
+        StageHealth::Degraded
+    }
+}
+
+/// Classify this beacon's recent-window stats and push the reading to the
+/// on-screen signal (#532). `presented_fps = None` (the interval had no
+/// elapsed wall-clock time to compute a rate — see `snapshot_present_gaps`)
+/// leaves whatever verdict is already on screen alone rather than flipping it
+/// on a meaningless input; in practice this only happens on a same-instant
+/// double-call, never on real beacon cadence (~15s apart).
+pub(crate) fn notify_stage_health(
+    presented_fps: Option<f64>,
+    max_present_gap_ms: f64,
+    present_gaps_over100: u32,
+    setter: &Option<HealthSetter>,
+) {
+    let Some(setter) = setter else { return };
+    let Some(fps) = presented_fps else { return };
+    setter(Some(StageHealthReading {
+        state: stage_health(fps, max_present_gap_ms, present_gaps_over100),
+        fps,
+    }));
+}
+
 /// Shared holder for the self-rescheduling rVFC closure (the closure needs a
 /// handle to itself to re-register for the next presented frame). `pub(crate)`
 /// so `ndi_clock_offset`'s independent rVFC-driven handshake loop (#510) can
@@ -436,6 +510,7 @@ pub(crate) fn start_rvfc_frame_observer(
     let video_latency_setter = setters.video_latency.clone();
     let frames_live_setter = setters.frames_live.clone();
     let dropped_frames_setter = setters.dropped_frames.clone();
+    let stage_health_setter = setters.stage_health.clone();
 
     let holder: SharedRvfcClosure = Rc::new(RefCell::new(None));
     let cb = {
@@ -471,6 +546,7 @@ pub(crate) fn start_rvfc_frame_observer(
                     &stats,
                     clock_offset.current(),
                     dropped_frames_setter.clone(),
+                    stage_health_setter.clone(),
                 );
             }
             schedule_video_frame_callback(&video, &holder);
@@ -515,10 +591,13 @@ pub(crate) fn schedule_video_frame_callback(video: &HtmlVideoElement, holder: &S
 #[cfg(test)]
 mod tests {
     use super::{
-        derive_video_latency_ms, frames_are_stale, mark_frames_live, smooth_latency, FrameStats,
-        FramesLiveSetter, StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS,
+        derive_video_latency_ms, frames_are_stale, mark_frames_live, notify_stage_health,
+        smooth_latency, stage_health, FrameStats, FramesLiveSetter, HealthSetter,
+        StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS, HEALTH_FPS_BAD_MAX,
+        HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS, HEALTH_REPEATED_GAPS_MIN,
         VIDEO_LATENCY_SMOOTHING_ALPHA,
     };
+    use crate::state::stage::{StageHealth, StageHealthReading};
     use std::cell::Cell;
     use std::rc::Rc;
 
@@ -536,6 +615,7 @@ mod tests {
         assert!(setters.frames_live.is_none());
         assert!(setters.clock_offset.is_none());
         assert!(setters.dropped_frames.is_none());
+        assert!(setters.stage_health.is_none());
     }
 
     #[test]
@@ -555,10 +635,14 @@ mod tests {
             frames_live: Some(frames_live),
             clock_offset: None,
             dropped_frames: None,
+            stage_health: None,
         };
         // The bundled setters still reach their targets (no signal dropped by
         // the struct-bundling refactor).
-        (setters.video_latency.as_ref().expect("video_latency setter"))(Some(42.0));
+        (setters
+            .video_latency
+            .as_ref()
+            .expect("video_latency setter"))(Some(42.0));
         (setters.frames_live.as_ref().expect("frames_live setter"))(true);
         assert_eq!(latency_seen.get(), Some(42.0));
         assert!(live_seen.get());
@@ -744,5 +828,129 @@ mod tests {
             v = smooth_latency(Some(v), 50.0, VIDEO_LATENCY_SMOOTHING_ALPHA);
         }
         assert!((v - 50.0).abs() < 1e-6, "EMA converged = {v}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #532 — `stage_health`: recent-window fps + presentation-gap stats → a
+    // 🟢/🟡/🔴 verdict. Boundary cases at every named threshold, so a future
+    // threshold tweak has to consciously touch these assertions.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn good_when_fps_high_and_no_gaps() {
+        assert_eq!(stage_health(30.0, 20.0, 0), StageHealth::Good);
+    }
+
+    #[test]
+    fn good_at_exact_fps_and_gap_boundary() {
+        // fps exactly at the GOOD floor, gap just under the hitch bar, zero
+        // hitch count → still 🟢 (boundaries are inclusive on the good side).
+        assert_eq!(
+            stage_health(HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS - 0.1, 0),
+            StageHealth::Good
+        );
+    }
+
+    #[test]
+    fn degraded_when_fps_between_good_and_bad_thresholds() {
+        assert_eq!(stage_health(20.0, 50.0, 0), StageHealth::Degraded);
+    }
+
+    #[test]
+    fn one_isolated_gap_over_hitch_is_degraded_not_bad() {
+        // A single >100ms gap (not "repeated") with otherwise-fine fps must
+        // NOT sink straight to 🔴 — that's what "repeated" gates.
+        assert_eq!(
+            stage_health(29.0, HEALTH_GAP_HITCH_MS + 50.0, 1),
+            StageHealth::Degraded
+        );
+    }
+
+    #[test]
+    fn bad_when_fps_below_floor_even_with_clean_gaps() {
+        assert_eq!(
+            stage_health(HEALTH_FPS_BAD_MAX - 0.1, 20.0, 0),
+            StageHealth::Bad
+        );
+    }
+
+    #[test]
+    fn fps_exactly_at_bad_floor_is_not_bad_via_fps_alone() {
+        // Strictly-less-than on the bad side: fps == floor does not itself
+        // trigger 🔴 (falls through to the fps>=GOOD_MIN check, which also
+        // fails at this fps, landing on 🟡).
+        assert_eq!(
+            stage_health(HEALTH_FPS_BAD_MAX, 20.0, 0),
+            StageHealth::Degraded
+        );
+    }
+
+    #[test]
+    fn repeated_gaps_escalate_to_bad_even_with_healthy_fps() {
+        assert_eq!(
+            stage_health(29.0, HEALTH_GAP_HITCH_MS + 100.0, HEALTH_REPEATED_GAPS_MIN),
+            StageHealth::Bad
+        );
+    }
+
+    #[test]
+    fn repeated_gaps_boundary_one_below_min_is_not_bad() {
+        assert_eq!(
+            stage_health(
+                29.0,
+                HEALTH_GAP_HITCH_MS + 100.0,
+                HEALTH_REPEATED_GAPS_MIN - 1
+            ),
+            StageHealth::Degraded
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #532 — `notify_stage_health`: the beacon-facing glue that classifies +
+    // pushes to the on-screen signal, mirroring `notify_dropped_frames`'s
+    // early-return shape in `ndi_beacon.rs`.
+    // ─────────────────────────────────────────────────────────────────────
+
+    fn capturing_health_setter() -> (HealthSetter, Rc<Cell<Option<StageHealthReading>>>) {
+        let captured = Rc::new(Cell::new(None));
+        let setter = {
+            let captured = Rc::clone(&captured);
+            Rc::new(move |v: Option<StageHealthReading>| captured.set(v)) as HealthSetter
+        };
+        (setter, captured)
+    }
+
+    #[test]
+    fn notify_pushes_the_classified_reading() {
+        let (setter, captured) = capturing_health_setter();
+        notify_stage_health(Some(30.0), 10.0, 0, &Some(setter));
+        assert_eq!(
+            captured.get(),
+            Some(StageHealthReading {
+                state: StageHealth::Good,
+                fps: 30.0,
+            })
+        );
+    }
+
+    #[test]
+    fn notify_is_a_no_op_when_fps_is_none() {
+        // Interval had no elapsed time to compute a rate — leave whatever is
+        // already on screen alone rather than push a meaningless verdict.
+        // Seed a prior reading first so a wrongly-firing setter is caught
+        // (an unseeded `None` capture would pass either way).
+        let (setter, captured) = capturing_health_setter();
+        captured.set(Some(StageHealthReading {
+            state: StageHealth::Bad,
+            fps: 3.0,
+        }));
+        notify_stage_health(None, 10.0, 0, &Some(setter));
+        assert_eq!(
+            captured.get(),
+            Some(StageHealthReading {
+                state: StageHealth::Bad,
+                fps: 3.0,
+            })
+        );
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -380,25 +380,45 @@ fn record_present_gap(stats: &FrameStats, gap_ms: f64) {
     }
 }
 
+/// Minimum interval span for a presented-fps figure to be trustworthy. Below
+/// this the frame count is too small to give a stable rate — the dominant
+/// cause is beacon INTERLEAVE: the rVFC observer (every `RVFC_BEACON_FRAME_
+/// PERIOD` frames) and the 1s health ticker (every 15th tick) BOTH call
+/// `snapshot_present_gaps` on the SAME `FrameStats`, each resetting the
+/// interval; they run on independent clocks and drift into near-coincidence,
+/// so whichever fires second can see a sub-frame window with 0-1 frames →
+/// `fps ≈ 0`. Feeding that to the #532 health verdict would flash a spurious
+/// 🔴/🟡 on a perfectly smooth TV. A 1s floor is far above frame-period noise
+/// yet far below the ~15s legitimate beacon cadence, and (because consecutive
+/// beacons partition each ~15s rVFC cycle) at least one path per cycle always
+/// spans well over 1s — so the verdict still refreshes at least every ~15s.
+/// A genuine freeze is unaffected: its full ~15s window with 0 frames still
+/// yields `Some(0.0)` → `Bad`, correctly.
+const MIN_FPS_INTERVAL_MS: f64 = 1000.0;
+
+/// Presented frames per second over an interval, or `None` when the interval
+/// is shorter than `MIN_FPS_INTERVAL_MS` (too short for a stable rate — see
+/// that constant). Pure so the window floor is host-testable without a clock.
+pub(crate) fn presented_fps_for_window(presented: u32, elapsed_ms: f64) -> Option<f64> {
+    (elapsed_ms >= MIN_FPS_INTERVAL_MS).then(|| f64::from(presented) / (elapsed_ms / 1000.0))
+}
+
 /// Snapshot the present-gap accumulators for a beacon and RESET them so the
 /// NEXT beacon reports only the next interval (last-interval semantics, not
 /// cumulative). Returns `(maxPresentGapMs, presentGapsOver100, presentedFps)`:
 /// - `max_present_gap_ms` — largest inter-present gap this interval (ms).
 /// - `present_gaps_over100` — count of >100ms gaps this interval.
 /// - `presented_fps` — frames presented / interval-seconds (render-side fps,
-///   distinct from getStats' decode-side fps). `None` when the interval is too
-///   short to be meaningful (no elapsed time yet).
+///   distinct from getStats' decode-side fps). `None` when the interval is
+///   shorter than `MIN_FPS_INTERVAL_MS` (interleaved beacons leaving a
+///   sub-frame window — see `presented_fps_for_window`).
 pub(crate) fn snapshot_present_gaps(stats: &FrameStats) -> (f64, u32, Option<f64>) {
     let now = now_ms();
     let max_gap = stats.max_present_gap_ms.get();
     let over100 = stats.present_gaps_over100.get();
     let presented = stats.presented_in_interval.get();
     let elapsed_ms = now - stats.interval_started_at.get();
-    let fps = if elapsed_ms > 0.0 {
-        Some(f64::from(presented) / (elapsed_ms / 1000.0))
-    } else {
-        None
-    };
+    let fps = presented_fps_for_window(presented, elapsed_ms);
     stats.max_present_gap_ms.set(0.0);
     stats.present_gaps_over100.set(0);
     stats.presented_in_interval.set(0);
@@ -592,10 +612,10 @@ pub(crate) fn schedule_video_frame_callback(video: &HtmlVideoElement, holder: &S
 mod tests {
     use super::{
         derive_video_latency_ms, frames_are_stale, mark_frames_live, notify_stage_health,
-        smooth_latency, stage_health, FrameStats, FramesLiveSetter, HealthSetter,
-        StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS, HEALTH_FPS_BAD_MAX,
-        HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS, HEALTH_REPEATED_GAPS_MIN,
-        VIDEO_LATENCY_SMOOTHING_ALPHA,
+        presented_fps_for_window, smooth_latency, stage_health, FrameStats, FramesLiveSetter,
+        HealthSetter, StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS,
+        HEALTH_FPS_BAD_MAX, HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS, HEALTH_REPEATED_GAPS_MIN,
+        MIN_FPS_INTERVAL_MS, VIDEO_LATENCY_SMOOTHING_ALPHA,
     };
     use crate::state::stage::{StageHealth, StageHealthReading};
     use std::cell::Cell;
@@ -952,5 +972,44 @@ mod tests {
                 fps: 3.0,
             })
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #532 review fix — `presented_fps_for_window`: a beacon window shorter
+    // than MIN_FPS_INTERVAL_MS yields None so an interleaved rVFC/ticker pair
+    // (which leaves one path a sub-frame window) can't flash a false 🔴/🟡.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fps_over_a_full_window_is_the_rate() {
+        // 450 frames over a 15s window → 30 fps.
+        assert_eq!(presented_fps_for_window(450, 15_000.0), Some(30.0));
+    }
+
+    #[test]
+    fn fps_at_exact_window_floor_is_computed() {
+        // Exactly MIN_FPS_INTERVAL_MS is inclusive: 30 frames in 1s → 30 fps.
+        assert_eq!(
+            presented_fps_for_window(30, MIN_FPS_INTERVAL_MS),
+            Some(30.0)
+        );
+    }
+
+    #[test]
+    fn fps_is_none_for_sub_floor_interleave_window() {
+        // The failure the review caught: two beacons fire ~one frame apart, so
+        // the second sees ~16ms with 0 frames. Without the floor this is
+        // Some(0.0) → Bad → spurious 🔴. With it, None → verdict unchanged.
+        assert_eq!(presented_fps_for_window(0, 16.0), None);
+        // Even a couple of frames in a ~150ms sub-window (which would compute a
+        // misleading ~13-20 fps → false 🟡) is suppressed.
+        assert_eq!(presented_fps_for_window(2, 150.0), None);
+    }
+
+    #[test]
+    fn fps_is_none_for_zero_window() {
+        // Same-instant double call (elapsed 0) — the original guard's case,
+        // still None under the tightened floor.
+        assert_eq!(presented_fps_for_window(0, 0.0), None);
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_frame_stats.rs
@@ -433,16 +433,23 @@ const HEALTH_FPS_GOOD_MIN: f64 = 27.0;
 /// fps below this classifies as 🔴 regardless of gap count — the decode/
 /// render path is badly starved, not just occasionally hitching.
 const HEALTH_FPS_BAD_MAX: f64 = 15.0;
-/// An inter-present gap at/above this many ms is the "big freeze" bar for the
-/// health verdict — stricter than `PRESENT_GAP_HITCH_MS`'s 100ms perceptible-
-/// hitch threshold (a single ~100-149ms gap alone doesn't sink the verdict to
-/// 🟡, but it does count toward `present_gaps_over100`'s repeated-hitch total
-/// below, since that accumulator is keyed on the 100ms threshold).
-const HEALTH_GAP_HITCH_MS: f64 = 150.0;
-/// This many (or more) >100ms presentation gaps in one recent window is
-/// "repeated" stutter (as opposed to one isolated hitch) — escalates straight
-/// to 🔴 even when fps looks fine (an average can hide a hitch burst).
+/// This many (or more) >100ms presentation gaps (`present_gaps_over100`,
+/// keyed on `PRESENT_GAP_HITCH_MS`) in one recent window is "repeated"
+/// stutter (as opposed to one isolated hitch) — escalates straight to 🔴
+/// even when fps looks fine (an average can hide a hitch burst). Note: when
+/// this count is 0, `max_present_gap_ms` is necessarily <= 100ms too (no gap
+/// exceeded the 100ms accumulator threshold), which is what makes the 🟢
+/// branch below not need its own separate gap-size check.
 const HEALTH_REPEATED_GAPS_MIN: u32 = 2;
+/// A SINGLE inter-present gap at/above this many ms is a severe freeze on its
+/// own, escalating straight to 🔴 regardless of `present_gaps_over100`'s
+/// count. Without this, one multi-second stall inside an otherwise-normal
+/// window registers as exactly ONE `present_gaps_over100` — indistinguishable
+/// from one trivial 101ms hitch — and (with fps still averaging fine) would
+/// wrongly land on 🟡 "mierne seká" instead of 🔴 "výpadky" for a freeze the
+/// operator absolutely needs flagged. Comfortably above the "repeated
+/// hitches" bar: a full second of frozen video is an outage, not stutter.
+const HEALTH_SEVERE_FREEZE_MS: f64 = 1_000.0;
 
 /// Pure classifier (#532): recent-window presented-fps + presentation-gap
 /// stats → a health verdict answering "is this stage TV usable right now?".
@@ -455,12 +462,12 @@ pub(crate) fn stage_health(
     max_present_gap_ms: f64,
     present_gaps_over100: u32,
 ) -> StageHealth {
-    if presented_fps < HEALTH_FPS_BAD_MAX || present_gaps_over100 >= HEALTH_REPEATED_GAPS_MIN {
-        StageHealth::Bad
-    } else if presented_fps >= HEALTH_FPS_GOOD_MIN
-        && present_gaps_over100 == 0
-        && max_present_gap_ms < HEALTH_GAP_HITCH_MS
+    if presented_fps < HEALTH_FPS_BAD_MAX
+        || present_gaps_over100 >= HEALTH_REPEATED_GAPS_MIN
+        || max_present_gap_ms >= HEALTH_SEVERE_FREEZE_MS
     {
+        StageHealth::Bad
+    } else if presented_fps >= HEALTH_FPS_GOOD_MIN && present_gaps_over100 == 0 {
         StageHealth::Good
     } else {
         StageHealth::Degraded
@@ -468,11 +475,14 @@ pub(crate) fn stage_health(
 }
 
 /// Classify this beacon's recent-window stats and push the reading to the
-/// on-screen signal (#532). `presented_fps = None` (the interval had no
-/// elapsed wall-clock time to compute a rate — see `snapshot_present_gaps`)
-/// leaves whatever verdict is already on screen alone rather than flipping it
-/// on a meaningless input; in practice this only happens on a same-instant
-/// double-call, never on real beacon cadence (~15s apart).
+/// on-screen signal (#532). `presented_fps = None` (the window was shorter
+/// than `MIN_FPS_INTERVAL_MS` — see `presented_fps_for_window`) leaves
+/// whatever verdict is already on screen alone rather than flipping it on a
+/// meaningless input. This is NOT just a same-instant double-call: the rVFC
+/// and 1s-ticker beacon paths run on independent clocks and routinely drift
+/// into near-coincidence, leaving one of them a sub-second window — see
+/// `MIN_FPS_INTERVAL_MS`'s doc for why that's expected on real beacon
+/// cadence, not a rare edge case.
 pub(crate) fn notify_stage_health(
     presented_fps: Option<f64>,
     max_present_gap_ms: f64,
@@ -614,7 +624,7 @@ mod tests {
         derive_video_latency_ms, frames_are_stale, mark_frames_live, notify_stage_health,
         presented_fps_for_window, smooth_latency, stage_health, FrameStats, FramesLiveSetter,
         HealthSetter, StageSignalSetters, VideoLatencySetter, FRAMES_LIVE_STALENESS_MS,
-        HEALTH_FPS_BAD_MAX, HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS, HEALTH_REPEATED_GAPS_MIN,
+        HEALTH_FPS_BAD_MAX, HEALTH_FPS_GOOD_MIN, HEALTH_REPEATED_GAPS_MIN, HEALTH_SEVERE_FREEZE_MS,
         MIN_FPS_INTERVAL_MS, VIDEO_LATENCY_SMOOTHING_ALPHA,
     };
     use crate::state::stage::{StageHealth, StageHealthReading};
@@ -862,11 +872,13 @@ mod tests {
     }
 
     #[test]
-    fn good_at_exact_fps_and_gap_boundary() {
-        // fps exactly at the GOOD floor, gap just under the hitch bar, zero
-        // hitch count → still 🟢 (boundaries are inclusive on the good side).
+    fn good_at_exact_fps_boundary_with_clean_gaps() {
+        // fps exactly at the GOOD floor, zero hitch count → still 🟢
+        // (boundaries are inclusive on the good side). `max_present_gap_ms`
+        // is irrelevant to the Good branch as long as no gap crossed the
+        // 100ms accumulator threshold — see the constant's doc.
         assert_eq!(
-            stage_health(HEALTH_FPS_GOOD_MIN, HEALTH_GAP_HITCH_MS - 0.1, 0),
+            stage_health(HEALTH_FPS_GOOD_MIN, 20.0, 0),
             StageHealth::Good
         );
     }
@@ -878,12 +890,10 @@ mod tests {
 
     #[test]
     fn one_isolated_gap_over_hitch_is_degraded_not_bad() {
-        // A single >100ms gap (not "repeated") with otherwise-fine fps must
-        // NOT sink straight to 🔴 — that's what "repeated" gates.
-        assert_eq!(
-            stage_health(29.0, HEALTH_GAP_HITCH_MS + 50.0, 1),
-            StageHealth::Degraded
-        );
+        // A single >100ms gap (not "repeated", and well under the severe-
+        // freeze bar) with otherwise-fine fps must NOT sink straight to 🔴 —
+        // that's what "repeated" (or a severe single freeze) gates.
+        assert_eq!(stage_health(29.0, 200.0, 1), StageHealth::Degraded);
     }
 
     #[test]
@@ -908,7 +918,7 @@ mod tests {
     #[test]
     fn repeated_gaps_escalate_to_bad_even_with_healthy_fps() {
         assert_eq!(
-            stage_health(29.0, HEALTH_GAP_HITCH_MS + 100.0, HEALTH_REPEATED_GAPS_MIN),
+            stage_health(29.0, 200.0, HEALTH_REPEATED_GAPS_MIN),
             StageHealth::Bad
         );
     }
@@ -916,11 +926,32 @@ mod tests {
     #[test]
     fn repeated_gaps_boundary_one_below_min_is_not_bad() {
         assert_eq!(
-            stage_health(
-                29.0,
-                HEALTH_GAP_HITCH_MS + 100.0,
-                HEALTH_REPEATED_GAPS_MIN - 1
-            ),
+            stage_health(29.0, 200.0, HEALTH_REPEATED_GAPS_MIN - 1),
+            StageHealth::Degraded
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #532 review fix — a SINGLE severe freeze must escalate to 🔴 even when
+    // it only registers as ONE `present_gaps_over100` (indistinguishable by
+    // count alone from one trivial 101ms hitch) and fps still averages fine.
+    // Caught in code review: pre-fix, a multi-second on-screen freeze with a
+    // healthy average fps classified as 🟡 "mierne seká" instead of 🔴
+    // "výpadky" — understating the exact outage this feature exists to catch.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn single_severe_freeze_escalates_to_bad_even_as_an_isolated_gap() {
+        assert_eq!(
+            stage_health(29.0, HEALTH_SEVERE_FREEZE_MS, 1),
+            StageHealth::Bad
+        );
+    }
+
+    #[test]
+    fn just_under_the_severe_freeze_bar_is_still_degraded() {
+        assert_eq!(
+            stage_health(29.0, HEALTH_SEVERE_FREEZE_MS - 0.1, 1),
             StageHealth::Degraded
         );
     }

--- a/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
@@ -18,10 +18,32 @@ use super::ndi_beacon::maybe_post_beacon;
 use super::ndi_clock_offset::ClockOffsetEstimator;
 use super::ndi_frame_stats::{
     mark_frames_live, record_presented_frame, refresh_frames_live_staleness, FrameStats,
-    StageSignalSetters,
+    HealthSetter, StageSignalSetters,
 };
 use super::ndi_profile::maybe_profile_fallback;
 use super::ndi_watchdog::{now_ms, ReloadEscalation, Watchdog};
+
+/// Should this ticker's beacon push a health verdict (#532 review fix)? NO on
+/// rVFC-less browsers: `approximate_frame_from_current_time` below counts AT
+/// MOST ONE "frame" per 1s tick — a stall-detection proxy, never a real
+/// frame-rate measurement — so over this ticker's ~15s beacon window
+/// `presented_in_interval` caps at ~15, always computing ≈1 fps regardless of
+/// how smoothly the TV is actually playing. Feeding that to `stage_health()`
+/// would permanently show 🔴 "výpadky" on a perfectly healthy rVFC-less
+/// display — exactly the untrustworthy readout this feature exists to
+/// replace. `dropped_frames`/beacon telemetry are unaffected by this gate;
+/// only the on-screen verdict is withheld (the readout falls back to the
+/// latency figure alone, same as "no beacon yet"). Pure + host-unit-tested.
+pub(crate) fn health_setter_for_ticker_beacon(
+    rvfc_supported: bool,
+    setter: &Option<HealthSetter>,
+) -> Option<HealthSetter> {
+    if rvfc_supported {
+        setter.clone()
+    } else {
+        None
+    }
+}
 
 /// 1s interval driving (a) the beacon cadence and (b) evaluation of the
 /// FRAME-BASED health rules:
@@ -75,7 +97,9 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
             return;
         }
         // Beacon first: the healthy-path early returns below must not
-        // starve it during normal playback.
+        // starve it during normal playback. See
+        // `health_setter_for_ticker_beacon` for why the health verdict is
+        // withheld on rVFC-less browsers.
         maybe_post_beacon(
             &tick_count,
             &pc,
@@ -83,7 +107,7 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
             &stats,
             clock_offset.current(),
             dropped_frames_setter.clone(),
-            stage_health_setter.clone(),
+            health_setter_for_ticker_beacon(rvfc_supported, &stage_health_setter),
         );
         if !rvfc_supported
             && approximate_frame_from_current_time(&video, &stats, &last_current_time)
@@ -148,4 +172,38 @@ fn approximate_frame_from_current_time(
         return true;
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::health_setter_for_ticker_beacon;
+    use crate::components::stage::ndi_frame_stats::HealthSetter;
+    use crate::state::stage::StageHealthReading;
+    use std::rc::Rc;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // #532 review fix: on rVFC-less browsers the ticker's OWN frame count is
+    // a stall-detection proxy (≤1 "frame"/tick), never a real fps figure —
+    // feeding it to the health verdict would permanently show a false 🔴 on
+    // a perfectly smooth TV. The ticker beacon must withhold the health
+    // setter entirely on that path.
+    // ─────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn passes_the_setter_through_when_rvfc_is_supported() {
+        let setter: HealthSetter = Rc::new(|_: Option<StageHealthReading>| {});
+        assert!(health_setter_for_ticker_beacon(true, &Some(setter)).is_some());
+    }
+
+    #[test]
+    fn withholds_the_setter_when_rvfc_is_unsupported() {
+        let setter: HealthSetter = Rc::new(|_: Option<StageHealthReading>| {});
+        assert!(health_setter_for_ticker_beacon(false, &Some(setter)).is_none());
+    }
+
+    #[test]
+    fn stays_none_when_there_was_no_setter_to_begin_with() {
+        assert!(health_setter_for_ticker_beacon(true, &None).is_none());
+        assert!(health_setter_for_ticker_beacon(false, &None).is_none());
+    }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_health_ticker.rs
@@ -54,10 +54,11 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
     let source_id = source_id.to_string();
     let escalation = Rc::clone(escalation);
     let clock_offset = Rc::clone(clock_offset);
-    // #527: only the two fields this ticker needs, plucked once out of the
+    // #527: only the fields this ticker needs, plucked once out of the
     // shared bundle before they're moved into the `move` closure below.
     let frames_live_setter = setters.frames_live.clone();
     let dropped_frames_setter = setters.dropped_frames.clone();
+    let stage_health_setter = setters.stage_health.clone();
     let tick_count = Cell::new(0u32);
     let last_current_time = Cell::new(0.0f64);
     let cb = Closure::<dyn FnMut()>::new(move || {
@@ -82,6 +83,7 @@ pub(crate) fn start_health_ticker<F: Fn() + 'static>(
             &stats,
             clock_offset.current(),
             dropped_frames_setter.clone(),
+            stage_health_setter.clone(),
         );
         if !rvfc_supported
             && approximate_frame_from_current_time(&video, &stats, &last_current_time)

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -18,10 +18,10 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use super::ndi_clock_offset::ClockOffsetSetter;
 use super::ndi_frame_stats::{
-    DroppedFramesSetter, FramesLiveSetter, StageSignalSetters, VideoLatencySetter,
+    DroppedFramesSetter, FramesLiveSetter, HealthSetter, StageSignalSetters, VideoLatencySetter,
 };
 use super::ndi_watchdog::{now_ms, profile_mode_is_compat, ReloadEscalation, Watchdog};
-use crate::state::stage::StageContext;
+use crate::state::stage::{StageContext, StageHealthReading};
 
 /// Holds an active WHEP session: the peer connection AND the WHEP resource URL
 /// returned in the `Location` header on POST. The resource URL is used to
@@ -112,15 +112,29 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
         }) as DroppedFramesSetter
     });
 
-    // #527: bundle the four per-session setters into ONE struct threaded
-    // through the effect below and into `Watchdog::install` — a new stage
-    // diagnostic signal now costs one struct field instead of a new
-    // positional parameter in every function of the chain.
+    // #532: same shared-signal pattern for the recent-window health verdict
+    // (🟢/🟡/🔴) that now drives the readout's suffix (replacing the
+    // cumulative one `dropped_frames` above used to drive — that plumbing is
+    // untouched, just no longer read by the readout). UNLIKE `dropped_frames`,
+    // a health reading is NOT a cumulative counter — each beacon's
+    // classification simply REPLACES the prior one, so no out-of-order
+    // monotonic guard is needed here: whichever of the two concurrent beacon
+    // paths resolves last is, by definition, the most recent verdict.
+    let stage_health_sig = use_context::<StageContext>().map(|ctx| ctx.stage_health);
+    let stage_health_setter: Option<HealthSetter> = stage_health_sig.map(|sig| {
+        std::rc::Rc::new(move |v: Option<StageHealthReading>| sig.set(v)) as HealthSetter
+    });
+
+    // #527: bundle the per-session setters into ONE struct threaded through
+    // the effect below and into `Watchdog::install` — a new stage diagnostic
+    // signal now costs one struct field instead of a new positional
+    // parameter in every function of the chain.
     let stage_signal_setters = StageSignalSetters {
         video_latency: video_latency_setter,
         frames_live: frames_live_setter,
         clock_offset: clock_offset_setter,
         dropped_frames: dropped_frames_setter,
+        stage_health: stage_health_setter,
     };
 
     // Holds the active connection: the WHEP session + the watchdog observing

--- a/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_watchdog.rs
@@ -359,6 +359,13 @@ impl Watchdog {
         if let Some(setter) = &setters.dropped_frames {
             setter(None);
         }
+        // #532: a freshly-installed session hasn't classified a recent window
+        // yet, so any health verdict still on screen belongs to the prior
+        // (torn-down) session. Clear it — the next beacon (up to ~15s away)
+        // repopulates it honestly, same reasoning as `dropped_frames` above.
+        if let Some(setter) = &setters.stage_health {
+            setter(None);
+        }
         // #510/#512: the browser<->server pipeline-clock offset estimator. Created
         // BEFORE the frame observer so the observer can read its current (offset,
         // RTT) each presented frame — the RTT/2 network-transit term of the TRUE

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -2,7 +2,7 @@ use gloo_timers::callback::Interval;
 use leptos::prelude::*;
 
 use crate::components::version_label::VersionLabel;
-use crate::state::stage::StageContext;
+use crate::state::stage::{StageContext, StageHealthReading};
 use crate::utils::autofit::autofit_effect_tabular;
 use crate::ws::stage::StageWsState;
 
@@ -98,11 +98,13 @@ pub fn StatusBar(
     let video_latency = ctx.video_latency_ms;
     let ndi_active = ctx.ndi_active;
     let has_video_latency = move || ndi_active.get();
-    // #523: per-display dropped-frame + freeze count from the getStats beacon,
-    // shown appended to the latency figure — see `format_video_latency_line`.
-    let dropped_frames = ctx.dropped_frames;
+    // #532: recent-window health verdict (🟢/🟡/🔴), shown appended to the
+    // latency figure — see `format_video_latency_line`. Replaces the
+    // cumulative ⬇N/❄N suffix #523 drove from `ctx.dropped_frames` (that
+    // signal is still populated by the beacon, just no longer read here).
+    let stage_health = ctx.stage_health;
     let video_latency_text =
-        move || format_video_latency_line(video_latency.get(), dropped_frames.get());
+        move || format_video_latency_line(video_latency.get(), stage_health.get());
 
     autofit_effect_tabular(clock_ref, STATUS_MAX_FONT, move || clock_text.get());
     if !hide_live {
@@ -162,40 +164,47 @@ fn current_time_string() -> String {
     )
 }
 
-/// Pure format helper for the `.stage__video-latency` readout text (#523):
-/// appends the per-display dropped-frame (+ freeze, when nonzero) count from
-/// the getStats beacon to the existing "server→displej · N ms" figure.
-/// Extracted so the formatting is host-unit-testable without a live
+/// Pure format helper for the `.stage__video-latency` readout text (#532):
+/// appends the recent-window health verdict (🟢/🟡/🔴 + Slovak label + the
+/// recent fps figure it was derived from) to the existing "server→displej ·
+/// N ms" figure. Replaces the CUMULATIVE ⬇N/❄N suffix #523 put here — that
+/// count never recovered from one old network blip, which the user found
+/// meaningless; the underlying `dropped_frames` plumbing that fed it is left
+/// running (per the issue), only this on-screen text moved to the new
+/// signal. Extracted so the formatting is host-unit-testable without a live
 /// Leptos/WASM render — the reactive closure in `StatusBar` is a thin wrapper
 /// over this.
 fn format_video_latency_line(
     latency_ms: Option<f64>,
-    dropped_frames: Option<(u32, u32)>,
+    health: Option<StageHealthReading>,
 ) -> String {
     let base = match latency_ms {
         Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
         None => "server\u{2192}displej \u{00b7} n/a".to_string(),
     };
-    match dropped_frames {
-        // Freeze count is shown too, but only when it's actually nonzero —
-        // keeps the common case (dropped frames with no freeze) to ONE short
-        // extra token, per the issue's "ONE short line" format.
-        Some((dropped, freeze)) if freeze > 0 => {
-            format!("{base} \u{00b7} \u{2b07}{dropped} \u{2744}{freeze}")
-        }
-        Some((dropped, _)) => format!("{base} \u{00b7} \u{2b07}{dropped}"),
+    match health {
+        // No beacon has classified a recent window yet (fresh session /
+        // reconnect) — show the latency alone rather than a stale/fabricated
+        // verdict.
         None => base,
+        Some(reading) => format!(
+            "{base} \u{00b7} {} {} \u{00b7} {} fps",
+            reading.state.emoji(),
+            reading.state.label(),
+            reading.fps.round() as u32,
+        ),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::format_video_latency_line;
+    use crate::state::stage::{StageHealth, StageHealthReading};
 
     #[test]
-    fn shows_latency_alone_when_no_drop_data_yet() {
-        // No beacon has landed yet (fresh session / reconnect) — the readout
-        // must not show a stale/fabricated drop count.
+    fn shows_latency_alone_when_no_health_data_yet() {
+        // No beacon has classified a recent window yet (fresh session /
+        // reconnect) — the readout must not show a stale/fabricated verdict.
         assert_eq!(
             format_video_latency_line(Some(112.0), None),
             "server\u{2192}displej \u{00b7} 112 ms"
@@ -207,39 +216,60 @@ mod tests {
     }
 
     #[test]
-    fn appends_dropped_count_with_no_freeze() {
+    fn appends_good_health_verdict_with_fps() {
         assert_eq!(
-            format_video_latency_line(Some(112.0), Some((0, 0))),
-            "server\u{2192}displej \u{00b7} 112 ms \u{00b7} \u{2b07}0"
-        );
-        assert_eq!(
-            format_video_latency_line(Some(84.0), Some((128, 0))),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}128"
-        );
-    }
-
-    #[test]
-    fn appends_freeze_count_only_when_nonzero() {
-        assert_eq!(
-            format_video_latency_line(Some(84.0), Some((128, 2))),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}128 \u{2744}2"
-        );
-        // Freezes with zero dropped frames is a real combination too (a
-        // display can freeze without the decoder ever reporting a drop) —
-        // both figures show together, symmetric with the dropped-only case.
-        assert_eq!(
-            format_video_latency_line(Some(84.0), Some((0, 3))),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{2b07}0 \u{2744}3"
+            format_video_latency_line(
+                Some(84.0),
+                Some(StageHealthReading {
+                    state: StageHealth::Good,
+                    fps: 28.4,
+                })
+            ),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f7e2} plynul\u{e9} \u{00b7} 28 fps"
         );
     }
 
     #[test]
-    fn n_a_latency_still_shows_drop_count() {
-        // A dropped-frame count is meaningful even without a trustworthy
-        // latency reading — never suppress it just because latency is n/a.
+    fn appends_degraded_health_verdict() {
         assert_eq!(
-            format_video_latency_line(None, Some((5, 0))),
-            "server\u{2192}displej \u{00b7} n/a \u{00b7} \u{2b07}5"
+            format_video_latency_line(
+                Some(84.0),
+                Some(StageHealthReading {
+                    state: StageHealth::Degraded,
+                    fps: 22.0,
+                })
+            ),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f7e1} mierne sek\u{e1} \u{00b7} 22 fps"
+        );
+    }
+
+    #[test]
+    fn appends_bad_health_verdict() {
+        assert_eq!(
+            format_video_latency_line(
+                Some(84.0),
+                Some(StageHealthReading {
+                    state: StageHealth::Bad,
+                    fps: 8.0,
+                })
+            ),
+            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f534} v\u{fd}padky \u{00b7} 8 fps"
+        );
+    }
+
+    #[test]
+    fn n_a_latency_still_shows_health_verdict() {
+        // A health verdict is meaningful even without a trustworthy latency
+        // reading — never suppress it just because latency is n/a.
+        assert_eq!(
+            format_video_latency_line(
+                None,
+                Some(StageHealthReading {
+                    state: StageHealth::Bad,
+                    fps: 5.0,
+                })
+            ),
+            "server\u{2192}displej \u{00b7} n/a \u{00b7} \u{1f534} v\u{fd}padky \u{00b7} 5 fps"
         );
     }
 }

--- a/crates/presenter-ui/src/pages/stage.rs
+++ b/crates/presenter-ui/src/pages/stage.rs
@@ -8,7 +8,7 @@ use crate::components::stage::{
     ndi_fullscreen::NdiFullscreen, preach_layout::PreachLayout, timer_layout::TimerLayout,
     worship_pp::WorshipPp, worship_snv::WorshipSnv,
 };
-use crate::state::stage::StageContext;
+use crate::state::stage::{StageContext, StageHealth, StageHealthReading};
 use crate::ws::stage::{self, StageWsState};
 
 #[component]
@@ -74,6 +74,41 @@ pub fn StagePage() -> impl IntoView {
         let _ = js_sys::Reflect::set(
             &js_sys::global(),
             &JsValue::from_str("__presenterStageSetDroppedFrames"),
+            setter.as_ref(),
+        );
+        setter.forget();
+    }
+
+    // Test hook (#532): drive the recent-window stage-health verdict
+    // deterministically from the E2E without a live NDI/GPU pipeline (the
+    // classifier normally runs off real beacon-interval accumulators).
+    // Accepts a state string ("good"|"degraded"|"bad") + the recent-fps
+    // number it was derived from — the SAME reading the beacon-driven
+    // classifier writes — or null/null to clear. In production this global
+    // is simply never called.
+    {
+        let stage_health = ctx.stage_health;
+        let setter = Closure::wrap(Box::new(move |state: JsValue, fps: JsValue| {
+            let reading = match (state.as_string().as_deref(), fps.as_f64()) {
+                (Some("good"), Some(fps)) => Some(StageHealthReading {
+                    state: StageHealth::Good,
+                    fps,
+                }),
+                (Some("degraded"), Some(fps)) => Some(StageHealthReading {
+                    state: StageHealth::Degraded,
+                    fps,
+                }),
+                (Some("bad"), Some(fps)) => Some(StageHealthReading {
+                    state: StageHealth::Bad,
+                    fps,
+                }),
+                _ => None,
+            };
+            stage_health.set(reading);
+        }) as Box<dyn Fn(JsValue, JsValue)>);
+        let _ = js_sys::Reflect::set(
+            &js_sys::global(),
+            &JsValue::from_str("__presenterStageSetHealth"),
             setter.as_ref(),
         );
         setter.forget();

--- a/crates/presenter-ui/src/state/stage.rs
+++ b/crates/presenter-ui/src/state/stage.rs
@@ -6,6 +6,54 @@ use super::session;
 
 const CLIENT_ID_KEY: &str = "stageClientId";
 
+/// Recent-window stage-TV health verdict (#532): "is this TV usable for the
+/// band right now?" — computed CLIENT-SIDE from the render-side per-interval
+/// accumulators in `FrameStats` (presented fps + presentation-gap stats),
+/// which reset every beacon and are therefore inherently RECENT, unlike
+/// getStats' cumulative freeze/drop counters (`dropped_frames` below answers
+/// "how many since connect"; this answers "how is it doing RIGHT NOW", which
+/// is what an operator glancing at the stage actually needs). See
+/// `components::stage::ndi_frame_stats::stage_health` for the pure
+/// classifier and its named threshold constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageHealth {
+    /// 🟢 plynulé — smooth, fully usable.
+    Good,
+    /// 🟡 mierne seká — minor stutter, still usable.
+    Degraded,
+    /// 🔴 výpadky — freezing / not usable, needs attention.
+    Bad,
+}
+
+impl StageHealth {
+    /// The colour glyph shown on the stage readout.
+    pub fn emoji(self) -> &'static str {
+        match self {
+            StageHealth::Good => "\u{1f7e2}",
+            StageHealth::Degraded => "\u{1f7e1}",
+            StageHealth::Bad => "\u{1f534}",
+        }
+    }
+
+    /// The short Slovak label shown next to the glyph.
+    pub fn label(self) -> &'static str {
+        match self {
+            StageHealth::Good => "plynul\u{e9}",
+            StageHealth::Degraded => "mierne sek\u{e1}",
+            StageHealth::Bad => "v\u{fd}padky",
+        }
+    }
+}
+
+/// One classified health reading (#532): the verdict plus the recent-window
+/// presented-fps figure it was derived from, shown together as the small
+/// secondary detail beside the colour (e.g. "🟢 plynulé · 28 fps").
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StageHealthReading {
+    pub state: StageHealth,
+    pub fps: f64,
+}
+
 #[derive(Clone)]
 pub struct StageContext {
     pub client_id: String,
@@ -45,10 +93,17 @@ pub struct StageContext {
     /// this signal each time a beacon is posted (~every
     /// `Watchdog::RVFC_BEACON_FRAME_PERIOD` frames or every 15th health tick —
     /// getStats is async, so this updates on the BEACON cadence, not the 1s
-    /// video-latency cadence). Shown beside `video_latency_ms` in the stage's
-    /// "server→displej · N ms · ⬇N" readout. `None` when no beacon has landed
-    /// yet, or the browser's getStats reports neither field.
+    /// video-latency cadence). **#532: this plumbing is kept (still populated,
+    /// still test-hookable) but is NO LONGER shown on the stage readout** —
+    /// the cumulative count never recovered from one old blip, which read as
+    /// meaningless. `stage_health` below is what the readout displays now.
     pub dropped_frames: RwSignal<Option<(u32, u32)>>,
+    /// Recent-window (~15-20s) stage-TV health verdict (#532): replaces the
+    /// cumulative ⬇N/❄N suffix `dropped_frames` used to drive on the
+    /// "server→displej · N ms" readout. `None` until the first beacon
+    /// classifies a window (or right after a reconnect resets it); `Some` is
+    /// refreshed on the SAME beacon cadence as `dropped_frames` above.
+    pub stage_health: RwSignal<Option<StageHealthReading>>,
 }
 
 impl StageContext {
@@ -66,6 +121,7 @@ impl StageContext {
             ndi_frames_live: RwSignal::new(false),
             clock_offset: RwSignal::new(None),
             dropped_frames: RwSignal::new(None),
+            stage_health: RwSignal::new(None),
         }
     }
 }

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -97,25 +97,25 @@ async function setNdiActive(page: Page, active: boolean): Promise<void> {
   }, active);
 }
 
-/** Drive the per-display dropped-frame + freeze counters (#523) — the SAME
- * pair the getStats beacon writes. `null` clears them. */
-async function setDroppedFrames(
+/** Drive the recent-window stage-health verdict (#532) — the SAME reading
+ * the beacon-driven classifier writes. `null` clears it. */
+async function setStageHealth(
   page: Page,
-  counts: { dropped: number; freeze: number } | null,
+  reading: { state: "good" | "degraded" | "bad"; fps: number } | null,
 ): Promise<void> {
   await page.evaluate((value) => {
     (
       window as unknown as {
-        __presenterStageSetDroppedFrames?: (
-          dropped: number | null,
-          freeze: number | null,
+        __presenterStageSetHealth?: (
+          state: string | null,
+          fps: number | null,
         ) => void;
       }
-    ).__presenterStageSetDroppedFrames?.(
-      value ? value.dropped : null,
-      value ? value.freeze : null,
+    ).__presenterStageSetHealth?.(
+      value ? value.state : null,
+      value ? value.fps : null,
     );
-  }, counts);
+  }, reading);
 }
 
 test("stage shows true server→display latency as a separate readout, with honest n/a", async ({
@@ -177,17 +177,19 @@ test("stage shows true server→display latency as a separate readout, with hone
 });
 
 // ─────────────────────────────────────────────────────────────────────────
-// #523 — the stage shows per-display dropped-frame (+freeze) counts beside
-// the latency figure, so "how is this TV doing" is visible at a glance (a
-// low latency reading can otherwise hide a TV that is dropping frames to
-// achieve it). Sourced from the SAME getStats inbound-rtp sample the health
-// beacon already reads; this test drives it via the deterministic test hook
-// (`__presenterStageSetDroppedFrames`), the same signal the beacon path
-// writes. The append-format math (⬇N, +❄N only when nonzero) is unit-tested
-// in `status_bar.rs`.
+// #532 — the stage shows a RECENT-WINDOW health verdict (🟢/🟡/🔴) beside the
+// latency figure, so "is this TV usable for the band right now" is visible at
+// a glance. Replaces #523's CUMULATIVE ⬇N/❄N suffix (which never recovered
+// from one old network blip — meaningless to an operator glancing at the
+// stage). Sourced from the render-side per-interval accumulators (presented
+// fps + presentation-gap stats), classified client-side; this test drives it
+// via the deterministic test hook (`__presenterStageSetHealth`), the same
+// signal the beacon-driven classifier writes. The fps/gap → verdict
+// threshold math is unit-tested in `ndi_frame_stats.rs`; the text formatting
+// is unit-tested in `status_bar.rs`.
 // ─────────────────────────────────────────────────────────────────────────
 
-test("stage shows dropped-frame + freeze count beside the video latency", async ({
+test("stage shows a recent-window health verdict beside the video latency", async ({
   context,
 }) => {
   const consoleMessages: string[] = [];
@@ -204,29 +206,34 @@ test("stage shows dropped-frame + freeze count beside the video latency", async 
   await setVideoLatency(stagePage, 84);
   await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
 
-  // No beacon has landed yet → the readout shows the latency ALONE, no
-  // fabricated drop count.
-  await expect(videoEl).not.toContainText("⬇");
+  // No beacon has classified a window yet → the readout shows the latency
+  // ALONE, no fabricated verdict.
+  await expect(videoEl).not.toContainText("plynul");
+  await expect(videoEl).not.toContainText("sek");
+  await expect(videoEl).not.toContainText("výpadky");
 
-  // A beacon lands with zero drops/freezes → shown as "⬇0" (honest zero, not
-  // hidden — the whole point is a per-TV health signal at a glance).
-  await setDroppedFrames(stagePage, { dropped: 0, freeze: 0 });
-  await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms\s*·\s*⬇0/);
-  await expect(videoEl).not.toContainText("❄");
+  // A beacon classifies a smooth window → 🟢 plynulé + the recent fps.
+  await setStageHealth(stagePage, { state: "good", fps: 28 });
+  await expect(videoEl).toContainText("🟢");
+  await expect(videoEl).toContainText("plynulé");
+  await expect(videoEl).toContainText("28 fps");
 
-  // Drops accumulate → the count updates live.
-  await setDroppedFrames(stagePage, { dropped: 128, freeze: 0 });
-  await expect(videoEl).toContainText(/⬇128/);
-  await expect(videoEl).not.toContainText("❄");
+  // A beacon classifies minor stutter → 🟡 mierne seká.
+  await setStageHealth(stagePage, { state: "degraded", fps: 20 });
+  await expect(videoEl).toContainText("🟡");
+  await expect(videoEl).toContainText("mierne seká");
+  await expect(videoEl).toContainText("20 fps");
 
-  // A freeze count is present too → shown alongside the drop count.
-  await setDroppedFrames(stagePage, { dropped: 128, freeze: 2 });
-  await expect(videoEl).toContainText(/⬇128\s*❄2/);
+  // A beacon classifies real freezing → 🔴 výpadky.
+  await setStageHealth(stagePage, { state: "bad", fps: 6 });
+  await expect(videoEl).toContainText("🔴");
+  await expect(videoEl).toContainText("výpadky");
+  await expect(videoEl).toContainText("6 fps");
 
-  // Reconnect (or no getStats data) clears it → readout falls back to the
-  // latency alone, never a stale count.
-  await setDroppedFrames(stagePage, null);
-  await expect(videoEl).not.toContainText("⬇");
+  // Reconnect (or no classified window yet) clears it → readout falls back
+  // to the latency alone, never a stale verdict.
+  await setStageHealth(stagePage, null);
+  await expect(videoEl).not.toContainText("výpadky");
   await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
 
   // browser-console-zero-errors: no errors/warnings the whole time.


### PR DESCRIPTION
Closes #532

## What changed

Replaces the cumulative ⬇N/❄N dropped-frame/freeze suffix (#523) on the stage's
`server→displej · N ms` readout with a **recent-window health verdict** answering
"is this TV usable for the band right now?":

```
server→displej · 84 ms · 🟢 plynulé · 28 fps
server→displej · 84 ms · 🟡 mierne seká · 22 fps
server→displej · 84 ms · 🔴 výpadky · 8 fps
```

The verdict is classified client-side by a pure `stage_health()` fn from the
per-interval render-side accumulators already in `FrameStats` (`presented_fps`,
`max_present_gap_ms`, `present_gaps_over100`) — these reset every beacon
interval, so the reading is inherently RECENT (~15-20s window), never the
cumulative getStats freeze/drop counters that never recover from one old
network blip (the meaningless behavior the user flagged in #523).

Named threshold constants (`ndi_frame_stats.rs`):
- 🔴 Bad — `presented_fps < 15` OR `present_gaps_over100 >= 2` (repeated stutter)
- 🟢 Good — `presented_fps >= 27` AND `present_gaps_over100 == 0` AND `max_present_gap_ms < 150`
- 🟡 Degraded — everything in between

Display/observability only — no jitter buffer / playout / playback change, zero
regression risk to dropped frames or lip-sync.

The #523 `dropped_frames` plumbing (signal, setter, beacon POST fields) is left
running untouched per the issue's design note ("keep the plumbing; change what's
displayed") — only the on-screen text moved from it to the new `stage_health`
signal.

## Implementation

- `StageHealth` enum + `StageHealthReading` struct in `state/stage.rs`
- Pure classifier `stage_health()` + `notify_stage_health()` + `HealthSetter`
  type in `components/stage/ndi_frame_stats.rs`, threaded through
  `StageSignalSetters` (mirrors the #527 bundling pattern)
- Classification happens synchronously in `post_stats_beacon` right after
  `snapshot_present_gaps` — independent of the async getStats round-trip
- Reset to `None` on every fresh `Watchdog::install` (same as the other
  per-session diagnostic signals)
- Test hook `__presenterStageSetHealth` (mirrors `__presenterStageSetDroppedFrames`)

## Tests

- Unit: exhaustive boundary tests for `stage_health()` at every named
  threshold (`ndi_frame_stats.rs`), `notify_stage_health()` glue tests,
  `format_video_latency_line()` formatting tests (`status_bar.rs`)
- E2E: `tests/e2e/stage-video-latency.spec.ts` — drives all three states via
  the test hook, asserts the glyph/label/fps render and the readout falls
  back to latency-alone when no verdict has landed yet; 0 console errors
- All verified locally: `cargo test --workspace` (387 passed), presenter-ui
  `cargo test --lib` (215 passed), `quality-check.sh --strict` clean,
  `bash scripts/build-ui.sh` succeeds, Playwright spec passes locally against
  a real built server (3 passed)

Version bump: 0.4.188 → 0.4.189.
