### PR TITLE
Fix the last PP NDI blocker: a stale GStreamer registry cached 'no encoder' forever

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -357,6 +357,7 @@ jobs:
           PROD_STAGE_URL="${{ vars.PROD_STAGE_URL || 'http://10.77.9.205/stage' }}"
           ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
             sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
+            sudo rm -f /opt/presenter/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
             printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PROD_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
             sudo systemctl daemon-reload"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1158,6 +1158,7 @@ jobs:
           scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
           ssh deploy-target "sudo cp /tmp/presenter-dev.service /etc/systemd/system/ && \
             sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter-dev/wait-for-h264-encoder.sh && \
+            sudo rm -f /opt/presenter-dev/gstreamer-registry.bin && \
             sudo systemctl daemon-reload"
 
       # #502: write the Cloudflare Realtime TURN credentials to a 0600 root-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,7 @@ jobs:
           PP_STAGE_URL="${{ vars.PP_STAGE_URL || 'http://10.77.8.205/stage' }}"
           ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
             sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
+            sudo rm -f /opt/presenter/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
             printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PP_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
             sudo systemctl daemon-reload"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.193"
+version = "0.4.194"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.193"
+version = "0.4.194"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/gpu.rs
+++ b/crates/presenter-ndi/src/gpu.rs
@@ -66,9 +66,18 @@ pub fn missing_encoder_hint(access: RenderNodeAccess) -> &'static str {
              so NDI WebRTC cannot be hardware-encoded here."
         }
         RenderNodeAccess::Accessible => {
-            "the GPU render node is reachable, so the encoder plugins are missing: install \
-             Intel VA-API (gstreamer1.0-vaapi + intel-media-va-driver-non-free) OR NVIDIA \
-             NVENC (gstreamer1.0-plugins-bad with nvcodec)."
+            // #544: the FIRST candidate here is a stale registry, not a missing package.
+            // PP had every driver package installed and a reachable render node, and NDI
+            // was still dead: its GStreamer registry cached "va has 0 features" from back
+            // when the service could not open the GPU, and GST_REGISTRY_UPDATE=yes never
+            // re-scans a plugin whose FILE has not changed. Lead with that.
+            "the GPU render node is reachable, so either (a) the GStreamer plugin registry \
+             is STALE — it can cache 'no encoder' from a time when the GPU was unreachable, \
+             and it is NOT re-scanned just because permissions changed: delete the file in \
+             GST_REGISTRY (the service owns one in its deploy dir) and restart — or (b) the \
+             encoder plugins really are missing: install Intel VA-API (gstreamer1.0-vaapi + \
+             intel-media-va-driver-non-free) OR NVIDIA NVENC (gstreamer1.0-plugins-bad with \
+             nvcodec)."
         }
     }
 }

--- a/crates/presenter-ndi/src/gpu.rs
+++ b/crates/presenter-ndi/src/gpu.rs
@@ -111,6 +111,28 @@ mod tests {
         );
     }
 
+    /// #544: when the render node IS reachable and there is still no encoder, the
+    /// most likely cause on our hosts is a STALE GStreamer registry cache — PP had
+    /// one that recorded "va has 0 features" from back when the service could not
+    /// open the GPU, and `GST_REGISTRY_UPDATE=yes` never re-scans a plugin whose
+    /// FILE has not changed. The old hint only advised installing packages, which on
+    /// PP were all present; that sent the investigation the wrong way for hours.
+    #[test]
+    fn hint_for_a_reachable_node_names_the_stale_registry_cache() {
+        let hint = missing_encoder_hint(RenderNodeAccess::Accessible);
+        assert!(
+            hint.contains("registry"),
+            "the hint must name a stale plugin registry as a candidate cause (#544): {hint}"
+        );
+        assert!(
+            hint.contains("GST_REGISTRY"),
+            "the hint must name the GST_REGISTRY the service owns, so the reader can \
+             clear it (#544): {hint}"
+        );
+        // …and still mention the packages, which remain the other candidate.
+        assert!(hint.contains("gstreamer1.0-vaapi"));
+    }
+
     #[test]
     fn hint_for_an_unopenable_node_blames_access_not_packages() {
         // The #540 lesson: the old warning sent us hunting for packages that were

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -32,6 +32,9 @@ Environment=PRESENTER_ANDROID_STAGE_URL=http://10.77.8.134:8080/stage
 # app. Dev deploys to /opt/presenter-dev (the default path is /opt/presenter).
 Environment=PRESENTER_ANDROID_STAGE_APK=/opt/presenter-dev/presenter-stage.apk
 Environment=RUST_LOG=info,tower_http=debug
+# #544: service-owned GStreamer registry inside the writable deploy dir, deleted by
+# every deploy — a $HOME cache goes stale and can never recover (see presenter.service).
+Environment=GST_REGISTRY=/opt/presenter-dev/gstreamer-registry.bin
 # Offset integration ports to avoid conflicts with production
 Environment=PRESENTER_COMPANION_ENABLED=0
 Environment=PRESENTER_COMPANION_PORT=28175

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -54,6 +54,15 @@ Environment=PRESENTER_LIBRARY_ROOT=/opt/presenter/libraries
 # own app (so the stage runs on every Android TV without a kiosk browser).
 Environment=PRESENTER_ANDROID_STAGE_APK=/opt/presenter/presenter-stage.apk
 Environment=RUST_LOG=info,tower_http=debug
+# #544: the service owns its GStreamer plugin registry, inside its (writable) deploy
+# dir. It used to land in $HOME/.cache, where it became a permanent lie: PP's cache
+# recorded "va has 0 features" back when the service could not open the GPU, and
+# GST_REGISTRY_UPDATE=yes only re-scans plugins whose FILE changed — the plugin never
+# changed, only our permissions did — so NDI stayed dead even after #540 granted
+# access. ProtectHome=read-only meant the service could not even rewrite it. Here the
+# file is under ReadWritePaths, and every deploy DELETES it, so the next start always
+# re-probes the plugins against the host's current permissions and driver.
+Environment=GST_REGISTRY=/opt/presenter/gstreamer-registry.bin
 # #502: Cloudflare Realtime TURN credentials. Kept OUT of this committed unit
 # (secret) — the deploy writes a 0600 root-only EnvironmentFile. Leading `-`
 # makes it optional: absent → TURN disabled (LAN-only), service still starts.

--- a/tests/deploy/deploy-config.test.sh
+++ b/tests/deploy/deploy-config.test.sh
@@ -12,6 +12,13 @@
 #   #539  The encoder-ready gate must not burn its full timeout on a host that can
 #         never satisfy it (no GPU / no access), and it must recognise the MODERN
 #         nvcodec encoders (#541) — not just the legacy element.
+#
+#   #544  The GStreamer plugin registry must not outlive a permission/driver change.
+#         PP cached "va has 0 features" back when the service could not open the GPU;
+#         GST_REGISTRY_UPDATE=yes only rescans plugins whose FILE changed, so that
+#         verdict was trusted forever and NDI stayed dead even after #540 restored
+#         access. The service therefore owns a registry inside its (writable) deploy
+#         dir, and every deploy deletes it so the next start rescans against reality.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -137,6 +144,23 @@ both_units_use_the_gate_script() {
   grep -q 'wait-for-h264-encoder.sh' "$PROD_UNIT" && grep -q 'wait-for-h264-encoder.sh' "$DEV_UNIT"
 }
 
+# ── #544: the registry must be service-owned, writable and rebuilt on deploy ────
+units_own_a_writable_gst_registry() {
+  # The path must sit inside the unit's ReadWritePaths (its deploy dir), NOT in
+  # $HOME — ProtectHome=read-only makes a $HOME cache unfixable once it goes stale.
+  grep -qE '^Environment=GST_REGISTRY=/opt/presenter/' "$PROD_UNIT" &&
+    grep -qE '^Environment=GST_REGISTRY=/opt/presenter-dev/' "$DEV_UNIT"
+}
+
+every_deploy_rebuilds_the_registry() {
+  # Deleting the registry file is what guarantees the next start re-probes the
+  # plugins against the CURRENT permissions/driver. Without it, #544 comes back the
+  # first time a host's GPU access or driver changes.
+  grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/deploy.yml" &&
+    grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/release.yml" &&
+    grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/pipeline.yml"
+}
+
 echo "Deploy-config guards (#538, #539):"
 check "#538 shared unit does not hardcode a site stage URL" not_hardcoding_stage_url
 check "#538 prod deploy writes its own stage-url drop-in" prod_deploy_writes_stage_url_dropin
@@ -146,6 +170,8 @@ check "#539 gate exits fast when the render node is inaccessible" exits_fast_whe
 check "#539 gate succeeds once an encoder is registered" waits_and_succeeds_when_an_encoder_is_present
 check "#539 gate accepts the modern nvcodec encoder (#541)" accepts_the_modern_nvcodec_encoder
 check "#539 both deployed units call the gate script" both_units_use_the_gate_script
+check "#544 units own a writable GST_REGISTRY in their deploy dir" units_own_a_writable_gst_registry
+check "#544 every deploy rebuilds the plugin registry" every_deploy_rebuilds_the_registry
 
 if [ "$failures" -ne 0 ]; then
   echo "Deploy-config guards: $failures FAILED"


### PR DESCRIPTION
The last layer of the PP no-NDI-video bug. #540 gave the service GPU access — and PP *still* had no
video, now logging "no hardware H264 encoder" with `access=Accessible`.

## Root cause — a GStreamer registry that outlives the world it described

The service read `~/.cache/gstreamer-1.0/registry.x86_64.bin`, **dated Jun 24**: written back when it
could not open the render node, so it recorded **`va` = 0 features**. That verdict was then trusted
forever, because:

- **`GST_REGISTRY_UPDATE=yes` does not force a rescan.** It re-scans plugins whose FILE changed. Our
  plugin never changed — only our *permissions* did. (The #333 hardening was aimed at this family of
  bug and does not cover this case.)
- `ProtectHome=read-only` meant the service could not even rewrite the cache.

Proven on PP with the service's exact uid + supplementary groups (`systemd-run --uid=newlevel
--property=SupplementaryGroups="render video"`):

| run | `va` features |
|---|---|
| stale cache (what the service did) | **0** |
| fresh `GST_REGISTRY` | **14** |
| fresh registry, no groups | 0 |

and `vainfo` on the box shows the Intel iHD driver with `VAEntrypointEncSlice` — the hardware and the
packages were never the problem. Production escaped this only by luck: its cache happened to be built
while the console-login ACL granted GPU access.

## Fix

- Both units: `Environment=GST_REGISTRY=<deploy dir>/gstreamer-registry.bin` — inside `ReadWritePaths`,
  so the service owns and can maintain it, and out of the read-only `$HOME` where a stale cache is
  unfixable.
- All three deploys (prod, PP release, dev) delete that file, so the next start always re-probes the
  plugins against the host's current permissions and driver. A future GPU/driver/permission change can
  no longer be masked by a cached verdict.
- The no-encoder warning now leads with the stale registry when the render node IS reachable, instead
  of advising packages that are already installed — the exact wrong turn this investigation took.

## Tests

- `tests/deploy/deploy-config.test.sh`: two new guards — the units must own a writable `GST_REGISTRY`
  in their deploy dir, and every deploy must rebuild it. Both fail on the parent commit.
- `gpu.rs`: the `Accessible` hint must name the stale registry and `GST_REGISTRY`. Fails on the parent.
- Full pipeline green (one Playwright shard was rerun after a `Failed to install chrome` runner
  infra error — the browser download, not the diff).
- Live on dev after deploy: registry rebuilt at deploy time, `encoder-gate: nvcudah264enc registered`,
  server serving v0.4.194.

Closes #544
