### PR TITLE
Release v0.4.204: Resolume chips join the top surface-nav row

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -160,3 +160,9 @@ await page.waitForSelector('[data-role="presentation-list"]');
 
 Related JSON-shape gotcha: `SlideText` serializes as an object — assert
 `slide.content.main.value`, never `slide.content.main` directly.
+
+## Operator header design rule (#573, user directive 2026-07-24)
+
+Connection/status indicators (Resolume chips etc.) live in the TOP brand/surface-nav row
+(`.operator__brand-nav`, next to the Stage/Camera/Tablet/Timer links), never next to the
+Stage Output controls in `operator__header-right`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ The project uses **Semantic Versioning** with a single `X.Y.Z` format on both br
 
 1. Dev work: version is `X.Y.Z`, push to dev, CI passes, dev deploy shows `vX.Y.Z (dev)`
 2. Release: create PR dev->main, no version change needed, all checks green
-3. Merge: human merges, main deploys, production shows `vX.Y.Z`
+3. Merge: Claude merges autonomously once every gate is green (user directive 2026-07-24), main deploys, production shows `vX.Y.Z`
 4. Post-release: bump to next version on dev, continue
 
 See `docs/architecture.md` for full versioning and release strategy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.203"
+version = "0.4.204"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.203"
+version = "0.4.204"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -152,7 +152,16 @@ pub fn Header() -> impl IntoView {
                 <div class="operator__header-brand">
                     <h1>"Presenter"</h1>
                     <span class="operator__version-badge">{move || version_text.get()}</span>
-                    <SurfaceNav />
+                    // #573: surface-nav pills + Resolume connection chips are
+                    // one absolutely-positioned group (`.operator__brand-nav`)
+                    // in the top brand row — connection/status indicators
+                    // belong next to Stage/Camera/Tablet/Timer, never next to
+                    // the Stage Output select (see `operator__header-right`
+                    // below, which no longer mounts the chips).
+                    <div class="operator__brand-nav">
+                        <SurfaceNav />
+                        <ResolumeStatusChips />
+                    </div>
                 </div>
                 <form class="operator__search" data-role="global-search-form" role="search" autocomplete="off"
                     on:submit=on_search_submit
@@ -232,7 +241,6 @@ pub fn Header() -> impl IntoView {
                         }).collect_view()}
                     </select>
                 </div>
-                <ResolumeStatusChips />
                 <StagePreview />
                 <div class="operator__mode-toggle">
                     {["live", "edit"].into_iter().map(|m| {

--- a/crates/presenter-ui/src/components/resolume_status.rs
+++ b/crates/presenter-ui/src/components/resolume_status.rs
@@ -4,6 +4,11 @@
 //! nothing when there are no enabled hosts — a deployment with no Resolume
 //! configured (e.g. the dev box) shows a clean absent state, never an empty
 //! placeholder or a console error.
+//!
+//! Placement (#573): mounted in the operator header's TOP brand row, inside
+//! `.operator__brand-nav`, immediately after `<SurfaceNav />` — connection
+//! status belongs next to the Stage/Camera/Tablet/Timer surface-nav pills,
+//! never next to the Stage Output select in `operator__header-right`.
 
 use leptos::prelude::*;
 

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -268,24 +268,29 @@ body.operator {
   color: var(--operator-muted);
 }
 
-/* #564: Resolume connection indicator — one chip per ENABLED host. Absent
-   entirely when no host is configured/enabled (no empty placeholder). */
+/* #564/#573: Resolume connection indicator — one chip per ENABLED host,
+   mounted in the top `.operator__brand-nav` group right after the
+   surface-nav pills. Absent entirely when no host is configured/enabled (no
+   empty placeholder). Sized to sit inline with `.operator__surface-nav-link`
+   — compact height, no wrapping. */
 .operator__resolume-chips {
   display: flex;
   align-items: center;
   gap: 0.4rem;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .operator__resolume-chip {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.3rem 0.55rem;
+  padding: 0.18rem 0.55rem;
   border-radius: 999px;
   background: var(--operator-panel);
   border: 1px solid var(--operator-border);
   font-size: 0.7rem;
+  line-height: 1.2;
   color: rgba(255, 255, 255, 0.75);
   white-space: nowrap;
   cursor: default;
@@ -2949,14 +2954,24 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
     font-weight: 600;
 }
 
-/* --- Surface-nav pills right of brand+version (#326) ------------------- */
-/* Absolute-positioned to avoid widening `.operator__header-left`'s         */
-/* intrinsic width — otherwise the view-nav tabs wrap to 2 rows.            */
+/* --- Brand-nav group: surface-nav pills + Resolume chips (#326, #573) -- */
+/* Absolute-positioned AS A GROUP to avoid widening                         */
+/* `.operator__header-left`'s intrinsic width — otherwise the view-nav      */
+/* tabs wrap to 2 rows. The surface-nav pills (Stage/Camera/Tablet/Timer)   */
+/* and the Resolume connection chips both live in this top brand row —     */
+/* connection/status indicators are never placed next to the Stage Output  */
+/* controls (#573 design rule).                                            */
 
-.operator__surface-nav {
+.operator__brand-nav {
     position: absolute;
     left: calc(100% + 0.75rem);
     top: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.operator__surface-nav {
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;

--- a/tests/e2e/resolume-status-chip.spec.ts
+++ b/tests/e2e/resolume-status-chip.spec.ts
@@ -64,6 +64,15 @@ test("no resolume host configured — the chip area renders absent, console clea
   await expect(page.locator('[data-role="resolume-status-chips"]')).toBeAttached();
   await expect(page.locator('[data-role="resolume-status-chip"]')).toHaveCount(0);
 
+  // #573: the chips live in the TOP brand/surface-nav row — never next to
+  // the Stage Output select in `operator__header-right`.
+  await expect(
+    page.locator('.operator__header-brand [data-role="resolume-status-chips"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('.operator__header-right [data-role="resolume-status-chips"]'),
+  ).toHaveCount(0);
+
   expect(consoleMessages).toEqual([]);
 });
 


### PR DESCRIPTION
## Summary
- #573: Resolume connection chips move from beside the Stage Output select into the top surface-nav row, alongside the Stage/Camera/Tablet/Timer links
- Rides v0.4.204 (no version bump needed for a release PR)

## Test plan
- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test --lib` for presenter-ui — all clean
- [x] `cargo fmt --all --check` at workspace root — clean
- [x] `bash scripts/build-ui.sh` + `cargo build --release -p presenter-server` — both succeed
- [x] `npx playwright test tests/e2e/resolume-status-chip.spec.ts` — 2/2 passed, asserts chips live in `.operator__header-brand`, not `.operator__header-right`
- [x] Full CI pipeline green on dev (22/22 jobs, including Deploy to Dev)
- [x] Dev `/healthz` confirms v0.4.204 live
