### PR TITLE
fix(ndi): a finder that never scanned is blindness, not an empty network (#546 follow-up)

### DIFF
--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -404,3 +404,32 @@ NDI_RUNTIME_DIR_V6=/usr/lib/ndi PRESENTER_NDI_TEST_NAME=PRESENTER-TEST \
 
 Clean up afterwards (`/deactivate`, `DELETE` the source, pid-targeted `kill` of the sender — never
 `pkill -f`, it matches your own shell).
+
+---
+
+## "No pipeline in the snapshot map" is NOT "the source is silent" (#546)
+
+`NdiManager::pipeline_snapshots()` gives up on the `active` mutex after **200 ms** and returns an
+**empty vec** — while `start_pipeline` HOLDS that same mutex across its **8 s caps-wait**. So during
+EVERY normal activation the map reads as empty. Any consumer that treats "no entry" as a fact about
+the SOURCE (rather than about our ability to LOOK) will report a perfectly healthy activation as
+"broadcaster silent" for those 8 seconds.
+
+Use **`pipeline_snapshots_checked() -> Option<Vec<..>>`** when the answer is shown to a human:
+`None` = the lock timed out (the manager is busy, almost always starting a pipeline) → say
+*Connecting*; `Some(vec![])` = we looked and there really is nothing → the silent-broadcaster case
+(#448). `pipeline_snapshots()` (the `unwrap_or_default()` wrapper) is fine for `/healthz`, which only
+wants a best-effort list and must never stall.
+
+Same shape one level up: a **discovery failure** (`discover_sources` errors, or the finder thread
+never came up because `NDIlib_find_create_v2` returned null) is NOT an empty network. Degrading it to
+"nothing is on the air" makes a broken server tell the operator that every sending machine at the
+site is off. Model the two apart (`Discovery::Blind` vs `Discovery::Names(..)`) and say *NDI
+unavailable*, never *not found on the network*, when blind. The classifier that encodes all of this
+is `presenter-server/src/state/video_source_status.rs` — pure, unit-tested, and the rule ORDER is the
+part that lies to the operator when it is wrong.
+
+**E2E consequence:** never hard-assert `ndiAvailable === false` in a default-lane spec. The GitHub
+runners have no libndi, **dev2 does** — and the same suite is run on dev2 before a merge. A spec that
+is green only on one host is not a guard. Branch on what the server reports about itself
+(`tests/e2e/video-source-status.spec.ts`), and assert something real in both branches.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -67,3 +67,32 @@ children=move |(idx, _entry)| {
   (`StageStateRequest.entry_index`). The sidebar resolves it via
   `worship_pp_helpers::active_sidebar_index(entries, snapshot_active_index)`
   (explicit index, fallback to first `is_active`). Don't re-derive by name/id.
+
+## Per-row live state in a `<For>`: key on identity, read the state through a `Memo`
+
+Keying a row on its live state (`format!("{id}-{state}")`) makes every state flap destroy and rebuild
+the whole row — buttons included. Key on identity (`id`, plus anything that changes the row's
+CONTROLS, e.g. `is_active`) and let the badge/hint read the state reactively.
+
+A plain closure capturing a `String` id is **not `Copy`**, so it cannot be moved into the four places
+that need it (class, `data-*`, text, hint). A `Memo` **is** `Copy`:
+
+```rust
+let row_id = source.id.clone();
+let status = Memo::new(move |_| statuses.with(|l| l.iter().find(|s| s.id == row_id).cloned()));
+let state_str = move || status.get().map(|s| s.state).unwrap_or_default();   // Copy closure ✓
+```
+The DTO must then derive `PartialEq` (Memo requires it). And `data-state=state_str` — NOT
+`data-state=move || state_str()`, which clippy rejects as a redundant closure.
+
+**A missing entry is not an error state.** `unwrap_or_default()` yields `""` on first paint and for a
+row added since the last poll — render that as a neutral "Checking…", never as the failure copy
+("NDI unavailable"), or a healthy server accuses itself for one frame (or forever, if the poll errors).
+
+**`on_cleanup` does not work for a `gloo_timers` Interval** in this crate: the Interval is not `Send`,
+and leptos' `on_cleanup` requires `Send` for the crate's **host** (non-wasm) test build, which is how
+`cargo test --lib` runs here. Use `interval.forget()`, like every other poller on the settings page —
+the timer dies with the page navigation (there is no client-side router).
+
+Reminder: this crate is **excluded from the workspace** — `cargo test -p presenter-ui` fails.
+Run `cd crates/presenter-ui && cargo test --lib`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.197"
+version = "0.4.198"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/discovery.rs
+++ b/crates/presenter-ndi/src/discovery.rs
@@ -5,21 +5,65 @@ use std::sync::{Arc, RwLock};
 use tracing::{debug, info, warn};
 
 /// A discovered NDI source on the network.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct NdiSourceInfo {
     pub name: String,
 }
 
 /// Thread-safe handle to the accumulated NDI source list.
 ///
-/// Cheap to clone — internally an `Arc<RwLock<Vec>>`.
+/// Cheap to clone — internally two `Arc`s.
+///
+/// It carries TWO facts, and conflating them is the bug this type exists to prevent
+/// (#546): *what* the finder has seen, and *whether the finder has ever looked at all*.
+/// An empty list can mean "nobody is broadcasting" — or it can mean the finder never came
+/// up (`NDIlib_find_create_v2` returned null, so [`run_finder_loop`] returned immediately
+/// and the list stays empty forever) or simply has not completed its first ~5 s scan yet.
+/// Reporting the latter as "nothing is on the network" makes the server tell an operator
+/// that every sending machine at the site is switched off.
 #[derive(Clone)]
-pub struct SourceList(pub(crate) Arc<RwLock<Vec<NdiSourceInfo>>>);
+pub struct SourceList {
+    sources: Arc<RwLock<Vec<NdiSourceInfo>>>,
+    /// Set once the finder has completed a scan and published its result. Never set if the
+    /// finder failed to start.
+    scanned: Arc<AtomicBool>,
+}
 
 impl SourceList {
-    /// Read a snapshot of all currently known NDI sources.
+    pub(crate) fn new() -> Self {
+        Self {
+            sources: Arc::new(RwLock::new(Vec::new())),
+            scanned: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Best-effort read of all currently known NDI sources — empty both when the finder
+    /// found nothing AND when it has not looked. `GET /ndi/sources` uses this.
+    ///
+    /// Anything that SHOWS the answer to a human wants [`Self::snapshot`] instead.
     pub fn read(&self) -> Vec<NdiSourceInfo> {
-        self.0.read().unwrap_or_else(|e| e.into_inner()).clone()
+        self.sources
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// What the finder has seen — or `None` when it has never completed a scan, i.e. we
+    /// are BLIND and must say so rather than report an empty network (#546).
+    pub fn snapshot(&self) -> Option<Vec<NdiSourceInfo>> {
+        if !self.scanned.load(Ordering::SeqCst) {
+            return None;
+        }
+        Some(self.read())
+    }
+
+    /// The finder publishes a completed scan. From here on the list is a FACT about the
+    /// network, empty or not.
+    pub(crate) fn publish(&self, list: Vec<NdiSourceInfo>) {
+        if let Ok(mut w) = self.sources.write() {
+            *w = list;
+        }
+        self.scanned.store(true, Ordering::SeqCst);
     }
 }
 
@@ -46,15 +90,15 @@ impl Drop for FinderShutdown {
 /// Returns a `SourceList` for reading discovered sources and a `FinderShutdown`
 /// handle that stops the thread when dropped.
 pub fn spawn_persistent_finder(sdk: Arc<NdiLib>) -> (SourceList, FinderShutdown) {
-    let sources = Arc::new(RwLock::new(Vec::new()));
-    let source_list = SourceList(Arc::clone(&sources));
+    let source_list = SourceList::new();
+    let thread_list = source_list.clone();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_clone = Arc::clone(&stop);
 
     let handle = std::thread::Builder::new()
         .name("ndi-finder".into())
         .spawn(move || {
-            run_finder_loop(sdk, sources, stop_clone);
+            run_finder_loop(sdk, thread_list, stop_clone);
         })
         .expect("failed to spawn NDI finder thread");
 
@@ -65,11 +109,7 @@ pub fn spawn_persistent_finder(sdk: Arc<NdiLib>) -> (SourceList, FinderShutdown)
     (source_list, shutdown)
 }
 
-fn run_finder_loop(
-    sdk: Arc<NdiLib>,
-    sources: Arc<RwLock<Vec<NdiSourceInfo>>>,
-    stop: Arc<AtomicBool>,
-) {
+fn run_finder_loop(sdk: Arc<NdiLib>, sources: SourceList, stop: Arc<AtomicBool>) {
     unsafe {
         let create_settings = NDIlib_find_create_t {
             show_local_sources: true,
@@ -110,10 +150,10 @@ fn run_finder_loop(
                 debug!("NDI sources updated: {} found", new_list.len());
             }
 
-            // Replace the source list atomically
-            if let Ok(mut w) = sources.write() {
-                *w = new_list;
-            }
+            // Publish the completed scan. This is also what marks the finder as having
+            // LOOKED at all — until the first publish, the server reports "we cannot see
+            // the network" rather than "the network is empty" (#546).
+            sources.publish(new_list);
         }
 
         (sdk.find_destroy)(finder);

--- a/crates/presenter-ndi/src/discovery.rs
+++ b/crates/presenter-ndi/src/discovery.rs
@@ -124,18 +124,18 @@ fn run_finder_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, RwLock};
 
     #[test]
     fn source_list_read_returns_current_snapshot() {
-        let list = SourceList(Arc::new(RwLock::new(vec![
+        let list = SourceList::new();
+        list.publish(vec![
             NdiSourceInfo {
                 name: "SRC-A".into(),
             },
             NdiSourceInfo {
                 name: "SRC-B".into(),
             },
-        ])));
+        ]);
         let snapshot = list.read();
         assert_eq!(snapshot.len(), 2);
         assert_eq!(snapshot[0].name, "SRC-A");
@@ -143,24 +143,62 @@ mod tests {
 
     #[test]
     fn source_list_update_replaces_contents() {
-        let inner = Arc::new(RwLock::new(vec![NdiSourceInfo { name: "OLD".into() }]));
-        let list = SourceList(Arc::clone(&inner));
-        {
-            let mut w = inner.write().unwrap();
-            *w = vec![
-                NdiSourceInfo {
-                    name: "NEW-1".into(),
-                },
-                NdiSourceInfo {
-                    name: "NEW-2".into(),
-                },
-                NdiSourceInfo {
-                    name: "NEW-3".into(),
-                },
-            ];
-        }
+        let list = SourceList::new();
+        list.publish(vec![NdiSourceInfo { name: "OLD".into() }]);
+        list.publish(vec![
+            NdiSourceInfo {
+                name: "NEW-1".into(),
+            },
+            NdiSourceInfo {
+                name: "NEW-2".into(),
+            },
+            NdiSourceInfo {
+                name: "NEW-3".into(),
+            },
+        ]);
         let snapshot = list.read();
         assert_eq!(snapshot.len(), 3);
         assert_eq!(snapshot[0].name, "NEW-1");
+    }
+
+    /// THE REAL BLINDNESS (deep-review of the #546 fix). A finder that never came up —
+    /// `NDIlib_find_create_v2` returned null, so `run_finder_loop` returns immediately and
+    /// the list stays empty FOREVER — is not a network with nothing on it. Before this, the
+    /// server reported that empty list as fact and told the operator that every sending
+    /// machine at the site was switched off.
+    #[test]
+    fn a_finder_that_has_never_scanned_has_no_snapshot_at_all() {
+        let list = SourceList::new();
+        assert_eq!(
+            list.snapshot(),
+            None,
+            "no scan has completed — we are BLIND, not looking at an empty network",
+        );
+        // …and the best-effort read (used by /ndi/sources) still answers, as before.
+        assert!(list.read().is_empty());
+    }
+
+    /// Once the finder has completed one scan, an empty list IS a fact about the network:
+    /// nothing is broadcasting. That must stay distinguishable from blindness.
+    #[test]
+    fn an_empty_network_after_a_completed_scan_is_a_fact_not_blindness() {
+        let list = SourceList::new();
+        list.publish(Vec::new());
+        assert_eq!(
+            list.snapshot(),
+            Some(Vec::new()),
+            "the finder looked and found nothing — that is an empty network",
+        );
+    }
+
+    #[test]
+    fn a_snapshot_carries_what_the_finder_published() {
+        let list = SourceList::new();
+        list.publish(vec![NdiSourceInfo {
+            name: "STREAM-PP (stream)".into(),
+        }]);
+        let snapshot = list.snapshot().expect("the finder has scanned");
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].name, "STREAM-PP (stream)");
     }
 }

--- a/crates/presenter-ndi/src/manager/lifecycle.rs
+++ b/crates/presenter-ndi/src/manager/lifecycle.rs
@@ -69,8 +69,21 @@ impl NdiManager {
         true
     }
 
+    /// Best-effort list of NDI sources — empty both when nothing is broadcasting AND when
+    /// the finder has not looked. `GET /ndi/sources` uses this.
     pub fn discover_sources(&self, _timeout_ms: u32) -> Result<Vec<discovery::NdiSourceInfo>> {
         Ok(self.source_list.read())
+    }
+
+    /// What the finder has actually SEEN — `None` when it has never completed a scan
+    /// (it failed to start, or has not finished its first ~5 s pass since startup).
+    ///
+    /// Anything that shows the answer to a human must use this, not
+    /// [`Self::discover_sources`]: an empty list from a finder that never looked is
+    /// blindness, and reporting it as an empty network makes the server accuse every
+    /// sending machine at the site of being switched off (#546).
+    pub fn discovery_snapshot(&self) -> Option<Vec<discovery::NdiSourceInfo>> {
+        self.source_list.snapshot()
     }
 
     /// Start a pipeline for the given source.

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -762,13 +762,19 @@ mod tests {
         );
     }
 
-    /// Deep review 🟡 #2: a discovery FAILURE leaves us blind. Degrading it to an empty
-    /// network would make a broken server tell the operator that every sending machine
-    /// at the site is off — the exact false accusation this module exists to prevent.
+    /// Deep review 🟡 #2: a blind finder leaves us blind. Degrading it to an empty network
+    /// would make a broken server tell the operator that every sending machine at the site
+    /// is off — the exact false accusation this module exists to prevent.
+    ///
+    /// The FIRST cut of this fix keyed on `discover_sources()` returning `Err` — which the
+    /// real `NdiManager` never does (it is `Ok(self.source_list.read())`). So the blindness
+    /// production ACTUALLY has — the finder thread never started (`NDIlib_find_create_v2`
+    /// returned null), or has not completed its first scan yet (every restart) — still read
+    /// as an empty network. The seam now asks the finder whether it has ever scanned.
     #[tokio::test]
-    async fn video_source_status_says_unknown_when_discovery_itself_fails() {
+    async fn video_source_status_says_unknown_when_the_finder_has_never_scanned() {
         let (state, _source_id, _id, fake) = state_with_fake(StartOutcome::Ok).await;
-        fake.fail_discovery();
+        fake.finder_never_scanned();
 
         let snapshot = state.video_source_status().await.expect("status snapshot");
 
@@ -781,6 +787,28 @@ mod tests {
             snapshot.sources.first().map(|s| s.state),
             Some("unknown"),
             "a discovery failure must never render as 'not found on the network'",
+        );
+    }
+
+    /// The other half of the same rule: once the finder HAS scanned, an empty list is a
+    /// fact about the network — nothing is broadcasting — and the mapped source really is
+    /// not found. Blindness must not swallow the genuine PP answer.
+    #[tokio::test]
+    async fn video_source_status_still_says_not_found_when_a_scanned_network_is_empty() {
+        let (state, source_id, _id, fake) = state_with_fake(StartOutcome::SilentSource).await;
+        fake.set_discovered(&[]); // the finder looked; nobody is on the air
+        state
+            .activate_video_source(source_id, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .expect("a silent source still activates (#448)");
+
+        let snapshot = state.video_source_status().await.expect("status snapshot");
+
+        assert!(snapshot.ndi_available, "we CAN see the network — it is just empty");
+        assert_eq!(
+            snapshot.sources.first().map(|s| s.state),
+            Some("not-found"),
+            "a scanned, empty network means the mapped name really is not there",
         );
     }
 

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -292,13 +292,19 @@ impl AppState {
             });
         };
 
-        let discovered: Option<Vec<String>> = match manager.discover_sources(0) {
-            Ok(sources) => Some(sources.into_iter().map(|s| s.name).collect()),
-            Err(e) => {
-                tracing::warn!(error = %e, "NDI discovery failed while reading source status");
-                None
-            }
-        };
+        // `None` = the finder has never completed a scan (it failed to start, or we have
+        // only just booted). That is BLINDNESS, not an empty network — and the difference
+        // is the whole ticket: an empty list reported as fact makes the page tell the
+        // operator that every sending machine at the site is switched off.
+        let discovered: Option<Vec<String>> = manager
+            .discovery_snapshot()
+            .map(|sources| sources.into_iter().map(|s| s.name).collect());
+        if discovered.is_none() {
+            tracing::warn!(
+                "NDI finder has not completed a scan — reporting the network as unseen \
+                 rather than empty (#546)"
+            );
+        }
 
         // `None` = the manager's lock was held past our budget (it is busy building a
         // pipeline), which is NOT the same fact as "there are no pipelines".
@@ -804,7 +810,10 @@ mod tests {
 
         let snapshot = state.video_source_status().await.expect("status snapshot");
 
-        assert!(snapshot.ndi_available, "we CAN see the network — it is just empty");
+        assert!(
+            snapshot.ndi_available,
+            "we CAN see the network — it is just empty"
+        );
         assert_eq!(
             snapshot.sources.first().map(|s| s.state),
             Some("not-found"),

--- a/crates/presenter-server/src/state/ndi_control.rs
+++ b/crates/presenter-server/src/state/ndi_control.rs
@@ -89,7 +89,7 @@ impl NdiManagerHandle {
         }
     }
 
-    /// Forward to [`NdiManager::discover_sources`].
+    /// Forward to [`NdiManager::discover_sources`] — best-effort, empty when blind.
     pub(crate) fn discover_sources(
         &self,
         timeout_ms: u32,
@@ -97,7 +97,19 @@ impl NdiManagerHandle {
         match self {
             Self::Real(m) => m.discover_sources(timeout_ms),
             #[cfg(test)]
-            Self::Fake(f) => f.discovered(),
+            Self::Fake(f) => Ok(f.discovery_snapshot().unwrap_or_default()),
+        }
+    }
+
+    /// Forward to [`NdiManager::discovery_snapshot`] — `None` when the finder has never
+    /// completed a scan, which the #546 status join must NOT read as an empty network.
+    pub(crate) fn discovery_snapshot(
+        &self,
+    ) -> Option<Vec<presenter_ndi::discovery::NdiSourceInfo>> {
+        match self {
+            Self::Real(m) => m.discovery_snapshot(),
+            #[cfg(test)]
+            Self::Fake(f) => f.discovery_snapshot(),
         }
     }
 
@@ -183,8 +195,9 @@ pub(crate) struct FakeNdiControl {
     /// `true` = the manager's lock is held (it is busy starting a pipeline), so the
     /// snapshot map cannot be read at all — the real 200 ms-timeout path.
     snapshots_unreadable: Mutex<bool>,
-    /// `true` = the NDI finder errors out, so this server cannot see the network.
-    discovery_fails: Mutex<bool>,
+    /// `true` = the finder has never completed a scan (it failed to start, or the server
+    /// has only just booted), so this server cannot see the network at all (#546).
+    finder_never_scanned: Mutex<bool>,
 }
 
 /// One recorded call against [`FakeNdiControl`].
@@ -242,22 +255,32 @@ impl FakeNdiControl {
             .push((source_id.to_string(), state));
     }
 
-    /// Make NDI discovery FAIL — the server is blind, not looking at an empty network (#546).
-    pub(crate) fn fail_discovery(&self) {
-        *self.discovery_fails.lock().expect("discovery_fails lock") = true;
+    /// The finder has never completed a scan — the server is BLIND, which is a different
+    /// fact from "the network is empty" (#546). This is the state a server is in when
+    /// `NDIlib_find_create_v2` returned null (forever) or has just booted (transiently).
+    pub(crate) fn finder_never_scanned(&self) {
+        *self
+            .finder_never_scanned
+            .lock()
+            .expect("finder_never_scanned lock") = true;
     }
 
-    fn discovered(&self) -> anyhow::Result<Vec<presenter_ndi::discovery::NdiSourceInfo>> {
-        if *self.discovery_fails.lock().expect("discovery_fails lock") {
-            return Err(anyhow::anyhow!("NDI finder unavailable"));
-        }
-        Ok(self
-            .discovered
+    fn discovery_snapshot(&self) -> Option<Vec<presenter_ndi::discovery::NdiSourceInfo>> {
+        if *self
+            .finder_never_scanned
             .lock()
-            .expect("discovered lock")
-            .iter()
-            .map(|name| presenter_ndi::discovery::NdiSourceInfo { name: name.clone() })
-            .collect())
+            .expect("finder_never_scanned lock")
+        {
+            return None;
+        }
+        Some(
+            self.discovered
+                .lock()
+                .expect("discovered lock")
+                .iter()
+                .map(|name| presenter_ndi::discovery::NdiSourceInfo { name: name.clone() })
+                .collect(),
+        )
     }
 
     /// Simulate the manager being BUSY (mid `start_pipeline`): its lock is held, so the

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.197"
+version = "0.4.198"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -40,6 +40,22 @@ pub(crate) fn status_class(state: &str) -> String {
     format!("settings__status settings__status--{modifier}")
 }
 
+/// How many CONSECUTIVE status-poll failures mean the card is genuinely stale — as opposed
+/// to a single blip (the page being torn down mid-fetch, a redeploy restarting the server).
+///
+/// A poll error must never be swallowed: stale badges the operator trusts are worse than no
+/// badges. But it must not scream at the first hiccup either — an in-flight fetch aborted by
+/// a page navigation is not an outage, and treating it as one filled the console (and failed
+/// the zero-console-noise E2E guards) every time a page closed. So: one failure is tolerated
+/// silently, two in a row and the card admits it does not know — the badges fall back to
+/// "Checking…" and the failure is logged once.
+pub(crate) const STALE_AFTER_FAILURES: u32 = 2;
+
+/// Is the card's data stale after this many consecutive poll failures?
+pub(crate) fn is_stale(consecutive_failures: u32) -> bool {
+    consecutive_failures >= STALE_AFTER_FAILURES
+}
+
 /// The card-header badge: does this server see the NDI network at all?
 ///
 /// `None` = the first status poll has not answered yet. It must NOT read as the failure
@@ -92,6 +108,8 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     let statuses = RwSignal::new(Vec::<VideoSourceStatusDto>::new());
     let new_label = RwSignal::new(String::new());
     let new_ndi_name = RwSignal::new(String::new());
+    // Consecutive status-poll failures — see `STALE_AFTER_FAILURES`.
+    let poll_failures = RwSignal::new(0u32);
 
     // #546: one call answers all three questions the operator has — can this server see
     // the NDI network, what is ON it, and is each mapped source actually working. Polled
@@ -101,13 +119,30 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
         leptos::task::spawn_local(async move {
             match ndi::get_video_source_status().await {
                 Ok(status) => {
+                    poll_failures.set(0);
                     ndi_available.set(Some(status.ndi_available));
                     discovered.set(status.discovered);
                     statuses.set(status.sources);
                 }
-                // Never swallow this: a failing poll means the badges are stale, and the
-                // whole point of the card is that the operator can trust what it says.
-                Err(err) => leptos::logging::warn!("video-source status poll failed: {err}"),
+                // Never swallow this: badges the operator trusts must not silently go stale.
+                // But one failure is a blip (a page being torn down mid-fetch is not an
+                // outage) — see `STALE_AFTER_FAILURES`. On the second in a row the card drops
+                // back to "Checking…" and says so, once.
+                Err(err) => {
+                    let failures = poll_failures.get_untracked() + 1;
+                    poll_failures.set(failures);
+                    if is_stale(failures) {
+                        if !is_stale(failures - 1) {
+                            leptos::logging::warn!(
+                                "video-source status poll failed {failures}x in a row — \
+                                 showing the card as unknown rather than stale: {err}"
+                            );
+                        }
+                        ndi_available.set(None);
+                        discovered.set(Vec::new());
+                        statuses.set(Vec::new());
+                    }
+                }
             }
         });
     };
@@ -406,6 +441,16 @@ mod tests {
             status_class(""),
             "settings__status settings__status--checking"
         );
+    }
+
+    /// A single failed poll is a blip — a page torn down mid-fetch, a server restarting
+    /// during a deploy. Two in a row means the card genuinely does not know any more.
+    #[test]
+    fn one_failed_poll_is_a_blip_two_in_a_row_is_stale() {
+        assert!(!is_stale(0));
+        assert!(!is_stale(1), "a single failure must not blank the card or shout");
+        assert!(is_stale(2));
+        assert!(is_stale(7));
     }
 
     /// The card HEADER badge told the same lie the row badges no longer tell: it is painted

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -377,6 +377,34 @@ mod tests {
         );
     }
 
+    /// The card HEADER badge told the same lie the row badges no longer tell: it is painted
+    /// from a plain `bool` initialised to `false`, so every load of a perfectly healthy
+    /// server flashed "NDI Unavailable" (and hid the "on the network now" list) until the
+    /// first poll landed — and stayed there forever if that poll errored.
+    #[test]
+    fn the_header_badge_says_checking_until_the_first_poll_answers() {
+        assert_eq!(header_badge_label(None), "Checking…");
+        assert_eq!(header_badge_label(Some(true)), "NDI Available");
+        assert_eq!(header_badge_label(Some(false)), "NDI Unavailable");
+    }
+
+    /// …and it must not wear the RED "off" class while it is merely waiting.
+    #[test]
+    fn the_header_badge_is_not_red_while_it_is_still_checking() {
+        assert_eq!(
+            header_badge_class(None),
+            "settings__badge settings__badge--checking"
+        );
+        assert_eq!(
+            header_badge_class(Some(true)),
+            "settings__badge settings__badge--ok"
+        );
+        assert_eq!(
+            header_badge_class(Some(false)),
+            "settings__badge settings__badge--off"
+        );
+    }
+
     #[test]
     fn class_is_built_from_the_state() {
         assert_eq!(

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -40,6 +40,29 @@ pub(crate) fn status_class(state: &str) -> String {
     format!("settings__status settings__status--{modifier}")
 }
 
+/// The card-header badge: does this server see the NDI network at all?
+///
+/// `None` = the first status poll has not answered yet. It must NOT read as the failure
+/// copy — that painted a red "NDI Unavailable" across a perfectly healthy server on every
+/// page load, and left it there forever if the poll errored. Same lie the row badges tell
+/// no more; the header was simply missed the first time round.
+pub(crate) fn header_badge_label(available: Option<bool>) -> &'static str {
+    match available {
+        None => "Checking…",
+        Some(true) => "NDI Available",
+        Some(false) => "NDI Unavailable",
+    }
+}
+
+/// The header badge's class. Neutral while checking — never the red "off" modifier.
+pub(crate) fn header_badge_class(available: Option<bool>) -> &'static str {
+    match available {
+        None => "settings__badge settings__badge--checking",
+        Some(true) => "settings__badge settings__badge--ok",
+        Some(false) => "settings__badge settings__badge--off",
+    }
+}
+
 /// What the operator should DO about this state — shown under the row. `None` when the
 /// state needs no action (live / ready / connecting).
 ///
@@ -63,7 +86,8 @@ pub(crate) fn status_hint(state: &str) -> Option<&'static str> {
 #[component]
 pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
     let sources = RwSignal::new(Vec::<VideoSourceDto>::new());
-    let ndi_available = RwSignal::new(false);
+    // `None` until the first poll answers — see `header_badge_label`.
+    let ndi_available = RwSignal::new(None::<bool>);
     let discovered = RwSignal::new(Vec::<String>::new());
     let statuses = RwSignal::new(Vec::<VideoSourceStatusDto>::new());
     let new_label = RwSignal::new(String::new());
@@ -77,7 +101,7 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
         leptos::task::spawn_local(async move {
             match ndi::get_video_source_status().await {
                 Ok(status) => {
-                    ndi_available.set(status.ndi_available);
+                    ndi_available.set(Some(status.ndi_available));
                     discovered.set(status.discovered);
                     statuses.set(status.sources);
                 }
@@ -122,7 +146,7 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
             match ndi::get_video_source_status().await {
                 Ok(status) => {
                     let count = status.discovered.len();
-                    ndi_available.set(status.ndi_available);
+                    ndi_available.set(Some(status.ndi_available));
                     discovered.set(status.discovered);
                     statuses.set(status.sources);
                     toast.show(&format!("Found {count} NDI source(s)"), "info");
@@ -199,12 +223,9 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                     <p>"Configure NDI sources for stage display"</p>
                 </div>
                 <div class="settings__badge-group">
-                    <span class=move || if ndi_available.get() {
-                        "settings__badge settings__badge--ok"
-                    } else {
-                        "settings__badge settings__badge--off"
-                    }>
-                        {move || if ndi_available.get() { "NDI Available" } else { "NDI Unavailable" }}
+                    <span class=move || header_badge_class(ndi_available.get())
+                        data-role="ndi-header-badge">
+                        {move || header_badge_label(ndi_available.get())}
                     </span>
                 </div>
             </header>
@@ -214,18 +235,13 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                     // Keyed on identity, NOT on the live state: the badge, hint and detail
                     // below read `statuses` through reactive closures, so they update on
                     // every poll without destroying and rebuilding the row (and its buttons).
-                    key=|s: &VideoSourceDto| format!("{}-{}", s.id, s.is_active)
+                    key=|s: &VideoSourceDto| s.id.clone()
                     children=move |source: VideoSourceDto| {
-                        let dot_class = if source.is_active {
-                            "settings__source-dot settings__source-dot--active"
-                        } else {
-                            "settings__source-dot"
-                        };
                         let id_activate = source.id.clone();
                         let id_delete = source.id.clone();
                         let id_status = source.id.clone();
                         let id_hint = source.id.clone();
-                        let is_active = source.is_active;
+                        let listed_active = source.is_active;
 
                         // This row's live status, re-read on every poll. A `Memo` (not a plain
                         // closure) because it is `Copy`, so the badge, the class, the hint and
@@ -237,6 +253,20 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                         });
                         let state_str = move || status.get().map(|st| st.state).unwrap_or_default();
                         let detail = move || status.get().and_then(|st| st.detail);
+                        // The DOT and the BUTTON come from the POLLED status, not from the
+                        // `sources` list — that list is only refetched by this tab's own
+                        // actions, so activating from a second tab (or Companion) used to leave
+                        // this row's badge saying "Live" next to a grey dot and an "Activate"
+                        // button, forever, until a manual reload. Fall back to the listed value
+                        // only until the first poll lands.
+                        let is_active = move || {
+                            status.get().map(|st| st.is_active).unwrap_or(listed_active)
+                        };
+                        let dot_class = move || if is_active() {
+                            "settings__source-dot settings__source-dot--active"
+                        } else {
+                            "settings__source-dot"
+                        };
                         view! {
                             <div class="settings__source-item" data-role="video-source-row"
                                 data-source-id=source.id.clone()>
@@ -262,15 +292,16 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
                                     data-state=state_str>
                                     {move || status_label(&state_str())}
                                 </span>
-                                {if is_active {
+                                {move || if is_active() {
                                     view! {
                                         <button class="settings__btn settings__btn--active"
                                             on:click=move |_| deactivate(())>"ACTIVE"</button>
                                     }.into_any()
                                 } else {
+                                    let id = id_activate.clone();
                                     view! {
                                         <button class="settings__btn settings__btn--activate"
-                                            on:click=move |_| activate(id_activate.clone())>"Activate"</button>
+                                            on:click=move |_| activate(id.clone())>"Activate"</button>
                                     }.into_any()
                                 }}
                                 <button class="settings__btn settings__btn--delete"
@@ -283,7 +314,7 @@ pub fn VideoSourcesCard(toast: ToastHandle) -> impl IntoView {
             // What is ACTUALLY on the network, right next to what is mapped. This one line
             // is what turns "RESOLUME-PP (cg-obs) vs STREAM-PP (stream)" from a two-hour
             // investigation into something the operator spots at a glance (#546).
-            <Show when=move || ndi_available.get()>
+            <Show when=move || ndi_available.get() == Some(true)>
                 <div class="settings__discovered" data-role="ndi-discovered">
                     <span class="settings__discovered-title">"On the network now: "</span>
                     <Show

--- a/crates/presenter-ui/styles/settings.css
+++ b/crates/presenter-ui/styles/settings.css
@@ -405,6 +405,12 @@ body.settings {
   max-width: 46ch;
 }
 
+/* The header badge before the first status poll answers — neutral, never the red "off". */
+.settings__badge--checking {
+  background: #e2e8f0;
+  color: #475569;
+}
+
 /* The pipeline's own error text, when it has one — the most specific "why" available. */
 .settings__source-detail {
   margin-top: 2px;

--- a/tests/e2e/video-source-status.spec.ts
+++ b/tests/e2e/video-source-status.spec.ts
@@ -79,7 +79,10 @@ test("status endpoint joins the rows, the network and the pipelines", async ({
   const body = await readStatus(request);
 
   const entry = body.sources.find((s: any) => s.id === source.id);
-  expect(entry, "the created source must appear in the status snapshot").toBeTruthy();
+  expect(
+    entry,
+    "the created source must appear in the status snapshot",
+  ).toBeTruthy();
   expect(entry.ndiName).toBe(GHOST);
 
   if (body.ndiAvailable) {
@@ -106,7 +109,9 @@ test("the settings card shows the source's status badge", async ({
   const ndiAvailable: boolean = (await readStatus(request)).ndiAvailable;
 
   await page.goto(new URL("/ui/settings", baseURL).toString());
-  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 60_000 });
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 60_000,
+  });
 
   const badge = page.locator(
     `[data-role="video-source-status"][data-source-id="${source.id}"]`,
@@ -116,7 +121,9 @@ test("the settings card shows the source's status badge", async ({
   );
 
   if (ndiAvailable) {
-    await expect(badge).toHaveText("Not found on the network", { timeout: 30_000 });
+    await expect(badge).toHaveText("Not found on the network", {
+      timeout: 30_000,
+    });
     await expect(badge).toHaveAttribute("data-state", "not-found");
     // The sentence that would have ended the PP outage in a minute.
     await expect(hint).toContainText("not on the network", { timeout: 30_000 });
@@ -130,5 +137,58 @@ test("the settings card shows the source's status badge", async ({
     await expect(page.locator('[data-role="ndi-discovered"]')).toHaveCount(0);
   }
 
+  // The card HEADER must agree with the server, and must never sit on the red failure
+  // copy — it used to be a bool initialised to false, so a healthy server painted "NDI
+  // Unavailable" on every load until the first poll landed.
+  const headerBadge = page.locator('[data-role="ndi-header-badge"]');
+  await expect(headerBadge).toHaveText(
+    ndiAvailable ? "NDI Available" : "NDI Unavailable",
+    { timeout: 30_000 },
+  );
+
   expect(errors, `console errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
+// The row's dot and ACTIVE/Activate button used to come from a list only THIS tab
+// refetches — so an activation from anywhere else (a second tab, Companion) left the row
+// contradicting its own badge until a manual reload. They now come from the same polled
+// status the badge does.
+test("the row's active state follows the server, not this tab's own actions", async ({
+  page,
+  request,
+}) => {
+  const source = await createSource(request, "cam-elsewhere", GHOST);
+
+  await page.goto(new URL("/ui/settings", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 60_000,
+  });
+
+  const row = page.locator(
+    `[data-role="video-source-row"][data-source-id="${source.id}"]`,
+  );
+  await expect(row.locator(".settings__btn--activate")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Activate OUT OF BAND — as another operator's tab or Companion would. A source whose
+  // broadcaster is silent still ACTIVATES (#448), with or without the NDI SDK, so this is
+  // deterministic on both lanes.
+  const res = await request.post(
+    new URL(
+      `/integrations/video-sources/${source.id}/activate`,
+      baseURL,
+    ).toString(),
+  );
+  expect(res.status()).toBe(200);
+  const entry = (await readStatus(request)).sources.find(
+    (s: any) => s.id === source.id,
+  );
+  expect(entry.isActive, "the server considers the source active").toBe(true);
+
+  // No reload, no click in this tab: the 5s poll alone must bring the row in line.
+  await expect(row.locator(".settings__btn--active")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(row.locator(".settings__source-dot--active")).toHaveCount(1);
 });


### PR DESCRIPTION
## The #546 blindness fix was fixed only behind the test fake

A three-lens adversarial verification of the shipped v0.4.197 found that one of the deep-review
fixes did not actually reach production:

`Discovery::Blind` was keyed on `discover_sources()` returning `Err` — which the real
`NdiManager` **cannot do**: it is `Ok(self.source_list.read())`. Only `FakeNdiControl` could
produce that `Err`, so the test was green for a reason production does not share, and the
blindness we ACTUALLY have still read as an empty network:

* `NDIlib_find_create_v2` returns null → `run_finder_loop` returns immediately and the source
  list stays empty **forever**, while the server keeps reporting `ndiAvailable: true`;
* transiently after **every restart**, until the finder's first ~5 s scan returns.

In both cases the settings page told the operator, for every mapped source: *"not on the network
— check the sending machine is on and its NDI output is switched on"*, plus *"On the network
now: nothing"*. That is exactly the false accusation #546 exists to prevent — a broken (or
merely just-booted) server sending the operator round every sending machine at the site.

**Fix:** `SourceList` now carries the two facts apart — WHAT the finder has seen, and WHETHER it
has ever looked (`scanned`, set on the first published scan, never set if the finder failed to
start). `NdiManager::discovery_snapshot() -> Option<Vec<..>>` exposes it; `discover_sources()`
keeps its best-effort shape for `GET /ndi/sources`. A never-scanned finder now yields
`unknown` / "NDI unavailable"; a scanned-but-empty network still yields the genuine `not-found`.

Two more real defects from the same verification:

* the card **header** badge kept the lie the row badges lost — a `bool` initialised to `false`
  painted a red "NDI Unavailable" over a healthy server on every page load until the first poll
  landed, and forever if that poll errored. Now `Option<bool>` → "Checking…".
* a row's dot and ACTIVE/Activate button read `is_active` from a list only that tab refetches, so
  an activation from a second tab or from Companion left the row contradicting its own badge
  until a manual reload. They now come from the same polled status the badge does.

RED `ede5e7ba` → GREEN `afa54c30`. Refs #546.
