### PR TITLE
Release 0.4.190 — #533 wasm-loader build fix + #532 docs

### DIFF
--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -246,3 +246,38 @@ expose a `__presenterStageSet*` global in `pages/stage.rs` (mirror `__presenterS
 / `__presenterStageSetNdiFramesLive`) and call it from the spec — these globals are always compiled
 (not feature-gated) and never called in production. Allow-list the expected 503/204 WHEP-backoff
 console lines (TIGHT regexes) so console-zero still catches real errors.
+
+### Swapping what a readout DISPLAYS while keeping the underlying signal alive (#532)
+
+When a ticket says "replace the on-screen X with Y, but keep X's plumbing" (X = a signal other code
+might still rely on, e.g. `dropped_frames` feeding server-side per-TV telemetry): DO exactly that —
+keep the OLD `RwSignal`/setter/beacon-population code fully intact and just stop READING it in the
+render closure (`status_bar.rs`'s `video_latency_text` switched from `ctx.dropped_frames` to the new
+`ctx.stage_health`). Don't delete the old signal "because nothing renders it now" — a review pass
+will flag it as write-only, but that's the CORRECT shape when the issue explicitly asks for it; note
+the decision in the PR/commit rather than reverting under review pressure.
+
+**Beacon-classification pattern:** if the new signal can be computed from data the beacon ALREADY
+gathers synchronously (e.g. `snapshot_present_gaps`'s `(max_gap, over100, fps)`, no getStats/network
+round-trip needed), classify it in `post_stats_beacon` BEFORE the `spawn_local` async block — it's
+both simpler and lands independent of getStats succeeding.
+
+**Multi-source-fps gotcha:** `stage_health`-style classifiers keyed on presented-fps must account for
+BOTH beacon-trigger paths: (a) the two ~15s-cadenced rVFC-count and 1s-ticker paths share one
+`FrameStats` and drift into near-coincidence, leaving one a sub-second window (`presented_fps_for_
+window`'s `MIN_FPS_INTERVAL_MS` floor fixes this — always floor a computed rate below ~1s); (b)
+rVFC-LESS browsers' `approximate_frame_from_current_time` proxy counts ≤1 "frame"/tick — a
+stall-detection signal, NEVER a real rate — so it always computes ≈1fps regardless of real
+smoothness; gate the classified-signal setter itself on `rvfc_supported` (see
+`health_setter_for_ticker_beacon` in `ndi_health_ticker.rs`) rather than trying to special-case the
+classifier's thresholds for that path.
+
+**Verifying a new per-TV signal on PRODUCTION with a genuinely live stream:** the deterministic
+`__presenterStageSet*` test hooks are LOCAL signal overrides with no protection against being
+overwritten by the real beacon — on an ACTUALLY STREAMING production source, the live telemetry
+keeps firing every ~15s and will race with (and usually win against) a manual test-hook call within
+a couple of round-trips. Don't fight this or treat it as a bug. Instead, read the REAL computed value
+as the verification evidence (e.g. `server→displej · 22 ms · 🟢 plynulé · 30 fps` sourced from the
+actual live NDI stream) — that's actually STRONGER proof than a synthetic override, since it exercises
+the entire real pipeline end-to-end. Use `/stage?preview=1` (the operator-preview mirror mode) to open
+a read-only tab that never grabs a wake lock or changes the broadcast layout for real displays.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.189"
+version = "0.4.190"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -339,3 +339,49 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
   E2E `tests/e2e/stage-fulltext-layout.spec.ts` (3: fullscreen render + autoscale short-vs-long font
   assertion, API marker → trigger switches live stage DOM, operator select→badge flow; 0 console errors).
 - Solo PR (dev→main, Closes #515), version 0.4.184.
+
+## 2026-07-03 — #532 Recent-window stage-TV health indicator (🟢/🟡/🔴) (PR #534, v0.4.189)
+
+- **Validated still real:** confirmed `format_video_latency_line` in `status_bar.rs` still showed the
+  cumulative `⬇N ❄N` suffix from #523 pre-fix — issue still applicable, not overcome.
+- **Version:** 0.4.188 → **0.4.189** (first commit `4e9a063f`), merged to main `a5aafc6f` before push.
+- **Feature commits:** `4e9a063f` (StageHealth enum + StageHealthReading in `state/stage.rs`; pure
+  `stage_health()` classifier + `notify_stage_health()` + `HealthSetter` in `ndi_frame_stats.rs`;
+  wired through `StageSignalSetters`/`post_stats_beacon`/`maybe_post_beacon`; `__presenterStageSetHealth`
+  test hook; `status_bar.rs` reads `stage_health` instead of `dropped_frames` for the readout text —
+  `dropped_frames` plumbing kept running per the issue's explicit "keep the plumbing" note).
+- **Code-review follow-up commits (adversarial multi-angle review before merge):**
+  `623451e2` fixed a beacon-interleave bug (two independent ~15s-cadenced beacon paths drifting into
+  near-coincidence → a sub-second window computing a spurious ~0fps) via `presented_fps_for_window`
+  with a `MIN_FPS_INTERVAL_MS` floor. `e2093b3f` (mine) fixed two more real bugs the review caught:
+  (1) `stage_health()`'s Bad branch only escalated on REPEATED (>=2) gaps, never on gap MAGNITUDE — a
+  single multi-second freeze registered as ONE `present_gaps_over100`, indistinguishable from a
+  trivial 101ms hitch, wrongly landing on 🟡 instead of 🔴; added `HEALTH_SEVERE_FREEZE_MS` (1000ms)
+  and removed dead code in the Good branch (`present_gaps_over100==0` already implies `max_gap<=100`,
+  making the old `HEALTH_GAP_HITCH_MS` check unreachable-false). (2) rVFC-less browsers' 1s-ticker
+  currentTime proxy caps at ~1fps (a stall-detection signal, never a real rate) — feeding that to the
+  verdict permanently showed 🔴 on a perfectly smooth rVFC-less TV; fixed via
+  `health_setter_for_ticker_beacon` withholding the health setter entirely on that path.
+- **Tests:** exhaustive `stage_health()` boundary tests at every threshold incl. severe-freeze
+  boundary, `notify_stage_health`/`presented_fps_for_window` glue tests, `health_setter_for_ticker_beacon`
+  unit tests (new, ndi_health_ticker.rs), `format_video_latency_line` formatting tests (status_bar.rs),
+  E2E `tests/e2e/stage-video-latency.spec.ts` (replaced the old #523 dropped-frame test with a
+  health-verdict test driving all 3 states + fallback via `__presenterStageSetHealth`; 0 console errors).
+- **Decision — left as-is (documented, not silently dropped):** review also flagged (a) `dropped_frames`
+  now write-only in production (explicitly by design per the issue's "keep the plumbing" instruction,
+  not a defect); (b) `post_stats_beacon`/`maybe_post_beacon` positional-param growth on adding
+  `health_setter` (mirrors the PRE-EXISTING `dropped_frames_setter` param shape from #523, not a new
+  inconsistency — restructuring the closure-capture code carried more risk than the cosmetic gain was
+  worth, especially mid-concurrent-edit); (c) `ndi_frame_stats.rs` at 956 lines crosses the 800-line
+  CI *warning* (not the 1000-line hard-fail) — deferred, non-blocking.
+- **Note on this cycle:** the feature commit + main-sync merge landed via an autonomous process running
+  concurrently with this worker session (same repo, same `dev` branch) before this worker's own
+  code-review pass ran — the worker picked up from that durable git state (`verify-issue-still-valid`
+  + `salvage-before-discarding-work` in spirit), ran its own adversarial review, found 2 more real bugs
+  beyond the concurrent process's own fix, and completed the cycle (review → fix → CI → merge → deploy).
+- **Post-deploy verification:** prod DOM read `v0.4.189` at http://10.77.9.205/stage; the LIVE NDI
+  stream's real beacon showed the feature working end-to-end with genuine data
+  (`server→displej · 22-31 ms · 🟢 plynulé · 28-31 fps`) — stronger evidence than the synthetic test
+  hook, which raced against and lost to the real telemetry (expected; the hook targets no-live-stream
+  E2E envs). 0 console errors/warnings.
+- Solo PR (dev→main #534, Closes #532), version 0.4.189.

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -15,11 +15,26 @@ echo "==> Building WASM UI with Trunk (MVP WASM for Safari 12)..."
 RUSTUP_TOOLCHAIN=nightly trunk build --release
 
 # Step 2: Transpile JS glue code to ES2017 (Safari 12 compatible syntax).
+# `--supported:import-meta=true` overrides the es2017 default (#533): the
+# trunk-generated wasm loader resolves the .wasm URL via
+# `new URL('...wasm', import.meta.url)`, and the module IS loaded as an ES
+# module at runtime (Safari 12.1+/iOS 12.2+, our actual target, supports
+# import.meta), so esbuild must NOT down-level import.meta to `{}` — doing so
+# empties the URL base and can break wasm loading. We keep every other es2017
+# syntax down-level; only import.meta is declared runtime-supported.
 echo "==> Transpiling JS for Safari 12..."
-esbuild dist/presenter-ui-*.js \
+esbuild_out=$(esbuild dist/presenter-ui-*.js \
   --target=es2017 \
+  --supported:import-meta=true \
   --outdir=dist/ \
-  --allow-overwrite
+  --allow-overwrite 2>&1)
+echo "$esbuild_out"
+# Regression guard (#533): the empty-import-meta warning must not reappear — it
+# means the wasm URL base was silently emptied. Fail the build if it does.
+if echo "$esbuild_out" | grep -q 'empty-import-meta'; then
+  echo "ERROR: esbuild emptied import.meta (#533 regression) — wasm URL base broken." >&2
+  exit 1
+fi
 
 # Step 3: Patch index.html for Safari 12.
 # - Wrap top-level await (ES2022) in async IIFE, keeping static import at top

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -48,4 +48,12 @@ sed -i 's| crossorigin="anonymous"||g' dist/index.html
 sed -i '/<link rel="modulepreload"/d' dist/index.html
 sed -i '/<link rel="preload"/d' dist/index.html
 
+# Regression guard (#533), positive form: the wasm loader MUST still resolve
+# its URL via import.meta.url in the shipped dist. Catches a future esbuild/
+# trunk change that empties it even without printing the warning above.
+if ! grep -q 'import\.meta\.url' dist/presenter-ui-*.js; then
+  echo "ERROR: dist wasm loader lost import.meta.url (#533 regression) — wasm URL base broken." >&2
+  exit 1
+fi
+
 echo "==> UI build complete."


### PR DESCRIPTION
Release 0.4.190 — #533 wasm-loader build fix + #532 playbook/log docs.

## Closes #533 — esbuild emptied import.meta under es2017

`scripts/build-ui.sh` transpiles the trunk JS glue to `es2017` for Safari-12
compatibility; that down-leveled `import.meta` to `{}`, emptying the base in the
wasm loader's `new URL('presenter-ui_bg.wasm', import.meta.url)` (the
`empty-import-meta` warning on every build). Fix: `--supported:import-meta=true`
— keeps every other es2017 syntax down-level while preserving the loader, since
the module is loaded as an ES module and the Safari-12.1+/iOS-12.2+ target
supports import.meta. The dist now ships `new URL("presenter-ui_bg.wasm",
import.meta.url)` intact. Two in-build regression guards fail the build if the
warning reappears OR the dist loses `import.meta.url`.

## Docs (no runtime change)

- `.claude/skills/ndi/SKILL.md`: #532 playbook lessons (readout-swap-keep-signal
  pattern; rVFC/ticker interleave + rVFC-less presented-fps gotchas; live-prod
  verification via `/stage?preview=1`).
- `docs/autopilot-log.md`: #532 cycle entry.

Version 0.4.190. The #532 health-indicator feature itself already shipped in
0.4.189 (PR #534). Verified on dev: full Pipeline green (Build ran build-ui.sh
guards clean; all Playwright + NDI-synthetic E2E green = wasm loads).
