### PR TITLE
Deploy config: per-site stage URL out of the shared unit, encoder gate that cannot stall

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -350,7 +350,16 @@ jobs:
       - name: Deploy systemd service
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter.service deploy-target:/tmp/presenter.service
-          ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && sudo systemctl daemon-reload"
+          # #539: the encoder-ready gate the unit calls from ExecStartPre.
+          scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
+          # #538: the stage URL is PER SITE and no longer lives in the shared unit —
+          # each deploy writes its own drop-in. SNV prod points its TVs at itself.
+          PROD_STAGE_URL="${{ vars.PROD_STAGE_URL || 'http://10.77.9.205/stage' }}"
+          ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
+            sudo mkdir -p /etc/systemd/system/presenter.service.d && \
+            printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PROD_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
+            sudo systemctl daemon-reload"
 
       # #502: write the Cloudflare Realtime TURN credentials to a 0600 root-only
       # EnvironmentFile (the committed unit references it as `EnvironmentFile=-`).

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -365,6 +365,11 @@ jobs:
           # false-positive guard. Proves the detection logic with mock
           # wedged-vs-healthy facts (no real GPU needed on the hosted runner).
           bash tests/ci/gpu-preflight.test.sh
+          # Guards for what we SHIP to the hosts (#538, #539): the shared unit must
+          # not hardcode one site's stage URL, every deploy must write its own
+          # drop-in, and the encoder-ready gate must skip (not stall 30s) on a host
+          # with no usable GPU while still recognising the modern nvcodec encoders.
+          bash tests/deploy/deploy-config.test.sh
 
   # ============================================
   # Quality Checks
@@ -1149,7 +1154,11 @@ jobs:
       - name: Deploy systemd service
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter-dev.service deploy-target:/tmp/presenter-dev.service
-          ssh deploy-target "sudo cp /tmp/presenter-dev.service /etc/systemd/system/ && sudo systemctl daemon-reload"
+          # #539: the encoder-ready gate the unit calls from ExecStartPre.
+          scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
+          ssh deploy-target "sudo cp /tmp/presenter-dev.service /etc/systemd/system/ && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter-dev/wait-for-h264-encoder.sh && \
+            sudo systemctl daemon-reload"
 
       # #502: write the Cloudflare Realtime TURN credentials to a 0600 root-only
       # EnvironmentFile (the committed unit references it as `EnvironmentFile=-`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,12 +355,14 @@ jobs:
       - name: Deploy systemd service
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter.service deploy-target:/tmp/presenter.service
-          # The shared unit hardcodes SNV's PRESENTER_ANDROID_STAGE_URL. PP needs
-          # its OWN stage URL (its server IP) so the watchdog points PP's TV at PP,
-          # not SNV (#470). Ship a per-env drop-in that overrides it. Override the
-          # default with the PP_STAGE_URL repo variable if PP's IP changes.
+          # #539: the encoder-ready gate the unit calls from ExecStartPre.
+          scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
+          # #470/#538: the stage URL is PER SITE and is NOT in the shared unit — each
+          # deploy writes its own drop-in. PP points its TV at PP, not at SNV. Override
+          # the default with the PP_STAGE_URL repo variable if PP's IP changes.
           PP_STAGE_URL="${{ vars.PP_STAGE_URL || 'http://10.77.8.205/stage' }}"
           ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
             printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PP_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
             sudo systemctl daemon-reload"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.192"
+version = "0.4.193"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.192"
+version = "0.4.193"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -90,30 +90,49 @@ fn presenter_service_blocks_start_until_h264_encoder_probeable() {
         assert!(
             exec_pre_trimmed.starts_with("ExecStartPre=-"),
             "{name}: ExecStartPre must use leading `-` (best-effort prefix). \
-             Without `-`, a 30s timeout (no GPU at all) makes systemd fail the \
-             whole unit — blocking non-NDI features (lyrics, Bible, timers) \
-             from starting. Item 6's encoder gate must be allowed to take \
-             over instead (#339). Line: {exec_pre}"
+             Without `-`, a host that cannot satisfy the gate (no GPU, or the script \
+             not yet deployed) would fail the whole unit — blocking non-NDI features \
+             (lyrics, Bible, timers) from starting. The encoder gate inside presenter \
+             takes over instead (#339). Line: {exec_pre}"
         );
+        // #539: the gate moved from an inline `timeout 30 sh -c 'until gst-inspect …'`
+        // into a script, because it must SKIP the wait on a host that can never satisfy
+        // it (no GPU / render node the service user cannot open) instead of burning the
+        // full timeout on every start, and it must know the modern nvcodec encoders
+        // (#541). The unit's job is to CALL that gate — the gate's own behaviour is
+        // pinned by tests/deploy/deploy-config.test.sh.
         assert!(
-            exec_pre.contains("gst-inspect-1.0"),
-            "{name}: ExecStartPre must use `gst-inspect-1.0` — canonical \
-             GStreamer feature query that matches what `presenter_ndi::\
-             hw_h264_encoder()` sees at startup (#339). Line: {exec_pre}"
+            exec_pre.contains("wait-for-h264-encoder.sh"),
+            "{name}: ExecStartPre must call the encoder-ready gate script \
+             (scripts/deploy/wait-for-h264-encoder.sh). Without it the binary can exec \
+             before /dev/dri/renderD128 is usable for VA-API and NDI stays down until a \
+             manual restart (#339, prod cold-reboot 2026-05-24 17:07 CEST). Line: {exec_pre}"
         );
+    }
+
+    // The gate script itself must still probe with gst-inspect-1.0 (the same view of the
+    // registry `presenter_ndi::hw_h264_encoder()` gets) and cover EVERY encoder we can
+    // actually use: VA-API (prod N100), the modern nvcodec elements a current NVIDIA
+    // driver provides (#541 — the legacy element is dead on 595+), and the legacy one for
+    // hosts still on an older driver. Waiting for a name we will never see would stall the
+    // start for the whole timeout on a perfectly healthy box.
+    let gate = include_str!("../../../../scripts/deploy/wait-for-h264-encoder.sh");
+    assert!(
+        gate.contains("gst-inspect-1.0"),
+        "the encoder gate must query the registry with gst-inspect-1.0 (#339)"
+    );
+    for encoder in [
+        "vah264enc",
+        "nvcudah264enc",
+        "nvautogpuh264enc",
+        "nvh264enc",
+    ] {
         assert!(
-            exec_pre.contains("vah264enc"),
-            "{name}: ExecStartPre must probe `vah264enc` (Intel/AMD VA-API — \
-             prod N100). The `va` plugin can register without features so a \
-             generic plugin check is insufficient (#339). Line: {exec_pre}"
-        );
-        assert!(
-            exec_pre.contains("nvh264enc"),
-            "{name}: ExecStartPre must ALSO probe `nvh264enc` (Nvidia NVENC — \
-             dev2 RTX). Without this branch the dev deploy unit-loops on a \
-             machine with Nvidia GPU because vah264enc never registers there \
-             (caught 2026-05-24 in CI run 26367361768 — #339 hotfix). \
-             Line: {exec_pre}"
+            gate.contains(encoder),
+            "the encoder gate must probe `{encoder}` — the server can select it \
+             (presenter_ndi::H264_ENCODER_CANDIDATES), so a gate that ignores it either \
+             stalls the start (waiting for an encoder that will never register) or lets \
+             the binary exec before the one it WILL use is ready (#339, #541)"
         );
     }
 }

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -13,13 +13,10 @@ Group=newlevel
 # relying on a console-login ACL (see presenter.service for the full incident).
 SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter-dev
-# #339: gate start on hardware H264 encoder being probeable. Mirrors
-# prod presenter.service; see that file for the full incident
-# context. Probes EITHER vah264enc (prod N100 Intel) OR nvh264enc
-# (dev2 RTX Nvidia). Leading `-` makes the gate non-fatal — if no
-# GPU is available at all, presenter still starts for non-NDI
-# features and item 6 skips NDI auto-restore.
-ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 --exists vah264enc || gst-inspect-1.0 --exists nvh264enc; do sleep 1; done'
+# #339/#539: encoder-ready gate — same script as prod (see presenter.service for the
+# full incident context). It skips the wait when the host has no usable GPU and knows
+# the modern nvcodec encoders (#541); it always exits 0.
+ExecStartPre=-/opt/presenter-dev/wait-for-h264-encoder.sh
 ExecStart=/opt/presenter-dev/presenter-server
 Restart=always
 RestartSec=5

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -26,28 +26,15 @@ Group=newlevel
 # grant belongs HERE so GPU access never depends on who happens to be logged in.
 SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter
-# #339: gate start on hardware H264 encoder being probeable. The race
-# that took prod down on 2026-05-24 (and reproduced on cold-reboot of
-# PR #334, 17:07 CEST) is: After=dev-dri-renderD128.device fires as
-# soon as udev creates the node, but the i915/VA-API features can
-# take 30-50s longer to register. Without this gate, item 1's
-# registry rescan runs against an empty va plugin and item 6's gate
-# skips auto-restore (correct safety behaviour, but operator still
-# has to manually restart 50s later). Polling gst-inspect-1.0 in a
-# 1s loop capped at 30s by `timeout` closes the race: systemd will
-# not exec the presenter binary until the encoder is visible to the
-# same probe presenter_ndi::hw_h264_encoder() uses at startup.
-#
-# Probe BOTH vah264enc (Intel/AMD VA-API — prod N100) AND nvh264enc
-# (Nvidia NVENC — dev2 RTX). The encoder probe inside presenter
-# returns the first one it finds; the gate matches that semantic.
-#
-# The leading `-` makes failures non-fatal: if the 30s timeout
-# expires (no GPU at all, BIOS disabled, kernel issue), systemd
-# still starts presenter so non-NDI features (lyrics, Bible,
-# timers, stage display) remain available. Item 6's encoder gate
-# then skips NDI auto-restore.
-ExecStartPre=-/usr/bin/timeout 30 sh -c 'until gst-inspect-1.0 --exists vah264enc || gst-inspect-1.0 --exists nvh264enc; do sleep 1; done'
+# #339/#539: wait until the H264 encoder the server will use is registered, so we
+# never start into the udev-fires-before-VA-API-registers window that took prod down
+# on 2026-05-24. The gate lives in a script (deployed alongside the binary) because it
+# also has to SKIP the wait on a host that can never satisfy it — no GPU, or a render
+# node the service user cannot open — instead of burning the full 30s on every start
+# (#539), and because it must know the modern nvcodec encoders (#541). The script
+# always exits 0: a missing encoder costs NDI, not the whole service. Leading `-` keeps
+# an older host (script not yet deployed) starting too.
+ExecStartPre=-/opt/presenter/wait-for-h264-encoder.sh
 ExecStart=/opt/presenter/presenter-server
 Restart=always
 RestartSec=5
@@ -56,11 +43,13 @@ RestartSec=5
 Environment=PRESENTER_PORT=80
 Environment=PRESENTER_DB_URL=sqlite:///opt/presenter/presenter.db
 Environment=PRESENTER_LIBRARY_ROOT=/opt/presenter/libraries
-# #404: stage URL the launcher opens on every Android stage display. The
-# launcher fires `am start -a VIEW -d <this URL> <package>` on each TV. Prod
-# points at its own /stage. If unset the launcher warns and skips (no broken
-# intent).
-Environment=PRESENTER_ANDROID_STAGE_URL=http://10.77.9.205/stage
+# #404/#538: PRESENTER_ANDROID_STAGE_URL — the URL the launcher opens on every
+# Android stage display (`am start -a VIEW -d <url> <package>`) — is PER SITE and is
+# therefore NOT set here. This unit is shared by every site (SNV prod, PP, any future
+# location); baking one site's URL into it meant a site deployed without an override
+# silently pointed its TVs at SNV's server. Each deploy writes its own
+# `presenter.service.d/stage-url.conf` drop-in instead (deploy.yml → SNV,
+# release.yml → PP). If it is unset the launcher warns and skips — no broken intent.
 # #472: the Presenter Stage APK the watchdog installs on any TV that needs our
 # own app (so the stage runs on every Android TV without a kiosk browser).
 Environment=PRESENTER_ANDROID_STAGE_APK=/opt/presenter/presenter-stage.apk

--- a/scripts/deploy/wait-for-h264-encoder.sh
+++ b/scripts/deploy/wait-for-h264-encoder.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Encoder-ready gate for presenter.service / presenter-dev.service (#339, #539, #541).
+#
+# WHY IT EXISTS (#339): `After=dev-dri-renderD128.device` fires as soon as udev creates
+# the node, but the i915 / VA-API features can take another 30-50s to register. Starting
+# presenter into that window left it with no encoder and NDI down until a manual restart
+# (prod incident 2026-05-24). So the unit waits here until the encoder the server will
+# actually use is visible to the SAME probe the server uses.
+#
+# WHY IT CHANGED (#539): the old inline `until gst-inspect-1.0 --exists vah264enc || …`
+# burned the FULL 30s timeout on any host that can never satisfy it — a host with no GPU,
+# or (the PP case, #540) one where the service user cannot open the render node. Every
+# start paid 30s for nothing. Now we check that a render node exists AND is openable
+# first, and skip the wait outright when it is not: there is nothing to wait for.
+#
+# WHY THE ENCODER LIST CHANGED (#541): NVIDIA 595 killed the legacy `nvh264enc`
+# ("Selected preset not supported"), so a current NVIDIA host registers only the modern
+# nvcodec elements. Waiting for the legacy name alone would burn the timeout on a
+# perfectly healthy box.
+#
+# ALWAYS EXITS 0. A missing encoder is not fatal — the server starts and serves lyrics,
+# Bible, timers and the stage display without NDI, and logs why (see presenter_ndi::gpu).
+#
+# Testable without a GPU: `PRESENTER_RENDER_NODE` / `PRESENTER_ENCODER_WAIT_SECS` are
+# injectable and the encoder probe goes through `gst-inspect-1.0` on PATH.
+# See tests/deploy/deploy-config.test.sh.
+
+RENDER_NODE="${PRESENTER_RENDER_NODE:-/dev/dri/renderD128}"
+WAIT_SECS="${PRESENTER_ENCODER_WAIT_SECS:-30}"
+
+# Priority order mirrors presenter_ndi::H264_ENCODER_CANDIDATES (minus the software
+# fallback, which needs no GPU and therefore no wait).
+ENCODERS=(vah264enc nvcudah264enc nvautogpuh264enc nvh264enc)
+
+if [ ! -e "$RENDER_NODE" ]; then
+  echo "encoder-gate: no render node at $RENDER_NODE — no GPU on this host, not waiting"
+  exit 0
+fi
+
+if [ ! -r "$RENDER_NODE" ] || [ ! -w "$RENDER_NODE" ]; then
+  echo "encoder-gate: $RENDER_NODE is not openable by $(id -un) — the service user needs" \
+    "the 'render' group (systemd: SupplementaryGroups=render, see #540). Not waiting:" \
+    "no encoder can register without access to the device."
+  exit 0
+fi
+
+deadline=$((SECONDS + WAIT_SECS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  for encoder in "${ENCODERS[@]}"; do
+    if gst-inspect-1.0 --exists "$encoder"; then
+      echo "encoder-gate: $encoder registered — starting presenter"
+      exit 0
+    fi
+  done
+  sleep 1
+done
+
+echo "encoder-gate: no H264 encoder registered within ${WAIT_SECS}s (tried: ${ENCODERS[*]})." \
+  "Starting presenter anyway — NDI will be unavailable until an encoder appears."
+exit 0

--- a/tests/deploy/deploy-config.test.sh
+++ b/tests/deploy/deploy-config.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Deploy-configuration guards (#538, #539).
+#
+# These assert the SHAPE of what we ship to the hosts — the class of bug that CI
+# never catches because it lives in the unit file and the deploy workflow, not in
+# the Rust:
+#
+#   #538  The shared `presenter.service` must not hardcode ONE site's stage URL.
+#         It did (SNV's), so PP had to override it with a drop-in and every future
+#         site that forgets one silently points its TVs at SNV.
+#
+#   #539  The encoder-ready gate must not burn its full timeout on a host that can
+#         never satisfy it (no GPU / no access), and it must recognise the MODERN
+#         nvcodec encoders (#541) — not just the legacy element.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WAIT_SCRIPT="$REPO_ROOT/scripts/deploy/wait-for-h264-encoder.sh"
+PROD_UNIT="$REPO_ROOT/scripts/deploy/presenter.service"
+DEV_UNIT="$REPO_ROOT/scripts/deploy/presenter-dev.service"
+
+failures=0
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    echo "  ok   — $name"
+  else
+    echo "  FAIL — $name"
+    failures=$((failures + 1))
+  fi
+}
+
+# ── #538: no site URL baked into the shared unit ────────────────────────────────
+not_hardcoding_stage_url() {
+  ! grep -qE '^Environment=PRESENTER_ANDROID_STAGE_URL=' "$PROD_UNIT"
+}
+
+prod_deploy_writes_stage_url_dropin() {
+  grep -q 'stage-url.conf' "$REPO_ROOT/.github/workflows/deploy.yml"
+}
+
+pp_release_writes_stage_url_dropin() {
+  grep -q 'stage-url.conf' "$REPO_ROOT/.github/workflows/release.yml"
+}
+
+# ── #539: the encoder-ready gate ───────────────────────────────────────────────
+# The script is driven entirely by env vars so it can be tested without a GPU:
+#   PRESENTER_RENDER_NODE     — path to probe instead of /dev/dri/renderD128
+#   PRESENTER_ENCODER_WAIT_SECS — timeout
+# and it finds encoders via `gst-inspect-1.0` on PATH, which we stub below.
+
+stub_gst_inspect() {
+  # $1 = space-separated list of encoder names that "exist"
+  local dir="$1" available="$2"
+  mkdir -p "$dir"
+  cat >"$dir/gst-inspect-1.0" <<EOF
+#!/usr/bin/env bash
+# stub: only the --exists form is used by the gate
+for e in $available; do [ "\$2" = "\$e" ] && exit 0; done
+exit 1
+EOF
+  chmod +x "$dir/gst-inspect-1.0"
+}
+
+exits_fast_without_a_render_node() {
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_inspect "$tmp/bin" ""
+  local start=$SECONDS
+  PATH="$tmp/bin:$PATH" \
+    PRESENTER_RENDER_NODE="$tmp/definitely-not-a-render-node" \
+    PRESENTER_ENCODER_WAIT_SECS=30 \
+    bash "$WAIT_SCRIPT" >/dev/null 2>&1
+  local rc=$?
+  local elapsed=$((SECONDS - start))
+  rm -rf "$tmp"
+  # The whole point of #539: a GPU-less host must not sit through the timeout —
+  # and it must still let the service start (rc 0), just without NDI.
+  [ "$rc" -eq 0 ] && [ "$elapsed" -lt 5 ]
+}
+
+exits_fast_when_the_node_is_not_accessible() {
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_inspect "$tmp/bin" ""
+  # A node that exists but this user cannot write — the #540 shape.
+  install -m 000 /dev/null "$tmp/renderD128"
+  local start=$SECONDS
+  PATH="$tmp/bin:$PATH" \
+    PRESENTER_RENDER_NODE="$tmp/renderD128" \
+    PRESENTER_ENCODER_WAIT_SECS=2 \
+    bash "$WAIT_SCRIPT" >/dev/null 2>&1
+  local rc=$?
+  local elapsed=$((SECONDS - start))
+  rm -rf "$tmp"
+  # Non-root: the gate sees it cannot open the node and skips at once. Root can
+  # open anything, so it falls through to the (short) bounded wait instead — both
+  # must exit 0 and neither may hang.
+  [ "$rc" -eq 0 ] && [ "$elapsed" -lt 5 ]
+}
+
+waits_and_succeeds_when_an_encoder_is_present() {
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_inspect "$tmp/bin" "vah264enc"
+  install -m 666 /dev/null "$tmp/renderD128"
+  PATH="$tmp/bin:$PATH" \
+    PRESENTER_RENDER_NODE="$tmp/renderD128" \
+    PRESENTER_ENCODER_WAIT_SECS=5 \
+    bash "$WAIT_SCRIPT" >/dev/null 2>&1
+  local rc=$?
+  rm -rf "$tmp"
+  [ "$rc" -eq 0 ]
+}
+
+accepts_the_modern_nvcodec_encoder() {
+  # #541: the gate used to poll ONLY vah264enc / nvh264enc. On a driver where the
+  # legacy element is dead, the modern one is the encoder we will actually use, so
+  # waiting for the legacy name would burn the whole timeout on a perfectly good host.
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_inspect "$tmp/bin" "nvcudah264enc"
+  install -m 666 /dev/null "$tmp/renderD128"
+  local start=$SECONDS
+  PATH="$tmp/bin:$PATH" \
+    PRESENTER_RENDER_NODE="$tmp/renderD128" \
+    PRESENTER_ENCODER_WAIT_SECS=20 \
+    bash "$WAIT_SCRIPT" >/dev/null 2>&1
+  local rc=$?
+  local elapsed=$((SECONDS - start))
+  rm -rf "$tmp"
+  [ "$rc" -eq 0 ] && [ "$elapsed" -lt 5 ]
+}
+
+both_units_use_the_gate_script() {
+  grep -q 'wait-for-h264-encoder.sh' "$PROD_UNIT" && grep -q 'wait-for-h264-encoder.sh' "$DEV_UNIT"
+}
+
+echo "Deploy-config guards (#538, #539):"
+check "#538 shared unit does not hardcode a site stage URL" not_hardcoding_stage_url
+check "#538 prod deploy writes its own stage-url drop-in" prod_deploy_writes_stage_url_dropin
+check "#538 PP release writes its own stage-url drop-in" pp_release_writes_stage_url_dropin
+check "#539 gate exits fast when there is no render node" exits_fast_without_a_render_node
+check "#539 gate exits fast when the render node is inaccessible" exits_fast_when_the_node_is_not_accessible
+check "#539 gate succeeds once an encoder is registered" waits_and_succeeds_when_an_encoder_is_present
+check "#539 gate accepts the modern nvcodec encoder (#541)" accepts_the_modern_nvcodec_encoder
+check "#539 both deployed units call the gate script" both_units_use_the_gate_script
+
+if [ "$failures" -ne 0 ]; then
+  echo "Deploy-config guards: $failures FAILED"
+  exit 1
+fi
+echo "Deploy-config guards: all passed"


### PR DESCRIPTION
The last two defects found while verifying PP after the v0.4.191 release. Both live in what we SHIP to
the hosts (unit file + deploy workflow), which is why no Rust test ever caught them.

## #538 — the shared unit hardcoded ONE site's stage URL

`presenter.service` is deployed to every location, and it carried
`Environment=PRESENTER_ANDROID_STAGE_URL=http://10.77.9.205/stage` — SNV's. PP had to override it with
a drop-in; any future site that forgets one silently points its stage TVs at SNV's server, which looks
exactly like a working deploy. It also left PP showing two conflicting values in `systemctl cat`, which
is what sent the original investigation down the wrong path.

(Correction to my first write-up on the issue: systemd applies drop-ins deterministically after the
main unit, so PP's value was never at risk of flipping. The defect is the site-specific value living in
a shared file at all.)

Fix: the URL leaves the committed unit; every deploy writes its own `presenter.service.d/stage-url.conf`
— `deploy.yml` → SNV (`vars.PROD_STAGE_URL`), `release.yml` → PP (`vars.PP_STAGE_URL`). Same values as
today, now owned by the deploy that knows the site.

## #539 — the encoder-ready gate stalled every start it could never satisfy

The `ExecStartPre` gate polled `gst-inspect-1.0 --exists vah264enc || nvh264enc` for a full 30s. On a
host that can never register either — no GPU, or (the PP case, #540) a render node the service user
cannot open — that is 30s of dead wait on every single start. And after #541 it was waiting for the
wrong names anyway: a current NVIDIA driver provides only the modern nvcodec elements.

Fix: the gate moves into `scripts/deploy/wait-for-h264-encoder.sh`, which
- skips immediately when there is no render node, or the service user cannot open it (naming the
  render-group fix from #540 in its message),
- polls for every encoder the server can actually select, including the modern nvcodec ones,
- always exits 0 — a missing encoder costs NDI, never lyrics/Bible/timers/stage.

Measured on dev2 after this deploy: `encoder-gate: nvcudah264enc registered — starting presenter`, in
29ms instead of 30s.

## Tests

- `tests/deploy/deploy-config.test.sh` (new, wired into the Test job): 8 guards — the unit carries no
  site URL, both deploys write a drop-in, the gate exits fast with no render node / an inaccessible
  one, succeeds once an encoder registers, accepts the modern nvcodec element, and both units call it.
  All 8 fail on the parent commit.
- The existing `presenter_service_blocks_start_until_h264_encoder_probeable` unit test is retargeted at
  the new shape: the unit must CALL the gate, and the gate must probe every candidate the server can
  select (`presenter_ndi::H264_ENCODER_CANDIDATES`) — strengthened, not relaxed.
- Full pipeline green, including the e2e-ndi lane on the real GPU.
- Live on dev after deploy: gate fires in 29ms, encoder `nvcudah264enc`, dev serves v0.4.193.

## Deploy note

Merging deploys to production (restarts `presenter.service` there) and writes SNV's stage-url drop-in.
PP picks all of this up at the release that follows.

Closes #538
Closes #539
