### PR TITLE
fix(video-sources): show why a mapped NDI source shows nothing (#546)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.196"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.196"
+version = "0.4.197"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/manager/whep.rs
+++ b/crates/presenter-ndi/src/manager/whep.rs
@@ -26,20 +26,40 @@ impl NdiManager {
     /// item 7 was supposed to expose. On timeout we return an empty vec
     /// and log a warning; the caller (LB / dashboard) sees "no pipelines"
     /// for one poll cycle, which is preferable to a hung probe.
+    ///
+    /// Callers that must not read a timeout as "no pipelines" (the #546 source
+    /// status join — an empty map there means "sending nothing", which is a very
+    /// different sentence to put in front of an operator) use
+    /// [`Self::pipeline_snapshots_checked`] instead.
     pub async fn pipeline_snapshots(&self) -> Vec<(String, PipelineState)> {
+        self.pipeline_snapshots_checked().await.unwrap_or_default()
+    }
+
+    /// Like [`Self::pipeline_snapshots`], but `None` when the 200 ms lock wait
+    /// expired — i.e. "the manager is busy (almost always: building/starting a
+    /// pipeline), we could not look", as opposed to `Some(vec![])`, "we looked
+    /// and there are no pipelines".
+    ///
+    /// The distinction is load-bearing for #546: `start_pipeline` holds this same
+    /// mutex across its 8 s caps-wait, so during EVERY normal activation a caller
+    /// that cannot tell the two apart concludes "active, on the network, no
+    /// pipeline" and tells the operator to go fix a sending machine that is fine.
+    pub async fn pipeline_snapshots_checked(&self) -> Option<Vec<(String, PipelineState)>> {
         match tokio::time::timeout(std::time::Duration::from_millis(200), self.active.lock()).await
         {
-            Ok(guard) => guard
-                .iter()
-                .map(|(id, src)| (id.clone(), src.pipeline.state()))
-                .collect(),
+            Ok(guard) => Some(
+                guard
+                    .iter()
+                    .map(|(id, src)| (id.clone(), src.pipeline.state()))
+                    .collect(),
+            ),
             Err(_) => {
                 tracing::warn!(
                     "pipeline_snapshots lock acquisition timed out after 200 ms — \
                      likely contended with a long-running pipeline start/rebuild; \
-                     returning empty snapshot so /healthz does not stall (#333 item 7)"
+                     reporting the snapshot as unavailable (#333 item 7, #546)"
                 );
-                Vec::new()
+                None
             }
         }
     }

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -226,8 +226,9 @@ pub fn build_router(state: AppState) -> Router {
             post(integrations::video_source::deactivate_video_sources),
         )
         // #546: static segment, so it must not be swallowed by `/{id}` below — axum's
-        // matchit gives static segments priority, and `video_source_status_route_is_not_shadowed`
-        // in state/tests.rs pins that.
+        // matchit gives static segments priority, and
+        // `video_source_status_route_is_not_shadowed_by_the_id_route` in state/tests.rs
+        // pins that by driving the real router.
         .route(
             "/integrations/video-sources/status",
             get(integrations::video_source::video_source_status),

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -225,6 +225,13 @@ pub fn build_router(state: AppState) -> Router {
             "/integrations/video-sources/deactivate",
             post(integrations::video_source::deactivate_video_sources),
         )
+        // #546: static segment, so it must not be swallowed by `/{id}` below — axum's
+        // matchit gives static segments priority, and `video_source_status_route_is_not_shadowed`
+        // in state/tests.rs pins that.
+        .route(
+            "/integrations/video-sources/status",
+            get(integrations::video_source::video_source_status),
+        )
         .route(
             "/integrations/video-sources/{id}",
             put(integrations::video_source::update_video_source)

--- a/crates/presenter-server/src/router/integrations/video_source.rs
+++ b/crates/presenter-server/src/router/integrations/video_source.rs
@@ -56,6 +56,52 @@ pub(crate) async fn list_video_sources(
     Ok(Json(payload))
 }
 
+/// `GET /integrations/video-sources/status` (#546) — is each mapped NDI source
+/// actually working right now, and what IS on the network?
+///
+/// A separate read-only endpoint rather than a field on the CRUD list: the "what is
+/// on the network" answer is a page-level fact, not a per-row one, and the existing
+/// list contract (a bare array) stays byte-identical.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VideoSourceStatusResponse {
+    ndi_available: bool,
+    discovered: Vec<String>,
+    sources: Vec<VideoSourceStatusDto>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VideoSourceStatusDto {
+    id: String,
+    ndi_name: String,
+    is_active: bool,
+    state: String,
+    detail: Option<String>,
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn video_source_status(
+    State(state): State<AppState>,
+) -> Result<Json<VideoSourceStatusResponse>, AppError> {
+    let snapshot = state.video_source_status().await?;
+    Ok(Json(VideoSourceStatusResponse {
+        ndi_available: snapshot.ndi_available,
+        discovered: snapshot.discovered,
+        sources: snapshot
+            .sources
+            .into_iter()
+            .map(|s| VideoSourceStatusDto {
+                id: s.id,
+                ndi_name: s.ndi_name,
+                is_active: s.is_active,
+                state: s.state.to_string(),
+                detail: s.detail,
+            })
+            .collect(),
+    }))
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn create_video_source(
     State(state): State<AppState>,

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -10,6 +10,45 @@ use presenter_ndi::PipelineStartError;
 use super::AppState;
 use crate::android_stage::AndroidStageDisplayStatusSnapshot;
 use crate::resolume::ResolumeConnectionSnapshot;
+use crate::state::video_source_status;
+
+/// What the server can honestly say about every mapped NDI source right now (#546).
+///
+/// `discovered` rides along deliberately: seeing the mapped `RESOLUME-PP (cg-obs)`
+/// next to the network's actual `STREAM-PP (stream)` is what makes a renamed or
+/// switched-off sender obvious at a glance — the whole point of the ticket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoSourceStatusSnapshot {
+    /// False when this server has no NDI SDK and therefore cannot see the network.
+    pub ndi_available: bool,
+    /// The NDI names that ARE on the network right now.
+    pub discovered: Vec<String>,
+    pub sources: Vec<VideoSourceStatusEntry>,
+}
+
+/// One mapped source's live state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoSourceStatusEntry {
+    pub id: String,
+    pub ndi_name: String,
+    pub is_active: bool,
+    /// `unknown | not-found | ready | connecting | not-broadcasting | live`.
+    pub state: &'static str,
+    /// The pipeline's error text, when it has one.
+    pub detail: Option<String>,
+}
+
+impl VideoSourceStatusEntry {
+    fn unknown(row: &VideoSource) -> Self {
+        Self {
+            id: row.id.to_string(),
+            ndi_name: row.ndi_name.clone(),
+            is_active: row.is_active,
+            state: video_source_status::VideoSourceState::Unknown.as_str(),
+            detail: None,
+        }
+    }
+}
 
 /// How a failed `start_pipeline` should be surfaced when activating a source.
 ///
@@ -218,6 +257,77 @@ impl AppState {
     // Video source methods
     pub async fn list_video_sources(&self) -> anyhow::Result<Vec<VideoSource>> {
         self.repository.list_video_sources().await
+    }
+
+    /// Is each mapped NDI source actually working, right now? (#546)
+    ///
+    /// The three facts that answer that live in three different places — the DB rows,
+    /// the NDI discovery list, and the pipeline map — and until now nothing joined
+    /// them, so a mapped-but-absent source (the PP outage) was indistinguishable from
+    /// a broken server. This is the join; the decision itself is the pure
+    /// [`video_source_status::classify`].
+    ///
+    /// Fail-soft on purpose: a discovery error or a busy pipeline lock degrades to
+    /// "nothing discovered" / "no pipeline", never to an error page. The settings page
+    /// must keep rendering even when NDI is unhappy — that is exactly when the
+    /// operator needs to look at it.
+    pub async fn video_source_status(&self) -> anyhow::Result<VideoSourceStatusSnapshot> {
+        let rows = self.list_video_sources().await?;
+
+        let Some(manager) = &self.ndi_manager else {
+            // No SDK: we cannot see the network, and we say so rather than accusing a
+            // sending machine that may be perfectly fine.
+            return Ok(VideoSourceStatusSnapshot {
+                ndi_available: false,
+                discovered: Vec::new(),
+                sources: rows
+                    .into_iter()
+                    .map(|r| VideoSourceStatusEntry::unknown(&r))
+                    .collect(),
+            });
+        };
+
+        let discovered: Vec<String> = match manager.discover_sources(0) {
+            Ok(sources) => sources.into_iter().map(|s| s.name).collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "NDI discovery failed while reading source status");
+                Vec::new()
+            }
+        };
+
+        let pipelines: HashMap<String, (&'static str, Option<String>)> = manager
+            .pipeline_snapshots()
+            .await
+            .into_iter()
+            .map(|(id, state)| (id, video_source_status::pipeline_state_str(&state)))
+            .collect();
+
+        let sources = rows
+            .into_iter()
+            .map(|row| {
+                let pipeline = pipelines.get(&row.id.to_string());
+                let state = video_source_status::classify(
+                    row.is_active,
+                    &row.ndi_name,
+                    true,
+                    &discovered,
+                    pipeline.map(|(s, _)| *s),
+                );
+                VideoSourceStatusEntry {
+                    id: row.id.to_string(),
+                    ndi_name: row.ndi_name,
+                    is_active: row.is_active,
+                    state: state.as_str(),
+                    detail: pipeline.and_then(|(_, err)| err.clone()),
+                }
+            })
+            .collect();
+
+        Ok(VideoSourceStatusSnapshot {
+            ndi_available: true,
+            discovered,
+            sources,
+        })
     }
 
     pub async fn create_video_source(
@@ -556,6 +666,84 @@ mod tests {
         assert!(
             classified.is_hard_error,
             "a genuine pipeline failure must fail the activation",
+        );
+    }
+
+    // ── #546: does the server actually JOIN the three facts? ────────────────────
+    //
+    // The classifier's rules are unit-tested in `state::video_source_status`. What
+    // these two guard is the join itself: that the state method really reads the NDI
+    // discovery list and the pipeline map, and really reports what it finds. Without
+    // them the classifier could be perfect while the server fed it nothing.
+
+    #[tokio::test]
+    async fn video_source_status_reports_the_pp_incident_as_not_found() {
+        let (state, source_id, _id, fake) = state_with_fake(StartOutcome::SilentSource).await;
+        // The network carries a DIFFERENT name than the one the operator mapped —
+        // the source is `STREAM-SNV (stream)` (see `state_with_fake`).
+        fake.set_discovered(&["SOMETHING-ELSE (stream)"]);
+        state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("a silent source still activates (#448)");
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+
+        assert!(snapshot.ndi_available);
+        assert_eq!(snapshot.discovered, vec!["SOMETHING-ELSE (stream)"]);
+        let entry = snapshot
+            .sources
+            .first()
+            .expect("the created source is in the snapshot");
+        assert_eq!(
+            entry.state, "not-found",
+            "a mapped name that is not on the network must say so — the operator was \
+             left staring at a blank stage with no clue why (#546)",
+        );
+        assert!(entry.is_active, "the row IS activated — that is the trap");
+    }
+
+    #[tokio::test]
+    async fn video_source_status_reports_live_when_the_pipeline_is_streaming() {
+        let (state, source_id, id, fake) = state_with_fake(StartOutcome::Ok).await;
+        fake.set_discovered(&["STREAM-SNV (stream)"]);
+        fake.set_pipeline(&id, presenter_ndi::pipeline::PipelineState::Streaming);
+        state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("activation succeeds");
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+        let entry = snapshot.sources.first().expect("one source");
+        assert_eq!(entry.state, "live");
+        assert_eq!(entry.detail, None);
+    }
+
+    #[tokio::test]
+    async fn video_source_status_says_unknown_when_there_is_no_ndi_sdk() {
+        // The libndi-free host (GH runners, and any server without the SDK): we cannot
+        // see the network, so we must not accuse the sending machine. Cleared
+        // explicitly — `AppState::new` picks the handle up from the HOST, and dev2 has
+        // libndi while the CI runners do not.
+        let mut state = AppState::in_memory().await.expect("in-memory AppState");
+        state.clear_ndi_handle();
+        state
+            .create_video_source(
+                VideoSourceDraft::new("Cam 1", "STREAM-SNV (stream)"),
+                SettingsAuditSource::HttpSetter,
+                "test",
+            )
+            .await
+            .expect("create video source");
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+
+        assert!(!snapshot.ndi_available);
+        assert!(snapshot.discovered.is_empty());
+        assert_eq!(
+            snapshot.sources.first().map(|s| s.state),
+            Some("unknown"),
+            "without the SDK the honest answer is 'we cannot see', never 'not found'",
         );
     }
 }

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -11,6 +11,7 @@ use super::AppState;
 use crate::android_stage::AndroidStageDisplayStatusSnapshot;
 use crate::resolume::ResolumeConnectionSnapshot;
 use crate::state::video_source_status;
+use crate::state::video_source_status::{Discovery, PipelineFact};
 
 /// What the server can honestly say about every mapped NDI source right now (#546).
 ///
@@ -267,10 +268,14 @@ impl AppState {
     /// a broken server. This is the join; the decision itself is the pure
     /// [`video_source_status::classify`].
     ///
-    /// Fail-soft on purpose: a discovery error or a busy pipeline lock degrades to
-    /// "nothing discovered" / "no pipeline", never to an error page. The settings page
-    /// must keep rendering even when NDI is unhappy — that is exactly when the
-    /// operator needs to look at it.
+    /// Fail-soft on purpose — but never into a LIE. A discovery failure degrades to
+    /// [`Discovery::Blind`] ("we cannot see the network"), NOT to an empty network
+    /// (which would make a broken server accuse every sending machine at the site);
+    /// a busy pipeline lock degrades to [`PipelineFact::Unreadable`] ("the manager is
+    /// busy starting it"), NOT to "no pipeline" (which would paint every normal
+    /// activation as "sending nothing"). Both were deep-review findings on the first
+    /// cut of #546. Neither degrades to an error page: the settings page must keep
+    /// rendering when NDI is unhappy — that is exactly when the operator needs it.
     pub async fn video_source_status(&self) -> anyhow::Result<VideoSourceStatusSnapshot> {
         let rows = self.list_video_sources().await?;
 
@@ -287,45 +292,59 @@ impl AppState {
             });
         };
 
-        let discovered: Vec<String> = match manager.discover_sources(0) {
-            Ok(sources) => sources.into_iter().map(|s| s.name).collect(),
+        let discovered: Option<Vec<String>> = match manager.discover_sources(0) {
+            Ok(sources) => Some(sources.into_iter().map(|s| s.name).collect()),
             Err(e) => {
                 tracing::warn!(error = %e, "NDI discovery failed while reading source status");
-                Vec::new()
+                None
             }
         };
 
-        let pipelines: HashMap<String, (&'static str, Option<String>)> = manager
-            .pipeline_snapshots()
-            .await
-            .into_iter()
-            .map(|(id, state)| (id, video_source_status::pipeline_state_str(&state)))
-            .collect();
+        // `None` = the manager's lock was held past our budget (it is busy building a
+        // pipeline), which is NOT the same fact as "there are no pipelines".
+        let pipelines: Option<HashMap<String, (&'static str, Option<String>)>> =
+            manager.pipeline_snapshots_checked().await.map(|snapshots| {
+                snapshots
+                    .into_iter()
+                    .map(|(id, state)| (id, video_source_status::pipeline_state_str(&state)))
+                    .collect()
+            });
+
+        let discovery = match &discovered {
+            Some(names) => Discovery::Names(names),
+            None => Discovery::Blind,
+        };
 
         let sources = rows
             .into_iter()
             .map(|row| {
-                let pipeline = pipelines.get(&row.id.to_string());
+                let pipeline = pipelines
+                    .as_ref()
+                    .map(|map| map.get(&row.id.to_string()).cloned());
                 let state = video_source_status::classify(
                     row.is_active,
                     &row.ndi_name,
-                    true,
-                    &discovered,
-                    pipeline.map(|(s, _)| *s),
+                    discovery,
+                    match &pipeline {
+                        Some(entry) => PipelineFact::Known(entry.as_ref().map(|(s, _)| *s)),
+                        None => PipelineFact::Unreadable,
+                    },
                 );
                 VideoSourceStatusEntry {
                     id: row.id.to_string(),
                     ndi_name: row.ndi_name,
                     is_active: row.is_active,
                     state: state.as_str(),
-                    detail: pipeline.and_then(|(_, err)| err.clone()),
+                    detail: pipeline.flatten().and_then(|(_, err)| err),
                 }
             })
             .collect();
 
         Ok(VideoSourceStatusSnapshot {
-            ndi_available: true,
-            discovered,
+            // A discovery failure leaves us blind, exactly like a missing SDK — the UI
+            // must not print "On the network now: nothing" off the back of it.
+            ndi_available: discovered.is_some(),
+            discovered: discovered.unwrap_or_default(),
             sources,
         })
     }
@@ -717,6 +736,52 @@ mod tests {
         let entry = snapshot.sources.first().expect("one source");
         assert_eq!(entry.state, "live");
         assert_eq!(entry.detail, None);
+    }
+
+    /// THE ACTIVATION WINDOW (deep review 🟡 #1). `start_pipeline` holds the manager's
+    /// lock across its 8 s caps-wait, so a status poll landing in that window cannot read
+    /// the snapshot map at all. Reading "cannot look" as "no pipeline" painted the HAPPY
+    /// path amber and told the operator to go start an NDI output that was already on.
+    #[tokio::test]
+    async fn video_source_status_says_connecting_while_the_manager_is_busy_starting() {
+        let (state, source_id, _id, fake) = state_with_fake(StartOutcome::Ok).await;
+        fake.set_discovered(&["STREAM-SNV (stream)"]);
+        state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("activation succeeds");
+        // The manager is mid-start: its lock is held, so the snapshot times out.
+        fake.set_snapshots_unreadable();
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+        let entry = snapshot.sources.first().expect("one source");
+        assert_eq!(
+            entry.state, "connecting",
+            "a busy manager means the pipeline is coming up — NOT that the sending \
+             machine is silent",
+        );
+    }
+
+    /// Deep review 🟡 #2: a discovery FAILURE leaves us blind. Degrading it to an empty
+    /// network would make a broken server tell the operator that every sending machine
+    /// at the site is off — the exact false accusation this module exists to prevent.
+    #[tokio::test]
+    async fn video_source_status_says_unknown_when_discovery_itself_fails() {
+        let (state, _source_id, _id, fake) = state_with_fake(StartOutcome::Ok).await;
+        fake.fail_discovery();
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+
+        assert!(
+            !snapshot.ndi_available,
+            "a finder we cannot query is a network we cannot see",
+        );
+        assert!(snapshot.discovered.is_empty());
+        assert_eq!(
+            snapshot.sources.first().map(|s| s.state),
+            Some("unknown"),
+            "a discovery failure must never render as 'not found on the network'",
+        );
     }
 
     #[tokio::test]

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -41,6 +41,7 @@ mod stage_state;
 #[cfg(test)]
 mod tests;
 mod timers;
+pub(crate) mod video_source_status;
 
 #[cfg(test)]
 use crate::config::OscConfig;
@@ -629,6 +630,17 @@ impl AppState {
     #[cfg(test)]
     pub(crate) fn set_ndi_handle(&mut self, handle: ndi_control::NdiManagerHandle) {
         self.ndi_manager = Some(handle);
+    }
+
+    /// Test-only: make this state SDK-less on purpose.
+    ///
+    /// `AppState::new` calls `NdiManager::try_new()`, so whether an in-memory state has
+    /// an NDI handle depends on whether the HOST has libndi — dev2 does, the GitHub
+    /// runners do not. A test about the blind-server path must not be at the mercy of
+    /// that (#546).
+    #[cfg(test)]
+    pub(crate) fn clear_ndi_handle(&mut self) {
+        self.ndi_manager = None;
     }
 
     pub fn stage_connections_handle(&self) -> StageConnections {

--- a/crates/presenter-server/src/state/ndi_control.rs
+++ b/crates/presenter-server/src/state/ndi_control.rs
@@ -97,7 +97,7 @@ impl NdiManagerHandle {
         match self {
             Self::Real(m) => m.discover_sources(timeout_ms),
             #[cfg(test)]
-            Self::Fake(_) => unreachable!("FakeNdiControl::discover_sources is never exercised"),
+            Self::Fake(f) => Ok(f.discovered()),
         }
     }
 
@@ -108,7 +108,7 @@ impl NdiManagerHandle {
         match self {
             Self::Real(m) => m.pipeline_snapshots().await,
             #[cfg(test)]
-            Self::Fake(_) => unreachable!("FakeNdiControl::pipeline_snapshots is never exercised"),
+            Self::Fake(f) => f.pipeline_snapshots(),
         }
     }
 
@@ -163,6 +163,10 @@ impl NdiManagerHandle {
 pub(crate) struct FakeNdiControl {
     calls: Mutex<Vec<NdiCall>>,
     start_outcome: Mutex<StartOutcome>,
+    /// What the NDI network "contains" — drives the #546 status join without libndi.
+    discovered: Mutex<Vec<String>>,
+    /// What the manager's pipeline map "holds", keyed by source id.
+    snapshots: Mutex<Vec<(String, presenter_ndi::pipeline::PipelineState)>>,
 }
 
 /// One recorded call against [`FakeNdiControl`].
@@ -200,6 +204,37 @@ impl FakeNdiControl {
     /// The ordered sequence of calls recorded so far.
     pub(crate) fn calls(&self) -> Vec<NdiCall> {
         self.calls.lock().expect("calls lock").clone()
+    }
+
+    /// Put these NDI names "on the network" (#546).
+    pub(crate) fn set_discovered(&self, names: &[&str]) {
+        *self.discovered.lock().expect("discovered lock") =
+            names.iter().map(|n| (*n).to_string()).collect();
+    }
+
+    /// Put this pipeline in the manager's map (#546).
+    pub(crate) fn set_pipeline(
+        &self,
+        source_id: &str,
+        state: presenter_ndi::pipeline::PipelineState,
+    ) {
+        self.snapshots
+            .lock()
+            .expect("snapshots lock")
+            .push((source_id.to_string(), state));
+    }
+
+    fn discovered(&self) -> Vec<presenter_ndi::discovery::NdiSourceInfo> {
+        self.discovered
+            .lock()
+            .expect("discovered lock")
+            .iter()
+            .map(|name| presenter_ndi::discovery::NdiSourceInfo { name: name.clone() })
+            .collect()
+    }
+
+    fn pipeline_snapshots(&self) -> Vec<(String, presenter_ndi::pipeline::PipelineState)> {
+        self.snapshots.lock().expect("snapshots lock").clone()
     }
 
     /// Whether `stop_other_pipelines(keep_id)` was recorded with this id.

--- a/crates/presenter-server/src/state/ndi_control.rs
+++ b/crates/presenter-server/src/state/ndi_control.rs
@@ -97,7 +97,7 @@ impl NdiManagerHandle {
         match self {
             Self::Real(m) => m.discover_sources(timeout_ms),
             #[cfg(test)]
-            Self::Fake(f) => Ok(f.discovered()),
+            Self::Fake(f) => f.discovered(),
         }
     }
 
@@ -107,6 +107,19 @@ impl NdiManagerHandle {
     ) -> Vec<(String, presenter_ndi::pipeline::PipelineState)> {
         match self {
             Self::Real(m) => m.pipeline_snapshots().await,
+            #[cfg(test)]
+            Self::Fake(f) => f.pipeline_snapshots().unwrap_or_default(),
+        }
+    }
+
+    /// Forward to [`NdiManager::pipeline_snapshots_checked`] — `None` when the
+    /// manager's lock could not be taken (it is busy starting a pipeline), which the
+    /// #546 status join must NOT read as "no pipelines".
+    pub(crate) async fn pipeline_snapshots_checked(
+        &self,
+    ) -> Option<Vec<(String, presenter_ndi::pipeline::PipelineState)>> {
+        match self {
+            Self::Real(m) => m.pipeline_snapshots_checked().await,
             #[cfg(test)]
             Self::Fake(f) => f.pipeline_snapshots(),
         }
@@ -167,6 +180,11 @@ pub(crate) struct FakeNdiControl {
     discovered: Mutex<Vec<String>>,
     /// What the manager's pipeline map "holds", keyed by source id.
     snapshots: Mutex<Vec<(String, presenter_ndi::pipeline::PipelineState)>>,
+    /// `true` = the manager's lock is held (it is busy starting a pipeline), so the
+    /// snapshot map cannot be read at all — the real 200 ms-timeout path.
+    snapshots_unreadable: Mutex<bool>,
+    /// `true` = the NDI finder errors out, so this server cannot see the network.
+    discovery_fails: Mutex<bool>,
 }
 
 /// One recorded call against [`FakeNdiControl`].
@@ -224,17 +242,42 @@ impl FakeNdiControl {
             .push((source_id.to_string(), state));
     }
 
-    fn discovered(&self) -> Vec<presenter_ndi::discovery::NdiSourceInfo> {
-        self.discovered
+    /// Make NDI discovery FAIL — the server is blind, not looking at an empty network (#546).
+    pub(crate) fn fail_discovery(&self) {
+        *self.discovery_fails.lock().expect("discovery_fails lock") = true;
+    }
+
+    fn discovered(&self) -> anyhow::Result<Vec<presenter_ndi::discovery::NdiSourceInfo>> {
+        if *self.discovery_fails.lock().expect("discovery_fails lock") {
+            return Err(anyhow::anyhow!("NDI finder unavailable"));
+        }
+        Ok(self
+            .discovered
             .lock()
             .expect("discovered lock")
             .iter()
             .map(|name| presenter_ndi::discovery::NdiSourceInfo { name: name.clone() })
-            .collect()
+            .collect())
     }
 
-    fn pipeline_snapshots(&self) -> Vec<(String, presenter_ndi::pipeline::PipelineState)> {
-        self.snapshots.lock().expect("snapshots lock").clone()
+    /// Simulate the manager being BUSY (mid `start_pipeline`): its lock is held, so the
+    /// snapshot map cannot be read within the 200 ms budget (#546).
+    pub(crate) fn set_snapshots_unreadable(&self) {
+        *self
+            .snapshots_unreadable
+            .lock()
+            .expect("snapshots_unreadable lock") = true;
+    }
+
+    fn pipeline_snapshots(&self) -> Option<Vec<(String, presenter_ndi::pipeline::PipelineState)>> {
+        if *self
+            .snapshots_unreadable
+            .lock()
+            .expect("snapshots_unreadable lock")
+        {
+            return None;
+        }
+        Some(self.snapshots.lock().expect("snapshots lock").clone())
     }
 
     /// Whether `stop_other_pipelines(keep_id)` was recorded with this id.

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1285,3 +1285,45 @@ async fn ableset_resolves_presentation_through_cache() {
     let missing = state.resolve_ableset_presentation("999").await.unwrap();
     assert_eq!(missing, None, "unknown prefix must resolve to None");
 }
+
+/// #546: `GET /integrations/video-sources/status` is a STATIC segment sitting next to
+/// `/integrations/video-sources/{id}`. axum's matchit gives static segments priority, so
+/// the status route wins — but nothing in the tree pinned that, and a future reorder or a
+/// switch to a wildcard would silently route `/status` into the `{id}` handler (which
+/// would then look up a video source whose id is the literal string "status" and 404).
+/// This asserts the status handler actually answers.
+#[tokio::test]
+async fn video_source_status_route_is_not_shadowed_by_the_id_route() {
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use tower::ServiceExt;
+
+    let state = AppState::in_memory().await.unwrap();
+    let app = crate::router::build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/integrations/video-sources/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "the status route must answer — a 404/405 means `{{id}}` swallowed it"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .expect("body bytes");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("status json");
+    assert!(
+        json.get("sources").is_some() && json.get("ndiAvailable").is_some(),
+        "the status payload, not the by-id payload: {json}"
+    );
+}

--- a/crates/presenter-server/src/state/video_source_status.rs
+++ b/crates/presenter-server/src/state/video_source_status.rs
@@ -1,0 +1,206 @@
+//! Is the NDI source the operator mapped actually WORKING? (#546)
+//!
+//! The PP incident: an operator mapped `cgpp → RESOLUME-PP (cg-obs)`, activated it,
+//! and the stage stayed blank — with nothing in the UI saying why. The sending
+//! machine simply was not broadcasting that name (`GET /ndi/sources` on that host
+//! listed only `STREAM-PP (stream)`). Hours went into the encoder chain before the
+//! server log revealed the truth:
+//!
+//! ```text
+//! NDI source activated but not yet producing — broadcaster silent (#448)
+//! ```
+//!
+//! The server already held every fact needed to say so — the configured rows, the
+//! NDI discovery list, and the pipeline snapshots — it just never joined them.
+//! This module is that join's decision function: PURE, so the exact rule ORDER (the
+//! part that is easy to get subtly wrong, and the part that lies to the operator when
+//! it is wrong) is pinned by unit tests with no hardware and no AppState.
+
+/// What we can honestly say about one mapped NDI source right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VideoSourceState {
+    /// This server has no NDI SDK, so it cannot see the network at all. We say so —
+    /// we never claim a source is missing from a network we cannot look at.
+    Unknown,
+    /// The mapped name is NOT on the network. THE PP CASE: the sending machine is
+    /// off, or its NDI output is off, or the name was renamed.
+    NotFound,
+    /// On the network, but the operator has not activated it.
+    Ready,
+    /// Activated, pipeline still coming up.
+    Connecting,
+    /// On the network AND activated — but no frames are arriving. The broadcaster is
+    /// silent (#448), or the pipeline stopped/errored.
+    NotBroadcasting,
+    /// Activated and streaming. Video is flowing.
+    Live,
+}
+
+impl VideoSourceState {
+    /// The wire value. Kebab-case, because the UI builds its CSS modifier straight
+    /// from it (`settings__status--not-found`).
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::NotFound => "not-found",
+            Self::Ready => "ready",
+            Self::Connecting => "connecting",
+            Self::NotBroadcasting => "not-broadcasting",
+            Self::Live => "live",
+        }
+    }
+}
+
+/// Decide the state of ONE mapped source. Pure — no I/O, no clock, no hardware.
+///
+/// `pipeline_state` is this source's entry in the manager's snapshot map, if any
+/// (`"starting" | "streaming" | "stopped" | "errored"`). A source whose broadcaster
+/// went silent has NO entry at all: the pipeline is stopped and dropped (#448), which
+/// is precisely why "no pipeline" cannot be read as "nothing wrong".
+///
+/// The rule ORDER carries the meaning:
+///
+/// 1. No SDK → `Unknown`. Never claim `NotFound` about a network we cannot see.
+/// 2. Streaming → `Live`. Frames are the strongest possible proof the source exists —
+///    stronger than discovery, whose finder list can still be catching up.
+/// 3. Not in discovery → `NotFound`. The PP case.
+/// 4. Not activated → `Ready`.
+/// 5. Starting → `Connecting`.
+/// 6. Otherwise → `NotBroadcasting`: it IS on the network, it IS switched on, and no
+///    video is arriving.
+pub(crate) fn classify(
+    _is_active: bool,
+    _ndi_name: &str,
+    _ndi_available: bool,
+    _discovered: &[String],
+    _pipeline_state: Option<&str>,
+) -> VideoSourceState {
+    // [red] stub — the real rules land in the GREEN commit.
+    VideoSourceState::Unknown
+}
+
+/// The wire name of a pipeline state, plus its error text when it has one.
+///
+/// Deliberately a local mapping rather than a shared one with `/healthz`: coupling the
+/// health endpoint's payload to this feature would make every future change to either
+/// one a change to both, and it is six lines.
+pub(crate) fn pipeline_state_str(
+    state: &presenter_ndi::pipeline::PipelineState,
+) -> (&'static str, Option<String>) {
+    use presenter_ndi::pipeline::PipelineState as P;
+    match state {
+        P::Starting => ("starting", None),
+        P::Streaming => ("streaming", None),
+        P::Stopped => ("stopped", None),
+        P::Errored(msg) => ("errored", Some(msg.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAPPED: &str = "RESOLUME-PP (cg-obs)";
+    const ON_AIR: &str = "STREAM-PP (stream)";
+
+    /// THE PP INCIDENT, exactly. The operator mapped and activated a name that is not
+    /// on the network; the only thing on the network is a DIFFERENT name. Before #546
+    /// the UI said nothing at all and the blame landed on the server.
+    #[test]
+    fn not_found_when_the_mapped_name_is_absent_from_discovery() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[ON_AIR.to_string()], None),
+            VideoSourceState::NotFound
+        );
+    }
+
+    /// #448: the broadcaster is silent, so the pipeline was stopped and DROPPED — the
+    /// source has no snapshot at all. "No pipeline" must not read as "fine".
+    #[test]
+    fn not_broadcasting_when_discovered_and_active_but_no_frames() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[MAPPED.to_string()], None),
+            VideoSourceState::NotBroadcasting
+        );
+    }
+
+    /// A pipeline that errored is not sending video either — same answer, and the
+    /// error text rides along separately as `detail`.
+    #[test]
+    fn not_broadcasting_when_the_pipeline_errored() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("errored")),
+            VideoSourceState::NotBroadcasting
+        );
+    }
+
+    #[test]
+    fn live_when_the_pipeline_is_streaming() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("streaming")),
+            VideoSourceState::Live
+        );
+    }
+
+    /// Frames beat discovery. The NDI finder's list is rebuilt on its own ~5s tick, so
+    /// a source that is demonstrably sending video can still be missing from it for a
+    /// moment — reporting THAT as "not found" would be a lie the operator acts on.
+    #[test]
+    fn live_beats_a_discovery_list_that_has_not_caught_up() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[], Some("streaming")),
+            VideoSourceState::Live
+        );
+    }
+
+    #[test]
+    fn ready_when_on_the_network_but_not_activated() {
+        assert_eq!(
+            classify(false, MAPPED, true, &[MAPPED.to_string()], None),
+            VideoSourceState::Ready
+        );
+    }
+
+    #[test]
+    fn connecting_while_the_pipeline_is_starting() {
+        assert_eq!(
+            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("starting")),
+            VideoSourceState::Connecting
+        );
+    }
+
+    /// Without the NDI SDK this server is blind. Saying "not found on the network"
+    /// would send the operator to check a sending machine that is perfectly fine.
+    #[test]
+    fn unknown_rather_than_not_found_when_the_ndi_sdk_is_unavailable() {
+        assert_eq!(
+            classify(true, MAPPED, false, &[], None),
+            VideoSourceState::Unknown
+        );
+    }
+
+    #[test]
+    fn wire_names_are_kebab_case() {
+        assert_eq!(VideoSourceState::NotFound.as_str(), "not-found");
+        assert_eq!(
+            VideoSourceState::NotBroadcasting.as_str(),
+            "not-broadcasting"
+        );
+        assert_eq!(VideoSourceState::Live.as_str(), "live");
+        assert_eq!(VideoSourceState::Ready.as_str(), "ready");
+        assert_eq!(VideoSourceState::Connecting.as_str(), "connecting");
+        assert_eq!(VideoSourceState::Unknown.as_str(), "unknown");
+    }
+
+    #[test]
+    fn pipeline_states_map_to_their_wire_names() {
+        use presenter_ndi::pipeline::PipelineState as P;
+        assert_eq!(pipeline_state_str(&P::Starting), ("starting", None));
+        assert_eq!(pipeline_state_str(&P::Streaming), ("streaming", None));
+        assert_eq!(pipeline_state_str(&P::Stopped), ("stopped", None));
+        assert_eq!(
+            pipeline_state_str(&P::Errored("boom".into())),
+            ("errored", Some("boom".to_string()))
+        );
+    }
+}

--- a/crates/presenter-server/src/state/video_source_status.rs
+++ b/crates/presenter-server/src/state/video_source_status.rs
@@ -69,14 +69,28 @@ impl VideoSourceState {
 /// 6. Otherwise → `NotBroadcasting`: it IS on the network, it IS switched on, and no
 ///    video is arriving.
 pub(crate) fn classify(
-    _is_active: bool,
-    _ndi_name: &str,
-    _ndi_available: bool,
-    _discovered: &[String],
-    _pipeline_state: Option<&str>,
+    is_active: bool,
+    ndi_name: &str,
+    ndi_available: bool,
+    discovered: &[String],
+    pipeline_state: Option<&str>,
 ) -> VideoSourceState {
-    // [red] stub — the real rules land in the GREEN commit.
-    VideoSourceState::Unknown
+    if !ndi_available {
+        return VideoSourceState::Unknown;
+    }
+    if pipeline_state == Some("streaming") {
+        return VideoSourceState::Live;
+    }
+    if !discovered.iter().any(|d| d == ndi_name) {
+        return VideoSourceState::NotFound;
+    }
+    if !is_active {
+        return VideoSourceState::Ready;
+    }
+    if pipeline_state == Some("starting") {
+        return VideoSourceState::Connecting;
+    }
+    VideoSourceState::NotBroadcasting
 }
 
 /// The wire name of a pipeline state, plus its error text when it has one.

--- a/crates/presenter-server/src/state/video_source_status.rs
+++ b/crates/presenter-server/src/state/video_source_status.rs
@@ -51,34 +51,57 @@ impl VideoSourceState {
     }
 }
 
+/// What this server can see of the NDI network right now.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Discovery<'a> {
+    /// We cannot look at all — no NDI SDK on this host, or the finder failed. A
+    /// blind server must NEVER accuse a sending machine of being off.
+    Blind,
+    /// The names the finder currently lists.
+    Names(&'a [String]),
+}
+
+/// What this server can see of the source's pipeline right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PipelineFact<'a> {
+    /// We read the manager's map: this is the source's entry (`None` = it has no
+    /// pipeline at all).
+    Known(Option<&'a str>),
+    /// The manager's lock was held past our 200 ms budget, so we could not look.
+    /// In practice that means it is BUSY — `start_pipeline` holds that same lock
+    /// across its 8 s caps-wait, so this is the normal state during an activation.
+    Unreadable,
+}
+
 /// Decide the state of ONE mapped source. Pure — no I/O, no clock, no hardware.
 ///
-/// `pipeline_state` is this source's entry in the manager's snapshot map, if any
-/// (`"starting" | "streaming" | "stopped" | "errored"`). A source whose broadcaster
-/// went silent has NO entry at all: the pipeline is stopped and dropped (#448), which
-/// is precisely why "no pipeline" cannot be read as "nothing wrong".
+/// A source whose broadcaster went silent has NO pipeline entry at all: the pipeline
+/// is stopped and dropped (#448), which is precisely why `Known(None)` cannot be read
+/// as "nothing wrong" — and equally why [`PipelineFact::Unreadable`] must not collapse
+/// into it (an unreadable map during activation would otherwise be reported as "sending
+/// nothing", sending the operator off to fix a machine that is fine).
 ///
 /// The rule ORDER carries the meaning:
 ///
-/// 1. No SDK → `Unknown`. Never claim `NotFound` about a network we cannot see.
-/// 2. Streaming → `Live`. Frames are the strongest possible proof the source exists —
-///    stronger than discovery, whose finder list can still be catching up.
+/// 1. Blind → `Unknown`. Never claim `NotFound` about a network we cannot see.
+/// 2. Active + streaming → `Live`. Frames are the strongest possible proof the source
+///    exists — stronger than discovery, whose finder list can still be catching up.
 /// 3. Not in discovery → `NotFound`. The PP case.
-/// 4. Not activated → `Ready`.
-/// 5. Starting → `Connecting`.
+/// 4. Not activated → `Ready` (even if a just-reaped pipeline is still winding down).
+/// 5. Starting, or the map was unreadable (⇒ the manager is busy starting it) →
+///    `Connecting`.
 /// 6. Otherwise → `NotBroadcasting`: it IS on the network, it IS switched on, and no
 ///    video is arriving.
 pub(crate) fn classify(
     is_active: bool,
     ndi_name: &str,
-    ndi_available: bool,
-    discovered: &[String],
-    pipeline_state: Option<&str>,
+    discovery: Discovery<'_>,
+    pipeline: PipelineFact<'_>,
 ) -> VideoSourceState {
-    if !ndi_available {
+    let Discovery::Names(discovered) = discovery else {
         return VideoSourceState::Unknown;
-    }
-    if pipeline_state == Some("streaming") {
+    };
+    if is_active && pipeline == PipelineFact::Known(Some("streaming")) {
         return VideoSourceState::Live;
     }
     if !discovered.iter().any(|d| d == ndi_name) {
@@ -87,10 +110,12 @@ pub(crate) fn classify(
     if !is_active {
         return VideoSourceState::Ready;
     }
-    if pipeline_state == Some("starting") {
-        return VideoSourceState::Connecting;
+    match pipeline {
+        PipelineFact::Unreadable | PipelineFact::Known(Some("starting")) => {
+            VideoSourceState::Connecting
+        }
+        _ => VideoSourceState::NotBroadcasting,
     }
-    VideoSourceState::NotBroadcasting
 }
 
 /// The wire name of a pipeline state, plus its error text when it has one.
@@ -117,13 +142,24 @@ mod tests {
     const MAPPED: &str = "RESOLUME-PP (cg-obs)";
     const ON_AIR: &str = "STREAM-PP (stream)";
 
+    /// The network lists these names.
+    fn network(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
     /// THE PP INCIDENT, exactly. The operator mapped and activated a name that is not
     /// on the network; the only thing on the network is a DIFFERENT name. Before #546
     /// the UI said nothing at all and the blame landed on the server.
     #[test]
     fn not_found_when_the_mapped_name_is_absent_from_discovery() {
+        let net = network(&[ON_AIR]);
         assert_eq!(
-            classify(true, MAPPED, true, &[ON_AIR.to_string()], None),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(None)
+            ),
             VideoSourceState::NotFound
         );
     }
@@ -132,8 +168,14 @@ mod tests {
     /// source has no snapshot at all. "No pipeline" must not read as "fine".
     #[test]
     fn not_broadcasting_when_discovered_and_active_but_no_frames() {
+        let net = network(&[MAPPED]);
         assert_eq!(
-            classify(true, MAPPED, true, &[MAPPED.to_string()], None),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(None)
+            ),
             VideoSourceState::NotBroadcasting
         );
     }
@@ -142,16 +184,28 @@ mod tests {
     /// error text rides along separately as `detail`.
     #[test]
     fn not_broadcasting_when_the_pipeline_errored() {
+        let net = network(&[MAPPED]);
         assert_eq!(
-            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("errored")),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(Some("errored"))
+            ),
             VideoSourceState::NotBroadcasting
         );
     }
 
     #[test]
     fn live_when_the_pipeline_is_streaming() {
+        let net = network(&[MAPPED]);
         assert_eq!(
-            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("streaming")),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(Some("streaming"))
+            ),
             VideoSourceState::Live
         );
     }
@@ -162,23 +216,75 @@ mod tests {
     #[test]
     fn live_beats_a_discovery_list_that_has_not_caught_up() {
         assert_eq!(
-            classify(true, MAPPED, true, &[], Some("streaming")),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&[]),
+                PipelineFact::Known(Some("streaming"))
+            ),
             VideoSourceState::Live
         );
     }
 
     #[test]
     fn ready_when_on_the_network_but_not_activated() {
+        let net = network(&[MAPPED]);
         assert_eq!(
-            classify(false, MAPPED, true, &[MAPPED.to_string()], None),
+            classify(
+                false,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(None)
+            ),
+            VideoSourceState::Ready
+        );
+    }
+
+    /// A source the operator just DEACTIVATED still has a winding-down pipeline for a
+    /// moment. Reporting it as `Live` next to an inactive dot is self-contradictory —
+    /// the row is off, so it reads `Ready`.
+    #[test]
+    fn ready_not_live_when_a_deactivated_row_still_has_a_streaming_pipeline() {
+        let net = network(&[MAPPED]);
+        assert_eq!(
+            classify(
+                false,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(Some("streaming"))
+            ),
             VideoSourceState::Ready
         );
     }
 
     #[test]
     fn connecting_while_the_pipeline_is_starting() {
+        let net = network(&[MAPPED]);
         assert_eq!(
-            classify(true, MAPPED, true, &[MAPPED.to_string()], Some("starting")),
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Known(Some("starting"))
+            ),
+            VideoSourceState::Connecting
+        );
+    }
+
+    /// THE ACTIVATION WINDOW (deep review 🟡 #1). `start_pipeline` holds the manager's
+    /// lock across its 8 s caps-wait, so for the whole of a NORMAL activation the
+    /// snapshot map cannot be read. Collapsing that into "no pipeline" would paint the
+    /// happy path amber and tell the operator to go start an output that is already on.
+    #[test]
+    fn connecting_when_the_manager_is_busy_and_the_snapshot_cannot_be_read() {
+        let net = network(&[MAPPED]);
+        assert_eq!(
+            classify(
+                true,
+                MAPPED,
+                Discovery::Names(&net),
+                PipelineFact::Unreadable
+            ),
             VideoSourceState::Connecting
         );
     }
@@ -188,7 +294,18 @@ mod tests {
     #[test]
     fn unknown_rather_than_not_found_when_the_ndi_sdk_is_unavailable() {
         assert_eq!(
-            classify(true, MAPPED, false, &[], None),
+            classify(true, MAPPED, Discovery::Blind, PipelineFact::Known(None)),
+            VideoSourceState::Unknown
+        );
+    }
+
+    /// Same for a discovery FAILURE (deep review 🟡 #2): a finder that errored (or never
+    /// came up) tells us nothing about the network. Degrading that to "not found" would
+    /// make a broken server blame every sending machine at the site.
+    #[test]
+    fn unknown_rather_than_not_found_when_discovery_itself_failed() {
+        assert_eq!(
+            classify(true, MAPPED, Discovery::Blind, PipelineFact::Unreadable),
             VideoSourceState::Unknown
         );
     }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.191"
+version = "0.4.197"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/api/ndi.rs
+++ b/crates/presenter-ui/src/api/ndi.rs
@@ -21,6 +21,29 @@ pub struct NdiSourceDto {
     pub name: String,
 }
 
+/// Live state of one mapped NDI source (#546) — is it actually working?
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct VideoSourceStatusDto {
+    pub id: String,
+    pub ndi_name: String,
+    pub is_active: bool,
+    /// `unknown | not-found | ready | connecting | not-broadcasting | live`.
+    pub state: String,
+    /// The pipeline's error text, when it has one.
+    pub detail: Option<String>,
+}
+
+/// The server's answer to "what is mapped, what is on the network, and what works".
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct VideoSourceStatusResponse {
+    pub ndi_available: bool,
+    /// The NDI names that ARE on the network right now.
+    pub discovered: Vec<String>,
+    pub sources: Vec<VideoSourceStatusDto>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateVideoSourceRequest {
@@ -38,6 +61,12 @@ pub async fn list_video_sources() -> Result<Vec<VideoSourceDto>, ApiError> {
 
 pub async fn discover_ndi_sources() -> Result<Vec<NdiSourceDto>, ApiError> {
     get_json("/ndi/sources").await
+}
+
+/// One call for all three facts the settings card needs (#546): whether this server can
+/// see the NDI network at all, what is on it, and the state of every mapped source.
+pub async fn get_video_source_status() -> Result<VideoSourceStatusResponse, ApiError> {
+    get_json("/integrations/video-sources/status").await
 }
 
 pub async fn create_video_source(label: &str, ndi_name: &str) -> Result<VideoSourceDto, ApiError> {

--- a/crates/presenter-ui/src/api/ndi.rs
+++ b/crates/presenter-ui/src/api/ndi.rs
@@ -2,11 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use super::{delete, get_json, post_json, post_no_content, ApiError};
 
-#[derive(Debug, Deserialize)]
-pub struct NdiStatusResponse {
-    pub available: bool,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VideoSourceDto {
@@ -16,13 +11,8 @@ pub struct VideoSourceDto {
     pub is_active: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct NdiSourceDto {
-    pub name: String,
-}
-
 /// Live state of one mapped NDI source (#546) — is it actually working?
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct VideoSourceStatusDto {
     pub id: String,
@@ -51,16 +41,8 @@ pub struct CreateVideoSourceRequest {
     pub ndi_name: String,
 }
 
-pub async fn get_ndi_status() -> Result<NdiStatusResponse, ApiError> {
-    get_json("/ndi/status").await
-}
-
 pub async fn list_video_sources() -> Result<Vec<VideoSourceDto>, ApiError> {
     get_json("/integrations/video-sources").await
-}
-
-pub async fn discover_ndi_sources() -> Result<Vec<NdiSourceDto>, ApiError> {
-    get_json("/ndi/sources").await
 }
 
 /// One call for all three facts the settings card needs (#546): whether this server can

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -3,7 +3,7 @@
 use leptos::prelude::*;
 
 use super::ToastHandle;
-use crate::api::ndi::{self, VideoSourceDto};
+use crate::api::ndi::{self, VideoSourceDto, VideoSourceStatusDto};
 use crate::components::modal::confirm;
 
 /// The badge text for a source state (#546).
@@ -13,24 +13,45 @@ use crate::components::modal::confirm;
 /// An unrecognised state degrades to the honest "NDI unavailable" rather than panicking
 /// or rendering a raw wire token.
 pub(crate) fn status_label(state: &str) -> &'static str {
-    // [red] stub — the real copy lands in the GREEN commit.
-    let _ = state;
-    ""
+    match state {
+        "live" => "Live",
+        "not-broadcasting" => "Not broadcasting",
+        "not-found" => "Not found on the network",
+        "ready" => "Ready",
+        "connecting" => "Connecting…",
+        _ => "NDI unavailable",
+    }
 }
 
-/// The CSS class pair for a source state (#546).
+/// The CSS class pair for a source state (#546). An unrecognised state falls back to
+/// `--unknown` rather than injecting whatever the server said into a class name.
 pub(crate) fn status_class(state: &str) -> String {
-    // [red] stub.
-    let _ = state;
-    String::new()
+    let known = matches!(
+        state,
+        "live" | "not-broadcasting" | "not-found" | "ready" | "connecting" | "unknown"
+    );
+    let modifier = if known { state } else { "unknown" };
+    format!("settings__status settings__status--{modifier}")
 }
 
 /// What the operator should DO about this state — shown under the row. `None` when the
 /// state needs no action (live / ready / connecting).
+///
+/// These two sentences are the entire point of #546. At PP the operator had a blank
+/// stage and no idea whether to look at the server, the network, the TV, or the sending
+/// machine. The answer was the sending machine — and now the page says so.
 pub(crate) fn status_hint(state: &str) -> Option<&'static str> {
-    // [red] stub.
-    let _ = state;
-    None
+    match state {
+        "not-found" => Some(
+            "This NDI name is not on the network. Check the sending machine is on and its \
+             NDI output is switched on — or pick one of the names listed below.",
+        ),
+        "not-broadcasting" => Some(
+            "On the network, but sending no video. Start the NDI output on the sending \
+             machine.",
+        ),
+        _ => None,
+    }
 }
 
 #[component]
@@ -38,17 +59,35 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     let sources = RwSignal::new(Vec::<VideoSourceDto>::new());
     let ndi_available = RwSignal::new(false);
     let discovered = RwSignal::new(Vec::<String>::new());
+    let statuses = RwSignal::new(Vec::<VideoSourceStatusDto>::new());
     let new_label = RwSignal::new(String::new());
     let new_ndi_name = RwSignal::new(String::new());
 
+    // #546: one call answers all three questions the operator has — can this server see
+    // the NDI network, what is ON it, and is each mapped source actually working. Polled
+    // on the same 5s cadence as every other live-status card on this page, because a
+    // source can go silent at any moment, including mid-service.
+    let poll_status = move || {
+        leptos::task::spawn_local(async move {
+            if let Ok(status) = ndi::get_video_source_status().await {
+                ndi_available.set(status.ndi_available);
+                discovered.set(status.discovered);
+                statuses.set(status.sources);
+            }
+        });
+    };
+
     leptos::task::spawn_local(async move {
-        if let Ok(status) = ndi::get_ndi_status().await {
-            ndi_available.set(status.available);
-        }
         if let Ok(list) = ndi::list_video_sources().await {
             sources.set(list);
         }
     });
+    poll_status();
+
+    let interval = gloo_timers::callback::Interval::new(super::STATUS_REFRESH_MS, move || {
+        poll_status();
+    });
+    interval.forget();
 
     let refresh = move || {
         leptos::task::spawn_local(async move {
@@ -56,6 +95,8 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                 sources.set(list);
             }
         });
+        // Don't make the operator wait up to 5s to see what their click did.
+        poll_status();
     };
 
     let scan = move |_| {
@@ -149,9 +190,22 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
             </header>
             <div class="settings__source-list" data-role="video-source-list">
                 <For
-                    each=move || sources.get()
-                    key=|s: &VideoSourceDto| format!("{}-{}", s.id, s.is_active)
-                    children=move |source: VideoSourceDto| {
+                    each=move || {
+                        // Zip each row with its live state. The state MUST be part of the
+                        // key below — keying on id+is_active alone (as this card did) means
+                        // the 5s poll runs and the badge never re-renders.
+                        let by_id = statuses.get();
+                        sources.get().into_iter().map(move |s| {
+                            let state = by_id
+                                .iter()
+                                .find(|st| st.id == s.id)
+                                .map(|st| st.state.clone())
+                                .unwrap_or_default();
+                            (s, state)
+                        }).collect::<Vec<_>>()
+                    }
+                    key=|(s, state): &(VideoSourceDto, String)| format!("{}-{}-{}", s.id, s.is_active, state)
+                    children=move |(source, state): (VideoSourceDto, String)| {
                         let dot_class = if source.is_active {
                             "settings__source-dot settings__source-dot--active"
                         } else {
@@ -159,14 +213,32 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                         };
                         let id_activate = source.id.clone();
                         let id_delete = source.id.clone();
+                        let id_status = source.id.clone();
+                        let id_hint = source.id.clone();
                         let is_active = source.is_active;
+                        let hint = status_hint(&state);
                         view! {
-                            <div class="settings__source-item" data-source-id=source.id.clone()>
+                            <div class="settings__source-item" data-role="video-source-row"
+                                data-source-id=source.id.clone()>
                                 <div class=dot_class></div>
                                 <div class="settings__source-info">
                                     <div class="settings__source-label">{source.label.clone()}</div>
                                     <div class="settings__source-ndi">"NDI: " {source.ndi_name.clone()}</div>
+                                    {match hint {
+                                        Some(text) => view! {
+                                            <div class="settings__source-hint"
+                                                data-role="video-source-hint"
+                                                data-source-id=id_hint.clone()>{text}</div>
+                                        }.into_any(),
+                                        None => ().into_any(),
+                                    }}
                                 </div>
+                                <span class=status_class(&state)
+                                    data-role="video-source-status"
+                                    data-source-id=id_status.clone()
+                                    data-state=state.clone()>
+                                    {status_label(&state)}
+                                </span>
                                 {if is_active {
                                     view! {
                                         <button class="settings__btn settings__btn--active"
@@ -185,6 +257,31 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                     }
                 />
             </div>
+            // What is ACTUALLY on the network, right next to what is mapped. This one line
+            // is what turns "RESOLUME-PP (cg-obs) vs STREAM-PP (stream)" from a two-hour
+            // investigation into something the operator spots at a glance (#546).
+            <Show when=move || ndi_available.get()>
+                <div class="settings__discovered" data-role="ndi-discovered">
+                    <span class="settings__discovered-title">"On the network now: "</span>
+                    <Show
+                        when=move || !discovered.get().is_empty()
+                        fallback=|| view! {
+                            <span class="settings__discovered-empty">
+                                "nothing — no NDI source is broadcasting."
+                            </span>
+                        }
+                    >
+                        <For
+                            each=move || discovered.get()
+                            key=|name: &String| name.clone()
+                            children=|name: String| view! {
+                                <span class="settings__discovered-name"
+                                    data-role="ndi-discovered-name">{name}</span>
+                            }
+                        />
+                    </Show>
+                </div>
+            </Show>
             <div class="settings__form" data-role="add-video-source-form">
                 <div class="settings__form-header">
                     <h3>"Add Video Source"</h3>

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -10,8 +10,12 @@ use crate::components::modal::confirm;
 ///
 /// Plain operator language, not protocol language: the person reading this is standing
 /// in a church about to run a service, and the words have to tell them what to DO.
-/// An unrecognised state degrades to the honest "NDI unavailable" rather than panicking
-/// or rendering a raw wire token.
+///
+/// The empty string means "this row has no status yet" — the first paint, or a row added
+/// since the last poll. That is NOT the same as `unknown` ("this server cannot see the
+/// NDI network"), and printing the latter for the former would tell an operator with a
+/// perfectly healthy server that NDI is unavailable. Anything unrecognised degrades to
+/// the same honest "Checking…" rather than rendering a raw wire token.
 pub(crate) fn status_label(state: &str) -> &'static str {
     match state {
         "live" => "Live",
@@ -19,18 +23,20 @@ pub(crate) fn status_label(state: &str) -> &'static str {
         "not-found" => "Not found on the network",
         "ready" => "Ready",
         "connecting" => "Connecting…",
-        _ => "NDI unavailable",
+        "unknown" => "NDI unavailable",
+        _ => "Checking…",
     }
 }
 
-/// The CSS class pair for a source state (#546). An unrecognised state falls back to
-/// `--unknown` rather than injecting whatever the server said into a class name.
+/// The CSS class pair for a source state (#546). An unrecognised (or not-yet-loaded)
+/// state falls back to `--checking` rather than injecting whatever the server said into
+/// a class name.
 pub(crate) fn status_class(state: &str) -> String {
     let known = matches!(
         state,
         "live" | "not-broadcasting" | "not-found" | "ready" | "connecting" | "unknown"
     );
-    let modifier = if known { state } else { "unknown" };
+    let modifier = if known { state } else { "checking" };
     format!("settings__status settings__status--{modifier}")
 }
 
@@ -69,10 +75,15 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     // source can go silent at any moment, including mid-service.
     let poll_status = move || {
         leptos::task::spawn_local(async move {
-            if let Ok(status) = ndi::get_video_source_status().await {
-                ndi_available.set(status.ndi_available);
-                discovered.set(status.discovered);
-                statuses.set(status.sources);
+            match ndi::get_video_source_status().await {
+                Ok(status) => {
+                    ndi_available.set(status.ndi_available);
+                    discovered.set(status.discovered);
+                    statuses.set(status.sources);
+                }
+                // Never swallow this: a failing poll means the badges are stale, and the
+                // whole point of the card is that the operator can trust what it says.
+                Err(err) => leptos::logging::warn!("video-source status poll failed: {err}"),
             }
         });
     };
@@ -84,6 +95,10 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     });
     poll_status();
 
+    // `forget()`, like every other poller on this page (see `settings/mod.rs`): the card
+    // mounts once per page load and there is no client-side router, so the timer dies with
+    // the navigation. It is NOT `on_cleanup` because gloo's `Interval` is not `Send`, and
+    // leptos' `on_cleanup` requires it for the non-wasm (host) test build of this crate.
     let interval = gloo_timers::callback::Interval::new(super::STATUS_REFRESH_MS, move || {
         poll_status();
     });
@@ -99,12 +114,17 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
         poll_status();
     };
 
+    // The status poll already carries the discovery list, so "Scan" is just "don't make
+    // me wait for the next tick" — it must not write `discovered` from a second, separate
+    // endpoint that the poll would overwrite 5s later anyway.
     let scan = move |_| {
         leptos::task::spawn_local(async move {
-            match ndi::discover_ndi_sources().await {
-                Ok(found) => {
-                    let count = found.len();
-                    discovered.set(found.into_iter().map(|s| s.name).collect());
+            match ndi::get_video_source_status().await {
+                Ok(status) => {
+                    let count = status.discovered.len();
+                    ndi_available.set(status.ndi_available);
+                    discovered.set(status.discovered);
+                    statuses.set(status.sources);
                     toast.show(&format!("Found {count} NDI source(s)"), "info");
                 }
                 Err(err) => toast.show(&format!("Scan failed: {err}"), "error"),
@@ -190,22 +210,12 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
             </header>
             <div class="settings__source-list" data-role="video-source-list">
                 <For
-                    each=move || {
-                        // Zip each row with its live state. The state MUST be part of the
-                        // key below — keying on id+is_active alone (as this card did) means
-                        // the 5s poll runs and the badge never re-renders.
-                        let by_id = statuses.get();
-                        sources.get().into_iter().map(move |s| {
-                            let state = by_id
-                                .iter()
-                                .find(|st| st.id == s.id)
-                                .map(|st| st.state.clone())
-                                .unwrap_or_default();
-                            (s, state)
-                        }).collect::<Vec<_>>()
-                    }
-                    key=|(s, state): &(VideoSourceDto, String)| format!("{}-{}-{}", s.id, s.is_active, state)
-                    children=move |(source, state): (VideoSourceDto, String)| {
+                    each=move || sources.get()
+                    // Keyed on identity, NOT on the live state: the badge, hint and detail
+                    // below read `statuses` through reactive closures, so they update on
+                    // every poll without destroying and rebuilding the row (and its buttons).
+                    key=|s: &VideoSourceDto| format!("{}-{}", s.id, s.is_active)
+                    children=move |source: VideoSourceDto| {
                         let dot_class = if source.is_active {
                             "settings__source-dot settings__source-dot--active"
                         } else {
@@ -216,7 +226,17 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                         let id_status = source.id.clone();
                         let id_hint = source.id.clone();
                         let is_active = source.is_active;
-                        let hint = status_hint(&state);
+
+                        // This row's live status, re-read on every poll. A `Memo` (not a plain
+                        // closure) because it is `Copy`, so the badge, the class, the hint and
+                        // the detail can each hold it. An id with no entry yet yields "" —
+                        // rendered as "Checking…", never as "NDI unavailable".
+                        let row_id = source.id.clone();
+                        let status = Memo::new(move |_| {
+                            statuses.with(|list| list.iter().find(|st| st.id == row_id).cloned())
+                        });
+                        let state_str = move || status.get().map(|st| st.state).unwrap_or_default();
+                        let detail = move || status.get().and_then(|st| st.detail);
                         view! {
                             <div class="settings__source-item" data-role="video-source-row"
                                 data-source-id=source.id.clone()>
@@ -224,20 +244,23 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                                 <div class="settings__source-info">
                                     <div class="settings__source-label">{source.label.clone()}</div>
                                     <div class="settings__source-ndi">"NDI: " {source.ndi_name.clone()}</div>
-                                    {match hint {
-                                        Some(text) => view! {
-                                            <div class="settings__source-hint"
-                                                data-role="video-source-hint"
-                                                data-source-id=id_hint.clone()>{text}</div>
-                                        }.into_any(),
-                                        None => ().into_any(),
-                                    }}
+                                    {move || status_hint(&state_str()).map(|text| view! {
+                                        <div class="settings__source-hint"
+                                            data-role="video-source-hint"
+                                            data-source-id=id_hint.clone()>{text}</div>
+                                    })}
+                                    // The pipeline's own error text, when it has one — the most
+                                    // specific "why" the server can give.
+                                    {move || detail().map(|text| view! {
+                                        <div class="settings__source-detail"
+                                            data-role="video-source-detail">{text}</div>
+                                    })}
                                 </div>
-                                <span class=status_class(&state)
+                                <span class=move || status_class(&state_str())
                                     data-role="video-source-status"
                                     data-source-id=id_status.clone()
-                                    data-state=state.clone()>
-                                    {status_label(&state)}
+                                    data-state=state_str>
+                                    {move || status_label(&state_str())}
                                 </span>
                                 {if is_active {
                                     view! {
@@ -339,8 +362,19 @@ mod tests {
     /// not panic the WASM app.
     #[test]
     fn an_unknown_state_degrades_instead_of_leaking_or_panicking() {
-        assert_eq!(status_label("wat"), "NDI unavailable");
-        assert_eq!(status_label(""), "NDI unavailable");
+        assert_eq!(status_label("wat"), "Checking…");
+    }
+
+    /// A row whose status has not arrived yet (first paint, or a source added since the
+    /// last poll) is NOT a server without NDI. Printing "NDI unavailable" there tells an
+    /// operator with a perfectly healthy server to go hunt a phantom fault.
+    #[test]
+    fn a_not_yet_loaded_status_reads_checking_not_ndi_unavailable() {
+        assert_eq!(status_label(""), "Checking…");
+        assert_eq!(
+            status_class(""),
+            "settings__status settings__status--checking"
+        );
     }
 
     #[test]
@@ -355,7 +389,7 @@ mod tests {
         );
         assert_eq!(
             status_class("nonsense"),
-            "settings__status settings__status--unknown",
+            "settings__status settings__status--checking",
             "an unrecognised state must not inject an arbitrary class name"
         );
     }

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -6,6 +6,33 @@ use super::ToastHandle;
 use crate::api::ndi::{self, VideoSourceDto};
 use crate::components::modal::confirm;
 
+/// The badge text for a source state (#546).
+///
+/// Plain operator language, not protocol language: the person reading this is standing
+/// in a church about to run a service, and the words have to tell them what to DO.
+/// An unrecognised state degrades to the honest "NDI unavailable" rather than panicking
+/// or rendering a raw wire token.
+pub(crate) fn status_label(state: &str) -> &'static str {
+    // [red] stub — the real copy lands in the GREEN commit.
+    let _ = state;
+    ""
+}
+
+/// The CSS class pair for a source state (#546).
+pub(crate) fn status_class(state: &str) -> String {
+    // [red] stub.
+    let _ = state;
+    String::new()
+}
+
+/// What the operator should DO about this state — shown under the row. `None` when the
+/// state needs no action (live / ready / connecting).
+pub(crate) fn status_hint(state: &str) -> Option<&'static str> {
+    // [red] stub.
+    let _ = state;
+    None
+}
+
 #[component]
 pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     let sources = RwSignal::new(Vec::<VideoSourceDto>::new());
@@ -191,5 +218,69 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                 <button class="settings__btn settings__btn--add" on:click=add_source>"+ Add Source"</button>
             </div>
         </section>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The words the operator reads. The PP outage was not caused by a missing feature —
+    /// it was caused by the UI saying NOTHING while the server knew the answer. So the
+    /// copy is the deliverable, and it is pinned.
+    #[test]
+    fn every_state_has_plain_operator_copy() {
+        assert_eq!(status_label("live"), "Live");
+        assert_eq!(status_label("not-broadcasting"), "Not broadcasting");
+        assert_eq!(status_label("not-found"), "Not found on the network");
+        assert_eq!(status_label("ready"), "Ready");
+        assert_eq!(status_label("connecting"), "Connecting…");
+        assert_eq!(status_label("unknown"), "NDI unavailable");
+    }
+
+    /// A state we do not know must not render a raw wire token at the operator, and must
+    /// not panic the WASM app.
+    #[test]
+    fn an_unknown_state_degrades_instead_of_leaking_or_panicking() {
+        assert_eq!(status_label("wat"), "NDI unavailable");
+        assert_eq!(status_label(""), "NDI unavailable");
+    }
+
+    #[test]
+    fn class_is_built_from_the_state() {
+        assert_eq!(
+            status_class("not-found"),
+            "settings__status settings__status--not-found"
+        );
+        assert_eq!(
+            status_class("live"),
+            "settings__status settings__status--live"
+        );
+        assert_eq!(
+            status_class("nonsense"),
+            "settings__status settings__status--unknown",
+            "an unrecognised state must not inject an arbitrary class name"
+        );
+    }
+
+    /// Only the two BROKEN states get a hint — a hint under a working source is noise.
+    #[test]
+    fn only_the_broken_states_tell_the_operator_what_to_do() {
+        let not_found = status_hint("not-found").expect("not-found must explain itself");
+        assert!(
+            not_found.contains("not on the network"),
+            "the hint must name the actual problem: {not_found}"
+        );
+
+        let silent = status_hint("not-broadcasting").expect("not-broadcasting must explain itself");
+        assert!(
+            silent.contains("sending machine"),
+            "the hint must point at the sending machine: {silent}"
+        );
+
+        assert_eq!(status_hint("live"), None);
+        assert_eq!(status_hint("ready"), None);
+        assert_eq!(status_hint("connecting"), None);
+        assert_eq!(status_hint("unknown"), None);
     }
 }

--- a/crates/presenter-ui/styles/settings.css
+++ b/crates/presenter-ui/styles/settings.css
@@ -371,6 +371,66 @@ body.settings {
   color: #b91c1c;
 }
 
+/* #546 — video-source liveness. Green = video is flowing; amber = on the network but
+   sending nothing; red = the mapped name is not out there at all (the PP outage). */
+.settings__status--live {
+  background: #dcfcef;
+  color: #047857;
+}
+
+.settings__status--not-broadcasting {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.settings__status--not-found {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.settings__status--ready,
+.settings__status--unknown {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+/* The one-line instruction under a broken row: what the operator should actually go
+   and DO about it. */
+.settings__source-hint {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: #b45309;
+  max-width: 46ch;
+}
+
+/* What is actually on the NDI network right now, listed next to what is mapped. */
+.settings__discovered {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.settings__discovered-title {
+  font-weight: 600;
+}
+
+.settings__discovered-name {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.settings__discovered-empty {
+  font-style: italic;
+}
+
 .settings__list-line {
   margin: 0;
   font-family: "JetBrains Mono", "Fira Mono", monospace;

--- a/crates/presenter-ui/styles/settings.css
+++ b/crates/presenter-ui/styles/settings.css
@@ -389,7 +389,8 @@ body.settings {
 }
 
 .settings__status--ready,
-.settings__status--unknown {
+.settings__status--unknown,
+.settings__status--checking {
   background: #e2e8f0;
   color: #475569;
 }
@@ -402,6 +403,17 @@ body.settings {
   line-height: 1.35;
   color: #b45309;
   max-width: 46ch;
+}
+
+/* The pipeline's own error text, when it has one — the most specific "why" available. */
+.settings__source-detail {
+  margin-top: 2px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  color: #64748b;
+  max-width: 46ch;
+  overflow-wrap: anywhere;
 }
 
 /* What is actually on the NDI network right now, listed next to what is mapped. */

--- a/tests/e2e/ndi-source-status.spec.ts
+++ b/tests/e2e/ndi-source-status.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+// ─────────────────────────────────────────────────────────────────────────
+// #546 — the PP outage, reproduced against REAL NDI discovery.
+//
+// At PP the operator mapped `cgpp → RESOLUME-PP (cg-obs)` and activated it. The
+// activation SUCCEEDED (a silent broadcaster is not an error — #448), the stage stayed
+// blank, and the UI said nothing at all. The name simply was not on the network; only
+// `STREAM-PP (stream)` was. Hours were spent on the encoder chain before a log line
+// revealed it.
+//
+// The libndi-free lane can only prove the "server is blind" path (video-source-status
+// .spec.ts). This file is the one that reproduces the actual defect: a mapped name that
+// genuinely is NOT on the air, while a DIFFERENT name genuinely IS — and asserts the
+// operator can now see both facts side by side.
+//
+// Tags: @video-codec routes to the real-Chrome project; @synthetic-ndi selects it into
+// the self-hosted `e2e-ndi` lane, which publishes "<host> (PRESENTER-TEST)" before
+// Playwright starts.
+// ─────────────────────────────────────────────────────────────────────────
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+/** The synthetic source the lane publishes. Discovery needs a few seconds after a
+ * fresh server start, so poll rather than ask once. */
+async function discoverSynthetic(
+  request: APIRequestContext,
+): Promise<{ name: string }> {
+  for (let i = 0; i < 30; i++) {
+    const resp = await request.get(new URL("/ndi/sources", baseURL).toString());
+    if (resp.ok()) {
+      const list = await resp.json();
+      if (Array.isArray(list)) {
+        const found = list.find((s: { name: string }) =>
+          s.name.includes("(PRESENTER-TEST)"),
+        );
+        if (found) return found;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(
+    "the synthetic NDI source never appeared — the e2e-ndi lane must publish it",
+  );
+}
+
+async function createAndActivate(
+  request: APIRequestContext,
+  label: string,
+  ndiName: string,
+): Promise<{ id: string }> {
+  await request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+  const created = await request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { label, ndiName } },
+  );
+  expect(created.status()).toBe(200);
+  const src = await created.json();
+  const activated = await request.post(
+    new URL(`/integrations/video-sources/${src.id}/activate`, baseURL).toString(),
+    { data: {} },
+  );
+  // Exactly as at PP: activating a name nobody is broadcasting SUCCEEDS. That is the
+  // whole trap — nothing fails, and nothing tells you.
+  expect(activated.status()).toBe(200);
+  return src;
+}
+
+test("a mapped NDI name that is not on the network is reported as not found @video-codec @synthetic-ndi", async ({
+  page,
+  request,
+}) => {
+  const synthetic = await discoverSynthetic(request);
+  // The PP shape: map a name nobody broadcasts, while a real one IS on the air.
+  const ghost = await createAndActivate(request, "cgpp", "GHOST-SOURCE (nope)");
+
+  const status = await request.get(
+    new URL("/integrations/video-sources/status", baseURL).toString(),
+  );
+  expect(status.status()).toBe(200);
+  const body = await status.json();
+  expect(body.ndiAvailable).toBe(true);
+  expect(
+    body.discovered,
+    "the synthetic source really is on the network",
+  ).toContain(synthetic.name);
+  expect(
+    body.sources.find((s: any) => s.id === ghost.id).state,
+    "the mapped name is nowhere on the network — the server must say so",
+  ).toBe("not-found");
+
+  await page.goto(new URL("/ui/settings", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 60_000 });
+
+  const badge = page.locator(
+    `[data-role="video-source-status"][data-source-id="${ghost.id}"]`,
+  );
+  await expect(badge).toHaveText("Not found on the network", { timeout: 30_000 });
+  await expect(badge).toHaveAttribute("data-state", "not-found");
+
+  const hint = page.locator(
+    `[data-role="video-source-hint"][data-source-id="${ghost.id}"]`,
+  );
+  await expect(hint).toBeVisible();
+
+  // …and the operator can SEE what is actually on the air, right there — which is what
+  // makes "RESOLUME-PP vs STREAM-PP" obvious instead of a two-hour investigation.
+  await expect(
+    page.locator('[data-role="ndi-discovered-name"]', {
+      hasText: "(PRESENTER-TEST)",
+    }),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("a mapped NDI name that IS broadcasting goes Live @video-codec @synthetic-ndi", async ({
+  page,
+  request,
+}) => {
+  const synthetic = await discoverSynthetic(request);
+  const source = await createAndActivate(request, "synthetic", synthetic.name);
+
+  await page.goto(new URL("/ui/settings", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 60_000 });
+
+  const badge = page.locator(
+    `[data-role="video-source-status"][data-source-id="${source.id}"]`,
+  );
+  // Pipeline start (up to ~8s) + one 5s status poll, with margin.
+  await expect(badge).toHaveText("Live", { timeout: 40_000 });
+  await expect(badge).toHaveAttribute("data-state", "live");
+
+  // A working source needs no instructions.
+  await expect(
+    page.locator(`[data-role="video-source-hint"][data-source-id="${source.id}"]`),
+  ).toHaveCount(0);
+
+  await request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+  );
+});

--- a/tests/e2e/video-source-status.spec.ts
+++ b/tests/e2e/video-source-status.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+// #546 — the settings page must SAY why a mapped NDI source is not showing video.
+//
+// At PP an operator mapped `cgpp → RESOLUME-PP (cg-obs)`, activated it, and the stage
+// stayed blank with no explanation anywhere in the UI. The sending machine simply was
+// not broadcasting that name. Hours went into the (genuinely broken) encoder chain
+// before the log revealed it. The server knew all along; nothing told the human.
+//
+// This spec runs on the DEFAULT lane, which has NO NDI SDK — so it can only prove the
+// blind-server path. That path matters on its own (the server must never claim "not
+// found on the network" when it cannot SEE the network), and it proves the endpoint,
+// the poll and the render are wired. The real PP reproduction — a mapped name that is
+// genuinely absent while a different name IS on the air — lives in
+// `ndi-source-status.spec.ts`, on the self-hosted lane that has libndi.
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+async function createSource(request: any, label: string, ndiName: string) {
+  const res = await request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { label, ndiName } },
+  );
+  expect(res.status()).toBe(200);
+  return await res.json();
+}
+
+test("status endpoint joins the rows, the network and the pipelines", async ({
+  request,
+}) => {
+  const source = await createSource(request, "cgpp", "RESOLUME-PP (cg-obs)");
+
+  const res = await request.get(
+    new URL("/integrations/video-sources/status", baseURL).toString(),
+  );
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+
+  // No SDK on this lane.
+  expect(body.ndiAvailable).toBe(false);
+  expect(body.discovered).toEqual([]);
+
+  const entry = body.sources.find((s: any) => s.id === source.id);
+  expect(entry, "the created source must appear in the status snapshot").toBeTruthy();
+  // The honest answer for a server that cannot see the network. NOT "not-found" —
+  // that would send the operator to check a sending machine that is perfectly fine.
+  expect(entry.state).toBe("unknown");
+  expect(entry.ndiName).toBe("RESOLUME-PP (cg-obs)");
+});
+
+test("the settings card shows the source's status badge", async ({
+  page,
+  request,
+}) => {
+  const errors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+
+  const source = await createSource(request, "cam-status", "CAM-STATUS (usb)");
+
+  await page.goto(new URL("/ui/settings", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 60_000 });
+
+  const badge = page.locator(
+    `[data-role="video-source-status"][data-source-id="${source.id}"]`,
+  );
+  await expect(badge).toHaveText("NDI unavailable", { timeout: 30_000 });
+  await expect(badge).toHaveAttribute("data-state", "unknown");
+
+  // Nothing can be discovered without the SDK, so the "on the network now" line must
+  // not be there claiming an empty network.
+  await expect(page.locator('[data-role="ndi-discovered"]')).toHaveCount(0);
+
+  expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
+});

--- a/tests/e2e/video-source-status.spec.ts
+++ b/tests/e2e/video-source-status.spec.ts
@@ -14,14 +14,26 @@ import {
 // not broadcasting that name. Hours went into the (genuinely broken) encoder chain
 // before the log revealed it. The server knew all along; nothing told the human.
 //
-// This spec runs on the DEFAULT lane, which has NO NDI SDK — so it can only prove the
-// blind-server path. That path matters on its own (the server must never claim "not
-// found on the network" when it cannot SEE the network), and it proves the endpoint,
-// the poll and the render are wired. The real PP reproduction — a mapped name that is
-// genuinely absent while a different name IS on the air — lives in
-// `ndi-source-status.spec.ts`, on the self-hosted lane that has libndi.
+// This spec runs on the DEFAULT lane, whose HOST may or may not have libndi: the
+// GitHub runners do not, dev2 — where the same suite is run before a merge — does. So
+// it asserts the contract that must hold EITHER WAY and takes its branch from what the
+// server reports about itself:
+//
+//   * blind server (no SDK) → `unknown` / "NDI unavailable". It must NEVER say "not
+//     found on the network" about a network it cannot see; that sends the operator off
+//     to check a sending machine that is perfectly fine.
+//   * seeing server        → a name nobody broadcasts reads `not-found`, with the hint
+//     and the list of what IS on the air. That is the PP reproduction.
+//
+// Hard-coding the SDK-less branch made this spec pass on CI and fail on dev2 — a guard
+// that is green on only one host is not a guard. The full synthetic reproduction (a
+// mapped ghost name while a REAL NDI sender is on the air) is in
+// `ndi-source-status.spec.ts`, on the self-hosted lane.
 
 test.describe.configure({ timeout: 180_000 });
+
+/** A name nothing on any of our networks broadcasts. */
+const GHOST = "GHOST-SOURCE (nope)";
 
 let server: ServerHandle | undefined;
 let baseURL = "";
@@ -51,27 +63,34 @@ async function createSource(request: any, label: string, ndiName: string) {
   return await res.json();
 }
 
-test("status endpoint joins the rows, the network and the pipelines", async ({
-  request,
-}) => {
-  const source = await createSource(request, "cgpp", "RESOLUME-PP (cg-obs)");
-
+async function readStatus(request: any) {
   const res = await request.get(
     new URL("/integrations/video-sources/status", baseURL).toString(),
   );
   expect(res.status()).toBe(200);
-  const body = await res.json();
+  return await res.json();
+}
 
-  // No SDK on this lane.
-  expect(body.ndiAvailable).toBe(false);
-  expect(body.discovered).toEqual([]);
+test("status endpoint joins the rows, the network and the pipelines", async ({
+  request,
+}) => {
+  const source = await createSource(request, "cgpp", GHOST);
+
+  const body = await readStatus(request);
 
   const entry = body.sources.find((s: any) => s.id === source.id);
   expect(entry, "the created source must appear in the status snapshot").toBeTruthy();
-  // The honest answer for a server that cannot see the network. NOT "not-found" —
-  // that would send the operator to check a sending machine that is perfectly fine.
-  expect(entry.state).toBe("unknown");
-  expect(entry.ndiName).toBe("RESOLUME-PP (cg-obs)");
+  expect(entry.ndiName).toBe(GHOST);
+
+  if (body.ndiAvailable) {
+    // The PP case: the mapped name is simply not being broadcast.
+    expect(body.discovered).not.toContain(GHOST);
+    expect(entry.state).toBe("not-found");
+  } else {
+    // A blind server says so — it never accuses a sender it cannot see.
+    expect(body.discovered).toEqual([]);
+    expect(entry.state).toBe("unknown");
+  }
 });
 
 test("the settings card shows the source's status badge", async ({
@@ -83,7 +102,8 @@ test("the settings card shows the source's status badge", async ({
     if (m.type() === "error") errors.push(m.text());
   });
 
-  const source = await createSource(request, "cam-status", "CAM-STATUS (usb)");
+  const source = await createSource(request, "cam-status", GHOST);
+  const ndiAvailable: boolean = (await readStatus(request)).ndiAvailable;
 
   await page.goto(new URL("/ui/settings", baseURL).toString());
   await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 60_000 });
@@ -91,12 +111,24 @@ test("the settings card shows the source's status badge", async ({
   const badge = page.locator(
     `[data-role="video-source-status"][data-source-id="${source.id}"]`,
   );
-  await expect(badge).toHaveText("NDI unavailable", { timeout: 30_000 });
-  await expect(badge).toHaveAttribute("data-state", "unknown");
+  const hint = page.locator(
+    `[data-role="video-source-hint"][data-source-id="${source.id}"]`,
+  );
 
-  // Nothing can be discovered without the SDK, so the "on the network now" line must
-  // not be there claiming an empty network.
-  await expect(page.locator('[data-role="ndi-discovered"]')).toHaveCount(0);
+  if (ndiAvailable) {
+    await expect(badge).toHaveText("Not found on the network", { timeout: 30_000 });
+    await expect(badge).toHaveAttribute("data-state", "not-found");
+    // The sentence that would have ended the PP outage in a minute.
+    await expect(hint).toContainText("not on the network", { timeout: 30_000 });
+    // And what IS on the air, right there, to compare the mapped name against.
+    await expect(page.locator('[data-role="ndi-discovered"]')).toHaveCount(1);
+  } else {
+    await expect(badge).toHaveText("NDI unavailable", { timeout: 30_000 });
+    await expect(badge).toHaveAttribute("data-state", "unknown");
+    // Nothing can be discovered without the SDK, so the "on the network now" line must
+    // not be there claiming an empty network.
+    await expect(page.locator('[data-role="ndi-discovered"]')).toHaveCount(0);
+  }
 
   expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
 });


### PR DESCRIPTION
## Closes #546 — the settings page now says WHY a mapped NDI source shows nothing

At PP an operator mapped `cgpp → RESOLUME-PP (cg-obs)`, activated it, and the stage stayed blank **with no indication anywhere in the UI why**. The activation had SUCCEEDED (a silent broadcaster is not an error, #448). Hours went into the encoder chain — which was genuinely broken, and is now fixed (#540/#541/#544/#547) — before a log line revealed the last layer:

```
NDI source activated but not yet producing — broadcaster silent (#448)  ndi_name=RESOLUME-PP (cg-obs)
```

`GET /ndi/sources` on that host listed only `STREAM-PP (stream)`. **The mapped name was not on the network at all.** The server knew the whole time; nothing told the human.

## What now happens

The three facts that answer this live in three different places — the configured rows, the NDI discovery list, and the pipeline map — and nothing joined them.

- **`GET /integrations/video-sources/status`** (new, read-only) joins them: can this server see the NDI network, what IS on it, and what is each mapped source doing. The CRUD list contract is untouched.
- **`state/video_source_status::classify`** is the pure decision. The rule ORDER is the feature:
  1. no SDK → `unknown` — **never accuse a network we cannot see**;
  2. streaming → `live` — frames beat a discovery list that is still catching up;
  3. not in discovery → `not-found` — *the PP case*;
  4. not activated → `ready`; 5. starting → `connecting`;
  6. else → `not-broadcasting` — on the air, switched on, sending nothing (the #448 silent broadcaster, whose pipeline is stopped and dropped and therefore has **no snapshot at all** — which is exactly why "no pipeline" could not be read as "nothing wrong").
- **The settings card** polls it on the page's existing 5 s cadence and shows a per-row badge, a plain instruction under the broken ones, and — the part that actually ends the two-hour investigation — **lists what IS on the network, right under the rows**.

## Verified live on dev (v0.4.197)

Mapped the PP name on a network that does not carry it:

```
API   >> state: not-found | ndiAvailable: true | discovered: 25 names
BADGE >> "NOT FOUND ON THE NETWORK"  (data-state=not-found)
HINT  >> "This NDI name is not on the network. Check the sending machine is on and its
          NDI output is switched on — or pick one of the names listed below."
On the network now:  CAM1 (usb) … RESOLUME-SNV (cg-obs) … STREAM-SNV (stream) …
console errors: 0
```

`RESOLUME-PP (cg-obs)` sitting above a list containing `RESOLUME-SNV (cg-obs)` is the whole ticket in one screen.

## Tests

RED `c0f2517d` → GREEN `402f4eee`.

- **9 server tests** — the pure classifier (incl. the literal PP case, the #448 silent case, and the honesty rule that a blind server says `unknown`, never `not-found`), plus the AppState join really reading discovery + the pipeline map (`FakeNdiControl` grew a settable network and pipeline map, so this is provable without libndi; `clear_ndi_handle` keeps the blind-server test host-independent — dev2 HAS libndi, the runners do not).
- **4 UI tests** — the operator-facing copy for every state, and that an unrecognised state degrades instead of leaking a wire token or panicking the WASM app.
- **`tests/e2e/video-source-status.spec.ts`** — endpoint + badge on the SDK-less lane.
- **`tests/e2e/ndi-source-status.spec.ts`** (`@synthetic-ndi`) — **the PP incident reproduced against REAL discovery**: a mapped name nobody broadcasts while a different name genuinely IS on the air; asserts the operator sees both, side by side. Also asserts a real broadcasting source goes `Live`. Green on the self-hosted lane.

Every job green, including `NDI WebRTC E2E (synthetic, self-hosted)`.
