### PR TITLE
fix(ndi,deploy): make the encoder-ready gate actually gate (#547) + stop caching a missing encoder (#548)

### DIFF
--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -357,6 +357,28 @@ curl -s http://$H/healthz | jq .ndi_pipelines      # [] = nothing producing; [{s
 by the auto-reconnect loop even when the NDI source is silent. Proof of flow is
 `healthz.ndi_pipelines[].state == "streaming"`, nothing less.
 
+### `gst-inspect --exists` answers from the registry CACHE — it is not a plugin scan (#547)
+
+This burned a whole class of "fix" that could never have worked, so keep it in mind for anything
+that polls GStreamer:
+
+- `gst-inspect-1.0 --exists <element>` is a **lookup in the cached registry file** (`$GST_REGISTRY`),
+  not a plugin load. Measured on dev2: **14 ms warm vs 916 ms cold** (only the cold run emits
+  `vaInitialize`). So a poll loop built on it performs ONE real scan and then re-reads that same
+  verdict — it can **never observe a late-registering encoder**, which is the entire reason a
+  boot-time gate exists.
+- `GST_REGISTRY_UPDATE=yes` does **not** save you: it only rescans plugins whose **file** changed.
+  A permission change (#540) or a driver change leaves the plugin file untouched, so a cached
+  "va has 0 features" verdict survives it forever (that IS #544).
+- **The only way to force a real rescan is to DELETE the registry file** — which is what the
+  encoder gate now does before every poll, and what every deploy does before starting the service.
+- A name lookup also answers a different question than the server asks. Since #541 the server only
+  trusts an encoder after a **real one-frame encode** (`videotestsrc num-buffers=1 ! … ! <enc> !
+  fakesink`). Probe the same way, or the gate green-lights an encoder the server then rejects.
+- Bound every gst call with `timeout`. A wedged driver (#445) makes one hang forever; inside an
+  `ExecStartPre` that hangs the unit past `TimeoutStartSec` and **fails the whole service** — the
+  `-` prefix only ignores a non-zero exit, not a start timeout.
+
 ### Probing WHEP yourself: use `channel: "chrome"`, never bundled Chromium
 
 Playwright's bundled Chromium has **no H264** — the server correctly rejects its offer with

--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -324,3 +324,61 @@ registers **zero** elements, and NDI dies silently with every driver package ins
 the systemd-logind console ACL (`getfacl /dev/dri/renderD128` showing `user:<u>:rw-`) — it exists only
 while somebody is logged in at the physical console, and it is what made prod *look* healthy while PP
 was dead. Check with `gst-inspect-1.0 va | grep -c '^  va'` (0 = no access).
+
+## "No video on the stage" — triage in the order the layers actually fail (#544, #546)
+
+Four independent layers must ALL hold, and each fails silently. Walk them in THIS order — the PP
+outage cost hours because the investigation kept re-checking layer 3 while layer 1 was the cause,
+and then declared victory at layer 3 while layer 4 was the real remaining blocker.
+
+```bash
+H=companion-pp.lan   # or presenter.lan / 10.77.8.134:8080
+
+# 1. Can the service reach the GPU?  (#540 — zero features = no render-group access)
+ssh $H "sudo -u newlevel GST_REGISTRY=/opt/presenter/gstreamer-registry.bin gst-inspect-1.0 va | grep -c '^  va'"
+
+# 2. Did an encoder actually get SELECTED at startup?  (#541 / #544)
+ssh $H "sudo journalctl -u presenter -b --no-pager | grep -E 'encoder-gate|WebRTC encoder|no hardware'"
+#    "encoder-gate: vah264enc registered" + "NDI WebRTC encoder: vah264enc" = layers 1+2 green.
+
+# 3. Is the NDI source the operator mapped ACTUALLY BROADCASTING?  ← the one that is easy to miss
+curl -s http://$H/ndi/sources                      # what is on the network RIGHT NOW
+curl -s http://$H/integrations/video-sources       # what is mapped
+curl -s http://$H/healthz | jq .ndi_pipelines      # [] = nothing producing; [{state:"streaming"}] = live
+#    Mapped name absent from /ndi/sources → the SENDING machine is off/renamed. Not our bug, and no
+#    amount of server-side debugging will fix it. The log says so:
+#    "NDI source activated but not yet producing — broadcaster silent (#448)".
+#    The UI does not surface this yet — that gap is #546.
+
+# 4. Does the BROWSER decode it?  (Chromium ≠ Chrome — see below)
+```
+
+**A "pipeline built" log line does NOT mean video is flowing.** The pipeline is (re)built every ~30 s
+by the auto-reconnect loop even when the NDI source is silent. Proof of flow is
+`healthz.ndi_pipelines[].state == "streaming"`, nothing less.
+
+### Probing WHEP yourself: use `channel: "chrome"`, never bundled Chromium
+
+Playwright's bundled Chromium has **no H264** — the server correctly rejects its offer with
+`WHEP offer carries no H264 rtpmap — rejecting consumer`, which reads like a server fault and is not.
+Launch real Chrome (same as `playwright.config.ts` does) and read the decoded-frame count:
+
+```js
+const browser = await chromium.launch({ channel: 'chrome', args: ['--autoplay-policy=no-user-gesture-required'] });
+// … page.goto('http://<host>/stage'); wait ~15 s
+const v = document.querySelector('video');          // in page.evaluate
+v.videoWidth /* 1280 */, v.getVideoPlaybackQuality().totalVideoFrames /* > 0 */
+```
+
+To verify the chain WITHOUT a live broadcaster (e.g. to prove a build before an event), publish the
+synthetic source and map it — this is exactly what the `e2e-ndi` lane does:
+
+```bash
+NDI_RUNTIME_DIR_V6=/usr/lib/ndi PRESENTER_NDI_TEST_NAME=PRESENTER-TEST \
+  cargo run -p presenter-ndi --features test-helpers --bin ndi_test_sender &
+# it appears as "DEV2 (PRESENTER-TEST)"; POST it to /integrations/video-sources, then
+# POST /integrations/video-sources/<id>/activate   ← activation is a POST to /activate, NOT a PATCH
+```
+
+Clean up afterwards (`/deactivate`, `DELETE` the source, pid-targeted `kill` of the sender — never
+`pkill -f`, it matches your own shell).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -366,6 +366,13 @@ jobs:
             sudo rm -f ${{ env.DEPLOY_DIR }}/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
             sudo systemctl daemon-reload"
+          # A newline in the variable would inject arbitrary [Service] directives into the
+          # drop-in — accept only a single-line http(s) URL.
+          case "$PROD_STAGE_URL" in
+            *[$'\n\r']* | '') echo "::error::PROD_STAGE_URL must be a single-line URL"; exit 1 ;;
+            http://* | https://*) ;;
+            *) echo "::error::PROD_STAGE_URL must start with http:// or https://"; exit 1 ;;
+          esac
           printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' "$PROD_STAGE_URL" |
             ssh deploy-target "sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && sudo systemctl daemon-reload"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -348,19 +348,26 @@ jobs:
           REMOTE_SCRIPT
 
       - name: Deploy systemd service
+        env:
+          # #538: the stage URL is PER SITE and no longer lives in the shared unit —
+          # each deploy writes its own drop-in. SNV prod points its TVs at itself.
+          # Passed through `env:` rather than interpolated straight into the shell line:
+          # the value ends up inside a remote ssh command, where a quote in it would run
+          # as a command under passwordless sudo.
+          PROD_STAGE_URL: ${{ vars.PROD_STAGE_URL || 'http://10.77.9.205/stage' }}
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter.service deploy-target:/tmp/presenter.service
           # #539: the encoder-ready gate the unit calls from ExecStartPre.
           scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
-          # #538: the stage URL is PER SITE and no longer lives in the shared unit —
-          # each deploy writes its own drop-in. SNV prod points its TVs at itself.
-          PROD_STAGE_URL="${{ vars.PROD_STAGE_URL || 'http://10.77.9.205/stage' }}"
+          # #544: the service's GStreamer registry must not survive this deploy — a driver
+          # or permission change would otherwise keep being judged by the old cache.
           ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
-            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
-            sudo rm -f /opt/presenter/gstreamer-registry.bin && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh ${{ env.DEPLOY_DIR }}/wait-for-h264-encoder.sh && \
+            sudo rm -f ${{ env.DEPLOY_DIR }}/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
-            printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PROD_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
             sudo systemctl daemon-reload"
+          printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' "$PROD_STAGE_URL" |
+            ssh deploy-target "sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && sudo systemctl daemon-reload"
 
       # #502: write the Cloudflare Realtime TURN credentials to a 0600 root-only
       # EnvironmentFile (the committed unit references it as `EnvironmentFile=-`).

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1156,9 +1156,10 @@ jobs:
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter-dev.service deploy-target:/tmp/presenter-dev.service
           # #539: the encoder-ready gate the unit calls from ExecStartPre.
           scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
+          # #544: the registry must not survive the deploy (see deploy.yml).
           ssh deploy-target "sudo cp /tmp/presenter-dev.service /etc/systemd/system/ && \
-            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter-dev/wait-for-h264-encoder.sh && \
-            sudo rm -f /opt/presenter-dev/gstreamer-registry.bin && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh ${{ env.DEPLOY_DIR }}/wait-for-h264-encoder.sh && \
+            sudo rm -f ${{ env.DEPLOY_DIR }}/gstreamer-registry.bin && \
             sudo systemctl daemon-reload"
 
       # #502: write the Cloudflare Realtime TURN credentials to a 0600 root-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,13 @@ jobs:
             sudo rm -f ${{ env.DEPLOY_DIR }}/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
             sudo systemctl daemon-reload"
+          # A newline in the variable would inject arbitrary [Service] directives into the
+          # drop-in — accept only a single-line http(s) URL.
+          case "$PP_STAGE_URL" in
+            *[$'\n\r']* | '') echo "::error::PP_STAGE_URL must be a single-line URL"; exit 1 ;;
+            http://* | https://*) ;;
+            *) echo "::error::PP_STAGE_URL must start with http:// or https://"; exit 1 ;;
+          esac
           printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' "$PP_STAGE_URL" |
             ssh deploy-target "sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && sudo systemctl daemon-reload"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,20 +353,26 @@ jobs:
           REMOTE_SCRIPT
 
       - name: Deploy systemd service
+        env:
+          # #470/#538: the stage URL is PER SITE and is NOT in the shared unit — each
+          # deploy writes its own drop-in. PP points its TV at PP, not at SNV. Override
+          # the default with the PP_STAGE_URL repo variable if PP's IP changes. Passed
+          # through `env:` rather than interpolated into the shell line: the value ends
+          # up inside a remote ssh command, where a quote in it would run as a command
+          # under passwordless sudo.
+          PP_STAGE_URL: ${{ vars.PP_STAGE_URL || 'http://10.77.8.205/stage' }}
         run: |
           scp -i ~/.ssh/id_deploy scripts/deploy/presenter.service deploy-target:/tmp/presenter.service
           # #539: the encoder-ready gate the unit calls from ExecStartPre.
           scp -i ~/.ssh/id_deploy scripts/deploy/wait-for-h264-encoder.sh deploy-target:/tmp/wait-for-h264-encoder.sh
-          # #470/#538: the stage URL is PER SITE and is NOT in the shared unit — each
-          # deploy writes its own drop-in. PP points its TV at PP, not at SNV. Override
-          # the default with the PP_STAGE_URL repo variable if PP's IP changes.
-          PP_STAGE_URL="${{ vars.PP_STAGE_URL || 'http://10.77.8.205/stage' }}"
+          # #544: the registry must not survive the deploy (see deploy.yml).
           ssh deploy-target "sudo cp /tmp/presenter.service /etc/systemd/system/ && \
-            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh /opt/presenter/wait-for-h264-encoder.sh && \
-            sudo rm -f /opt/presenter/gstreamer-registry.bin && \
+            sudo install -m 0755 /tmp/wait-for-h264-encoder.sh ${{ env.DEPLOY_DIR }}/wait-for-h264-encoder.sh && \
+            sudo rm -f ${{ env.DEPLOY_DIR }}/gstreamer-registry.bin && \
             sudo mkdir -p /etc/systemd/system/presenter.service.d && \
-            printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' '${PP_STAGE_URL}' | sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && \
             sudo systemctl daemon-reload"
+          printf '[Service]\nEnvironment=PRESENTER_ANDROID_STAGE_URL=%s\n' "$PP_STAGE_URL" |
+            ssh deploy-target "sudo tee /etc/systemd/system/presenter.service.d/stage-url.conf >/dev/null && sudo systemctl daemon-reload"
 
       - name: Start service
         # Run even if an earlier step failed (#469): a deploy that stops the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.195"
+version = "0.4.196"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.194"
+version = "0.4.195"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.195"
+version = "0.4.196"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.194"
+version = "0.4.195"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -438,3 +438,130 @@ mod pick_h264_encoder_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod encoder_cache_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn empty_cache() -> Mutex<HashMap<String, EncoderVerdict>> {
+        Mutex::new(HashMap::new())
+    }
+
+    /// #548, the regression. "Element not in the registry" is the TRANSIENT
+    /// boot-race state the encoder gate exists to ride out (#339: VA-API can take
+    /// 30-50s after udev to register `vah264enc`). Caching that verdict for the
+    /// process lifetime freezes it: the server that started a second too early
+    /// would never see the encoder appear, would fall through to software
+    /// `x264enc` — the CPU-melt shape of #335 — and the 30s NDI auto-reconnect
+    /// self-heal (#333 item 6) could never recover it without a restart.
+    #[test]
+    fn a_not_registered_verdict_is_never_cached_so_a_late_plugin_still_heals() {
+        let cache = empty_cache();
+        let calls = AtomicUsize::new(0);
+        // The #339 host: the element is missing on the first probe, registers
+        // before the second.
+        let probe = |_name: &str| {
+            if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                EncoderVerdict::NotRegistered
+            } else {
+                EncoderVerdict::Usable
+            }
+        };
+
+        assert_eq!(
+            cached_encoder_verdict(&cache, "vah264enc", probe),
+            EncoderVerdict::NotRegistered
+        );
+        assert_eq!(
+            cached_encoder_verdict(&cache, "vah264enc", probe),
+            EncoderVerdict::Usable,
+            "a missing element must be RE-PROBED — caching 'not registered' pins the \
+             host on software x264enc for the life of the process (#548)"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "both calls must reach the probe");
+    }
+
+    /// The #541 shape — the element IS registered, the driver refuses to encode
+    /// with it ("Selected preset not supported"). That cannot heal without a
+    /// driver change, which needs a restart anyway, so it stays cached: re-probing
+    /// it would open a fresh NVENC session on every 30s reconnect tick (consumer
+    /// GeForce cards cap concurrent sessions).
+    #[test]
+    fn a_driver_rejection_is_cached_and_not_re_probed() {
+        let cache = empty_cache();
+        let calls = AtomicUsize::new(0);
+        let probe = |_name: &str| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            EncoderVerdict::CannotEncode
+        };
+
+        assert_eq!(
+            cached_encoder_verdict(&cache, "nvh264enc", probe),
+            EncoderVerdict::CannotEncode
+        );
+        assert_eq!(
+            cached_encoder_verdict(&cache, "nvh264enc", probe),
+            EncoderVerdict::CannotEncode
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "a driver-level rejection is stable — probe it once per process"
+        );
+    }
+
+    /// A working encoder does not stop working: cache the positive so the probe
+    /// stays off the 30s reconnect tick.
+    #[test]
+    fn a_usable_verdict_is_cached() {
+        let cache = empty_cache();
+        let calls = AtomicUsize::new(0);
+        let probe = |_name: &str| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            EncoderVerdict::Usable
+        };
+
+        assert_eq!(
+            cached_encoder_verdict(&cache, "vah264enc", probe),
+            EncoderVerdict::Usable
+        );
+        assert_eq!(
+            cached_encoder_verdict(&cache, "vah264enc", probe),
+            EncoderVerdict::Usable
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Verdicts are per element name — a cached `nvh264enc` rejection must not
+    /// answer for `vah264enc`.
+    #[test]
+    fn verdicts_are_keyed_by_encoder_name() {
+        let cache = empty_cache();
+        let probe = |name: &str| {
+            if name == "vah264enc" {
+                EncoderVerdict::Usable
+            } else {
+                EncoderVerdict::CannotEncode
+            }
+        };
+
+        assert_eq!(
+            cached_encoder_verdict(&cache, "nvh264enc", probe),
+            EncoderVerdict::CannotEncode
+        );
+        assert_eq!(
+            cached_encoder_verdict(&cache, "vah264enc", probe),
+            EncoderVerdict::Usable
+        );
+    }
+
+    /// Only `Usable` selects an encoder — both failure verdicts are a "no" to
+    /// `pick_h264_encoder`.
+    #[test]
+    fn only_a_usable_verdict_selects_the_encoder() {
+        assert!(EncoderVerdict::Usable.is_usable());
+        assert!(!EncoderVerdict::CannotEncode.is_usable());
+        assert!(!EncoderVerdict::NotRegistered.is_usable());
+    }
+}

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -185,10 +185,18 @@ fn pick_h264_encoder(
 /// alone then picked an unloadable encoder and the pipeline build failed.
 /// Probing loadability skips it and falls through to a real, loadable encoder.
 ///
-/// Verdicts are memoized SELECTIVELY (`cached_encoder_verdict`): a stable verdict
-/// is cached so the probe stays off the 30 s NDI-reconnect tick, but "the element
-/// is not registered" is re-probed every time — that is the transient boot-race
-/// state, and caching it would freeze the #333 item 6 self-heal (#548).
+/// Verdicts are memoized SELECTIVELY (`cached_encoder_verdict`): a STABLE verdict is
+/// cached so the probe stays off the 30 s NDI-reconnect tick; "the element is not
+/// registered" is not, because that is a fact about the plugin registry rather than
+/// about the encoder, and this process cannot prove it will stay true (#548).
+///
+/// What that does NOT buy: an in-process recovery from the boot race. The plugin
+/// registry is read once at `gst_init()`, and nothing re-scans it afterwards — an
+/// element missing at init stays missing for the life of the process, cached or not.
+/// The boot race is prevented by the ExecStartPre encoder gate
+/// (`scripts/deploy/wait-for-h264-encoder.sh`), which holds the service back until an
+/// encoder really encodes; recovering a host that already started wrong needs the
+/// registry deleted and the service restarted (see `gpu::missing_encoder_hint`).
 pub fn hw_h264_encoder() -> Option<&'static str> {
     pick_h264_encoder(H264_ENCODER_CANDIDATES, encoder_is_usable)
 }
@@ -235,12 +243,17 @@ impl EncoderVerdict {
 
     /// May this verdict be remembered for the life of the process?
     ///
-    /// #548: `NotRegistered` may NOT. It is exactly the state the encoder gate exists
-    /// to ride out (#339: VA-API can register `vah264enc` 30-50 s after udev), so
-    /// caching it freezes a server that started a second too early onto the next
-    /// candidate — in the worst case software `x264enc`, which always works and melts
-    /// the N100's CPU (#335) — and the 30 s NDI auto-reconnect self-heal (#333 item 6)
-    /// can then never recover it without a restart.
+    /// #548: `NotRegistered` may NOT. The other two are facts about the ENCODER — a
+    /// working element does not stop working, and a driver that refuses one cannot
+    /// change its mind without a driver change (which needs a restart anyway). But
+    /// "not in the registry" is a fact about the plugin REGISTRY, whose contents this
+    /// process does not own: remembering it would be recording someone else's state as
+    /// our own. Re-probing it is nearly free (an `ElementFactory::find` miss — never a
+    /// real encode, so no NVENC session is opened on the 30 s reconnect tick).
+    ///
+    /// It is NOT a self-heal: the registry is read once at `gst_init()` and never
+    /// re-scanned, so an element missing at init stays missing for this process either
+    /// way. The gate prevents the race; a restart is what recovers from it.
     fn is_stable(self) -> bool {
         !matches!(self, EncoderVerdict::NotRegistered)
     }
@@ -512,19 +525,18 @@ mod encoder_cache_tests {
         Mutex::new(HashMap::new())
     }
 
-    /// #548, the regression. "Element not in the registry" is the TRANSIENT
-    /// boot-race state the encoder gate exists to ride out (#339: VA-API can take
-    /// 30-50s after udev to register `vah264enc`). Caching that verdict for the
-    /// process lifetime freezes it: the server that started a second too early
-    /// would never see the encoder appear, would fall through to software
-    /// `x264enc` — the CPU-melt shape of #335 — and the 30s NDI auto-reconnect
-    /// self-heal (#333 item 6) could never recover it without a restart.
+    /// #548: "element not in the registry" is a fact about the plugin REGISTRY, not
+    /// about the encoder — this process does not own it and cannot prove it stays
+    /// true, so it is never remembered. (It is NOT an in-process self-heal: the
+    /// registry is read once at `gst_init()` and never re-scanned. The ExecStartPre
+    /// gate prevents the boot race; a restart recovers from it. Re-probing costs an
+    /// `ElementFactory::find` miss, never an encode — so no NVENC session is opened
+    /// on the 30s reconnect tick.)
     #[test]
-    fn a_not_registered_verdict_is_never_cached_so_a_late_plugin_still_heals() {
+    fn a_not_registered_verdict_is_never_cached() {
         let cache = empty_cache();
         let calls = AtomicUsize::new(0);
-        // The #339 host: the element is missing on the first probe, registers
-        // before the second.
+        // A registry that answers "missing" once and then knows the element.
         let probe = |_name: &str| {
             if calls.fetch_add(1, Ordering::SeqCst) == 0 {
                 EncoderVerdict::NotRegistered
@@ -540,8 +552,8 @@ mod encoder_cache_tests {
         assert_eq!(
             cached_encoder_verdict(&cache, "vah264enc", probe),
             EncoderVerdict::Usable,
-            "a missing element must be RE-PROBED — caching 'not registered' pins the \
-             host on software x264enc for the life of the process (#548)"
+            "a missing element must be RE-PROBED, never remembered — the plugin \
+             registry is not ours to record a verdict about (#548)"
         );
         assert_eq!(
             calls.load(Ordering::SeqCst),

--- a/crates/presenter-ndi/src/lib.rs
+++ b/crates/presenter-ndi/src/lib.rs
@@ -129,7 +129,11 @@ pub fn init() -> anyhow::Result<()> {
 /// not supported"), so on a current driver the legacy element registers, builds,
 /// and then dies on the first frame (#541). Software `x264enc` is the last
 /// resort (no session cap, CPU cost only).
-pub(crate) const H264_ENCODER_CANDIDATES: &[&str] = &[
+///
+/// Public so the deploy guards can assert the encoder-ready gate covers exactly the
+/// encoders the server can select — a hand-copied list in the test silently stops
+/// covering a 5th candidate the moment one is added here.
+pub const H264_ENCODER_CANDIDATES: &[&str] = &[
     "vah264enc",
     "nvcudah264enc",
     "nvautogpuh264enc",
@@ -181,12 +185,10 @@ fn pick_h264_encoder(
 /// alone then picked an unloadable encoder and the pipeline build failed.
 /// Probing loadability skips it and falls through to a real, loadable encoder.
 ///
-/// Construction is cheap and side-effect-free: GStreamer element creation only
-/// allocates the GObject — hardware (CUDA/VA display) is opened later at the
-/// READY state transition, not at `build()`. So this stays safe to call on the
-/// 30 s NDI-reconnect tick, and re-probing every call preserves the #333 item 6
-/// self-heal: a host whose registry recovers resumes without a process restart
-/// (so it is intentionally NOT memoized).
+/// Verdicts are memoized SELECTIVELY (`cached_encoder_verdict`): a stable verdict
+/// is cached so the probe stays off the 30 s NDI-reconnect tick, but "the element
+/// is not registered" is re-probed every time — that is the transient boot-race
+/// state, and caching it would freeze the #333 item 6 self-heal (#548).
 pub fn hw_h264_encoder() -> Option<&'static str> {
     pick_h264_encoder(H264_ENCODER_CANDIDATES, encoder_is_usable)
 }
@@ -202,51 +204,106 @@ pub fn hw_h264_encoder() -> Option<&'static str> {
 /// encoder had already been selected. So the probe pushes ONE tiny frame through
 /// the element and only then calls it usable.
 ///
-/// Cost: a 320x240 single-frame encode, on the FIRST query per element name only
-/// — the verdict is cached for the process (`ENCODER_USABILITY` below), because a
-/// driver-level rejection cannot heal without a driver change, which needs a
-/// restart anyway. Caching also keeps this off the 30 s NDI-reconnect tick and,
-/// crucially, stops the probe from opening a second NVENC session while a
-/// pipeline is streaming (consumer GeForce cards cap concurrent sessions).
+/// Cost: a 320x240 single-frame encode, on the FIRST query per element name only —
+/// for a STABLE verdict. Caching keeps this off the 30 s NDI-reconnect tick and,
+/// crucially, stops the probe from opening a second NVENC session while a pipeline
+/// is streaming (consumer GeForce cards cap concurrent sessions).
 fn encoder_is_usable(name: &str) -> bool {
     let cache = ENCODER_USABILITY.get_or_init(|| Mutex::new(HashMap::new()));
+    cached_encoder_verdict(cache, name, probe_encoder_can_encode).is_usable()
+}
+
+/// What a functional probe found out about one encoder element.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EncoderVerdict {
+    /// The element is not in the registry (or cannot be instantiated) — the #443 /
+    /// #339 boot-race shape. TRANSIENT: the plugin may register seconds from now.
+    NotRegistered,
+    /// The element is there, but the driver refused to encode with it — the #541
+    /// shape ("Selected preset not supported"). STABLE: it cannot heal without a
+    /// driver change, which needs a restart anyway.
+    CannotEncode,
+    /// It pushed a real frame through. STABLE.
+    Usable,
+}
+
+impl EncoderVerdict {
+    /// Only a real encode selects an encoder — both failure verdicts are a "no".
+    pub(crate) fn is_usable(self) -> bool {
+        matches!(self, EncoderVerdict::Usable)
+    }
+
+    /// May this verdict be remembered for the life of the process?
+    ///
+    /// #548: `NotRegistered` may NOT. It is exactly the state the encoder gate exists
+    /// to ride out (#339: VA-API can register `vah264enc` 30-50 s after udev), so
+    /// caching it freezes a server that started a second too early onto the next
+    /// candidate — in the worst case software `x264enc`, which always works and melts
+    /// the N100's CPU (#335) — and the 30 s NDI auto-reconnect self-heal (#333 item 6)
+    /// can then never recover it without a restart.
+    fn is_stable(self) -> bool {
+        !matches!(self, EncoderVerdict::NotRegistered)
+    }
+}
+
+/// Probe `name`, reusing a previously-cached STABLE verdict. The probe is injected
+/// so the cache POLICY (what may be remembered) is unit-testable without a GPU.
+fn cached_encoder_verdict(
+    cache: &Mutex<HashMap<String, EncoderVerdict>>,
+    name: &str,
+    probe: impl Fn(&str) -> EncoderVerdict,
+) -> EncoderVerdict {
     if let Ok(guard) = cache.lock() {
         if let Some(&verdict) = guard.get(name) {
             return verdict;
         }
     }
 
-    let verdict = probe_encoder_can_encode(name);
-    if !verdict {
-        tracing::warn!(
+    let verdict = probe(name);
+    match verdict {
+        EncoderVerdict::CannotEncode => tracing::warn!(
             encoder = name,
             "encoder is registered but cannot encode on this host — skipping it"
-        );
+        ),
+        EncoderVerdict::NotRegistered => tracing::debug!(
+            encoder = name,
+            "encoder is not registered (yet) — will re-probe, it may still appear (#339)"
+        ),
+        EncoderVerdict::Usable => {}
     }
-    if let Ok(mut guard) = cache.lock() {
-        guard.insert(name.to_string(), verdict);
+
+    if verdict.is_stable() {
+        if let Ok(mut guard) = cache.lock() {
+            guard.insert(name.to_string(), verdict);
+        }
     }
     verdict
 }
 
-/// Per-process cache of the functional encoder probe (see `encoder_is_usable`).
-static ENCODER_USABILITY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+/// Per-process cache of the functional encoder probe (see `cached_encoder_verdict`).
+static ENCODER_USABILITY: OnceLock<Mutex<HashMap<String, EncoderVerdict>>> = OnceLock::new();
 
 /// Push one frame through `videotestsrc ! videoconvert ! <encoder> ! fakesink`
 /// and report whether it encoded without an error message on the bus.
-fn probe_encoder_can_encode(name: &str) -> bool {
+fn probe_encoder_can_encode(name: &str) -> EncoderVerdict {
     use gstreamer::prelude::*;
 
-    // Element-not-registered / not-instantiable is the #443 case and is still a
-    // "no" — parse::launch covers both without a separate build() probe.
+    // Not advertised at all → nothing to encode with, and (unlike the two verdicts
+    // below) it may still show up: this is the transient case, kept uncached (#548).
+    if gstreamer::ElementFactory::find(name).is_none() {
+        return EncoderVerdict::NotRegistered;
+    }
+
+    // Advertised but not instantiable is the #443 registry-drift case — treated as
+    // transient too, for the same reason: a registry rescan can make it real.
     let Ok(pipeline) = gstreamer::parse::launch(&format!(
         "videotestsrc num-buffers=1 ! video/x-raw,width=320,height=240,framerate=30/1 \
          ! videoconvert ! {name} ! fakesink sync=false"
     )) else {
-        return false;
+        return EncoderVerdict::NotRegistered;
     };
 
-    let usable = (|| {
+    let encoded = (|| {
         let bus = pipeline.bus()?;
         if pipeline.set_state(gstreamer::State::Playing).is_err() {
             return Some(false);
@@ -262,7 +319,14 @@ fn probe_encoder_can_encode(name: &str) -> bool {
     .unwrap_or(false);
 
     let _ = pipeline.set_state(gstreamer::State::Null);
-    usable
+
+    // The element IS registered (checked above), so a failure here is the driver
+    // refusing it — stable, and safe to remember.
+    if encoded {
+        EncoderVerdict::Usable
+    } else {
+        EncoderVerdict::CannotEncode
+    }
 }
 
 /// Upper bound for the one-shot encoder probe. Generous enough for a cold CUDA /
@@ -479,7 +543,11 @@ mod encoder_cache_tests {
             "a missing element must be RE-PROBED — caching 'not registered' pins the \
              host on software x264enc for the life of the process (#548)"
         );
-        assert_eq!(calls.load(Ordering::SeqCst), 2, "both calls must reach the probe");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "both calls must reach the probe"
+        );
     }
 
     /// The #541 shape — the element IS registered, the driver refuses to encode

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -110,23 +110,37 @@ fn presenter_service_blocks_start_until_h264_encoder_probeable() {
         );
     }
 
-    // The gate script itself must still probe with gst-inspect-1.0 (the same view of the
-    // registry `presenter_ndi::hw_h264_encoder()` gets) and cover EVERY encoder we can
-    // actually use: VA-API (prod N100), the modern nvcodec elements a current NVIDIA
-    // driver provides (#541 — the legacy element is dead on 595+), and the legacy one for
-    // hosts still on an older driver. Waiting for a name we will never see would stall the
-    // start for the whole timeout on a perfectly healthy box.
+    // The gate must probe the way the SERVER decides — a real one-frame encode through
+    // `gst-launch-1.0` (#541/#547), not a `gst-inspect --exists` name lookup, which only
+    // re-reads the cached plugin registry and therefore can neither see a late-registering
+    // encoder nor notice a registered-but-broken one.
     let gate = include_str!("../../../../scripts/deploy/wait-for-h264-encoder.sh");
     assert!(
-        gate.contains("gst-inspect-1.0"),
-        "the encoder gate must query the registry with gst-inspect-1.0 (#339)"
+        gate.contains("gst-launch-1.0") && gate.contains("videotestsrc"),
+        "the encoder gate must probe FUNCTIONALLY (videotestsrc → encoder → fakesink via \
+         gst-launch-1.0), the same check presenter_ndi runs before it trusts an encoder. \
+         A name-only `gst-inspect --exists` answers from the registry cache: it green-lit \
+         encoders the server then rejected, and its poll loop never rescanned (#547)."
     );
-    for encoder in [
-        "vah264enc",
-        "nvcudah264enc",
-        "nvautogpuh264enc",
-        "nvh264enc",
-    ] {
+    // …and it must not fall back to one. (Comments may still NAME `gst-inspect-1.0` —
+    // they explain why it is wrong — so only executable lines are checked.)
+    let name_lookup_in_code = gate
+        .lines()
+        .map(str::trim_start)
+        .filter(|line| !line.starts_with('#'))
+        .any(|line| line.contains("gst-inspect-1.0"));
+    assert!(
+        !name_lookup_in_code,
+        "the gate must not probe with a `gst-inspect` registry name lookup (#547)"
+    );
+
+    // …and it must cover EVERY encoder the server can select — derived from the server's
+    // own list, so adding a 5th candidate cannot silently escape the gate. The software
+    // fallback is excluded: it needs no GPU, so there is nothing to wait for.
+    for encoder in presenter_ndi::H264_ENCODER_CANDIDATES
+        .iter()
+        .filter(|name| **name != "x264enc")
+    {
         assert!(
             gate.contains(encoder),
             "the encoder gate must probe `{encoder}` — the server can select it \

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -137,18 +137,32 @@ fn presenter_service_blocks_start_until_h264_encoder_probeable() {
     // …and it must cover EVERY encoder the server can select — derived from the server's
     // own list, so adding a 5th candidate cannot silently escape the gate. The software
     // fallback is excluded: it needs no GPU, so there is nothing to wait for.
-    for encoder in presenter_ndi::H264_ENCODER_CANDIDATES
+    //
+    // Read the gate's actual `ENCODERS=(…)` array, NOT the file text: half the candidate
+    // names also appear in the script's prose (it explains WHY nvh264enc is dead), so a
+    // whole-file `contains` was green even with the name deleted from the array.
+    let probed = gate
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("ENCODERS=("))
+        .and_then(|rest| rest.split(')').next())
+        .expect("the gate must declare its candidates as ENCODERS=(…)")
+        .split_whitespace()
+        .collect::<Vec<_>>();
+
+    let expected: Vec<_> = presenter_ndi::H264_ENCODER_CANDIDATES
         .iter()
-        .filter(|name| **name != "x264enc")
-    {
-        assert!(
-            gate.contains(encoder),
-            "the encoder gate must probe `{encoder}` — the server can select it \
-             (presenter_ndi::H264_ENCODER_CANDIDATES), so a gate that ignores it either \
-             stalls the start (waiting for an encoder that will never register) or lets \
-             the binary exec before the one it WILL use is ready (#339, #541)"
-        );
-    }
+        .copied()
+        .filter(|name| *name != "x264enc")
+        .collect();
+
+    assert_eq!(
+        probed, expected,
+        "the encoder gate must probe exactly the encoders the server can select, in the \
+         same priority order (presenter_ndi::H264_ENCODER_CANDIDATES minus the software \
+         fallback). A gate that misses one either stalls the start (waiting for an \
+         encoder that will never register) or lets the binary exec before the one it \
+         WILL use is ready (#339, #541)"
+    );
 }
 
 /// Regression for #335: cap presenter.service resource usage so a runaway

--- a/scripts/deploy/presenter-dev.service
+++ b/scripts/deploy/presenter-dev.service
@@ -14,12 +14,14 @@ Group=newlevel
 SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter-dev
 # #339/#539: encoder-ready gate — same script as prod (see presenter.service for the
-# full incident context). It skips the wait when the host has no usable GPU and knows
-# the modern nvcodec encoders (#541); it always exits 0.
-ExecStartPre=-/opt/presenter-dev/wait-for-h264-encoder.sh
+# full incident context). It skips the wait when the host has no usable GPU, knows the
+# modern nvcodec encoders (#541), and forces a real plugin rescan on every poll (#547);
+# it always exits 0. `timeout` hard-bounds it so a wedged driver cannot fail the unit.
+ExecStartPre=-/usr/bin/timeout 80 /opt/presenter-dev/wait-for-h264-encoder.sh
 ExecStart=/opt/presenter-dev/presenter-server
 Restart=always
 RestartSec=5
+TimeoutStartSec=120
 
 # Environment
 Environment=PRESENTER_PORT=8080

--- a/scripts/deploy/presenter.service
+++ b/scripts/deploy/presenter.service
@@ -26,18 +26,29 @@ Group=newlevel
 # grant belongs HERE so GPU access never depends on who happens to be logged in.
 SupplementaryGroups=render video
 WorkingDirectory=/opt/presenter
-# #339/#539: wait until the H264 encoder the server will use is registered, so we
+# #339/#539: wait until the H264 encoder the server will use can actually encode, so we
 # never start into the udev-fires-before-VA-API-registers window that took prod down
 # on 2026-05-24. The gate lives in a script (deployed alongside the binary) because it
 # also has to SKIP the wait on a host that can never satisfy it — no GPU, or a render
 # node the service user cannot open — instead of burning the full 30s on every start
-# (#539), and because it must know the modern nvcodec encoders (#541). The script
-# always exits 0: a missing encoder costs NDI, not the whole service. Leading `-` keeps
-# an older host (script not yet deployed) starting too.
-ExecStartPre=-/opt/presenter/wait-for-h264-encoder.sh
+# (#539), because it must know the modern nvcodec encoders (#541), and because it has to
+# force a real plugin rescan on every poll (#547 — a gst name lookup answers from the
+# cached registry, so a poll built on it never sees a late-registering encoder). The
+# script always exits 0: a missing encoder costs NDI, not the whole service. Leading `-`
+# keeps an older host (script not yet deployed) starting too.
+#
+# #547: `timeout` hard-bounds the WHOLE gate. Its own per-probe timeouts cap the normal
+# path, but a gst call wedged in a broken driver (#445) would otherwise hang ExecStartPre
+# until TimeoutStartSec and then FAIL the unit — which is exactly the "a missing encoder
+# must not cost the whole service" promise above. 80s > the gate's own worst case (30s
+# wait + one round of 4x8s probes) and < TimeoutStartSec below.
+ExecStartPre=-/usr/bin/timeout 80 /opt/presenter/wait-for-h264-encoder.sh
 ExecStart=/opt/presenter/presenter-server
 Restart=always
 RestartSec=5
+# Pinned rather than inherited (DefaultTimeoutStartSec=90s): the gate's budget must stay
+# comfortably under it, and that relationship should be visible in one file.
+TimeoutStartSec=120
 
 # Environment
 Environment=PRESENTER_PORT=80

--- a/scripts/deploy/wait-for-h264-encoder.sh
+++ b/scripts/deploy/wait-for-h264-encoder.sh
@@ -1,37 +1,70 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Encoder-ready gate for presenter.service / presenter-dev.service (#339, #539, #541).
+# Encoder-ready gate for presenter.service / presenter-dev.service (#339, #539, #541, #547).
 #
 # WHY IT EXISTS (#339): `After=dev-dri-renderD128.device` fires as soon as udev creates
 # the node, but the i915 / VA-API features can take another 30-50s to register. Starting
 # presenter into that window left it with no encoder and NDI down until a manual restart
 # (prod incident 2026-05-24). So the unit waits here until the encoder the server will
-# actually use is visible to the SAME probe the server uses.
+# actually use can really encode on this host.
 #
-# WHY IT CHANGED (#539): the old inline `until gst-inspect-1.0 --exists vah264enc || …`
+# WHY IT SKIPS (#539): the old inline `until gst-inspect-1.0 --exists vah264enc || …`
 # burned the FULL 30s timeout on any host that can never satisfy it — a host with no GPU,
-# or (the PP case, #540) one where the service user cannot open the render node. Every
-# start paid 30s for nothing. Now we check that a render node exists AND is openable
-# first, and skip the wait outright when it is not: there is nothing to wait for.
+# or (the PP case, #540) one where the service user cannot open the render node. So we
+# check that a render node exists AND is openable first, and skip the wait outright when
+# it is not: there is nothing to wait for.
 #
-# WHY THE ENCODER LIST CHANGED (#541): NVIDIA 595 killed the legacy `nvh264enc`
+# WHY THE ENCODER LIST IS WHAT IT IS (#541): NVIDIA 595 killed the legacy `nvh264enc`
 # ("Selected preset not supported"), so a current NVIDIA host registers only the modern
 # nvcodec elements. Waiting for the legacy name alone would burn the timeout on a
 # perfectly healthy box.
 #
+# WHY IT PROBES THIS WAY (#547) — the two traps this gate fell into before:
+#
+#   1. `gst-inspect-1.0 --exists <name>` is a REGISTRY-CACHE LOOKUP, not a plugin load
+#      (measured: 14ms warm vs 916ms cold, and no vaInitialize on the warm path). So a
+#      poll loop built on it performs ONE real scan and then re-reads that same verdict
+#      every second — it can never see a late-registering encoder, which is the entire
+#      #339 scenario it exists for. Worse, a start that INHERITS a warm registry (reboot,
+#      Restart=always; the deploy-time delete of #544 only covers the first start after a
+#      deploy) scans nothing at all. So: DELETE the registry before every poll. The
+#      probe rebuilds it, and the last one leaves a correct registry for the server.
+#
+#   2. Name-presence is not the server's question. Since #541 the server decides with a
+#      real one-frame encode (`presenter_ndi::probe_encoder_can_encode`) — an element can
+#      be registered and still be rejected by the driver. A name-only gate therefore
+#      green-lit encoders the server then refused. So we run the SAME encode here.
+#
+# EVERY external call is bounded by `timeout`: a gst call blocking in a wedged driver
+# (#445) would otherwise hang ExecStartPre until TimeoutStartSec and FAIL the unit —
+# taking lyrics, Bible and timers down over a missing encoder. The unit bounds the whole
+# script as well (belt and braces).
+#
 # ALWAYS EXITS 0. A missing encoder is not fatal — the server starts and serves lyrics,
 # Bible, timers and the stage display without NDI, and logs why (see presenter_ndi::gpu).
 #
-# Testable without a GPU: `PRESENTER_RENDER_NODE` / `PRESENTER_ENCODER_WAIT_SECS` are
-# injectable and the encoder probe goes through `gst-inspect-1.0` on PATH.
-# See tests/deploy/deploy-config.test.sh.
+# Testable without a GPU: `PRESENTER_RENDER_NODE`, `PRESENTER_ENCODER_WAIT_SECS` and
+# `PRESENTER_ENCODER_PROBE_TIMEOUT_SECS` are injectable and the probe goes through
+# `gst-launch-1.0` on PATH. See tests/deploy/deploy-config.test.sh.
 
 RENDER_NODE="${PRESENTER_RENDER_NODE:-/dev/dri/renderD128}"
 WAIT_SECS="${PRESENTER_ENCODER_WAIT_SECS:-30}"
+PROBE_TIMEOUT_SECS="${PRESENTER_ENCODER_PROBE_TIMEOUT_SECS:-8}"
+REGISTRY="${GST_REGISTRY:-}"
 
 # Priority order mirrors presenter_ndi::H264_ENCODER_CANDIDATES (minus the software
 # fallback, which needs no GPU and therefore no wait).
 ENCODERS=(vah264enc nvcudah264enc nvautogpuh264enc nvh264enc)
+
+# The same one-frame encode the server runs before it trusts an encoder (#541). Bounded,
+# silent, and side-effect-free — no hardware is held after it returns.
+probe_encoder() {
+  local encoder="$1"
+  timeout "$PROBE_TIMEOUT_SECS" gst-launch-1.0 -q --gst-debug-level=0 \
+    videotestsrc num-buffers=1 \
+    ! video/x-raw,width=320,height=240,framerate=30/1 \
+    ! videoconvert ! "$encoder" ! fakesink sync=false >/dev/null 2>&1
+}
 
 if [ ! -e "$RENDER_NODE" ]; then
   echo "encoder-gate: no render node at $RENDER_NODE — no GPU on this host, not waiting"
@@ -46,16 +79,27 @@ if [ ! -r "$RENDER_NODE" ] || [ ! -w "$RENDER_NODE" ]; then
 fi
 
 deadline=$((SECONDS + WAIT_SECS))
-while [ "$SECONDS" -lt "$deadline" ]; do
+while :; do
+  # #547: force a REAL plugin scan. Every gst tool answers from this cache, so without
+  # the delete the poll below just re-reads the previous verdict — including a stale one
+  # inherited across a reboot.
+  if [ -n "$REGISTRY" ]; then
+    rm -f "$REGISTRY"
+  fi
+
   for encoder in "${ENCODERS[@]}"; do
-    if gst-inspect-1.0 --exists "$encoder"; then
-      echo "encoder-gate: $encoder registered — starting presenter"
+    if probe_encoder "$encoder"; then
+      echo "encoder-gate: $encoder encodes on this host — starting presenter"
       exit 0
     fi
   done
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    break
+  fi
   sleep 1
 done
 
-echo "encoder-gate: no H264 encoder registered within ${WAIT_SECS}s (tried: ${ENCODERS[*]})." \
+echo "encoder-gate: no H264 encoder could encode within ${WAIT_SECS}s (tried: ${ENCODERS[*]})." \
   "Starting presenter anyway — NDI will be unavailable until an encoder appears."
 exit 0

--- a/scripts/deploy/wait-for-h264-encoder.sh
+++ b/scripts/deploy/wait-for-h264-encoder.sh
@@ -58,13 +58,36 @@ ENCODERS=(vah264enc nvcudah264enc nvautogpuh264enc nvh264enc)
 
 # The same one-frame encode the server runs before it trusts an encoder (#541). Bounded,
 # silent, and side-effect-free — no hardware is held after it returns.
+#
+# `timeout -k`: a plain SIGTERM does not reach a gst process stuck in an uninterruptible
+# driver ioctl (the #445 shape), so follow up with SIGKILL.
 probe_encoder() {
   local encoder="$1"
-  timeout "$PROBE_TIMEOUT_SECS" gst-launch-1.0 -q --gst-debug-level=0 \
+  timeout -k 2 "$PROBE_TIMEOUT_SECS" gst-launch-1.0 -q --gst-debug-level=0 \
     videotestsrc num-buffers=1 \
     ! video/x-raw,width=320,height=240,framerate=30/1 \
     ! videoconvert ! "$encoder" ! fakesink sync=false >/dev/null 2>&1
 }
+
+# Same probe, UNSUPPRESSED — run once on the give-up path so the journal carries WHY.
+# #541 was diagnosed entirely from the driver's own words ("Selected preset not
+# supported"); a bare "could not encode" would have told us nothing.
+explain_probe_failure() {
+  local encoder="$1"
+  echo "encoder-gate: last attempt at $encoder said:"
+  timeout -k 2 "$PROBE_TIMEOUT_SECS" gst-launch-1.0 \
+    videotestsrc num-buffers=1 \
+    ! video/x-raw,width=320,height=240,framerate=30/1 \
+    ! videoconvert ! "$encoder" ! fakesink sync=false 2>&1 |
+    grep -viE '^(setting pipeline|pipeline is|redistribute|execution ended|got eos)' |
+    tail -8 || true
+}
+
+if ! command -v gst-launch-1.0 >/dev/null 2>&1; then
+  echo "encoder-gate: gst-launch-1.0 is not installed (package gstreamer1.0-tools) —" \
+    "cannot probe, not waiting. NDI will be unavailable if the server finds no encoder."
+  exit 0
+fi
 
 if [ ! -e "$RENDER_NODE" ]; then
   echo "encoder-gate: no render node at $RENDER_NODE — no GPU on this host, not waiting"
@@ -83,8 +106,11 @@ while :; do
   # #547: force a REAL plugin scan. Every gst tool answers from this cache, so without
   # the delete the poll below just re-reads the previous verdict — including a stale one
   # inherited across a reboot.
+  # `|| true`: rm -f is quiet about a missing file but NOT about an unremovable one (a
+  # root-owned registry left behind by a manual `sudo gst-launch`), and `set -e` would
+  # then kill this script mid-loop — breaking the always-exit-0 contract above.
   if [ -n "$REGISTRY" ]; then
-    rm -f "$REGISTRY"
+    rm -f "$REGISTRY" || true
   fi
 
   for encoder in "${ENCODERS[@]}"; do
@@ -102,4 +128,5 @@ done
 
 echo "encoder-gate: no H264 encoder could encode within ${WAIT_SECS}s (tried: ${ENCODERS[*]})." \
   "Starting presenter anyway — NDI will be unavailable until an encoder appears."
+explain_probe_failure "${ENCODERS[0]}"
 exit 0

--- a/tests/deploy/deploy-config.test.sh
+++ b/tests/deploy/deploy-config.test.sh
@@ -111,12 +111,18 @@ run_gate() {
   # $5 = registry path ("" = unset)
   local bin="$1" node="$2" wait_secs="$3" probe_timeout="$4" registry="$5"
   local start=$SECONDS
+  # A caller expecting the gate to bound ITSELF sets GATE_HARNESS_TIMEOUT, so a gate
+  # that lost its bounds fails the test instead of stalling CI behind it.
+  local harness=("bash" "$WAIT_SCRIPT")
+  if [ -n "${GATE_HARNESS_TIMEOUT:-}" ]; then
+    harness=("timeout" "-k" "5" "$GATE_HARNESS_TIMEOUT" "bash" "$WAIT_SCRIPT")
+  fi
   set +e
   out="$(GST_REGISTRY="$registry" PATH="$bin:$PATH" \
     PRESENTER_RENDER_NODE="$node" \
     PRESENTER_ENCODER_WAIT_SECS="$wait_secs" \
     PRESENTER_ENCODER_PROBE_TIMEOUT_SECS="$probe_timeout" \
-    bash "$WAIT_SCRIPT" 2>&1)"
+    "${harness[@]}" 2>&1)"
   rc=$?
   set -e
   elapsed=$((SECONDS - start))
@@ -230,7 +236,10 @@ bounds_every_probe_so_a_wedged_driver_cannot_hang_the_unit() {
   tmp="$(mktemp -d)"
   stub_gst_launch "$tmp/bin" "vah264enc" 0 60 # every probe blocks for 60s
   install -m 666 /dev/null "$tmp/renderD128"
-  run_gate "$tmp/bin" "$tmp/renderD128" 3 2 "$tmp/registry.bin"
+  # The outer bound is part of the assertion: without `timeout` in the gate this would
+  # otherwise sit through 4 x 60s of blocked probes before failing — a 4-minute CI stall
+  # for a regression that should be caught in seconds.
+  GATE_HARNESS_TIMEOUT=40 run_gate "$tmp/bin" "$tmp/renderD128" 3 2 "$tmp/registry.bin"
   rm -rf "$tmp"
   # 4 candidates x 2s probe timeout + the 3s deadline, with generous slack.
   [ "$rc" -eq 0 ] && [ "$elapsed" -lt 25 ]
@@ -293,10 +302,14 @@ every_deploy_rebuilds_the_registry() {
 every_deploy_ships_the_gate_script() {
   # The unit calls the gate with a leading `-` (never fatal), so a deploy that stops
   # installing the script disables the gate SILENTLY — no failure, no log, NDI just
-  # races the driver again. Assert every deploy actually puts the script on the host.
-  grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/deploy.yml" &&
-    grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/release.yml" &&
-    grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/pipeline.yml"
+  # races the driver again. Both halves must be there: the scp that puts the file ON the
+  # host, and the install that puts it in the deploy dir. Grepping the bare filename
+  # would stay green with the scp deleted.
+  local wf
+  for wf in deploy.yml release.yml pipeline.yml; do
+    grep -qE 'scp .*wait-for-h264-encoder\.sh' "$REPO_ROOT/.github/workflows/$wf" || return 1
+    grep -qE 'install .*wait-for-h264-encoder\.sh' "$REPO_ROOT/.github/workflows/$wf" || return 1
+  done
 }
 
 echo "Deploy-config guards (#538, #539, #544, #547):"

--- a/tests/deploy/deploy-config.test.sh
+++ b/tests/deploy/deploy-config.test.sh
@@ -162,7 +162,7 @@ probes_functionally_rather_than_by_name() {
   stub_gst_launch "$tmp/bin" "vah264enc"
   install -m 666 /dev/null "$tmp/renderD128"
   run_gate "$tmp/bin" "$tmp/renderD128" 5 8 "$tmp/registry.bin"
-  local calls="$tmp/calls"
+  local calls="$tmp/bin/calls"
   local ok=1
   { [ "$rc" -eq 0 ] &&
     [ -f "$calls" ] &&
@@ -186,12 +186,18 @@ forces_a_registry_rescan_on_every_poll() {
   # Pre-existing (warm) registry — exactly what a reboot inherits.
   echo stale >"$tmp/registry.bin"
   run_gate "$tmp/bin" "$tmp/renderD128" 20 8 "$tmp/registry.bin"
-  local states="$tmp/registry-state"
+  local states="$tmp/bin/registry-state"
   local ok=1
+  # Each POLL must start cold. (Within one poll the first probe rebuilds the
+  # registry, so the remaining candidates of that same poll legitimately see it
+  # warm — that is one genuine scan per poll, which is the point.) So: the very
+  # first probe must be cold DESPITE the stale registry we planted, and a later
+  # poll must have gone cold again — proving the delete happens every round and
+  # not just once at startup.
   { [ "$rc" -eq 0 ] &&
     grep -q 'encodes on this host' <<<"$out" &&
     [ -f "$states" ] &&
-    [ "$(grep -c warm "$states" || true)" -eq 0 ] &&
+    [ "$(head -1 "$states")" = "cold" ] &&
     [ "$(grep -c cold "$states" || true)" -ge 2 ]; } || ok=0
   rm -rf "$tmp"
   [ "$ok" -eq 1 ]
@@ -265,15 +271,23 @@ units_own_a_writable_gst_registry() {
     grep -qE '^Environment=GST_REGISTRY=/opt/presenter-dev/' "$DEV_UNIT"
 }
 
+deploy_deletes_the_registry_under_its_deploy_dir() {
+  # $1 = workflow, $2 = the deploy dir that workflow targets (and that its unit points
+  # GST_REGISTRY into). Assert BOTH: the workflow really targets that dir, and it really
+  # deletes the registry there. A bare mention of the filename (a leftover comment) used
+  # to satisfy this guard with the `rm` gone.
+  local wf="$REPO_ROOT/.github/workflows/$1" dir="$2"
+  grep -qE "^ *DEPLOY_DIR: *$dir *\$" "$wf" &&
+    grep -qE 'rm -f +(\$\{\{ *env\.DEPLOY_DIR *\}\}|'"$dir"')/gstreamer-registry\.bin' "$wf"
+}
+
 every_deploy_rebuilds_the_registry() {
-  # Deleting the registry file is what guarantees the next start re-probes the
-  # plugins against the CURRENT permissions/driver. Without it, #544 comes back the
-  # first time a host's GPU access or driver changes. Match the actual `rm` of the
-  # actual path the unit points GST_REGISTRY at — a bare mention of the filename
-  # (a leftover comment) used to satisfy this guard.
-  grep -qE 'rm -f +/opt/presenter/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/deploy.yml" &&
-    grep -qE 'rm -f +/opt/presenter/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/release.yml" &&
-    grep -qE 'rm -f +/opt/presenter-dev/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/pipeline.yml"
+  # Deleting the registry file is what guarantees the next start re-probes the plugins
+  # against the CURRENT permissions/driver. Without it, #544 comes back the first time a
+  # host's GPU access or driver changes.
+  deploy_deletes_the_registry_under_its_deploy_dir deploy.yml /opt/presenter &&
+    deploy_deletes_the_registry_under_its_deploy_dir release.yml /opt/presenter &&
+    deploy_deletes_the_registry_under_its_deploy_dir pipeline.yml /opt/presenter-dev
 }
 
 every_deploy_ships_the_gate_script() {

--- a/tests/deploy/deploy-config.test.sh
+++ b/tests/deploy/deploy-config.test.sh
@@ -19,6 +19,15 @@
 #         verdict was trusted forever and NDI stayed dead even after #540 restored
 #         access. The service therefore owns a registry inside its (writable) deploy
 #         dir, and every deploy deletes it so the next start rescans against reality.
+#
+#   #547  The gate must actually PROBE on every poll. `gst-inspect --exists` answers
+#         from the cached registry, so the old loop performed ONE real scan and then
+#         re-read that same verdict 29 times — it could never see a late-registering
+#         encoder (#339's whole scenario), and on a start that inherited a warm
+#         registry (reboot, Restart=always) it scanned nothing at all. The gate must
+#         therefore delete the registry before each poll, probe FUNCTIONALLY (the same
+#         real encode the server does, #541), and bound every external call so a
+#         wedged driver cannot hang ExecStartPre and fail the whole unit.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -57,30 +66,67 @@ pp_release_writes_stage_url_dropin() {
 #   PRESENTER_ENCODER_WAIT_SECS — timeout
 # and it finds encoders via `gst-inspect-1.0` on PATH, which we stub below.
 
-stub_gst_inspect() {
-  # $1 = space-separated list of encoder names that "exist"
-  local dir="$1" available="$2"
+# The gate probes FUNCTIONALLY — it runs the same one-frame encode the server runs
+# (`videotestsrc num-buffers=1 ! … ! <encoder> ! fakesink`), not a name lookup (#547).
+# This stub stands in for `gst-launch-1.0` and models the two behaviours that matter:
+#
+#   * it answers from the plugin REGISTRY CACHE — so it records, on every call,
+#     whether the registry file was still present (warm) or had been deleted (cold).
+#     A gate that does not delete it is re-reading one stale verdict, which is the
+#     whole of #547. A real probe rebuilds the registry, so the stub recreates it.
+#   * an encoder can register LATE (`available_after` seconds — the #339 boot race),
+#     and a probe can HANG (`block_secs` — a wedged driver, #445).
+stub_gst_launch() {
+  # $1 = bin dir, $2 = encoders that can encode, $3 = seconds until they register,
+  # $4 = seconds each probe blocks
+  local dir="$1" available="$2" available_after="${3:-0}" block_secs="${4:-0}"
   mkdir -p "$dir"
-  cat >"$dir/gst-inspect-1.0" <<EOF
+  cat >"$dir/gst-launch-1.0" <<EOF
 #!/usr/bin/env bash
-# stub: only the --exists form is used by the gate
-for e in $available; do [ "\$2" = "\$e" ] && exit 0; done
+set -euo pipefail
+started_at="$dir/started-at"
+if [ ! -f "\$started_at" ]; then date +%s >"\$started_at"; fi
+echo "\$*" >>"$dir/calls"
+if [ -n "\${GST_REGISTRY:-}" ] && [ -e "\$GST_REGISTRY" ]; then
+  echo warm >>"$dir/registry-state"
+else
+  echo cold >>"$dir/registry-state"
+fi
+if [ -n "\${GST_REGISTRY:-}" ]; then : >"\$GST_REGISTRY"; fi
+if [ "$block_secs" -gt 0 ]; then sleep "$block_secs"; fi
+if [ \$(( \$(date +%s) - \$(cat "\$started_at") )) -lt $available_after ]; then exit 1; fi
+for e in $available; do
+  for a in "\$@"; do
+    if [ "\$a" = "\$e" ]; then exit 0; fi
+  done
+done
 exit 1
 EOF
-  chmod +x "$dir/gst-inspect-1.0"
+  chmod +x "$dir/gst-launch-1.0"
+}
+
+# Runs the gate against a stubbed toolchain. Sets $rc / $elapsed / $out for the caller.
+run_gate() {
+  # $1 = bin dir, $2 = render-node path, $3 = wait secs, $4 = per-probe timeout secs,
+  # $5 = registry path ("" = unset)
+  local bin="$1" node="$2" wait_secs="$3" probe_timeout="$4" registry="$5"
+  local start=$SECONDS
+  set +e
+  out="$(GST_REGISTRY="$registry" PATH="$bin:$PATH" \
+    PRESENTER_RENDER_NODE="$node" \
+    PRESENTER_ENCODER_WAIT_SECS="$wait_secs" \
+    PRESENTER_ENCODER_PROBE_TIMEOUT_SECS="$probe_timeout" \
+    bash "$WAIT_SCRIPT" 2>&1)"
+  rc=$?
+  set -e
+  elapsed=$((SECONDS - start))
 }
 
 exits_fast_without_a_render_node() {
   local tmp
   tmp="$(mktemp -d)"
-  stub_gst_inspect "$tmp/bin" ""
-  local start=$SECONDS
-  PATH="$tmp/bin:$PATH" \
-    PRESENTER_RENDER_NODE="$tmp/definitely-not-a-render-node" \
-    PRESENTER_ENCODER_WAIT_SECS=30 \
-    bash "$WAIT_SCRIPT" >/dev/null 2>&1
-  local rc=$?
-  local elapsed=$((SECONDS - start))
+  stub_gst_launch "$tmp/bin" ""
+  run_gate "$tmp/bin" "$tmp/definitely-not-a-render-node" 30 8 ""
   rm -rf "$tmp"
   # The whole point of #539: a GPU-less host must not sit through the timeout —
   # and it must still let the service start (rc 0), just without NDI.
@@ -90,35 +136,98 @@ exits_fast_without_a_render_node() {
 exits_fast_when_the_node_is_not_accessible() {
   local tmp
   tmp="$(mktemp -d)"
-  stub_gst_inspect "$tmp/bin" ""
-  # A node that exists but this user cannot write — the #540 shape.
+  stub_gst_launch "$tmp/bin" ""
+  # A node that exists but this user cannot open — the #540 shape.
   install -m 000 /dev/null "$tmp/renderD128"
-  local start=$SECONDS
-  PATH="$tmp/bin:$PATH" \
-    PRESENTER_RENDER_NODE="$tmp/renderD128" \
-    PRESENTER_ENCODER_WAIT_SECS=2 \
-    bash "$WAIT_SCRIPT" >/dev/null 2>&1
-  local rc=$?
-  local elapsed=$((SECONDS - start))
+  run_gate "$tmp/bin" "$tmp/renderD128" 2 8 ""
   rm -rf "$tmp"
-  # Non-root: the gate sees it cannot open the node and skips at once. Root can
-  # open anything, so it falls through to the (short) bounded wait instead — both
-  # must exit 0 and neither may hang.
-  [ "$rc" -eq 0 ] && [ "$elapsed" -lt 5 ]
+  # Non-root: the gate must SAY it cannot open the node (that message is the only
+  # thing that tells an operator the service user is missing the `render` group,
+  # #540) and skip at once. Root can open anything, so it falls through to the
+  # (short) bounded wait instead — both must exit 0 and neither may hang.
+  if [ "$rc" -ne 0 ] || [ "$elapsed" -ge 5 ]; then return 1; fi
+  if [ "$(id -u)" -ne 0 ]; then
+    grep -q "not openable" <<<"$out" && grep -q "render" <<<"$out"
+  fi
 }
 
-waits_and_succeeds_when_an_encoder_is_present() {
+probes_functionally_rather_than_by_name() {
+  # #547: `gst-inspect --exists <name>` only asks the cached registry whether the
+  # NAME is known. The server decides with a real one-frame encode (#541), so a
+  # host whose first REGISTERED candidate is broken satisfied a name-only gate
+  # while the server then rejected that same encoder. The gate must run the same
+  # encode — i.e. it must invoke gst-launch with a videotestsrc→encoder pipeline.
   local tmp
   tmp="$(mktemp -d)"
-  stub_gst_inspect "$tmp/bin" "vah264enc"
+  stub_gst_launch "$tmp/bin" "vah264enc"
   install -m 666 /dev/null "$tmp/renderD128"
-  PATH="$tmp/bin:$PATH" \
-    PRESENTER_RENDER_NODE="$tmp/renderD128" \
-    PRESENTER_ENCODER_WAIT_SECS=5 \
-    bash "$WAIT_SCRIPT" >/dev/null 2>&1
-  local rc=$?
+  run_gate "$tmp/bin" "$tmp/renderD128" 5 8 "$tmp/registry.bin"
+  local calls="$tmp/calls"
+  local ok=1
+  { [ "$rc" -eq 0 ] &&
+    [ -f "$calls" ] &&
+    grep -q 'videotestsrc' "$calls" &&
+    grep -q 'vah264enc' "$calls"; } || ok=0
   rm -rf "$tmp"
-  [ "$rc" -eq 0 ]
+  [ "$ok" -eq 1 ]
+}
+
+forces_a_registry_rescan_on_every_poll() {
+  # THE #547 REGRESSION. Every gst tool answers from the cached plugin registry, so
+  # unless the gate deletes it first, poll 2..N re-read poll 1's verdict and the
+  # loop is decorative. Worse: a start that inherits a warm registry (reboot,
+  # Restart=always — the registry is only deleted at DEPLOY time) never scans at all.
+  # The stub records warm/cold per call; every call must be COLD.
+  local tmp
+  tmp="$(mktemp -d)"
+  # Encoder registers only after 3s → the gate must poll several times to find it.
+  stub_gst_launch "$tmp/bin" "vah264enc" 3
+  install -m 666 /dev/null "$tmp/renderD128"
+  # Pre-existing (warm) registry — exactly what a reboot inherits.
+  echo stale >"$tmp/registry.bin"
+  run_gate "$tmp/bin" "$tmp/renderD128" 20 8 "$tmp/registry.bin"
+  local states="$tmp/registry-state"
+  local ok=1
+  { [ "$rc" -eq 0 ] &&
+    grep -q 'encodes on this host' <<<"$out" &&
+    [ -f "$states" ] &&
+    [ "$(grep -c warm "$states" || true)" -eq 0 ] &&
+    [ "$(grep -c cold "$states" || true)" -ge 2 ]; } || ok=0
+  rm -rf "$tmp"
+  [ "$ok" -eq 1 ]
+}
+
+finds_a_late_registering_encoder() {
+  # #339's actual scenario: udev creates the render node, but VA-API registers its
+  # encoders another 30-50s later. That IS what the gate exists for — it must still
+  # be probing (not re-reading a cached "no") when the encoder finally appears.
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_launch "$tmp/bin" "vah264enc" 4
+  install -m 666 /dev/null "$tmp/renderD128"
+  run_gate "$tmp/bin" "$tmp/renderD128" 20 8 "$tmp/registry.bin"
+  local ok=1
+  { [ "$rc" -eq 0 ] &&
+    grep -q 'vah264enc encodes on this host' <<<"$out" &&
+    [ "$elapsed" -ge 4 ] && [ "$elapsed" -lt 20 ]; } || ok=0
+  rm -rf "$tmp"
+  [ "$ok" -eq 1 ]
+}
+
+bounds_every_probe_so_a_wedged_driver_cannot_hang_the_unit() {
+  # The old gate was `ExecStartPre=-/usr/bin/timeout 30 sh -c …` — hard-bounded. The
+  # rewrite moved the deadline INSIDE the loop, where it is only evaluated BETWEEN
+  # iterations: one gst call blocking in a wedged driver (#445, a recurring dev2
+  # event) hangs ExecStartPre until TimeoutStartSec and then FAILS the unit — taking
+  # lyrics, Bible and timers down over a missing encoder. Every probe must be bounded.
+  local tmp
+  tmp="$(mktemp -d)"
+  stub_gst_launch "$tmp/bin" "vah264enc" 0 60 # every probe blocks for 60s
+  install -m 666 /dev/null "$tmp/renderD128"
+  run_gate "$tmp/bin" "$tmp/renderD128" 3 2 "$tmp/registry.bin"
+  rm -rf "$tmp"
+  # 4 candidates x 2s probe timeout + the 3s deadline, with generous slack.
+  [ "$rc" -eq 0 ] && [ "$elapsed" -lt 25 ]
 }
 
 accepts_the_modern_nvcodec_encoder() {
@@ -127,21 +236,25 @@ accepts_the_modern_nvcodec_encoder() {
   # waiting for the legacy name would burn the whole timeout on a perfectly good host.
   local tmp
   tmp="$(mktemp -d)"
-  stub_gst_inspect "$tmp/bin" "nvcudah264enc"
+  stub_gst_launch "$tmp/bin" "nvcudah264enc"
   install -m 666 /dev/null "$tmp/renderD128"
-  local start=$SECONDS
-  PATH="$tmp/bin:$PATH" \
-    PRESENTER_RENDER_NODE="$tmp/renderD128" \
-    PRESENTER_ENCODER_WAIT_SECS=20 \
-    bash "$WAIT_SCRIPT" >/dev/null 2>&1
-  local rc=$?
-  local elapsed=$((SECONDS - start))
+  run_gate "$tmp/bin" "$tmp/renderD128" 20 8 "$tmp/registry.bin"
   rm -rf "$tmp"
   [ "$rc" -eq 0 ] && [ "$elapsed" -lt 5 ]
 }
 
 both_units_use_the_gate_script() {
   grep -q 'wait-for-h264-encoder.sh' "$PROD_UNIT" && grep -q 'wait-for-h264-encoder.sh' "$DEV_UNIT"
+}
+
+units_hard_bound_the_gate() {
+  # Belt to the script's own per-probe braces: the unit caps the WHOLE gate with
+  # `timeout`, and pins TimeoutStartSec explicitly instead of inheriting
+  # DefaultTimeoutStartSec (90s) — which the gate's own budget must stay under.
+  grep -qE '^ExecStartPre=-/usr/bin/timeout [0-9]+ /opt/presenter/wait-for-h264-encoder\.sh' "$PROD_UNIT" &&
+    grep -qE '^ExecStartPre=-/usr/bin/timeout [0-9]+ /opt/presenter-dev/wait-for-h264-encoder\.sh' "$DEV_UNIT" &&
+    grep -qE '^TimeoutStartSec=' "$PROD_UNIT" &&
+    grep -qE '^TimeoutStartSec=' "$DEV_UNIT"
 }
 
 # ── #544: the registry must be service-owned, writable and rebuilt on deploy ────
@@ -155,23 +268,39 @@ units_own_a_writable_gst_registry() {
 every_deploy_rebuilds_the_registry() {
   # Deleting the registry file is what guarantees the next start re-probes the
   # plugins against the CURRENT permissions/driver. Without it, #544 comes back the
-  # first time a host's GPU access or driver changes.
-  grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/deploy.yml" &&
-    grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/release.yml" &&
-    grep -q 'gstreamer-registry.bin' "$REPO_ROOT/.github/workflows/pipeline.yml"
+  # first time a host's GPU access or driver changes. Match the actual `rm` of the
+  # actual path the unit points GST_REGISTRY at — a bare mention of the filename
+  # (a leftover comment) used to satisfy this guard.
+  grep -qE 'rm -f +/opt/presenter/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/deploy.yml" &&
+    grep -qE 'rm -f +/opt/presenter/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/release.yml" &&
+    grep -qE 'rm -f +/opt/presenter-dev/gstreamer-registry\.bin' "$REPO_ROOT/.github/workflows/pipeline.yml"
 }
 
-echo "Deploy-config guards (#538, #539):"
+every_deploy_ships_the_gate_script() {
+  # The unit calls the gate with a leading `-` (never fatal), so a deploy that stops
+  # installing the script disables the gate SILENTLY — no failure, no log, NDI just
+  # races the driver again. Assert every deploy actually puts the script on the host.
+  grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/deploy.yml" &&
+    grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/release.yml" &&
+    grep -q 'wait-for-h264-encoder.sh' "$REPO_ROOT/.github/workflows/pipeline.yml"
+}
+
+echo "Deploy-config guards (#538, #539, #544, #547):"
 check "#538 shared unit does not hardcode a site stage URL" not_hardcoding_stage_url
 check "#538 prod deploy writes its own stage-url drop-in" prod_deploy_writes_stage_url_dropin
 check "#538 PP release writes its own stage-url drop-in" pp_release_writes_stage_url_dropin
 check "#539 gate exits fast when there is no render node" exits_fast_without_a_render_node
 check "#539 gate exits fast when the render node is inaccessible" exits_fast_when_the_node_is_not_accessible
-check "#539 gate succeeds once an encoder is registered" waits_and_succeeds_when_an_encoder_is_present
 check "#539 gate accepts the modern nvcodec encoder (#541)" accepts_the_modern_nvcodec_encoder
 check "#539 both deployed units call the gate script" both_units_use_the_gate_script
 check "#544 units own a writable GST_REGISTRY in their deploy dir" units_own_a_writable_gst_registry
 check "#544 every deploy rebuilds the plugin registry" every_deploy_rebuilds_the_registry
+check "#547 gate probes functionally (real encode), not by name" probes_functionally_rather_than_by_name
+check "#547 gate forces a real plugin rescan on EVERY poll" forces_a_registry_rescan_on_every_poll
+check "#547 gate finds an encoder that registers late (#339)" finds_a_late_registering_encoder
+check "#547 gate bounds every probe (a wedged driver cannot hang the unit)" bounds_every_probe_so_a_wedged_driver_cannot_hang_the_unit
+check "#547 units hard-bound the gate with timeout + TimeoutStartSec" units_hard_bound_the_gate
+check "#547 every deploy ships the gate script" every_deploy_ships_the_gate_script
 
 if [ "$failures" -ne 0 ]; then
   echo "Deploy-config guards: $failures FAILED"


### PR DESCRIPTION
Follow-up to the v0.4.194 NDI/deploy fixes (#538–#544). A deep review of that shipped diff found the encoder-ready gate **did not do the job it was built for**, and the functional encoder probe cached the wrong thing. Both are fixed here.

## Closes #547 — the gate was decorative

`gst-inspect-1.0 --exists <name>` is a **registry-cache lookup**, not a plugin load (measured on dev2: 14 ms warm vs 916 ms cold; only the cold path emits `vaInitialize`). Consequences:

- the 30 s poll performed **exactly one** real scan and then re-read that verdict 29 times → it could never see a **late-registering encoder**, which is the entire #339 scenario the gate exists for;
- any start that inherited a warm registry (**reboot**, `Restart=always` — the deploy-time delete of #544 only covers the first start after a deploy) **scanned nothing at all**, so the cold-boot race was still wide open. PP deploys only on a Release and reboots in between — the exact host #544 was filed for;
- the gate asked a different question than the server: since #541 the server only trusts an encoder after a **real one-frame encode**. Live proof from a dev start: gate said `nvcudah264enc registered`, server said `vah264enc … registered but cannot encode`.
- the outer `timeout` had been dropped, so a `gst-inspect` wedged in a broken driver (#445) would hang `ExecStartPre` until `DefaultTimeoutStartSec` and then **fail the whole unit** — taking lyrics, Bible and timers down over a missing encoder. `ExecStartPre=-` ignores a non-zero exit, not a start timeout.

**Now:** the gate deletes `$GST_REGISTRY` before **every** poll (the only thing that forces a real rescan), probes **functionally** with `videotestsrc num-buffers=1 ! … ! <enc> ! fakesink` (the same check the server runs), bounds every probe with `timeout`, and the unit bounds the whole gate (`ExecStartPre=-/usr/bin/timeout 80 …` + an explicit `TimeoutStartSec=120`). It still always exits 0 and still skips instantly on a host with no GPU / no render-node access (#539).

## Closes #548 — the probe cached a transient verdict

`encoder_is_usable()` memoized `false` for the process lifetime — **including "element not registered"**, which is precisely the transient boot-race state. Chained with #547 (server starts early), `vah264enc` would be cached as unusable forever and the host would silently fall through to software **`x264enc`** — the CPU-melt shape of #335 — with the 30 s reconnect self-heal (#333 item 6) unable to recover it without a restart.

Probing now returns `EncoderVerdict { NotRegistered, CannotEncode, Usable }` and only the **stable** verdicts are cached: `Usable` (a working encoder does not stop working) and `CannotEncode` (a driver rejection cannot heal without a driver change). `NotRegistered` is re-probed every time.

## Also from the review

- stage URLs pass through `env:` instead of being interpolated into a remote `ssh` line (a quote in the value would have run under passwordless sudo);
- deploy steps use `${{ env.DEPLOY_DIR }}` instead of hardcoded `/opt/presenter{,-dev}`;
- deploy guards tightened: the registry `rm` must target the workflow's **own** deploy dir (a leftover comment used to satisfy the grep), every workflow must **ship** the gate script (with `ExecStartPre=-`, dropping the scp silently disabled the gate), and the gate must cover `presenter_ndi::H264_ENCODER_CANDIDATES` **derived** — a hand-copied list stopped covering a 5th candidate the moment one was added;
- the gate runs quiet (`--gst-debug-level=0`) so its own `encoder-gate:` lines are not buried under a full scan's WARN spam.

## Tests

RED `537d1306` → GREEN `f41dc37d`.

- `tests/deploy/deploy-config.test.sh` — 6 new guards: probes functionally / forces a real rescan on **every** poll / finds a **late-registering** encoder / bounds every probe so a wedged driver cannot hang the unit / units hard-bound the gate / every deploy ships the script. The stub models the registry cache (records warm-vs-cold per call) and late registration.
- `crates/presenter-ndi/src/lib.rs` — 5 cache-policy tests: `NotRegistered` is re-probed (self-heal), `CannotEncode` and `Usable` are cached once, verdicts keyed by name, only `Usable` selects.

## Verified live on dev (v0.4.196)

```
encoder-gate: nvcudah264enc encodes on this host — starting presenter
NDI WebRTC encoder: nvcudah264enc          ← gate and server now agree
/opt/presenter-dev/gstreamer-registry.bin  ← rebuilt at deploy
```
