### PR TITLE
Fix #536 — stage health readout overflow (small colored dot instead of emoji+word)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.190"
+version = "0.4.191"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.189"
+version = "0.4.191"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/status_bar.rs
+++ b/crates/presenter-ui/src/components/stage/status_bar.rs
@@ -2,7 +2,7 @@ use gloo_timers::callback::Interval;
 use leptos::prelude::*;
 
 use crate::components::version_label::VersionLabel;
-use crate::state::stage::{StageContext, StageHealthReading};
+use crate::state::stage::{StageContext, StageHealth};
 use crate::utils::autofit::autofit_effect_tabular;
 use crate::ws::stage::StageWsState;
 
@@ -103,8 +103,7 @@ pub fn StatusBar(
     // cumulative ⬇N/❄N suffix #523 drove from `ctx.dropped_frames` (that
     // signal is still populated by the beacon, just no longer read here).
     let stage_health = ctx.stage_health;
-    let video_latency_text =
-        move || format_video_latency_line(video_latency.get(), stage_health.get());
+    let video_latency_text = move || format_video_latency_line(video_latency.get());
 
     autofit_effect_tabular(clock_ref, STATUS_MAX_FONT, move || clock_text.get());
     if !hide_live {
@@ -145,6 +144,14 @@ pub fn StatusBar(
             <div node_ref=video_latency_ref class="stage__video-latency" data-role="video-latency">
                 <span class="stage__debug-label">"video-latency"</span>
                 {video_latency_text}
+                // #532/#536: recent-window health verdict as a SMALL colored
+                // dot (green/amber/red) + fps — replaces the wide emoji+word
+                // suffix that overflowed the narrow readout box off-screen.
+                {move || stage_health.get().map(|r| view! {
+                    " \u{00b7} "
+                    <span class=stage_health_dot_class(r.state) data-role="health-dot"></span>
+                    {format!(" {} fps", r.fps.round() as u32)}
+                })}
             </div>
         })}
         <div class="stage__version">
@@ -173,103 +180,68 @@ fn current_time_string() -> String {
 /// running (per the issue), only this on-screen text moved to the new
 /// signal. Extracted so the formatting is host-unit-testable without a live
 /// Leptos/WASM render — the reactive closure in `StatusBar` is a thin wrapper
-/// over this.
-fn format_video_latency_line(
-    latency_ms: Option<f64>,
-    health: Option<StageHealthReading>,
-) -> String {
-    let base = match latency_ms {
+/// over this. #536: this now returns ONLY the latency figure; the health
+/// verdict is rendered separately as a small colored DOT (+ fps) span in the
+/// view, because the old emoji+word suffix (`🟢 plynulé · 28 fps`) overflowed
+/// the narrow (24%-wide) readout box and was truncated / pushed off-screen on
+/// the real stage TVs, and the emoji glyph could not be sized down.
+fn format_video_latency_line(latency_ms: Option<f64>) -> String {
+    match latency_ms {
         Some(ms) => format!("server\u{2192}displej \u{00b7} {} ms", ms as u32),
         None => "server\u{2192}displej \u{00b7} n/a".to_string(),
-    };
-    match health {
-        // No beacon has classified a recent window yet (fresh session /
-        // reconnect) — show the latency alone rather than a stale/fabricated
-        // verdict.
-        None => base,
-        Some(reading) => format!(
-            "{base} \u{00b7} {} {} \u{00b7} {} fps",
-            reading.state.emoji(),
-            reading.state.label(),
-            reading.fps.round() as u32,
-        ),
+    }
+}
+
+/// CSS class for the recent-window health DOT (#536): a small colored circle
+/// (green/amber/red) whose SIZE is controlled by `stage.css` — unlike the old
+/// emoji glyph, which rendered oversized and could not be shrunk. The color
+/// alone conveys "usable right now?", so the Slovak word is dropped (it was
+/// what overflowed the box). Pure + host-unit-tested.
+fn stage_health_dot_class(state: StageHealth) -> &'static str {
+    match state {
+        StageHealth::Good => "stage__health-dot stage__health-dot--good",
+        StageHealth::Degraded => "stage__health-dot stage__health-dot--degraded",
+        StageHealth::Bad => "stage__health-dot stage__health-dot--bad",
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_video_latency_line;
-    use crate::state::stage::{StageHealth, StageHealthReading};
+    use super::{format_video_latency_line, stage_health_dot_class};
+    use crate::state::stage::StageHealth;
 
     #[test]
-    fn shows_latency_alone_when_no_health_data_yet() {
-        // No beacon has classified a recent window yet (fresh session /
-        // reconnect) — the readout must not show a stale/fabricated verdict.
+    fn shows_latency_number_when_measured() {
         assert_eq!(
-            format_video_latency_line(Some(112.0), None),
+            format_video_latency_line(Some(112.0)),
             "server\u{2192}displej \u{00b7} 112 ms"
         );
+    }
+
+    #[test]
+    fn shows_n_a_when_no_trustworthy_latency() {
         assert_eq!(
-            format_video_latency_line(None, None),
+            format_video_latency_line(None),
             "server\u{2192}displej \u{00b7} n/a"
         );
     }
 
     #[test]
-    fn appends_good_health_verdict_with_fps() {
-        assert_eq!(
-            format_video_latency_line(
-                Some(84.0),
-                Some(StageHealthReading {
-                    state: StageHealth::Good,
-                    fps: 28.4,
-                })
-            ),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f7e2} plynul\u{e9} \u{00b7} 28 fps"
-        );
-    }
-
-    #[test]
-    fn appends_degraded_health_verdict() {
-        assert_eq!(
-            format_video_latency_line(
-                Some(84.0),
-                Some(StageHealthReading {
-                    state: StageHealth::Degraded,
-                    fps: 22.0,
-                })
-            ),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f7e1} mierne sek\u{e1} \u{00b7} 22 fps"
-        );
-    }
-
-    #[test]
-    fn appends_bad_health_verdict() {
-        assert_eq!(
-            format_video_latency_line(
-                Some(84.0),
-                Some(StageHealthReading {
-                    state: StageHealth::Bad,
-                    fps: 8.0,
-                })
-            ),
-            "server\u{2192}displej \u{00b7} 84 ms \u{00b7} \u{1f534} v\u{fd}padky \u{00b7} 8 fps"
-        );
-    }
-
-    #[test]
-    fn n_a_latency_still_shows_health_verdict() {
-        // A health verdict is meaningful even without a trustworthy latency
-        // reading — never suppress it just because latency is n/a.
-        assert_eq!(
-            format_video_latency_line(
-                None,
-                Some(StageHealthReading {
-                    state: StageHealth::Bad,
-                    fps: 5.0,
-                })
-            ),
-            "server\u{2192}displej \u{00b7} n/a \u{00b7} \u{1f534} v\u{fd}padky \u{00b7} 5 fps"
-        );
+    fn health_dot_class_is_distinct_and_color_coded_per_state() {
+        // Each state maps to its own modifier so stage.css can colour + SIZE
+        // the dot (the whole point of #536 — a small, controllable dot instead
+        // of the oversized emoji). Base class shared; modifier distinct.
+        let good = stage_health_dot_class(StageHealth::Good);
+        let degraded = stage_health_dot_class(StageHealth::Degraded);
+        let bad = stage_health_dot_class(StageHealth::Bad);
+        assert_eq!(good, "stage__health-dot stage__health-dot--good");
+        assert_eq!(degraded, "stage__health-dot stage__health-dot--degraded");
+        assert_eq!(bad, "stage__health-dot stage__health-dot--bad");
+        assert_ne!(good, degraded);
+        assert_ne!(degraded, bad);
+        assert_ne!(good, bad);
+        for c in [good, degraded, bad] {
+            assert!(c.starts_with("stage__health-dot "));
+        }
     }
 }

--- a/crates/presenter-ui/src/state/stage.rs
+++ b/crates/presenter-ui/src/state/stage.rs
@@ -15,39 +15,24 @@ const CLIENT_ID_KEY: &str = "stageClientId";
 /// is what an operator glancing at the stage actually needs). See
 /// `components::stage::ndi_frame_stats::stage_health` for the pure
 /// classifier and its named threshold constants.
+/// The verdict drives a small colored dot on the stage readout (green/amber/
+/// red — see `status_bar::stage_health_dot_class` + `.stage__health-dot` in
+/// stage.css). #536: the dot replaced an emoji+word suffix that overflowed the
+/// narrow readout box; the color alone conveys usability, so no glyph/label
+/// method lives here anymore.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StageHealth {
-    /// 🟢 plynulé — smooth, fully usable.
+    /// Green dot — smooth, fully usable.
     Good,
-    /// 🟡 mierne seká — minor stutter, still usable.
+    /// Amber dot — minor stutter, still usable.
     Degraded,
-    /// 🔴 výpadky — freezing / not usable, needs attention.
+    /// Red dot — freezing / not usable, needs attention.
     Bad,
-}
-
-impl StageHealth {
-    /// The colour glyph shown on the stage readout.
-    pub fn emoji(self) -> &'static str {
-        match self {
-            StageHealth::Good => "\u{1f7e2}",
-            StageHealth::Degraded => "\u{1f7e1}",
-            StageHealth::Bad => "\u{1f534}",
-        }
-    }
-
-    /// The short Slovak label shown next to the glyph.
-    pub fn label(self) -> &'static str {
-        match self {
-            StageHealth::Good => "plynul\u{e9}",
-            StageHealth::Degraded => "mierne sek\u{e1}",
-            StageHealth::Bad => "v\u{fd}padky",
-        }
-    }
 }
 
 /// One classified health reading (#532): the verdict plus the recent-window
 /// presented-fps figure it was derived from, shown together as the small
-/// secondary detail beside the colour (e.g. "🟢 plynulé · 28 fps").
+/// secondary detail beside the colored dot (e.g. "● 28 fps").
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StageHealthReading {
     pub state: StageHealth,

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -241,6 +241,31 @@ body.stage {
     text-align: right;
 }
 
+/* #536: recent-window health verdict as a SMALL colored dot inside the
+   `.stage__video-latency` readout — replaces the emoji+word suffix that
+   overflowed the 24%-wide box off-screen and rendered an oversized glyph.
+   Sized in `em` so it tracks the readout's small 1vw font (a compact dot,
+   never a big ball); color alone conveys usability, inheriting the readout's
+   low opacity so it stays de-emphasized. */
+.stage__health-dot {
+    display: inline-block;
+    width: 0.62em;
+    height: 0.62em;
+    border-radius: 50%;
+    vertical-align: baseline;
+    /* fallback if a modifier is somehow missing — neutral, not alarming */
+    background-color: #64748b;
+}
+.stage__health-dot--good {
+    background-color: #22c55e;
+}
+.stage__health-dot--degraded {
+    background-color: #eab308;
+}
+.stage__health-dot--bad {
+    background-color: #ef4444;
+}
+
 /* ===== Group pills ===== */
 
 .stage__group-pill {

--- a/tests/e2e/stage-video-latency.spec.ts
+++ b/tests/e2e/stage-video-latency.spec.ts
@@ -201,39 +201,47 @@ test("stage shows a recent-window health verdict beside the video latency", asyn
   });
 
   const videoEl = stagePage.locator(".stage__video-latency");
+  const dot = stagePage.locator(
+    ".stage__video-latency [data-role='health-dot']",
+  );
 
   await setNdiActive(stagePage, true);
   await setVideoLatency(stagePage, 84);
   await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
 
-  // No beacon has classified a window yet → the readout shows the latency
-  // ALONE, no fabricated verdict.
-  await expect(videoEl).not.toContainText("plynul");
-  await expect(videoEl).not.toContainText("sek");
-  await expect(videoEl).not.toContainText("výpadky");
+  // No beacon has classified a window yet → latency ALONE, no verdict dot.
+  await expect(dot).toHaveCount(0);
 
-  // A beacon classifies a smooth window → 🟢 plynulé + the recent fps.
+  // #536: the verdict renders as a SMALL colored dot (green/amber/red) + fps —
+  // NOT the old emoji+word suffix that overflowed the box off-screen. The dot's
+  // modifier class carries the state; the word and emoji are gone entirely.
   await setStageHealth(stagePage, { state: "good", fps: 28 });
-  await expect(videoEl).toContainText("🟢");
-  await expect(videoEl).toContainText("plynulé");
+  await expect(dot).toHaveClass(/stage__health-dot--good/);
   await expect(videoEl).toContainText("28 fps");
+  await expect(videoEl).not.toContainText("plynul"); // word dropped
+  await expect(videoEl).not.toContainText("🟢"); // emoji dropped
 
-  // A beacon classifies minor stutter → 🟡 mierne seká.
   await setStageHealth(stagePage, { state: "degraded", fps: 20 });
-  await expect(videoEl).toContainText("🟡");
-  await expect(videoEl).toContainText("mierne seká");
+  await expect(dot).toHaveClass(/stage__health-dot--degraded/);
   await expect(videoEl).toContainText("20 fps");
 
-  // A beacon classifies real freezing → 🔴 výpadky.
   await setStageHealth(stagePage, { state: "bad", fps: 6 });
-  await expect(videoEl).toContainText("🔴");
-  await expect(videoEl).toContainText("výpadky");
+  await expect(dot).toHaveClass(/stage__health-dot--bad/);
   await expect(videoEl).toContainText("6 fps");
 
-  // Reconnect (or no classified window yet) clears it → readout falls back
-  // to the latency alone, never a stale verdict.
+  // #536 REGRESSION GUARD: with the verdict shown, the readout content must FIT
+  // its box — no horizontal overflow (scrollWidth > clientWidth) that ellipsis-
+  // truncates it and pushes it off the stage TV. Exactly what the old
+  // emoji+word suffix broke.
+  const fits = await videoEl.evaluate(
+    (el) => el.scrollWidth <= el.clientWidth + 1,
+  );
+  expect(fits).toBe(true);
+
+  // Reconnect (or no classified window yet) clears it → the dot disappears and
+  // the readout falls back to the latency alone, never a stale verdict.
   await setStageHealth(stagePage, null);
-  await expect(videoEl).not.toContainText("výpadky");
+  await expect(dot).toHaveCount(0);
   await expect(videoEl).toContainText(/server→displej\s*·\s*84\s*ms/);
 
   // browser-console-zero-errors: no errors/warnings the whole time.


### PR DESCRIPTION
Fix #536 — stage TV health readout overflowed off-screen (regression from #532).

The #532 verdict suffix `· 🟢 plynulé · N fps` was too long for the narrow
`.stage__video-latency` box → truncated / pushed off the real stage TVs, and
the emoji rendered oversized.

Fix (v0.4.191):
- Verdict now a SMALL CSS-sized colored dot (green/amber/red, ~0.62em) via
  `.stage__health-dot`, not the emoji.
- Dropped the Slovak word (color conveys usability) — the length culprit.
- Kept a short fps figure. Removed the now-unused `emoji()`/`label()`.
- E2E asserts the dot's modifier class + fps AND a regression guard that the
  readout content fits its box (`scrollWidth <= clientWidth`).

Verified on dev 0.4.191 (Playwright @1920×1080): `server→displej · 84 ms · ● 28
fps` fits the box exactly (scrollW==clientW, no overflow), dot is a 12px green
circle. Full Pipeline green incl. the new fit guard.
