### PR TITLE
Release v0.4.203: presentation copy between libraries + Resolume chip names

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -241,3 +241,12 @@ decision a PURE helper and unit-test it — don't bury it in the async path:
 ```bash
 gh api -X PATCH repos/zbynekdrlik/presenter/pulls/<N> -F "body=@body.md"
 ```
+
+## presenter-ui Is a Workspace `exclude` — Root fmt/clippy/test NEVER See It
+
+`crates/presenter-ui` (WASM) is in `[workspace] exclude`, so `cargo fmt --all`,
+`cargo clippy --workspace`, and `cargo test` from the root silently skip it. Run its
+checks FROM THE CRATE DIR: `cd crates/presenter-ui && cargo fmt --check && cargo clippy
+--all-targets -- -D warnings && cargo test --lib`. CI's Format job checks it explicitly
+(second step, `working-directory: crates/presenter-ui`) — an unformatted presenter-ui
+file now fails CI, so always `cargo fmt` inside the crate before pushing UI changes.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -142,3 +142,21 @@ shows the test's LIBRARY as a match but never surfaces its PRESENTATION, and
 `Conflict409A`, `Conflict409RecoverA` — never a space-separated lone letter.
 Every existing 409/race test in `wasm-slide-multiselect.spec.ts` already follows
 this; keep new ones consistent.
+
+## E2E: the library SIDEBAR lists only FAVORITES — select fresh libraries via the modal (#570)
+
+`[data-role="library-item"]` in the operator sidebar renders only favorite
+libraries (plus the count button). A library an E2E test just created via the
+API is NOT in the sidebar — a `hasText` click on it times out with zero
+matches. Select it through the "Show all libraries" modal instead:
+
+```ts
+await page.locator('[data-role="library-more"]').click();
+await page
+  .locator(`[data-role="library-row"][data-library-id="${lib.id}"] .operator__list-button`)
+  .click();
+await page.waitForSelector('[data-role="presentation-list"]');
+```
+
+Related JSON-shape gotcha: `SlideText` serializes as an object — assert
+`slide.content.main.value`, never `slide.content.main` directly.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1158,9 +1158,11 @@ jobs:
           set -e
           # Issue #279: prod-snapshot DB carries production-side hosts that would
           # cause dev to send commands to live hardware. Rewrite to mock endpoints
-          # baked into the dev binary (--features mock-integrations). The previous
-          # "Replace dev database" step guarantees the DB exists at this path.
-          sqlite3 /opt/presenter-dev/presenter.db "UPDATE resolume_hosts SET host='127.0.0.1', port=8091, label=label || ' (mock)'; UPDATE ableset_settings SET host='127.0.0.1', http_port=39042; DELETE FROM android_stage_displays; DELETE FROM video_sources;"
+          # baked into the dev binary (--features mock-integrations). Since #565
+          # the snapshot replace is SKIPPED when prod is offline, so this step can
+          # re-run on an already-mocked DB — the label rewrite must be idempotent
+          # (REPLACE strips prior ' (mock)' suffixes before appending exactly one).
+          sqlite3 /opt/presenter-dev/presenter.db "UPDATE resolume_hosts SET host='127.0.0.1', port=8091, label=REPLACE(label, ' (mock)', '') || ' (mock)'; UPDATE ableset_settings SET host='127.0.0.1', http_port=39042; DELETE FROM android_stage_displays; DELETE FROM video_sources;"
           echo "Integration tables redirected to localhost mock endpoints"
           REMOTE_SCRIPT
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1161,7 +1161,9 @@ jobs:
           # baked into the dev binary (--features mock-integrations). Since #565
           # the snapshot replace is SKIPPED when prod is offline, so this step can
           # re-run on an already-mocked DB — the label rewrite must be idempotent
-          # (REPLACE strips prior ' (mock)' suffixes before appending exactly one).
+          # (REPLACE strips prior ' (mock)' suffixes before appending exactly one;
+          # note REPLACE strips ALL occurrences, so a prod label with a literal
+          # mid-string ' (mock)' would collapse — implausible, dev-only cosmetic).
           sqlite3 /opt/presenter-dev/presenter.db "UPDATE resolume_hosts SET host='127.0.0.1', port=8091, label=REPLACE(label, ' (mock)', '') || ' (mock)'; UPDATE ableset_settings SET host='127.0.0.1', http_port=39042; DELETE FROM android_stage_displays; DELETE FROM video_sources;"
           echo "Integration tables redirected to localhost mock endpoints"
           REMOTE_SCRIPT

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # presenter-ui is a workspace `exclude` (WASM crate), so the root
+      # `cargo fmt --all` never sees it — check it explicitly.
+      - name: Check formatting (presenter-ui)
+        run: cargo fmt --check
+        working-directory: crates/presenter-ui
+
   # ============================================
   # Clippy Linting
   # ============================================

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -905,40 +905,77 @@ jobs:
               IdentityFile ~/.ssh/id_prod
           EOF
 
-      - name: Test migration against production DB
+      - name: Fetch production DB snapshot (delta-synced cache)
+        id: prod_snapshot
         run: |
           set -e
-          # Prod is a physical machine that gets powered off when equipment travels to
-          # events. A DEV deploy must not be held hostage by a deliberately-offline prod:
-          # when prod is UNREACHABLE, warn loudly and skip this pre-check (it re-arms by
-          # itself the moment prod is back). A reachable prod that fails the copy or the
-          # migration still HARD-FAILS below — the gate itself is not weakened.
+          # #565: ONE snapshot fetch per run — the migration pre-check AND the
+          # dev-DB refresh below both read this cached copy (previously each
+          # pulled its own FULL snapshot: 2 × 75 MB gz over a ~21 KB/s
+          # inter-site bridge when the rig travels ≈ the whole deploy-dev job
+          # crawling for ~an hour). The cache is PERSISTENT on the runner and
+          # rsync delta-syncs it, so steady-state runs transfer only the
+          # SQLite pages that changed since the previous run.
+          #
+          # Prod is a physical machine that gets powered off when equipment
+          # travels to events. A DEV deploy must not be held hostage by a
+          # deliberately-offline prod: when prod is UNREACHABLE, notice-skip
+          # (available=false skips both consumer steps; they re-arm by
+          # themselves the moment prod is back). A reachable prod that fails
+          # the snapshot or the sync still HARD-FAILS.
           if ! ssh -i ~/.ssh/id_prod -o ConnectTimeout=10 -o BatchMode=yes prod-server true 2>/dev/null; then
-            # ::notice:: (not ::warning::) — this is a DELIBERATE, documented skip,
-            # not a swallowed failure; the strict quality gate forbids the
-            # warning-then-exit-0 soft-fail shape and a reachable-prod failure
-            # still hard-fails below.
-            echo "::notice::Production host is unreachable (powered off?). Skipping the prod-DB migration pre-check for this DEV deploy — it runs again automatically once prod is back online. The prod deploy workflow still gates on it."
+            echo "::notice::Production host is unreachable (powered off?). Skipping the prod-DB migration pre-check AND the dev-DB snapshot refresh for this DEV deploy — both run again automatically once prod is back online. The prod deploy workflow still gates on the migration check."
+            echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Copying production database for migration testing..."
+          CACHE_DIR="/var/tmp/presenter-ci"
+          CACHE_DB="$CACHE_DIR/prod-db-cache.db"
+          mkdir -p "$CACHE_DIR"
+          # Consistent online-backup snapshot on the prod box — a raw copy of
+          # the LIVE SQLite file races concurrent writes; over a slow link the
+          # multi-minute copy window guarantees a torn, "malformed" image (hit
+          # 2026-07-17 at an event). UNCOMPRESSED on purpose: rsync's delta
+          # algorithm needs the stable on-disk page layout to match blocks
+          # against the cache; compression happens in transit (-z).
+          if ! ssh -i ~/.ssh/id_prod prod-server "python3 -c \"import sqlite3; s=sqlite3.connect('/opt/presenter/presenter.db'); d=sqlite3.connect('/tmp/prod-ci-snapshot.db'); s.backup(d); d.close(); s.close()\""; then
+            echo "::error::Could not snapshot the production database on prod-server (python3 sqlite3 backup). Fix prod SSH access / python3 before retrying."
+            exit 1
+          fi
+          sync_snapshot() {
+            # flock: the cache is shared machine state — never let two runs
+            # rsync --inplace into it concurrently.
+            flock "$CACHE_DIR/.fetch-lock" \
+              rsync -z --inplace --partial --timeout=600 \
+                -e "ssh -i ~/.ssh/id_prod" \
+                prod-server:/tmp/prod-ci-snapshot.db "$CACHE_DB"
+          }
+          check_snapshot() {
+            python3 -c "import sqlite3,sys; c=sqlite3.connect('file:'+sys.argv[1]+'?mode=ro',uri=True); r=c.execute('PRAGMA quick_check(1)').fetchone(); sys.exit(0 if r and r[0]=='ok' else 1)" "$CACHE_DB"
+          }
+          if ! sync_snapshot || ! check_snapshot; then
+            echo "::warning::Delta sync failed or the cached snapshot failed its integrity check — discarding the cache and doing ONE full re-fetch."
+            rm -f "$CACHE_DB"
+            sync_snapshot
+            check_snapshot || { echo "::error::Prod DB snapshot is corrupt even after a full re-fetch. Cannot trust it for the migration test or the dev-DB refresh."; exit 1; }
+          fi
+          ssh -i ~/.ssh/id_prod prod-server "rm -f /tmp/prod-ci-snapshot.db"
+          SNAP_SIZE=$(stat -c %s "$CACHE_DB")
+          if [ "$SNAP_SIZE" -lt 1048576 ]; then
+            echo "::error::Production DB snapshot suspiciously small (${SNAP_SIZE} bytes). Aborting to avoid testing/deploying garbage."
+            exit 1
+          fi
+          echo "Snapshot cached at $CACHE_DB (${SNAP_SIZE} bytes)"
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+      - name: Test migration against production DB
+        if: steps.prod_snapshot.outputs.available == 'true'
+        run: |
+          set -e
           PROD_DB="/tmp/prod-migration-test-$$.db"
-          # A raw scp of a LIVE SQLite file races concurrent writes — over a slow
-          # inter-site link the multi-minute copy window guarantees a torn,
-          # "malformed" image (hit 2026-07-17 at an event). Take a CONSISTENT
-          # snapshot with SQLite's online backup API on the prod box, gzip it
-          # (~8x smaller — the slow-bridge copy drops from hours to minutes),
-          # then pull the compressed snapshot.
-          if ! ssh -i ~/.ssh/id_prod prod-server "python3 -c \"import sqlite3; s=sqlite3.connect('/opt/presenter/presenter.db'); d=sqlite3.connect('/tmp/prod-ci-snapshot.db'); s.backup(d); d.close(); s.close()\" && gzip -1f /tmp/prod-ci-snapshot.db"; then
-            echo "::error::Could not snapshot the production database on prod-server (python3 sqlite3 backup). The migration test cannot run. Fix prod SSH access / python3 before retrying."
-            exit 1
-          fi
-          if ! scp -i ~/.ssh/id_prod prod-server:/tmp/prod-ci-snapshot.db.gz "$PROD_DB.gz"; then
-            echo "::error::Could not copy production database snapshot from prod-server. The migration test cannot run, which means we cannot verify the new binary won't break production. Fix prod SSH access (DEPLOY_SSH_KEY secret must be installed in prod's authorized_keys) before retrying."
-            exit 1
-          fi
-          ssh -i ~/.ssh/id_prod prod-server "rm -f /tmp/prod-ci-snapshot.db.gz"
-          gunzip -f "$PROD_DB.gz"
+          # Work on a COPY — the server run below migrates the DB in place,
+          # and the shared cache must stay byte-identical to prod so the next
+          # run's rsync delta stays minimal.
+          cp /var/tmp/presenter-ci/prod-db-cache.db "$PROD_DB"
           echo "Testing new binary against production database..."
           chmod +x target/release/presenter-server
           PRESENTER_DB_URL="sqlite://$PROD_DB" PRESENTER_PORT=0 \
@@ -1086,37 +1123,19 @@ jobs:
           REMOTE_SCRIPT
 
       - name: Replace dev database with production snapshot
+        # #565: reads the snapshot cached by the "Fetch production DB
+        # snapshot" step — no second full pull over the slow inter-site link.
+        # Prod unreachable (available != 'true') → step skips and dev keeps
+        # its CURRENT database; the refresh re-arms once prod is back online.
+        if: steps.prod_snapshot.outputs.available == 'true'
         run: |
           set -e
-          # Prod gets powered off when equipment travels to events. While it is
-          # deliberately unreachable, keep dev's CURRENT database instead of failing the
-          # whole dev deploy; the snapshot refresh re-arms on its own once prod is back.
-          # A reachable prod that fails the copy still hard-fails below.
-          if ! ssh -i ~/.ssh/id_prod -o ConnectTimeout=10 -o BatchMode=yes prod-server true 2>/dev/null; then
-            echo "::notice::Production host is unreachable (powered off?). Keeping dev's current database for this deploy — the prod snapshot refresh resumes automatically once prod is back online."
-            exit 0
-          fi
-          echo "Fetching production database snapshot..."
           PROD_TMP="/tmp/prod-db-snapshot-$$.db"
-          # Consistent SQLite online-backup snapshot + gzip — a raw scp of the live
-          # file tears under concurrent writes (see the migration-test step above).
-          if ! ssh -i ~/.ssh/id_prod prod-server "python3 -c \"import sqlite3; s=sqlite3.connect('/opt/presenter/presenter.db'); d=sqlite3.connect('/tmp/prod-ci-snapshot2.db'); s.backup(d); d.close(); s.close()\" && gzip -1f /tmp/prod-ci-snapshot2.db"; then
-            echo "::error::Could not snapshot the production database on prod-server. Dev DB will retain its current state — this is a regression risk. Fix prod SSH access / python3 before proceeding."
-            exit 1
-          fi
-          if ! scp -i ~/.ssh/id_prod prod-server:/tmp/prod-ci-snapshot2.db.gz "$PROD_TMP.gz" 2>/dev/null; then
-            echo "::error::Could not copy production database snapshot. Dev DB will retain its current state — this is a regression risk. Fix prod SSH access before proceeding."
-            exit 1
-          fi
-          ssh -i ~/.ssh/id_prod prod-server "rm -f /tmp/prod-ci-snapshot2.db.gz"
-          gunzip -f "$PROD_TMP.gz"
+          # Copy out of the shared cache — the deploy consumes the copy, the
+          # cache stays pristine for the next run's rsync delta.
+          cp /var/tmp/presenter-ci/prod-db-cache.db "$PROD_TMP"
           PROD_SIZE=$(stat -c %s "$PROD_TMP")
-          if [ "$PROD_SIZE" -lt 1024 ]; then
-            echo "::error::Production DB snapshot suspiciously small (${PROD_SIZE} bytes). Aborting to avoid wiping dev with garbage."
-            rm -f "$PROD_TMP"
-            exit 1
-          fi
-          echo "Production snapshot fetched (${PROD_SIZE} bytes). Uploading to dev server..."
+          echo "Production snapshot ready (${PROD_SIZE} bytes). Uploading to dev server..."
           scp -i ~/.ssh/id_deploy "$PROD_TMP" deploy-target:/opt/presenter-dev/presenter.db.new
           rm -f "$PROD_TMP"
           ssh deploy-target << 'REMOTE_SCRIPT'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.201"
+version = "0.4.202"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.202"
+version = "0.4.203"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -6,6 +6,8 @@ mod playlist;
 mod presentation;
 #[cfg(test)]
 mod presentation_atomicity_tests;
+#[cfg(test)]
+mod presentation_copy_tests;
 mod resolume;
 mod search;
 #[cfg(test)]

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -1,4 +1,6 @@
-use super::util::{build_slide_active_model, parse_uuid, to_domain_slide, RepositoryError};
+use super::util::{
+    build_slide_active_model, parse_uuid, to_domain_slide, to_domain_slide_wire, RepositoryError,
+};
 use super::Repository;
 use crate::entities::{presentation as presentation_entity, slide as slide_entity};
 use anyhow::anyhow;
@@ -150,8 +152,13 @@ impl Repository {
         let source_id = presentation_id.to_string();
         let target_lib = target_library_id.to_string();
 
+        // All reads happen INSIDE the same transaction as the writes — a
+        // pool-read-then-txn-write split would leave a TOCTOU window where a
+        // concurrent edit/sync changes the source between snapshot and copy.
+        let txn = self.db.begin().await?;
+
         if crate::entities::library::Entity::find_by_id(target_lib.clone())
-            .one(&self.db)
+            .one(&txn)
             .await?
             .is_none()
         {
@@ -161,26 +168,25 @@ impl Repository {
         let source = presentation_entity::Entity::find()
             .filter(presentation_entity::Column::Id.eq(source_id.clone()))
             .filter(presentation_entity::Column::DeletedAt.is_null())
-            .one(&self.db)
+            .one(&txn)
             .await?
             .ok_or_else(|| anyhow!("presentation not found"))?;
 
         let source_slides = slide_entity::Entity::find()
             .filter(slide_entity::Column::PresentationId.eq(source_id.clone()))
             .order_by_asc(slide_entity::Column::Position)
-            .all(&self.db)
+            .all(&txn)
             .await?;
 
         let markers = crate::entities::slide_stage_layout::Entity::find()
             .filter(
                 crate::entities::slide_stage_layout::Column::PresentationId.eq(source_id.clone()),
             )
-            .all(&self.db)
+            .all(&txn)
             .await?;
 
         let new_uuid = uuid::Uuid::new_v4();
         let new_id_str = new_uuid.to_string();
-        let txn = self.db.begin().await?;
 
         presentation_entity::Entity::insert(presentation_entity::ActiveModel {
             id: Set(new_id_str.clone()),
@@ -197,7 +203,10 @@ impl Repository {
 
         for (index, model) in source_slides.into_iter().enumerate() {
             let old_slide_id = model.id.clone();
-            let fresh = Slide::new(index as u32, to_domain_slide(model)?.content);
+            // `_wire` (unchecked) — a legacy oversize row must copy verbatim,
+            // not fail the whole copy with a validation 500 (#558 U1 has the
+            // full rationale for reads of stored rows).
+            let fresh = Slide::new(index as u32, to_domain_slide_wire(model)?.content);
             let active = build_slide_active_model(&fresh, &new_id_str, index as i32);
             slide_entity::Entity::insert(active).exec(&txn).await?;
 

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -135,6 +135,93 @@ impl Repository {
         detail.ok_or_else(|| anyhow!("failed to load newly created presentation"))
     }
 
+    /// #570: deep-copy a presentation into another (or the same) library.
+    /// The copy gets a NEW presentation id, a NEW sync_id (it syncs as its
+    /// own song under #555 LWW — never pairs with the original), and NEW
+    /// slide ids; per-slide stage-layout markers (#515) are remapped onto
+    /// the fresh slide ids. The original is not touched, so playlists
+    /// referencing it are unaffected.
+    #[instrument(skip_all)]
+    pub async fn copy_presentation_to_library(
+        &self,
+        presentation_id: PresentationId,
+        target_library_id: LibraryId,
+    ) -> anyhow::Result<(LibraryId, String, Presentation)> {
+        let source_id = presentation_id.to_string();
+        let target_lib = target_library_id.to_string();
+
+        if crate::entities::library::Entity::find_by_id(target_lib.clone())
+            .one(&self.db)
+            .await?
+            .is_none()
+        {
+            return Err(anyhow!("target library not found"));
+        }
+
+        let source = presentation_entity::Entity::find()
+            .filter(presentation_entity::Column::Id.eq(source_id.clone()))
+            .filter(presentation_entity::Column::DeletedAt.is_null())
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("presentation not found"))?;
+
+        let source_slides = slide_entity::Entity::find()
+            .filter(slide_entity::Column::PresentationId.eq(source_id.clone()))
+            .order_by_asc(slide_entity::Column::Position)
+            .all(&self.db)
+            .await?;
+
+        let markers = crate::entities::slide_stage_layout::Entity::find()
+            .filter(
+                crate::entities::slide_stage_layout::Column::PresentationId.eq(source_id.clone()),
+            )
+            .all(&self.db)
+            .await?;
+
+        let new_uuid = uuid::Uuid::new_v4();
+        let new_id_str = new_uuid.to_string();
+        let txn = self.db.begin().await?;
+
+        presentation_entity::Entity::insert(presentation_entity::ActiveModel {
+            id: Set(new_id_str.clone()),
+            library_id: Set(target_lib),
+            name: Set(source.name.clone()),
+            search_name: Set(fold_query(&source.name)),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+            sync_id: Set(uuid::Uuid::new_v4().to_string()),
+            deleted_at: Set(None),
+        })
+        .exec(&txn)
+        .await?;
+
+        for (index, model) in source_slides.into_iter().enumerate() {
+            let old_slide_id = model.id.clone();
+            let fresh = Slide::new(index as u32, to_domain_slide(model)?.content);
+            let active = build_slide_active_model(&fresh, &new_id_str, index as i32);
+            slide_entity::Entity::insert(active).exec(&txn).await?;
+
+            if let Some(marker) = markers.iter().find(|m| m.slide_id == old_slide_id) {
+                crate::entities::slide_stage_layout::Entity::insert(
+                    crate::entities::slide_stage_layout::ActiveModel {
+                        slide_id: Set(fresh.id.to_string()),
+                        presentation_id: Set(new_id_str.clone()),
+                        layout_code: Set(marker.layout_code.clone()),
+                    },
+                )
+                .exec(&txn)
+                .await?;
+            }
+        }
+
+        txn.commit().await?;
+
+        let detail = self
+            .fetch_presentation_detail(PresentationId::from_uuid(new_uuid))
+            .await?;
+        detail.ok_or_else(|| anyhow!("failed to load copied presentation"))
+    }
+
     #[instrument(skip_all)]
     pub async fn rename_presentation(
         &self,

--- a/crates/presenter-persistence/src/repository/presentation_copy_tests.rs
+++ b/crates/presenter-persistence/src/repository/presentation_copy_tests.rs
@@ -1,0 +1,169 @@
+//! #570: deep-copy a presentation into another library. Kept in its own file
+//! (not `tests.rs`, which is already over the file-size cap) per the
+//! presenter-ci playbook.
+use crate::entities::presentation as presentation_entity;
+use crate::Repository;
+use presenter_core::{LibraryId, Slide, SlideContent, SlideText};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+async fn repo() -> Repository {
+    Repository::connect_in_memory()
+        .await
+        .expect("in-memory repo")
+}
+
+fn slide(order: u32, main: &str, group: Option<&str>) -> Slide {
+    Slide::new(
+        order,
+        SlideContent::new(
+            SlideText::new(main).unwrap(),
+            SlideText::new(format!("{main}-translation")).unwrap(),
+            SlideText::new(format!("{main}-stage")).unwrap(),
+            group.map(presenter_core::slide::SlideGroup::new),
+        ),
+    )
+}
+
+/// Two libraries + a two-slide source song in the first; returns
+/// (repo, source_library, target_library, source_presentation).
+async fn setup() -> (
+    Repository,
+    presenter_core::Library,
+    presenter_core::Library,
+    presenter_core::Presentation,
+) {
+    let repo = repo().await;
+    let lib_a = repo.create_library("Source Lib").await.unwrap();
+    let lib_b = repo.create_library("Target Lib").await.unwrap();
+    let slides = vec![slide(0, "verse", Some("Verse 1")), slide(1, "chorus", None)];
+    let (_, _, source) = repo
+        .create_presentation(lib_a.id, "Amazing Song", Some(&slides))
+        .await
+        .unwrap();
+    (repo, lib_a, lib_b, source)
+}
+
+#[tokio::test]
+async fn copy_lands_in_the_target_library_with_same_content_but_fresh_ids() {
+    let (repo, _, lib_b, source) = setup().await;
+
+    let (copied_lib, copied_lib_name, copy) = repo
+        .copy_presentation_to_library(source.id, lib_b.id)
+        .await
+        .unwrap();
+
+    assert_eq!(copied_lib, lib_b.id, "copy must land in the target library");
+    assert_eq!(copied_lib_name, "Target Lib");
+    assert_ne!(copy.id, source.id, "copy must be a NEW presentation");
+    assert_eq!(copy.name, source.name);
+    assert_eq!(copy.slides.len(), source.slides.len());
+    for (copied, original) in copy.slides.iter().zip(source.slides.iter()) {
+        assert_eq!(copied.content, original.content, "content copied verbatim");
+        assert_ne!(copied.id, original.id, "every slide id must be fresh");
+    }
+
+    // The copy syncs as its OWN song (#555) — never pairs with the original.
+    let sync_ids: Vec<String> = presentation_entity::Entity::find()
+        .all(&repo.db)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.sync_id)
+        .collect();
+    assert_eq!(sync_ids.len(), 2);
+    assert_ne!(sync_ids[0], sync_ids[1], "sync_id must be fresh");
+}
+
+#[tokio::test]
+async fn copy_is_independent_of_the_original_after_edits_and_delete() {
+    let (repo, _, lib_b, source) = setup().await;
+    let (_, _, copy) = repo
+        .copy_presentation_to_library(source.id, lib_b.id)
+        .await
+        .unwrap();
+
+    // Mutate + trash the ORIGINAL.
+    repo.update_slide_content(
+        source.id,
+        source.slides[0].id,
+        &slide(0, "rewritten", None).content,
+    )
+    .await
+    .unwrap();
+    repo.delete_presentation(source.id).await.unwrap();
+
+    let (_, _, copy_after) = repo
+        .fetch_presentation_detail(copy.id)
+        .await
+        .unwrap()
+        .expect("copy must survive edits + deletion of the original");
+    assert_eq!(
+        copy_after.slides[0].content.main.value(),
+        "verse",
+        "the copy's content must not follow the original's edits"
+    );
+}
+
+#[tokio::test]
+async fn copy_remaps_slide_stage_layout_markers_onto_the_new_slide_ids() {
+    let (repo, _, lib_b, source) = setup().await;
+    repo.set_slide_stage_layout(source.id, source.slides[1].id, "ndi-fullscreen")
+        .await
+        .unwrap();
+
+    let (_, _, copy) = repo
+        .copy_presentation_to_library(source.id, lib_b.id)
+        .await
+        .unwrap();
+
+    let markers = repo.list_slide_stage_layouts(copy.id).await.unwrap();
+    assert_eq!(
+        markers.get(&copy.slides[1].id.to_string()),
+        Some(&"ndi-fullscreen".to_string()),
+        "marker must follow the copied slide under its NEW id"
+    );
+    assert!(
+        !markers.contains_key(&source.slides[1].id.to_string()),
+        "the copy's markers must not point at the ORIGINAL slide id"
+    );
+}
+
+#[tokio::test]
+async fn copy_into_a_missing_library_errors_and_writes_nothing() {
+    let (repo, _, _, source) = setup().await;
+
+    let err = repo
+        .copy_presentation_to_library(source.id, LibraryId::new())
+        .await
+        .expect_err("copy into a vanished library must fail");
+    assert!(
+        err.to_string().contains("target library not found"),
+        "{err}"
+    );
+
+    let count = presentation_entity::Entity::find()
+        .all(&repo.db)
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(count, 1, "no copy row may be written on failure");
+}
+
+#[tokio::test]
+async fn copying_a_trashed_presentation_errors() {
+    let (repo, _, lib_b, source) = setup().await;
+    repo.delete_presentation(source.id).await.unwrap();
+
+    let err = repo
+        .copy_presentation_to_library(source.id, lib_b.id)
+        .await
+        .expect_err("a soft-deleted song must not be copyable");
+    assert!(err.to_string().contains("presentation not found"), "{err}");
+
+    let live = presentation_entity::Entity::find()
+        .filter(presentation_entity::Column::DeletedAt.is_null())
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert!(live.is_empty(), "no copy row may be written on failure");
+}

--- a/crates/presenter-server/src/resolume/port_drift_integration_tests.rs
+++ b/crates/presenter-server/src/resolume/port_drift_integration_tests.rs
@@ -13,6 +13,7 @@ use presenter_core::{ResolumeHost, ResolumeHostId};
 use reqwest::Client;
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -70,6 +71,36 @@ fn host_config(port: u16) -> ResolumeHost {
     )
 }
 
+/// Drive the fail→classify→probe cycle until the driver's dial state reaches
+/// `expected_active`, bounded (retry-with-assert, per the project's E2E
+/// discipline). A ONE-SHOT assert on a single cycle is racy on a loaded
+/// runner: the dropped mock's shutdown is asynchronous, so the first dial
+/// can land accepted-then-reset (classified Reset, not ConnectRefused — no
+/// probe), and the 500ms probe budget can starve under llvm-cov
+/// instrumentation (both seen as a real coverage-job flake, 2026-07-20).
+/// Production recovers the same way this loop does — the driver probes again
+/// on the NEXT connect-refused failure — so retrying does not weaken the
+/// contract: the driver MUST reach `expected_active` within the bound.
+async fn drive_until_active_port(
+    driver: &mut HostDriver,
+    status: &Arc<RwLock<ResolumeConnectionSnapshot>>,
+    expected_active: Option<u16>,
+    context: &str,
+) {
+    for _ in 0..20 {
+        if driver.active_port == expected_active {
+            return;
+        }
+        // An Ok here means the OLD mock was still draining its shutdown and
+        // answered — not a failure of the drift logic; dial again.
+        if let Err(err) = driver.refresh_mapping().await {
+            driver.record_error(err, status).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(driver.active_port, expected_active, "{context}");
+}
+
 fn fresh_snapshot() -> Arc<RwLock<ResolumeConnectionSnapshot>> {
     Arc::new(RwLock::new(ResolumeConnectionSnapshot {
         state: ResolumeConnectionState::Connecting,
@@ -114,19 +145,15 @@ async fn driver_adopts_the_drifted_port_after_a_connection_refused_and_reconnect
     let server_b = MockServer::builder().listener(listener_b).start().await;
     mount_arena(&server_b).await;
 
-    // The next fetch against the (now-refused) configured port fails;
-    // record_error classifies it as ConnectRefused and probes the window.
-    let err = driver
-        .refresh_mapping()
-        .await
-        .expect_err("the configured port now refuses connections");
-    driver.record_error(err, &status).await;
-
-    assert_eq!(
-        driver.active_port,
+    // Fetches against the (now-refused) configured port fail; record_error
+    // classifies ConnectRefused and probes the window until adoption.
+    drive_until_active_port(
+        &mut driver,
+        &status,
         Some(drifted_port),
-        "the driver must adopt the drifted port after a connect-refused probe"
-    );
+        "the driver must adopt the drifted port after a connect-refused probe",
+    )
+    .await;
     let snap = status.read().await.clone();
     assert_eq!(
         snap.active_port,
@@ -170,19 +197,16 @@ async fn driver_heals_back_to_the_configured_port_once_it_answers_again() {
     let server_c = MockServer::builder().listener(listener_c).start().await;
     mount_arena(&server_c).await;
 
-    // The next fetch (still dialing the now-dead drifted port) fails, and the
-    // probe — which ALWAYS scans from the CONFIGURED port first — finds it
-    // healthy again and heals back.
-    let err = driver
-        .refresh_mapping()
-        .await
-        .expect_err("the drifted port now refuses connections");
-    driver.record_error(err, &status).await;
-
-    assert_eq!(
-        driver.active_port, None,
-        "healing back to the configured port must clear active_port"
-    );
+    // Fetches (still dialing the now-dead drifted port) fail, and the probe
+    // — which ALWAYS scans from the CONFIGURED port first — finds it healthy
+    // again and heals back.
+    drive_until_active_port(
+        &mut driver,
+        &status,
+        None,
+        "healing back to the configured port must clear active_port",
+    )
+    .await;
     let snap = status.read().await.clone();
     assert_eq!(
         snap.active_port, None,

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -299,6 +299,10 @@ pub fn build_router(state: AppState) -> Router {
             post(sync::restore_presentation),
         )
         .route(
+            "/presentations/{id}/copy",
+            post(presentations::copy_presentation),
+        )
+        .route(
             "/presentations/{id}",
             get(presentations::get_presentation_detail)
                 .patch(presentations::update_presentation)
@@ -597,6 +601,8 @@ fn parse_uuid(field: &str, value: &str) -> Result<Uuid, AppError> {
         .map_err(|_| AppError::bad_request_message(format!("{field} must be a valid UUID")))
 }
 
+#[cfg(test)]
+mod presentations_copy_tests;
 #[cfg(test)]
 mod presentations_paste_tests;
 #[cfg(test)]

--- a/crates/presenter-server/src/router/presentations.rs
+++ b/crates/presenter-server/src/router/presentations.rs
@@ -24,6 +24,12 @@ pub(super) struct RenamePresentationRequest {
     pub(super) name: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CopyPresentationRequest {
+    pub(super) target_library_id: String,
+}
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct CreateSlideRequest {
@@ -116,6 +122,42 @@ pub(super) async fn delete_presentation(
         .delete_presentation(PresentationId::from_uuid(presentation_uuid))
         .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// #570: deep-copy a presentation into another library. Returns the copy's
+/// detail (its NEW id) so the client can navigate straight to it.
+#[instrument(skip_all)]
+pub(super) async fn copy_presentation(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(payload): Json<CopyPresentationRequest>,
+) -> Result<(StatusCode, Json<PresentationDetailDto>), AppError> {
+    let presentation_uuid = super::parse_uuid("presentationId", &id)?;
+    let library_uuid = super::parse_uuid("targetLibraryId", &payload.target_library_id)?;
+    let (library_id, library_name, presentation) = state
+        .copy_presentation(
+            PresentationId::from_uuid(presentation_uuid),
+            LibraryId::from_uuid(library_uuid),
+        )
+        .await
+        .map_err(|err| {
+            let msg = err.to_string();
+            // The repository refuses these two with typed messages — surface
+            // them as client errors, not opaque 500s.
+            if msg.contains("not found") {
+                AppError::not_found(msg)
+            } else {
+                err.into()
+            }
+        })?;
+    Ok((
+        StatusCode::CREATED,
+        Json(PresentationDetailDto {
+            library_id,
+            library_name,
+            presentation,
+        }),
+    ))
 }
 
 #[instrument(skip_all)]

--- a/crates/presenter-server/src/router/presentations.rs
+++ b/crates/presenter-server/src/router/presentations.rs
@@ -141,13 +141,15 @@ pub(super) async fn copy_presentation(
         )
         .await
         .map_err(|err| {
-            let msg = err.to_string();
-            // The repository refuses these two with typed messages — surface
-            // them as client errors, not opaque 500s.
-            if msg.contains("not found") {
-                AppError::not_found(msg)
-            } else {
-                err.into()
+            // EXACT match on the repository's two refusal messages — a
+            // substring test would mis-map any internal error that happens
+            // to contain "not found" to a client error.
+            match err.to_string().as_str() {
+                // The body-referenced target vanished — the REQUEST is
+                // unprocessable (422), not a missing URL resource.
+                "target library not found" => AppError::unprocessable("target library not found"),
+                "presentation not found" => AppError::not_found("presentation not found"),
+                _ => err.into(),
             }
         })?;
     Ok((

--- a/crates/presenter-server/src/router/presentations_copy_tests.rs
+++ b/crates/presenter-server/src/router/presentations_copy_tests.rs
@@ -1,6 +1,6 @@
 //! Router-level tests for `POST /presentations/{id}/copy` (#570): a valid
-//! copy returns 201 + the copy's detail; a vanished target library or a
-//! vanished presentation returns 404, not an opaque 500.
+//! copy returns 201 + the copy's detail; a vanished presentation is 404, a
+//! vanished body-referenced target library is 422 — never an opaque 500.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -80,7 +80,7 @@ async fn copy_returns_201_with_the_new_presentation_in_the_target_library() {
 }
 
 #[tokio::test]
-async fn copy_into_a_vanished_library_is_a_404() {
+async fn copy_into_a_vanished_library_is_a_422() {
     let state = AppState::in_memory().await.unwrap();
     let (pres_id, _) = seed(&state).await;
     let app = build_router(state);
@@ -91,7 +91,7 @@ async fn copy_into_a_vanished_library_is_a_404() {
         serde_json::json!({ "targetLibraryId": uuid::Uuid::new_v4().to_string() }),
     )
     .await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
 
 #[tokio::test]

--- a/crates/presenter-server/src/router/presentations_copy_tests.rs
+++ b/crates/presenter-server/src/router/presentations_copy_tests.rs
@@ -1,0 +1,110 @@
+//! Router-level tests for `POST /presentations/{id}/copy` (#570): a valid
+//! copy returns 201 + the copy's detail; a vanished target library or a
+//! vanished presentation returns 404, not an opaque 500.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::router::build_router;
+use crate::state::AppState;
+
+async fn post_json(
+    app: &axum::Router,
+    uri: &str,
+    body: serde_json::Value,
+) -> axum::http::Response<Body> {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn body_json(response: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Source library + one-slide presentation + a target library; returns
+/// (presentation_id, target_library_id).
+async fn seed(state: &AppState) -> (String, String) {
+    let source_lib = state.create_library("Source Lib").await.unwrap();
+    let target_lib = state.create_library("Target Lib").await.unwrap();
+    let slides = [presenter_core::Slide::new(
+        0,
+        presenter_core::SlideContent::new(
+            presenter_core::SlideText::new("verse").unwrap(),
+            presenter_core::SlideText::new("").unwrap(),
+            presenter_core::SlideText::new("").unwrap(),
+            None,
+        ),
+    )];
+    let (_, _, presentation, _) = state
+        .create_presentation(source_lib.id, "Song", Some(&slides))
+        .await
+        .unwrap();
+    (presentation.id.to_string(), target_lib.id.to_string())
+}
+
+#[tokio::test]
+async fn copy_returns_201_with_the_new_presentation_in_the_target_library() {
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, target_lib_id) = seed(&state).await;
+    let app = build_router(state);
+
+    let response = post_json(
+        &app,
+        &format!("/presentations/{pres_id}/copy"),
+        serde_json::json!({ "targetLibraryId": target_lib_id }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let json = body_json(response).await;
+    assert_eq!(json["libraryId"], target_lib_id);
+    assert_eq!(json["libraryName"], "Target Lib");
+    assert_eq!(json["presentation"]["name"], "Song");
+    assert_ne!(
+        json["presentation"]["id"], pres_id,
+        "the copy must have its own id"
+    );
+}
+
+#[tokio::test]
+async fn copy_into_a_vanished_library_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, _) = seed(&state).await;
+    let app = build_router(state);
+
+    let response = post_json(
+        &app,
+        &format!("/presentations/{pres_id}/copy"),
+        serde_json::json!({ "targetLibraryId": uuid::Uuid::new_v4().to_string() }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn copying_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let (_, target_lib_id) = seed(&state).await;
+    let app = build_router(state);
+
+    let response = post_json(
+        &app,
+        &format!("/presentations/{}/copy", uuid::Uuid::new_v4()),
+        serde_json::json!({ "targetLibraryId": target_lib_id }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -60,6 +60,26 @@ impl AppState {
         Ok((id, lib_name, presentation, summary))
     }
 
+    /// #570: deep-copy a presentation into another (or the same) library.
+    /// Same post-write bookkeeping as `create_presentation` — the copy IS a
+    /// newly created song (fresh ids, fresh sync_id).
+    pub async fn copy_presentation(
+        &self,
+        presentation_id: PresentationId,
+        target_library_id: LibraryId,
+    ) -> anyhow::Result<(LibraryId, String, Presentation)> {
+        let (library_id, library_name, presentation) = self
+            .repository
+            .copy_presentation_to_library(presentation_id, target_library_id)
+            .await?;
+        self.cache_presentation_ref(&presentation).await;
+        self.live_hub.publish(LiveEvent::BibleSlidesChanged {
+            presentation_id: presentation.id.to_string(),
+        });
+        self.nudge_sync();
+        Ok((library_id, library_name, presentation))
+    }
+
     pub async fn rename_presentation(
         &self,
         presentation_id: PresentationId,

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.202"
+version = "0.4.203"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/api/presentations.rs
+++ b/crates/presenter-ui/src/api/presentations.rs
@@ -89,6 +89,27 @@ struct RenameRequest {
     name: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CopyPresentationRequest {
+    target_library_id: String,
+}
+
+/// #570: deep-copy the presentation into another library. Returns the COPY's
+/// detail (its new id + the target library's name).
+pub async fn copy_to_library(
+    id: &str,
+    target_library_id: &str,
+) -> Result<PresentationDetail, ApiError> {
+    post_json(
+        &format!("/presentations/{id}/copy"),
+        &CopyPresentationRequest {
+            target_library_id: target_library_id.to_string(),
+        },
+    )
+    .await
+}
+
 pub async fn rename(id: &str, name: &str) -> Result<(), ApiError> {
     patch_no_content(
         &format!("/presentations/{id}"),

--- a/crates/presenter-ui/src/api/sync.rs
+++ b/crates/presenter-ui/src/api/sync.rs
@@ -17,5 +17,9 @@ pub async fn list_trash() -> Result<Vec<TrashedSongDto>, ApiError> {
 }
 
 pub async fn restore_song(id: &str) -> Result<(), ApiError> {
-    post_no_content(&format!("/presentations/{id}/restore"), &serde_json::json!({})).await
+    post_no_content(
+        &format!("/presentations/{id}/restore"),
+        &serde_json::json!({}),
+    )
+    .await
 }

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -177,9 +177,30 @@ pub fn PresentationModals() -> impl IntoView {
         let op = op.clone();
         let ctx = ctx.clone();
         move |_| {
+            // Re-entry guard: copy is NOT idempotent — a double-click during
+            // the round-trip would create two copies (the button is also
+            // disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let target_id = op.modal_target_id.get_untracked().unwrap_or_default();
-            let lib_id = copy_target.get_untracked();
+            // The signal can be empty if the modal opened before libraries
+            // loaded — fall back to the first library, which is what the
+            // browser visually shows as the selected option.
+            let mut lib_id = copy_target.get_untracked();
+            if lib_id.is_empty() {
+                lib_id = ctx
+                    .libraries
+                    .get_untracked()
+                    .first()
+                    .map(|lib| lib.id.to_string())
+                    .unwrap_or_default();
+            }
             if target_id.is_empty() || lib_id.is_empty() {
+                // Never silently no-op — say why nothing happened.
+                ctx.toast_variant.set("error".to_string());
+                ctx.toast_message
+                    .set(Some("No target library available".to_string()));
                 return;
             }
             op.submitting.set(true);
@@ -471,6 +492,10 @@ pub fn PresentationModals() -> impl IntoView {
         let libraries = ctx.libraries;
         move || libraries.get()
     };
+    // Disable the edit-modal's mutating buttons while a request is in
+    // flight — copy is not idempotent, so a double-click must not fire twice.
+    let submitting_sig = op.submitting;
+    let is_submitting = move || submitting_sig.get();
 
     view! {
         // Presentation edit (rename) modal
@@ -522,6 +547,7 @@ pub fn PresentationModals() -> impl IntoView {
                             <button
                                 type="button"
                                 data-role="presentation-copy-confirm"
+                                prop:disabled=is_submitting
                                 on:click=on_copy
                             >"Copy"</button>
                         </div>
@@ -531,13 +557,16 @@ pub fn PresentationModals() -> impl IntoView {
                             type="button"
                             class="operator__library-edit-delete"
                             data-role="presentation-edit-delete"
+                            prop:disabled=is_submitting
                             on:click=on_edit_delete
                         >"Delete presentation"</button>
                         <div class="operator__library-edit-actions">
                             <button type="button" data-role="presentation-edit-cancel"
                                 on:click=on_edit_cancel
                             >"Cancel"</button>
-                            <button type="submit" data-role="presentation-edit-save">"Save changes"</button>
+                            <button type="submit" data-role="presentation-edit-save"
+                                prop:disabled=is_submitting
+                            >"Save changes"</button>
                         </div>
                     </footer>
                 </form>

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -14,6 +14,8 @@ pub fn PresentationModals() -> impl IntoView {
 
     // Edit modal signals
     let edit_name = RwSignal::new(String::new());
+    // #570: target library for "Copy to library" (library id as String).
+    let copy_target = RwSignal::new(String::new());
 
     // Create modal signals
     let create_name = RwSignal::new(String::new());
@@ -36,6 +38,18 @@ pub fn PresentationModals() -> impl IntoView {
                         edit_name.set(pres.name.clone());
                     }
                 }
+                // #570: default the copy target to the first OTHER library —
+                // the common intent — falling back to the current one when it
+                // is the only library.
+                let current_lib = ctx.selected_library_id.get_untracked();
+                let libs = ctx.libraries.get_untracked();
+                let default_target = libs
+                    .iter()
+                    .find(|lib| Some(lib.id.to_string()) != current_lib)
+                    .or_else(|| libs.first())
+                    .map(|lib| lib.id.to_string())
+                    .unwrap_or_default();
+                copy_target.set(default_target);
             } else if modal.as_deref() == Some("presentation-create") {
                 create_name.set(String::new());
                 create_step.set("options".to_string());
@@ -154,6 +168,62 @@ pub fn PresentationModals() -> impl IntoView {
                 }
                 toast_variant.set("success".to_string());
                 toast_message.set(Some("Presentation deleted".to_string()));
+            });
+        }
+    };
+
+    // Edit: copy to library (#570)
+    let on_copy = {
+        let op = op.clone();
+        let ctx = ctx.clone();
+        move |_| {
+            let target_id = op.modal_target_id.get_untracked().unwrap_or_default();
+            let lib_id = copy_target.get_untracked();
+            if target_id.is_empty() || lib_id.is_empty() {
+                return;
+            }
+            op.submitting.set(true);
+
+            let presentations = ctx.presentations;
+            let libraries = ctx.libraries;
+            let selected_lib_id = ctx.selected_library_id;
+            let toast_message = ctx.toast_message;
+            let toast_variant = ctx.toast_variant;
+            let submitting = op.submitting;
+            let open_modal = op.open_modal;
+            let modal_target = op.modal_target_id;
+
+            leptos::task::spawn_local(async move {
+                let result = crate::api::presentations::copy_to_library(&target_id, &lib_id).await;
+
+                // Refresh the current library's list (covers copy-into-the-
+                // same-library) and the library counts.
+                if let Some(current) = selected_lib_id.get_untracked() {
+                    if let Ok(pres) = crate::api::libraries::list_presentations(&current).await {
+                        presentations.set(pres);
+                    }
+                }
+                if let Ok(libs) = crate::api::libraries::list_libraries().await {
+                    libraries.set(libs);
+                }
+
+                submitting.set(false);
+                open_modal.set(None);
+                modal_target.set(None);
+                if let Some(body) = crate::utils::window::document_body() {
+                    body.dataset().delete("modalOpen");
+                }
+
+                match result {
+                    Ok(detail) => {
+                        toast_variant.set("success".to_string());
+                        toast_message.set(Some(format!("Copied to \"{}\"", detail.library_name)));
+                    }
+                    Err(e) => {
+                        toast_variant.set("error".to_string());
+                        toast_message.set(Some(format!("Copy error: {e}")));
+                    }
+                }
             });
         }
     };
@@ -395,6 +465,13 @@ pub fn PresentationModals() -> impl IntoView {
 
     let paste_text = op.paste_text;
 
+    // #570: `each` needs a NAMED closure (view! macro limitation — see the
+    // presenter-ui skill).
+    let library_options = {
+        let libraries = ctx.libraries;
+        move || libraries.get()
+    };
+
     view! {
         // Presentation edit (rename) modal
         <div class="operator__library-edit operator__presentation-edit" data-role="presentation-edit-modal"
@@ -423,6 +500,31 @@ pub fn PresentationModals() -> impl IntoView {
                                 on:input=move |ev| edit_name.set(event_target_value(&ev))
                             />
                         </label>
+                        // #570: copy this presentation into another library.
+                        <div class="operator__presentation-copy-row" data-role="presentation-copy-row">
+                            <label>
+                                <span data-role="presentation-copy-label">"Copy to library"</span>
+                                <select
+                                    data-role="presentation-copy-target"
+                                    prop:value=move || copy_target.get()
+                                    on:change=move |ev| copy_target.set(event_target_value(&ev))
+                                >
+                                    <For
+                                        each=library_options
+                                        key=|lib: &presenter_core::LibrarySummary| lib.id.to_string()
+                                        children=move |lib: presenter_core::LibrarySummary| {
+                                            let id = lib.id.to_string();
+                                            view! { <option value=id>{lib.name}</option> }
+                                        }
+                                    />
+                                </select>
+                            </label>
+                            <button
+                                type="button"
+                                data-role="presentation-copy-confirm"
+                                on:click=on_copy
+                            >"Copy"</button>
+                        </div>
                     </div>
                     <footer class="operator__library-edit-footer">
                         <button

--- a/crates/presenter-ui/src/components/resolume_status.rs
+++ b/crates/presenter-ui/src/components/resolume_status.rs
@@ -49,11 +49,12 @@ pub(crate) fn port_drift_note(configured_port: u16, active_port: Option<u16>) ->
 }
 
 /// The full tooltip text (native `title` attribute — no custom popover
-/// needed for this MVP): connection cause + retry countdown while erroring,
-/// the configured-vs-active port drift note, and any missing composition
-/// clips (#563g).
+/// needed for this MVP): the host's FULL label first (the visible chip text
+/// ellipsizes past 12ch), then connection cause + retry countdown while
+/// erroring, the configured-vs-active port drift note, and any missing
+/// composition clips (#563g).
 pub(crate) fn chip_tooltip(dto: &ResolumeConnectionStatusDto) -> String {
-    let mut lines = Vec::new();
+    let mut lines = vec![dto.label.clone()];
     match dto.state.as_str() {
         "connected" => lines.push("Connected".to_string()),
         "error" => {
@@ -117,7 +118,6 @@ pub fn ResolumeStatusChips() -> impl IntoView {
                 key=|h: &ResolumeConnectionStatusDto| h.host_id.clone()
                 children=move |host: ResolumeConnectionStatusDto| {
                     let host_id = host.host_id.clone();
-                    let label = host.label.clone();
                     let status = Memo::new(move |_| {
                         hosts.with(|list| list.iter().find(|h| h.host_id == host_id).cloned())
                     });
@@ -130,21 +130,24 @@ pub fn ResolumeStatusChips() -> impl IntoView {
                     let dot_class = move || {
                         format!("operator__resolume-dot operator__resolume-dot--{}", dot_state())
                     };
+                    // The visible text is the HOST'S NAME (its configured
+                    // label) — with several walls configured, "Connected"
+                    // alone never says WHICH Resolume the chip is. State
+                    // lives in the dot color + tooltip. Read through the
+                    // `status` Memo (not a one-shot capture) so a rename
+                    // refreshes on the next poll like the dot does.
+                    let label = move || status.get().map(|h| h.label).unwrap_or_default();
                     let tooltip = move || status.get().map(|h| chip_tooltip(&h)).unwrap_or_default();
                     view! {
                         <span
                             class="operator__resolume-chip"
                             data-role="resolume-status-chip"
-                            data-host-label=label.clone()
+                            data-host-label=label
                             data-state=dot_state
                             title=tooltip
                         >
                             <span class=dot_class aria-hidden="true"></span>
-                            // The visible text is the HOST'S NAME (its configured
-                            // label) — with several walls configured, "Connected"
-                            // alone never says WHICH Resolume the chip is. State
-                            // lives in the dot color + tooltip.
-                            <span class="operator__resolume-chip-label">{label.clone()}</span>
+                            <span class="operator__resolume-chip-label">{label}</span>
                         </span>
                     }
                 }
@@ -242,6 +245,14 @@ mod tests {
         assert!(text.contains("Connected"));
         assert!(!text.contains("Not reachable"));
         assert!(!text.contains("Port drifted"));
+    }
+
+    #[test]
+    fn tooltip_opens_with_the_full_host_label() {
+        // The visible chip text ellipsizes past 12ch — the tooltip is where
+        // a long name stays fully readable, so it must lead with the label.
+        let text = chip_tooltip(&dto("connected", None));
+        assert!(text.starts_with("resolume-pp\n"), "{text}");
     }
 
     #[test]

--- a/crates/presenter-ui/src/components/resolume_status.rs
+++ b/crates/presenter-ui/src/components/resolume_status.rs
@@ -28,15 +28,6 @@ pub(crate) fn chip_dot_state(state: &str, failing_for_secs: Option<i64>) -> &'st
     }
 }
 
-/// The short label text next to the dot.
-pub(crate) fn chip_label(dot_state: &str) -> &'static str {
-    match dot_state {
-        "green" => "Connected",
-        "red" => "Down",
-        _ => "Retrying…",
-    }
-}
-
 /// Plain-language cause for the tooltip — never a raw wire token like
 /// `connect_refused`.
 pub(crate) fn error_kind_label(kind: Option<&str>) -> &'static str {
@@ -139,7 +130,6 @@ pub fn ResolumeStatusChips() -> impl IntoView {
                     let dot_class = move || {
                         format!("operator__resolume-dot operator__resolume-dot--{}", dot_state())
                     };
-                    let label_text = move || chip_label(dot_state());
                     let tooltip = move || status.get().map(|h| chip_tooltip(&h)).unwrap_or_default();
                     view! {
                         <span
@@ -150,7 +140,11 @@ pub fn ResolumeStatusChips() -> impl IntoView {
                             title=tooltip
                         >
                             <span class=dot_class aria-hidden="true"></span>
-                            <span class="operator__resolume-chip-label">{label_text}</span>
+                            // The visible text is the HOST'S NAME (its configured
+                            // label) — with several walls configured, "Connected"
+                            // alone never says WHICH Resolume the chip is. State
+                            // lives in the dot color + tooltip.
+                            <span class="operator__resolume-chip-label">{label.clone()}</span>
                         </span>
                     }
                 }
@@ -186,20 +180,17 @@ mod tests {
     #[test]
     fn connected_is_green() {
         assert_eq!(chip_dot_state("connected", None), "green");
-        assert_eq!(chip_label("green"), "Connected");
     }
 
     #[test]
     fn erroring_under_two_minutes_is_yellow_not_red() {
         assert_eq!(chip_dot_state("error", Some(119)), "yellow");
-        assert_eq!(chip_label("yellow"), "Retrying…");
     }
 
     #[test]
     fn erroring_past_two_minutes_is_red() {
         assert_eq!(chip_dot_state("error", Some(120)), "red");
         assert_eq!(chip_dot_state("error", Some(600)), "red");
-        assert_eq!(chip_label("red"), "Down");
     }
 
     #[test]
@@ -235,7 +226,10 @@ mod tests {
     #[test]
     fn error_kind_labels_are_plain_language_never_raw_wire_tokens() {
         assert_eq!(error_kind_label(Some("timeout")), "timed out");
-        assert_eq!(error_kind_label(Some("connect_refused")), "connection refused");
+        assert_eq!(
+            error_kind_label(Some("connect_refused")),
+            "connection refused"
+        );
         assert_eq!(error_kind_label(Some("connect_other")), "could not connect");
         assert_eq!(error_kind_label(Some("reset")), "connection reset");
         assert_eq!(error_kind_label(Some("other")), "request failed");
@@ -273,6 +267,9 @@ mod tests {
         let mut d = dto("connected", None);
         d.missing_clips = vec!["#timer".to_string(), "#song-name".to_string()];
         let text = chip_tooltip(&d);
-        assert!(text.contains("Composition missing: #timer, #song-name"), "{text}");
+        assert!(
+            text.contains("Composition missing: #timer, #song-name"),
+            "{text}"
+        );
     }
 }

--- a/crates/presenter-ui/src/pages/settings/video_sources.rs
+++ b/crates/presenter-ui/src/pages/settings/video_sources.rs
@@ -448,7 +448,10 @@ mod tests {
     #[test]
     fn one_failed_poll_is_a_blip_two_in_a_row_is_stale() {
         assert!(!is_stale(0));
-        assert!(!is_stale(1), "a single failure must not blank the card or shout");
+        assert!(
+            !is_stale(1),
+            "a single failure must not blank the card or shout"
+        );
         assert!(is_stale(2));
         assert!(is_stale(7));
     }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1823,6 +1823,38 @@ body.operator[data-view="settings"] [data-view-panel="settings"] {
   cursor: pointer;
 }
 
+/* #570: "Copy to library" row in the presentation-edit modal. */
+.operator__presentation-copy-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.operator__presentation-copy-row label {
+  flex: 1;
+  min-width: 0;
+}
+
+.operator__presentation-copy-row select {
+  border-radius: 10px;
+  border: 1px solid var(--operator-border);
+  padding: 0.6rem 0.7rem;
+  font-size: 1rem;
+  color: var(--operator-text);
+  background: var(--operator-bg);
+  width: 100%;
+}
+
+.operator__presentation-copy-row button {
+  border: 1px solid var(--operator-border);
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--operator-text);
+  background: var(--operator-bg);
+}
+
 .operator__library-edit-actions [data-role="library-edit-cancel"] {
   background: rgba(148, 163, 184, 0.18);
   color: var(--operator-muted);

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -291,6 +291,15 @@ body.operator {
   cursor: default;
 }
 
+/* The chip text is the host's arbitrary-length configured label — bound it
+   so several walls with long names can't overflow the sticky header (the
+   full name stays readable in the chip tooltip). */
+.operator__resolume-chip-label {
+  max-width: 12ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .operator__resolume-dot {
   width: 8px;
   height: 8px;

--- a/tests/e2e/presentation-copy.spec.ts
+++ b/tests/e2e/presentation-copy.spec.ts
@@ -109,12 +109,12 @@ test("API: copy is a deep, independent duplicate in the target library", async (
   );
   expect(detailResp.ok()).toBeTruthy();
 
-  // A vanished target library is a clean 404, not a 500.
+  // A vanished body-referenced target library is a clean 422, not a 500.
   const badResp = await request.post(
     new URL(`/presentations/${copy.presentation.id}/copy`, baseURL).toString(),
     { data: { targetLibraryId: "11111111-2222-3333-4444-555555555555" } },
   );
-  expect(badResp.status()).toBe(404);
+  expect(badResp.status()).toBe(422);
 });
 
 test("UI: edit-modal copy flow lands the song in the target library", async ({
@@ -167,11 +167,13 @@ test("UI: edit-modal copy flow lands the song in the target library", async ({
     { timeout: 5_000 },
   );
 
-  // Pick the target library and copy.
+  // Pick the target library and copy — via DOUBLE click: the second click
+  // must be swallowed by the re-entry guard (copy is not idempotent; a
+  // double-click must never create two copies).
   await page
     .locator('[data-role="presentation-copy-target"]')
     .selectOption(targetLib.id);
-  await page.locator('[data-role="presentation-copy-confirm"]').click();
+  await page.locator('[data-role="presentation-copy-confirm"]').dblclick();
 
   // Modal closes + success toast names the target library.
   await page.waitForFunction(

--- a/tests/e2e/presentation-copy.spec.ts
+++ b/tests/e2e/presentation-copy.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * #570: copy a presentation from one library to another.
+ *
+ * API layer: the copy is a deep, independent duplicate in the target library.
+ * UI layer: the presentation-edit modal's "Copy to library" flow works end to
+ * end in the WASM operator (select target, confirm, toast, list refresh).
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+});
+
+type Library = { id: string; name: string };
+type Detail = {
+  libraryId: string;
+  libraryName: string;
+  presentation: {
+    id: string;
+    name: string;
+    slides: Array<{ id: string; content: { main: { value: string } } }>;
+  };
+};
+
+async function createLibrary(
+  request: import("@playwright/test").APIRequestContext,
+  name: string,
+): Promise<Library> {
+  const resp = await request.post(new URL("/libraries", baseURL).toString(), {
+    data: { name },
+  });
+  expect(resp.ok()).toBeTruthy();
+  return resp.json();
+}
+
+async function createSong(
+  request: import("@playwright/test").APIRequestContext,
+  libraryId: string,
+  name: string,
+): Promise<Detail["presentation"]> {
+  const resp = await request.post(
+    new URL(`/libraries/${libraryId}/presentations`, baseURL).toString(),
+    {
+      data: {
+        name,
+        slides: [{ main: "CopyVerseOne" }, { main: "CopyVerseTwo" }],
+      },
+    },
+  );
+  expect(resp.ok()).toBeTruthy();
+  const payload: { presentation: Detail["presentation"] } = await resp.json();
+  return payload.presentation;
+}
+
+test("API: copy is a deep, independent duplicate in the target library", async ({
+  request,
+}) => {
+  const stamp = Date.now();
+  const sourceLib = await createLibrary(request, `CopyApiSrc${stamp}`);
+  const targetLib = await createLibrary(request, `CopyApiDst${stamp}`);
+  const source = await createSong(request, sourceLib.id, `CopyApiSong${stamp}`);
+
+  const copyResp = await request.post(
+    new URL(`/presentations/${source.id}/copy`, baseURL).toString(),
+    { data: { targetLibraryId: targetLib.id } },
+  );
+  expect(copyResp.status()).toBe(201);
+  const copy: Detail = await copyResp.json();
+
+  expect(copy.libraryId).toBe(targetLib.id);
+  expect(copy.presentation.id).not.toBe(source.id);
+  expect(copy.presentation.name).toBe(source.name);
+  expect(copy.presentation.slides.map((s) => s.content.main.value)).toEqual([
+    "CopyVerseOne",
+    "CopyVerseTwo",
+  ]);
+  const sourceSlideIds = new Set(source.slides.map((s) => s.id));
+  for (const slide of copy.presentation.slides) {
+    expect(sourceSlideIds.has(slide.id)).toBeFalsy();
+  }
+
+  // Deleting the ORIGINAL must not touch the copy.
+  const delResp = await request.delete(
+    new URL(`/presentations/${source.id}`, baseURL).toString(),
+  );
+  expect(delResp.ok()).toBeTruthy();
+  const detailResp = await request.get(
+    new URL(`/presentations/${copy.presentation.id}`, baseURL).toString(),
+  );
+  expect(detailResp.ok()).toBeTruthy();
+
+  // A vanished target library is a clean 404, not a 500.
+  const badResp = await request.post(
+    new URL(`/presentations/${copy.presentation.id}/copy`, baseURL).toString(),
+    { data: { targetLibraryId: "11111111-2222-3333-4444-555555555555" } },
+  );
+  expect(badResp.status()).toBe(404);
+});
+
+test("UI: edit-modal copy flow lands the song in the target library", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const sourceLib = await createLibrary(request, `CopyUiSrc${stamp}`);
+  const targetLib = await createLibrary(request, `CopyUiDst${stamp}`);
+  const source = await createSong(request, sourceLib.id, `CopyUiSong${stamp}`);
+
+  await page.goto(`${baseURL}/ui/operator`);
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector('[data-role="library-item"]', {
+    timeout: 30_000,
+  });
+
+  // The sidebar shows only FAVORITE libraries — select a freshly created
+  // library through the "Show all libraries" modal.
+  const openLibrary = async (libraryId: string) => {
+    await page.locator('[data-role="library-more"]').click();
+    await page
+      .locator(
+        `[data-role="library-row"][data-library-id="${libraryId}"] .operator__list-button`,
+      )
+      .click();
+    await page.waitForSelector('[data-role="presentation-list"]', {
+      timeout: 15_000,
+    });
+  };
+
+  // Open the SOURCE library and enter edit mode.
+  await openLibrary(sourceLib.id);
+  await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-mode") === "edit",
+    { timeout: 5_000 },
+  );
+
+  // Open the presentation-edit modal for the source song.
+  await page
+    .locator(
+      `[data-action="presentation-rename"][data-presentation-id="${source.id}"]`,
+    )
+    .click();
+  await page.waitForSelector(
+    '[data-role="presentation-edit-modal"][data-open="true"]',
+    { timeout: 5_000 },
+  );
+
+  // Pick the target library and copy.
+  await page
+    .locator('[data-role="presentation-copy-target"]')
+    .selectOption(targetLib.id);
+  await page.locator('[data-role="presentation-copy-confirm"]').click();
+
+  // Modal closes + success toast names the target library.
+  await page.waitForFunction(
+    () =>
+      !document.querySelector(
+        '[data-role="presentation-edit-modal"][data-open="true"]',
+      ),
+    { timeout: 10_000 },
+  );
+  await expect(page.locator('[data-role="toast"]')).toContainText(
+    targetLib.name,
+    { timeout: 5_000 },
+  );
+
+  // The copy is in the target library; the original stayed in the source.
+  await openLibrary(targetLib.id);
+  await expect(
+    page.locator('[data-role="presentation-item"]', { hasText: source.name }),
+  ).toHaveCount(1, { timeout: 10_000 });
+
+  await openLibrary(sourceLib.id);
+  await expect(
+    page.locator('[data-role="presentation-item"]', { hasText: source.name }),
+  ).toHaveCount(1, { timeout: 10_000 });
+});

--- a/tests/e2e/resolume-status-chip.spec.ts
+++ b/tests/e2e/resolume-status-chip.spec.ts
@@ -99,19 +99,18 @@ test("an enabled host tracks the mock's connection state: green while up, yellow
     `[data-role="resolume-status-chip"][data-host-label="${label}"]`,
   );
   await expect(chip).toHaveAttribute("data-state", "green", { timeout: 30_000 });
-  await expect(chip.locator(".operator__resolume-chip-label")).toHaveText(
-    "Connected",
-  );
+  // The visible chip text is the HOST'S NAME — with several walls
+  // configured, a bare "Connected" never says WHICH Resolume it is.
+  // Connection state lives in the dot color + tooltip.
+  await expect(chip.locator(".operator__resolume-chip-label")).toHaveText(label);
   await expect(chip).toHaveAttribute("title", /Connected/);
 
   // Simulate the mock going offline (Arena crashing / unreachable) — the
-  // chip must flip to yellow ("Retrying…") and its tooltip must name a
-  // concrete cause, not stay stuck showing "Connected".
+  // chip must flip to yellow while KEEPING the host's name as its text,
+  // and its tooltip must name a concrete cause.
   mockResolume.setOnline(false);
   await expect(chip).toHaveAttribute("data-state", "yellow", { timeout: 30_000 });
-  await expect(chip.locator(".operator__resolume-chip-label")).toHaveText(
-    "Retrying…",
-  );
+  await expect(chip.locator(".operator__resolume-chip-label")).toHaveText(label);
   await expect(chip).toHaveAttribute("title", /Not reachable/);
 
   // Recovery: back online, the chip must return to green on its own.


### PR DESCRIPTION
Release v0.4.203 — dev → main

## User-facing
- **#570 — Copy a presentation into another library** via the operator edit modal (deep independent copy: slides + stage-layout markers; original + playlists untouched; double-submit guard, 422/404 semantics). Closes #570.
- **Resolume chips show the connection NAME** instead of "Connected"; state in dot color + tooltip. Closes #565.

## CI / tests
- Delta-synced prod-DB snapshot per deploy-dev; idempotent mock-label rewrite; presenter-ui fmt gate; port-drift tests de-flaked.

Dev CI green (run 30094252671, incl. E2E + deploy-dev); dev verified live at v0.4.203.
