### PR TITLE
Fix NDI on PP + prod: GPU render access, modern NVENC selection, rust 1.97 lints

### DIFF
--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -281,3 +281,46 @@ as the verification evidence (e.g. `server→displej · 22 ms · 🟢 plynulé �
 actual live NDI stream) — that's actually STRONGER proof than a synthetic override, since it exercises
 the entire real pipeline end-to-end. Use `/stage?preview=1` (the operator-preview mirror mode) to open
 a read-only tab that never grabs a wake lock or changes the broadcast layout for real displays.
+
+## Encoder selection — the two lies (#443, #541)
+
+`hw_h264_encoder()` picks the H264 encoder for the shared-encoder pipeline. Two hard-won rules:
+
+1. **Registry presence lies** (#443): an element can be advertised and fail to instantiate.
+2. **Instantiation lies too** (#541): NVIDIA driver 595.71.05 (dev2, 2026-07-03) dropped the LEGACY
+   nvenc preset API — `nvh264enc` still registers AND still constructs, then dies at caps negotiation
+   with *"Selected preset not supported"*, surfacing only as an opaque
+   `Could not configure supporting library` at pipeline start.
+
+So the probe pushes ONE real frame through `videotestsrc ! <encoder> ! fakesink` and requires EOS.
+Verdicts are cached per element per process (a driver rejection cannot heal without a driver change,
+and a live probe would open a second NVENC session mid-stream — consumer GeForce caps those).
+
+Candidate order: `vah264enc` (prod N100) → `nvcudah264enc` → `nvautogpuh264enc` → `nvh264enc` (legacy,
+older drivers only) → `x264enc`. The modern nvcodec elements ignore the legacy `zerolatency` boolean —
+they need `tune=ultra-low-latency` + `zero-reorder-delay=true` + `rate-control=cbr`, or you silently
+ship a B-frame (reordering) encoder to the stage TVs.
+
+**Triage recipe when e2e-ndi starts failing with an encoder error and the #445 GPU preflight PASSES:**
+
+```bash
+# 1. Is it the GPU, or the encoder element?
+nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader   # wedge = 100% + no process
+# 2. Can each encoder actually encode RIGHT NOW?
+for e in vah264enc nvh264enc nvcudah264enc nvautogpuh264enc x264enc; do
+  gst-inspect-1.0 --exists $e && gst-launch-1.0 -q videotestsrc num-buffers=5 \
+    ! video/x-raw,width=640,height=360 ! videoconvert ! $e ! h264parse ! fakesink 2>&1 | head -2
+done
+# 3. Did a driver land after the last green run?  (this is what #541 turned out to be)
+grep -h nvidia /var/log/dpkg.log* | grep -E ' install | upgrade ' | tail -5
+gh run list --branch dev --workflow=pipeline.yml --limit 12 --json createdAt,conclusion
+```
+
+## GPU access on a deployed host (#540)
+
+The service runs as an ordinary user; `/dev/dri/renderD128` is `root:render 0660`. Without
+`SupplementaryGroups=render` in the unit the process cannot open it, the GStreamer `va` plugin
+registers **zero** elements, and NDI dies silently with every driver package installed. Do NOT rely on
+the systemd-logind console ACL (`getfacl /dev/dri/renderD128` showing `user:<u>:rw-`) — it exists only
+while somebody is logged in at the physical console, and it is what made prod *look* healthy while PP
+was dead. Check with `gst-inspect-1.0 va | grep -c '^  va'` (0 = no access).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.189"
+version = "0.4.192"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.191"
+version = "0.4.192"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-importer/src/lib.rs
+++ b/crates/presenter-importer/src/lib.rs
@@ -145,17 +145,14 @@ impl<'a> ProPresenterImporter<'a> {
             .upsert_library(&library)
             .await
             .with_context(|| {
-                format!(
-                    "failed to upsert library {} into persistence",
-                    &library.name
-                )
+                format!("failed to upsert library {} into persistence", library.name)
             })?;
 
         if library.name.eq_ignore_ascii_case("NEW LEVEL") {
             self.repository
                 .set_library_favorite(library.id, true)
                 .await
-                .with_context(|| format!("failed to mark library {} as favorite", &library.name))?;
+                .with_context(|| format!("failed to mark library {} as favorite", library.name))?;
         }
         Ok(Some(summary))
     }

--- a/crates/presenter-importer/src/rtf.rs
+++ b/crates/presenter-importer/src/rtf.rs
@@ -122,11 +122,7 @@ where
 {
     let mut hex = String::new();
     for _ in 0..2 {
-        if let Some(c) = chars.next() {
-            hex.push(c);
-        } else {
-            return None;
-        }
+        hex.push(chars.next()?);
     }
     let byte = u8::from_str_radix(&hex, 16).ok()?;
     let binding = [byte];

--- a/crates/presenter-ndi/src/gpu.rs
+++ b/crates/presenter-ndi/src/gpu.rs
@@ -13,8 +13,122 @@
 //! at the physical console and systemd-logind left a per-seat ACL on the node — a
 //! reboot without that login would have killed NDI there the same way.
 
+use std::fs::OpenOptions;
+use std::io::ErrorKind;
+use std::path::Path;
+
+/// The DRM render node the VA-API / NVENC stack opens to expose its encoders.
+pub const RENDER_NODE: &str = "/dev/dri/renderD128";
+
+/// Whether this process can actually reach the GPU (#540).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderNodeAccess {
+    /// No render node at all — the host has no usable GPU.
+    Missing,
+    /// The node exists but this process cannot open it. Almost always a
+    /// permission problem: the service user is not in the `render` group and
+    /// holds no logind ACL. Encoders will NOT register, however many driver
+    /// packages are installed.
+    Unopenable,
+    /// The node exists and opens — the GPU is reachable.
+    Accessible,
+}
+
+/// Classify access to the host's render node.
+pub fn render_node_access() -> RenderNodeAccess {
+    classify_render_node(Path::new(RENDER_NODE))
+}
+
+fn classify_render_node(path: &Path) -> RenderNodeAccess {
+    match OpenOptions::new().read(true).write(true).open(path) {
+        Ok(_) => RenderNodeAccess::Accessible,
+        Err(e) if e.kind() == ErrorKind::NotFound => RenderNodeAccess::Missing,
+        Err(_) => RenderNodeAccess::Unopenable,
+    }
+}
+
+/// The actionable half of the "no H264 encoder" startup warning (#540).
+///
+/// The old message said "install gstreamer1.0-vaapi / intel-media-va-driver" —
+/// on PP every one of those packages WAS installed and the real cause was that
+/// the service could not open the render node. Naming the cause the host is
+/// actually in turns a multi-hour hunt into a one-line fix.
+pub fn missing_encoder_hint(access: RenderNodeAccess) -> &'static str {
+    match access {
+        RenderNodeAccess::Unopenable => {
+            "the GPU render node exists but this process cannot OPEN it — the service user \
+             lacks render-node access (systemd: SupplementaryGroups=render, or add the user \
+             to the `render` group). Driver packages are NOT the problem; the `va` plugin \
+             registers no elements without access to the device."
+        }
+        RenderNodeAccess::Missing => {
+            "this host has no DRM render node (/dev/dri/renderD128) — no GPU is available, \
+             so NDI WebRTC cannot be hardware-encoded here."
+        }
+        RenderNodeAccess::Accessible => {
+            "the GPU render node is reachable, so the encoder plugins are missing: install \
+             Intel VA-API (gstreamer1.0-vaapi + intel-media-va-driver-non-free) OR NVIDIA \
+             NVENC (gstreamer1.0-plugins-bad with nvcodec)."
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::{classify_render_node, missing_encoder_hint, RenderNodeAccess};
+    use std::path::{Path, PathBuf};
+
+    fn nonexistent_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "presenter-no-such-render-node-{}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn absent_render_node_is_missing() {
+        assert_eq!(
+            classify_render_node(&nonexistent_path()),
+            RenderNodeAccess::Missing
+        );
+    }
+
+    #[test]
+    fn present_but_unopenable_node_is_unopenable() {
+        // A directory exists but can never be opened read-write — the same shape
+        // the service hit on PP, where the node existed and open() was refused.
+        assert_eq!(
+            classify_render_node(&std::env::temp_dir()),
+            RenderNodeAccess::Unopenable
+        );
+    }
+
+    #[test]
+    fn openable_node_is_accessible() {
+        assert_eq!(
+            classify_render_node(Path::new("/dev/null")),
+            RenderNodeAccess::Accessible
+        );
+    }
+
+    #[test]
+    fn hint_for_an_unopenable_node_blames_access_not_packages() {
+        // The #540 lesson: the old warning sent us hunting for packages that were
+        // already installed. The hint for a permission failure must say so.
+        let hint = missing_encoder_hint(RenderNodeAccess::Unopenable);
+        assert!(hint.contains("SupplementaryGroups=render"));
+        assert!(hint.contains("render` group"));
+        assert!(hint.contains("NOT the problem"));
+
+        // …and the other two states must NOT give that advice.
+        assert!(!missing_encoder_hint(RenderNodeAccess::Missing).contains("SupplementaryGroups"));
+        assert!(missing_encoder_hint(RenderNodeAccess::Missing).contains("no GPU"));
+        assert!(missing_encoder_hint(RenderNodeAccess::Accessible).contains("gstreamer1.0-vaapi"));
+    }
+}
+
+#[cfg(test)]
+mod unit_file_tests {
     use std::path::Path;
 
     /// #540 regression guard. Both deployed units run the server as an ordinary

--- a/crates/presenter-ndi/src/gpu.rs
+++ b/crates/presenter-ndi/src/gpu.rs
@@ -1,0 +1,53 @@
+//! GPU render-node access (#540).
+//!
+//! The VA-API / NVENC GStreamer plugins can only register their encoder
+//! elements if the process can OPEN the DRM render node (`/dev/dri/renderD128`,
+//! `root:render 0660`). When it cannot, the `va` plugin registers ZERO elements,
+//! `hw_h264_encoder()` returns `None`, and NDI silently never starts — with every
+//! driver package correctly installed, which is exactly what made the PP outage
+//! (2026-07-12) so hard to read: the startup warning told us to install packages
+//! that were already there.
+//!
+//! Access must therefore be granted by the SERVICE UNIT (`SupplementaryGroups=render`),
+//! never inherited by accident. Production had it only because someone was logged in
+//! at the physical console and systemd-logind left a per-seat ACL on the node — a
+//! reboot without that login would have killed NDI there the same way.
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    /// #540 regression guard. Both deployed units run the server as an ordinary
+    /// user, and the render node is `root:render 0660` — so a unit that does not
+    /// grant the `render` group cannot open the GPU. On PP this registered zero
+    /// VA elements and NDI never started; on prod it "worked" only via a
+    /// console-login ACL. The grant belongs in the unit, so assert it there.
+    #[test]
+    fn deployed_units_grant_the_service_user_gpu_render_access() {
+        let deploy_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/deploy");
+
+        for unit in ["presenter.service", "presenter-dev.service"] {
+            let path = deploy_dir.join(unit);
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+            let grants_render = text
+                .lines()
+                .map(str::trim)
+                .filter_map(|line| line.strip_prefix("SupplementaryGroups="))
+                .any(|groups| {
+                    groups
+                        .split([' ', ',', '\t'])
+                        .any(|group| group == "render")
+                });
+
+            assert!(
+                grants_render,
+                "{unit} must grant the service user the `render` group \
+                 (SupplementaryGroups=render …) — without it the process cannot open \
+                 /dev/dri/renderD128, the GStreamer `va` plugin registers no encoder, \
+                 and NDI dies silently (#540)"
+            );
+        }
+    }
+}

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod clock;
 pub mod discovery;
+pub mod gpu;
 pub mod manager;
 pub mod ndi_sdk;
 pub mod pipeline;

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -18,7 +18,8 @@ pub use manager::StatusCallback;
 pub use pipeline::{PipelineSnapshot, SessionSnapshot, StreamProfile};
 pub use whep_session::{IceCandidate, WhepConnectionState, WhepSession};
 
-use std::sync::OnceLock;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 /// Holds the outcome of the one-shot `gstreamer::init()` + plugin registration.
 /// Subsequent `init()` calls return the SAME outcome — a previously failed
@@ -119,11 +120,28 @@ pub fn init() -> anyhow::Result<()> {
     }
 }
 
-/// Pick the first H264 encoder candidate (in priority order) that actually
-/// loads. The registry/loadability probe is injected via `can_load` so this
-/// is a PURE function — unit-testable without depending on the machine's live
-/// GStreamer registry state (#443). `hw_h264_encoder()` is the only caller and
-/// supplies the real probe.
+/// H264 encoders we will use, in priority order.
+///
+/// VA-API first: it is what the production N100 has, and it carries no
+/// concurrent-session cap. Then the MODERN nvcodec elements — `nvcudah264enc`
+/// and `nvautogpuh264enc` — ahead of the LEGACY `nvh264enc`: NVIDIA driver
+/// 595.71.05 rejects the legacy element's preset API outright ("Selected preset
+/// not supported"), so on a current driver the legacy element registers, builds,
+/// and then dies on the first frame (#541). Software `x264enc` is the last
+/// resort (no session cap, CPU cost only).
+pub(crate) const H264_ENCODER_CANDIDATES: &[&str] = &[
+    "vah264enc",
+    "nvcudah264enc",
+    "nvautogpuh264enc",
+    "nvh264enc",
+    "x264enc",
+];
+
+/// Pick the first H264 encoder candidate (in priority order) that is actually
+/// USABLE. The probe is injected via `is_usable` so this is a PURE function —
+/// unit-testable without depending on the machine's live GStreamer registry or
+/// GPU driver (#443, #541). `hw_h264_encoder()` is the only caller and supplies
+/// the real probe.
 fn pick_h264_encoder(
     candidates: &[&'static str],
     can_load: impl Fn(&str) -> bool,
@@ -170,10 +188,86 @@ fn pick_h264_encoder(
 /// self-heal: a host whose registry recovers resumes without a process restart
 /// (so it is intentionally NOT memoized).
 pub fn hw_h264_encoder() -> Option<&'static str> {
-    pick_h264_encoder(&["vah264enc", "nvh264enc", "x264enc"], |name| {
-        gstreamer::ElementFactory::make(name).build().is_ok()
-    })
+    pick_h264_encoder(H264_ENCODER_CANDIDATES, encoder_is_usable)
 }
+
+/// Can this encoder element actually ENCODE on this host — not merely be
+/// constructed (#541)?
+///
+/// #443 taught us that registry presence lies (an advertised element may fail to
+/// instantiate). Driver 595.71.05 taught us that instantiation lies too: the
+/// legacy `nvh264enc` builds happily and then fails at caps negotiation
+/// ("Selected preset not supported"), which surfaced only as an opaque
+/// `Could not configure supporting library` at pipeline start — after the
+/// encoder had already been selected. So the probe pushes ONE tiny frame through
+/// the element and only then calls it usable.
+///
+/// Cost: a 320x240 single-frame encode, on the FIRST query per element name only
+/// — the verdict is cached for the process (`ENCODER_USABILITY` below), because a
+/// driver-level rejection cannot heal without a driver change, which needs a
+/// restart anyway. Caching also keeps this off the 30 s NDI-reconnect tick and,
+/// crucially, stops the probe from opening a second NVENC session while a
+/// pipeline is streaming (consumer GeForce cards cap concurrent sessions).
+fn encoder_is_usable(name: &str) -> bool {
+    let cache = ENCODER_USABILITY.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock() {
+        if let Some(&verdict) = guard.get(name) {
+            return verdict;
+        }
+    }
+
+    let verdict = probe_encoder_can_encode(name);
+    if !verdict {
+        tracing::warn!(
+            encoder = name,
+            "encoder is registered but cannot encode on this host — skipping it"
+        );
+    }
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(name.to_string(), verdict);
+    }
+    verdict
+}
+
+/// Per-process cache of the functional encoder probe (see `encoder_is_usable`).
+static ENCODER_USABILITY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+
+/// Push one frame through `videotestsrc ! videoconvert ! <encoder> ! fakesink`
+/// and report whether it encoded without an error message on the bus.
+fn probe_encoder_can_encode(name: &str) -> bool {
+    use gstreamer::prelude::*;
+
+    // Element-not-registered / not-instantiable is the #443 case and is still a
+    // "no" — parse::launch covers both without a separate build() probe.
+    let Ok(pipeline) = gstreamer::parse::launch(&format!(
+        "videotestsrc num-buffers=1 ! video/x-raw,width=320,height=240,framerate=30/1 \
+         ! videoconvert ! {name} ! fakesink sync=false"
+    )) else {
+        return false;
+    };
+
+    let usable = (|| {
+        let bus = pipeline.bus()?;
+        if pipeline.set_state(gstreamer::State::Playing).is_err() {
+            return Some(false);
+        }
+        // EOS = the frame made it through the encoder. Error = it did not
+        // (driver rejected the preset, no CUDA device, session cap, …).
+        let msg = bus.timed_pop_filtered(
+            gstreamer::ClockTime::from_seconds(ENCODER_PROBE_TIMEOUT_SECS),
+            &[gstreamer::MessageType::Eos, gstreamer::MessageType::Error],
+        )?;
+        Some(msg.type_() == gstreamer::MessageType::Eos)
+    })()
+    .unwrap_or(false);
+
+    let _ = pipeline.set_state(gstreamer::State::Null);
+    usable
+}
+
+/// Upper bound for the one-shot encoder probe. Generous enough for a cold CUDA /
+/// VA display init, short enough that a hung driver cannot stall startup.
+const ENCODER_PROBE_TIMEOUT_SECS: u64 = 10;
 
 #[cfg(test)]
 mod gst_init_tests {
@@ -296,8 +390,7 @@ mod pick_h264_encoder_tests {
     fn broken_legacy_nvenc_falls_through_to_the_modern_cuda_encoder() {
         // The driver-595 host: no Intel VA-API, legacy nvenc unusable, modern
         // nvcodec + software usable.
-        let usable =
-            |name: &str| matches!(name, "nvcudah264enc" | "nvautogpuh264enc" | "x264enc");
+        let usable = |name: &str| matches!(name, "nvcudah264enc" | "nvautogpuh264enc" | "x264enc");
 
         assert_eq!(
             pick_h264_encoder(H264_ENCODER_CANDIDATES, usable),
@@ -331,8 +424,7 @@ mod pick_h264_encoder_tests {
             Some("nvautogpuh264enc")
         );
 
-        let only_legacy_and_software =
-            |name: &str| matches!(name, "nvh264enc" | "x264enc");
+        let only_legacy_and_software = |name: &str| matches!(name, "nvh264enc" | "x264enc");
         assert_eq!(
             pick_h264_encoder(H264_ENCODER_CANDIDATES, only_legacy_and_software),
             Some("nvh264enc"),

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -285,4 +285,64 @@ mod pick_h264_encoder_tests {
         let picked = pick_h264_encoder(CANDIDATES, |name| name != "nvh264enc");
         assert_eq!(picked, Some("vah264enc"));
     }
+
+    /// #541: NVIDIA driver 595.71.05 (installed on dev2 2026-07-03) leaves the
+    /// LEGACY `nvh264enc` element registered and constructible, but it dies at
+    /// caps negotiation with "Selected preset not supported" — every NDI
+    /// pipeline build then failed on the CI runner. The modern nvcodec elements
+    /// (`nvcudah264enc` / `nvautogpuh264enc`) encode fine on the same driver.
+    /// So the real candidate list must offer them BEFORE the legacy element.
+    #[test]
+    fn broken_legacy_nvenc_falls_through_to_the_modern_cuda_encoder() {
+        // The driver-595 host: no Intel VA-API, legacy nvenc unusable, modern
+        // nvcodec + software usable.
+        let usable =
+            |name: &str| matches!(name, "nvcudah264enc" | "nvautogpuh264enc" | "x264enc");
+
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, usable),
+            Some("nvcudah264enc"),
+            "with the legacy nvh264enc unusable, the modern CUDA NVENC encoder must be \
+             chosen — falling back to software x264enc would throw away the GPU, and \
+             picking nvh264enc is what broke every NDI pipeline build (#541)"
+        );
+    }
+
+    /// The real candidate list's priority, asserted behaviourally: VA-API first
+    /// (production N100), then modern NVENC, then the legacy element, then
+    /// software. Each row removes the winner above it.
+    #[test]
+    fn real_candidate_order_is_vaapi_modern_nvenc_legacy_nvenc_software() {
+        let all = |_: &str| true;
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, all),
+            Some("vah264enc")
+        );
+
+        let no_va = |name: &str| name != "vah264enc";
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, no_va),
+            Some("nvcudah264enc")
+        );
+
+        let no_va_no_cuda = |name: &str| !matches!(name, "vah264enc" | "nvcudah264enc");
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, no_va_no_cuda),
+            Some("nvautogpuh264enc")
+        );
+
+        let only_legacy_and_software =
+            |name: &str| matches!(name, "nvh264enc" | "x264enc");
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, only_legacy_and_software),
+            Some("nvh264enc"),
+            "a host where the legacy element still works (older driver) keeps using it"
+        );
+
+        let software_only = |name: &str| name == "x264enc";
+        assert_eq!(
+            pick_h264_encoder(H264_ENCODER_CANDIDATES, software_only),
+            Some("x264enc")
+        );
+    }
 }

--- a/crates/presenter-ndi/src/pipeline/build.rs
+++ b/crates/presenter-ndi/src/pipeline/build.rs
@@ -329,7 +329,23 @@ fn build_encoder(encoder_name: &str) -> Result<gst::Element> {
                 .property("target-usage", 6u32)
                 .property("bitrate", DEFAULT_BITRATE_KBPS);
         }
+        "nvcudah264enc" | "nvautogpuh264enc" => {
+            // #541: the MODERN nvcodec encoders. Current NVIDIA drivers (595.71.05+)
+            // reject the legacy element's preset API outright, so these are what
+            // NVENC means from now on. Their tuning knobs differ from nvh264enc:
+            // low latency is `tune=ultra-low-latency` + `zero-reorder-delay` (no
+            // B-frame reordering) + CBR, not the old `zerolatency` boolean.
+            encoder_builder = encoder_builder
+                .property("gop-size", 60i32)
+                .property("zero-reorder-delay", true)
+                .property_from_str("tune", "ultra-low-latency")
+                .property_from_str("rate-control", "cbr")
+                .property("bitrate", DEFAULT_BITRATE_KBPS);
+        }
         "nvh264enc" => {
+            // Legacy NVENC element — kept for hosts still on a driver that
+            // supports its preset API. On 595.71.05+ it fails at caps
+            // negotiation and `hw_h264_encoder()`'s probe skips it (#541).
             encoder_builder = encoder_builder
                 .property("gop-size", 60i32)
                 .property("zerolatency", true)

--- a/crates/presenter-ndi/src/pipeline/tests.rs
+++ b/crates/presenter-ndi/src/pipeline/tests.rs
@@ -387,11 +387,27 @@ fn pipeline_tuning_properties_are_low_latency() {
     let encoder = p.pipeline.by_name("encoder").expect("encoder named");
     let factory = encoder.factory().expect("factory").name().to_string();
     let gop: i64 = match factory.as_str() {
-        "nvh264enc" => encoder.property::<i32>("gop-size") as i64,
+        // #541: the modern nvcodec encoders name the knob `gop-size` like the
+        // legacy element, and carry the low-latency tuning on `tune` +
+        // `zero-reorder-delay` instead of the old `zerolatency` boolean.
+        "nvh264enc" | "nvcudah264enc" | "nvautogpuh264enc" => {
+            encoder.property::<i32>("gop-size") as i64
+        }
         "vah264enc" | "x264enc" => encoder.property::<u32>("key-int-max") as i64,
         other => panic!("unexpected encoder factory {other}"),
     };
     assert_eq!(gop, 60, "GOP must be 60 frames");
+
+    // 4. #541: whichever encoder was selected, it must be configured for LOW
+    //    LATENCY — the modern nvcodec elements ignore the legacy `zerolatency`
+    //    property, so a copy-paste of the old tuning would silently ship a
+    //    reordering (B-frame) encoder to the stage TVs.
+    if matches!(factory.as_str(), "nvcudah264enc" | "nvautogpuh264enc") {
+        assert!(
+            encoder.property::<bool>("zero-reorder-delay"),
+            "modern NVENC must run with zero reorder delay (no B-frame latency)"
+        );
+    }
 }
 
 /// The video encoder factories `iterate_encoders` counts (the single shared

--- a/crates/presenter-server/src/main.rs
+++ b/crates/presenter-server/src/main.rs
@@ -113,11 +113,18 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("NDI WebRTC encoder: {name}");
             }
             None => {
+                // #540: say WHY there is no encoder. The old message only ever
+                // advised installing driver packages — on PP every package was
+                // installed and the real cause was that the service could not open
+                // /dev/dri/renderD128 (no render-group grant), so the `va` plugin
+                // registered nothing. Report the host's actual render-node state.
+                let access = presenter_ndi::gpu::render_node_access();
                 tracing::warn!(
+                    render_node = presenter_ndi::gpu::RENDER_NODE,
+                    ?access,
                     "no hardware H264 encoder (vah264enc / nvh264enc) registered — \
-                     NDI WebRTC pipeline build will fail at activation. \
-                     Install Intel VA-API (gstreamer1.0-vaapi + intel-media-va-driver-non-free) \
-                     OR NVIDIA NVENC (gstreamer1.0-plugins-bad with nvcodec)."
+                     NDI WebRTC pipeline build will fail at activation. {}",
+                    presenter_ndi::gpu::missing_encoder_hint(access)
                 );
             }
         }

--- a/crates/presenter-server/src/resolume/driver.rs
+++ b/crates/presenter-server/src/resolume/driver.rs
@@ -375,7 +375,7 @@ impl HostDriver {
             let clip_id = target.clip_id;
             let url = format!(
                 "{}/composition/clips/by-id/{}/connect",
-                &endpoint.base_url, clip_id
+                endpoint.base_url, clip_id
             );
             let host_header = endpoint.host_header.clone();
             debug!(clip_id, "resolume.trigger_clip");

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -9,6 +9,9 @@ After=network.target dev-dri-renderD128.device
 Type=simple
 User=newlevel
 Group=newlevel
+# #540: render-group grant so the service can open /dev/dri/renderD128 without
+# relying on a console-login ACL (see presenter.service for the full incident).
+SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter-dev
 # #339: gate start on hardware H264 encoder being probeable. Mirrors
 # prod presenter.service; see that file for the full incident

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -16,6 +16,15 @@ After=network.target dev-dri-renderD128.device
 Type=simple
 User=newlevel
 Group=newlevel
+# #540: the GPU render node is root:render 0660, so an ordinary service user can
+# only open it via the `render` group. Without this grant the GStreamer `va`
+# plugin registers ZERO elements, hw_h264_encoder() returns None and NDI never
+# starts — on a host where every driver package is installed (the PP outage,
+# 2026-07-12). Prod appeared healthy only because a console login left a
+# systemd-logind per-seat ACL (user:newlevel:rw-) on the node; the first reboot
+# without that login would have killed VA-API on the production wall too. The
+# grant belongs HERE so GPU access never depends on who happens to be logged in.
+SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter
 # #339: gate start on hardware H264 encoder being probeable. The race
 # that took prod down on 2026-05-24 (and reproduced on cold-reboot of


### PR DESCRIPTION
Three defects found while verifying PP after the v0.4.191 release. All three were silently breaking
NDI video or CI; none of them was visible from the code alone.

## #540 — the service user could not open the GPU (NDI dead on PP, prod on borrowed time)

`presenter.service` runs as an ordinary user, `/dev/dri/renderD128` is `root:render 0660`, and no unit
granted the `render` group. The process therefore could not open the render node, GStreamer's `va`
plugin registered **zero** elements (`14` on prod), `hw_h264_encoder()` returned `None`, and the NDI
pipeline was never built — on a host where every driver package was installed. That is why PP showed
nothing on the `ndi-fullscreen` layout with a correctly mapped, active source.

Production only *appeared* healthy because a console login left a systemd-logind ACL
(`user:newlevel:rw-`) on the node since 2026-06-20. **A reboot with nobody logged in at the console
would have killed VA-API on the production wall the same way.**

Fix: `SupplementaryGroups=render video` in both units, so GPU access never depends on who is logged in.
The startup warning now names the actual cause (render node Missing / Unopenable / Accessible) instead
of always advising a package install.

## #541 — NVIDIA 595 driver broke the legacy NVENC element; our probe selected it anyway

Driver 595.71.05 (dev2, 2026-07-03) dropped the legacy nvenc preset API. `nvh264enc` still registers
and still *constructs*, then dies at caps negotiation ("Selected preset not supported") — every
`e2e-ndi` run has failed since, with an opaque `Could not configure supporting library`.

#443 taught us registry presence lies. This driver taught us instantiation lies too. The probe now
pushes ONE frame through the element and requires EOS before calling it usable, and the candidate list
gains the modern nvcodec encoders ahead of the legacy one, tuned for low latency
(`tune=ultra-low-latency`, `zero-reorder-delay`, CBR — they ignore the legacy `zerolatency` boolean).

Verified live on dev2: selection now returns `nvcudah264enc`, and it encodes.

## rust 1.97 clippy

CI's stable toolchain rolled to 1.97.0 mid-flight and the new lints fire on pre-existing code, failing
the Clippy job on every run regardless of the diff. Three mechanical rewrites (`question_mark`,
`needless_borrows_for_generic_args`).

## Tests

- RED→GREEN per fix: the unit-file guard (`#540`) and the encoder-selection tests (`#541`) both fail on
  the parent commit and pass here.
- The tuning test now also pins low-latency config for the modern NVENC elements.
- Full pipeline green, **including the e2e-ndi lane on the real GPU** — the lane that had been failing.

## Deploy note

Merging deploys to production, which restarts `presenter.service` there. The service must pick up the
new unit (`systemctl daemon-reload` happens in the deploy). PP picks the fix up at the next release.

Closes #540
Closes #541
