### PR TITLE
Bundle: fix #575 (AbleSet cache staleness) + #571 (dead double-submit guard) + #574 (operator version-drift recovery)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.204"
+version = "0.4.205"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -39,6 +39,18 @@ impl AppState {
         self.repository.get_ableset_settings().await
     }
 
+    /// Invalidate the resolved AbleSet song-name cache (#575). Cheap — clears
+    /// only the resolved `prefix -> id` map; `ensure_ableset_cache` lazily
+    /// rebuilds it from the DB on the next `resolve_ableset_presentation`
+    /// call. Call this after ANY mutation that changes which presentations
+    /// exist, their names, or which library they belong to. The AbleSet
+    /// settings themselves (which library / prefix length to track) are
+    /// untouched by these mutations, so a full struct reset is unnecessary —
+    /// only the resolved entries can go stale.
+    pub(crate) async fn invalidate_ableset_cache(&self) {
+        self.caches.ableset.write().await.entries.clear();
+    }
+
     pub async fn update_ableset_settings(
         &self,
         draft: AbleSetSettingsDraft,

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -33,11 +33,19 @@ impl AppState {
     }
 
     pub async fn rename_library(&self, library_id: LibraryId, name: &str) -> anyhow::Result<()> {
-        self.repository.rename_library(library_id, name).await
+        self.repository.rename_library(library_id, name).await?;
+        // #575: a rename can change whether this library matches the
+        // AbleSet-tracked library name.
+        self.invalidate_ableset_cache().await;
+        Ok(())
     }
 
     pub async fn delete_library(&self, library_id: LibraryId) -> anyhow::Result<()> {
-        self.repository.delete_library(library_id).await
+        self.repository.delete_library(library_id).await?;
+        // #575: deleting a library cascades its presentations away — any
+        // resolved AbleSet entries pointing at them must not survive.
+        self.invalidate_ableset_cache().await;
+        Ok(())
     }
 
     pub async fn create_presentation(
@@ -56,7 +64,7 @@ impl AppState {
         });
         let summaries = self.repository.list_library_summaries(None).await?;
         let summary = summaries.into_iter().find(|summary| summary.id == id);
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok((id, lib_name, presentation, summary))
     }
 
@@ -76,7 +84,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation.id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok((library_id, library_name, presentation))
     }
 
@@ -95,7 +103,7 @@ impl AppState {
                 pres.name = name.to_string();
             }
         }
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(())
     }
 
@@ -105,7 +113,7 @@ impl AppState {
             let mut guard = self.caches.presentation.write().await;
             guard.remove(&presentation_id);
         }
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(())
     }
 

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -217,7 +217,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation_id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(slides)
     }
 
@@ -295,7 +295,7 @@ impl AppState {
             presentation_id: presentation_id.to_string(),
         });
 
-        self.nudge_sync();
+        self.nudge_sync().await;
 
         Ok(updated_slide)
     }
@@ -329,7 +329,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation_id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(slides)
     }
 
@@ -382,7 +382,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation_id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(slides)
     }
 
@@ -424,7 +424,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation_id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(slides)
     }
 
@@ -465,7 +465,7 @@ impl AppState {
         self.live_hub.publish(LiveEvent::BibleSlidesChanged {
             presentation_id: presentation_id.to_string(),
         });
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(slides)
     }
 }

--- a/crates/presenter-server/src/state/sync.rs
+++ b/crates/presenter-server/src/state/sync.rs
@@ -200,6 +200,11 @@ impl AppState {
     }
 
     /// Restore a trashed song; a restore is a local edit that must propagate.
+    /// Deliberately calls BOTH `drop_presentation_caches()` (also clears the
+    /// AbleSet cache, #575) AND `nudge_sync()` (which does the same,
+    /// harmlessly redundant here) — the former handles the sync engine's own
+    /// bulk-apply path, the latter is the seam every OTHER local mutation
+    /// goes through; restore is the one call site that needs both.
     pub async fn restore_presentation(
         &self,
         presentation_id: presenter_core::PresentationId,

--- a/crates/presenter-server/src/state/sync.rs
+++ b/crates/presenter-server/src/state/sync.rs
@@ -185,8 +185,13 @@ impl SyncCoordinator {
 }
 
 impl AppState {
-    /// Fire-and-forget nudge after a local song mutation.
-    pub(crate) fn nudge_sync(&self) {
+    /// Fire-and-forget nudge after a local song mutation. Also invalidates
+    /// the resolved AbleSet cache (#575) — every caller of `nudge_sync` is a
+    /// mutation that can change which presentations exist or what they're
+    /// named, and the cache must never be left resolving stale/missing ids
+    /// until the next unrelated AbleSet-settings save.
+    pub(crate) async fn nudge_sync(&self) {
+        self.invalidate_ableset_cache().await;
         self.sync.nudge();
     }
 
@@ -203,14 +208,18 @@ impl AppState {
             .restore_presentation(presentation_id)
             .await?;
         self.drop_presentation_caches().await;
-        self.nudge_sync();
+        self.nudge_sync().await;
         Ok(())
     }
 
     /// Synced-in / restored rows invalidate the per-id presentation cache wholesale —
-    /// entries are lazily reloaded from the DB on next access.
+    /// entries are lazily reloaded from the DB on next access. Also invalidates the
+    /// resolved AbleSet cache (#575) — this is the wholesale post-mutation
+    /// convergence point the sync engine itself calls (which never goes through
+    /// `nudge_sync`, to avoid re-nudging the very sync loop that just ran).
     pub(crate) async fn drop_presentation_caches(&self) {
         self.caches.presentation.write().await.clear();
+        self.invalidate_ableset_cache().await;
     }
 
     /// #558 V2: evict ONE presentation's cache entry — used after a

--- a/crates/presenter-server/src/state/sync_integration_tests.rs
+++ b/crates/presenter-server/src/state/sync_integration_tests.rs
@@ -555,7 +555,7 @@ async fn real_sync_loop_survives_past_startup_and_completes_multiple_cycles() {
 
     b.maybe_spawn_sync(Some(a_url));
 
-    b.nudge_sync();
+    b.nudge_sync().await;
     let first = wait_for_next_cycle(&b, None, std::time::Duration::from_secs(10)).await;
     assert!(
         first.last_success.is_some(),
@@ -564,7 +564,7 @@ async fn real_sync_loop_survives_past_startup_and_completes_multiple_cycles() {
 
     // A second, independent nudge must ALSO complete a cycle - proving the
     // loop is still alive, not that it happened to survive one lucky race.
-    b.nudge_sync();
+    b.nudge_sync().await;
     let second = wait_for_next_cycle(&b, first.last_run, std::time::Duration::from_secs(10)).await;
     assert!(
         second.last_success.is_some(),
@@ -596,7 +596,7 @@ async fn two_spawns_on_one_app_state_leave_exactly_one_live_loop() {
     b.maybe_spawn_sync(Some(a_url.clone()));
     b.maybe_spawn_sync(Some(a_url)); // a second spawn call on the SAME AppState
 
-    b.nudge_sync();
+    b.nudge_sync().await;
     let first = wait_for_next_cycle(&b, None, std::time::Duration::from_secs(10)).await;
     assert!(
         first.last_success.is_some(),
@@ -605,7 +605,7 @@ async fn two_spawns_on_one_app_state_leave_exactly_one_live_loop() {
 
     // A second, independent nudge must ALSO complete a cycle - proving the
     // surviving loop is still alive, not that it happened to run once.
-    b.nudge_sync();
+    b.nudge_sync().await;
     let second = wait_for_next_cycle(&b, first.last_run, std::time::Duration::from_secs(10)).await;
     assert!(
         second.last_success.is_some(),
@@ -656,7 +656,7 @@ async fn an_all_fail_cycle_reports_unhealthy_instead_of_success() {
     }
 
     b.maybe_spawn_sync(Some(a_url));
-    b.nudge_sync();
+    b.nudge_sync().await;
     let status = wait_for_next_cycle(&b, None, std::time::Duration::from_secs(10)).await;
 
     assert!(

--- a/crates/presenter-server/src/state/sync_integration_tests.rs
+++ b/crates/presenter-server/src/state/sync_integration_tests.rs
@@ -780,3 +780,70 @@ async fn an_edit_op_lock_is_not_held_while_the_peer_content_fetch_is_in_flight()
         "the sync cycle must still complete normally once the fetch is released"
     );
 }
+
+#[tokio::test]
+async fn sync_apply_invalidates_the_ableset_cache_on_the_pulling_side() {
+    // #575 acceptance: a song arriving via PP<->SNV sync must become
+    // AbleSet-resolvable on the pulling side WITHOUT a settings re-save.
+    // Before the fix, `run_sync_cycle`'s post-apply `drop_presentation_caches`
+    // only cleared the per-id presentation cache — the separate AbleSet
+    // prefix->id cache never noticed a sync-applied change at all.
+    //
+    // The cache MUST be built NON-EMPTY before the sync cycle: an empty
+    // cache is already force-rebuilt on every resolve regardless of this
+    // fix (`ensure_ableset_cache`'s `cache.entries.is_empty()` escape
+    // hatch), which would make an empty-cache test pass even without the
+    // fix — a false negative.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+
+    // B already tracks a library named "Songs" via AbleSet and has an
+    // EXISTING song resolved into a non-empty cache.
+    let (_lib_id, existing_id) = make_song(&b, "Songs", "099 Existing").await;
+    let draft = presenter_core::AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Songs".to_string(),
+        song_prefix_length: 3,
+    };
+    b.update_ableset_settings(
+        draft,
+        presenter_persistence::SettingsAuditSource::HttpSetter,
+        "test",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        b.resolve_ableset_presentation("099").await.unwrap(),
+        Some(existing_id),
+        "cache must be non-empty before the sync cycle — this is what proves the fix"
+    );
+
+    // A NEW song is created on A, in a library also named "Songs" (a
+    // separate row from B's — sync matches library by name).
+    make_song(&a, "Songs", "001 Amazing Grace").await;
+
+    // B pulls it via a real sync cycle — no AbleSet settings touched on B.
+    let (_pulled, applied, _errors) = run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert_eq!(applied, 1, "B must pull the new song from A");
+
+    let resolved = b
+        .resolve_ableset_presentation("001")
+        .await
+        .expect("resolve must not error");
+    assert!(
+        resolved.is_some(),
+        "a song that just arrived via sync must be AbleSet-resolvable without a \
+         settings re-save"
+    );
+    let libs = b.libraries().await.unwrap();
+    let synced = find_song(&libs, "001 Amazing Grace").expect("synced song exists on B");
+    assert_eq!(
+        resolved,
+        Some(synced.id),
+        "resolved id must be the newly synced-in presentation"
+    );
+}

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1479,10 +1479,7 @@ async fn ableset_cache_invalidates_after_library_rename() {
     );
 
     // Rename the tracked library WITHOUT touching AbleSet settings.
-    state
-        .rename_library(library.id, "New Name")
-        .await
-        .unwrap();
+    state.rename_library(library.id, "New Name").await.unwrap();
 
     // The cache's own `library_name` was "Old Name"; the actual DB library
     // is now "New Name", so a stale cache would keep resolving against a

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1367,6 +1367,136 @@ async fn ableset_resolves_presentation_through_cache() {
     assert_eq!(missing, None, "unknown prefix must resolve to None");
 }
 
+#[tokio::test]
+async fn ableset_cache_invalidates_after_presentation_create_delete_rename() {
+    // #575 regression: `AbleSetLibraryCache` was invalidated ONLY by
+    // `update_ableset_settings` — create/delete/rename left it stale
+    // forever (the 2026-07-24 SNV incident: a deleted song kept resolving,
+    // new songs never did, until the settings were re-saved verbatim).
+    // Build the cache once, then create/delete/rename presentations WITHOUT
+    // touching AbleSet settings again, and prove every mutation is reflected
+    // on the very next resolve.
+    let state = AppState::in_memory().await.unwrap();
+
+    let library = state.create_library("Hymnal").await.unwrap();
+    let (_, _, original, _) = state
+        .create_presentation(library.id, "001 Original", None)
+        .await
+        .unwrap();
+    let (_, _, keep, _) = state
+        .create_presentation(library.id, "002 Keep", None)
+        .await
+        .unwrap();
+
+    let draft = AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Hymnal".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(
+            draft,
+            presenter_persistence::SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+
+    // Build the cache: "001" resolves to the original presentation.
+    assert_eq!(
+        state.resolve_ableset_presentation("001").await.unwrap(),
+        Some(original.id),
+        "cache must resolve the seeded song before any mutation"
+    );
+
+    // Mutate the presentation set WITHOUT touching AbleSet settings again —
+    // this is the exact scenario that left the cache stale in production.
+    let (_, _, created, _) = state
+        .create_presentation(library.id, "003 Brand New", None)
+        .await
+        .unwrap();
+    state.delete_presentation(original.id).await.unwrap();
+    state
+        .rename_presentation(keep.id, "004 Renamed")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        state.resolve_ableset_presentation("003").await.unwrap(),
+        Some(created.id),
+        "a song created after the cache was built must be resolvable without a settings re-save"
+    );
+    assert_eq!(
+        state.resolve_ableset_presentation("001").await.unwrap(),
+        None,
+        "a deleted song must stop resolving without a settings re-save"
+    );
+    assert_eq!(
+        state.resolve_ableset_presentation("004").await.unwrap(),
+        Some(keep.id),
+        "a renamed song must resolve under its new prefix without a settings re-save"
+    );
+    assert_eq!(
+        state.resolve_ableset_presentation("002").await.unwrap(),
+        None,
+        "the old prefix of a renamed song must stop resolving after the rename"
+    );
+}
+
+#[tokio::test]
+async fn ableset_cache_invalidates_after_library_rename() {
+    // #575: renaming the AbleSet-tracked library must not leave the cache
+    // resolving against the OLD library-name match forever.
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library("Old Name").await.unwrap();
+    let (_, _, song, _) = state
+        .create_presentation(library.id, "001 Song", None)
+        .await
+        .unwrap();
+
+    let draft = AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Old Name".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(
+            draft,
+            presenter_persistence::SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        state.resolve_ableset_presentation("001").await.unwrap(),
+        Some(song.id)
+    );
+
+    // Rename the tracked library WITHOUT touching AbleSet settings.
+    state
+        .rename_library(library.id, "New Name")
+        .await
+        .unwrap();
+
+    // The cache's own `library_name` was "Old Name"; the actual DB library
+    // is now "New Name", so a stale cache would keep resolving against a
+    // library that AbleSet settings claim to track but no longer exists
+    // under that name. After invalidation, resolve must rebuild against the
+    // CURRENT settings.library_name ("Old Name") — which no longer matches
+    // any library — and correctly return None.
+    assert_eq!(
+        state.resolve_ableset_presentation("001").await.unwrap(),
+        None,
+        "after the tracked library is renamed away, a stale cache entry must not survive"
+    );
+}
+
 /// #546: `GET /integrations/video-sources/status` is a STATIC segment sitting next to
 /// `/integrations/video-sources/{id}`. axum's matchit gives static segments priority, so
 /// the status route wins — but nothing in the tree pinned that, and a future reorder or a

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -129,8 +129,21 @@ pub fn Header() -> impl IntoView {
         op.mobile_nav_open.update(|v| *v = !*v);
     };
 
-    // Fetch version from /healthz
+    // #574: version-drift detection. An operator tab left open across a
+    // deploy must recover on its own instead of silently misbehaving with
+    // stale WASM until someone manually reloads (2026-07-24 SNV incident).
+    //
+    // NOTE: `presenter-ui` is workspace-EXCLUDED with its OWN unrelated
+    // Cargo.toml version (0.1.x — see the deploy skill) — `env!("CARGO_PKG_VERSION")`
+    // would therefore NEVER match the real server version and would show
+    // this banner on every single page load. The only baseline that is
+    // actually comparable to a later poll is the version THIS tab's own
+    // first `/healthz` response reported.
+    const VERSION_POLL_INTERVAL_MS: u32 = 15_000;
+
     let version_text = RwSignal::new(String::new());
+    let known_version = RwSignal::new(String::new());
+    let new_version_available = RwSignal::new(false);
     {
         leptos::task::spawn_local(async move {
             if let Ok(health) =
@@ -142,11 +155,49 @@ pub fn Header() -> impl IntoView {
                     format!("v{} ({})", health.version, health.channel)
                 };
                 version_text.set(text);
+                known_version.set(health.version);
             }
         });
     }
 
+    // Poll periodically; a mismatch against the captured baseline means the
+    // server was redeployed underneath this open tab.
+    {
+        let interval = gloo_timers::callback::Interval::new(VERSION_POLL_INTERVAL_MS, move || {
+            leptos::task::spawn_local(async move {
+                if let Ok(health) =
+                    crate::api::get_json::<crate::api::HealthzResponse>("/healthz").await
+                {
+                    let baseline = known_version.get_untracked();
+                    if !baseline.is_empty() && health.version != baseline {
+                        new_version_available.set(true);
+                    }
+                }
+            });
+        });
+        interval.forget();
+    }
+
+    let reload_now = move |_| {
+        if let Some(w) = web_sys::window() {
+            let _ = w.location().reload();
+        }
+    };
+
     view! {
+        // #574: prominent, dismiss-free "new version" banner. Never yanks
+        // the page mid-action on its own — the operator clicks Reload when
+        // ready.
+        <Show when=move || new_version_available.get() fallback=|| ()>
+            <div class="operator__version-banner" data-role="version-update-banner">
+                <span>"A new version is available."</span>
+                <button
+                    type="button"
+                    data-role="version-update-reload"
+                    on:click=reload_now
+                >"Reload"</button>
+            </div>
+        </Show>
         <header class="operator__header">
             <div class="operator__header-left">
                 <div class="operator__header-brand">

--- a/crates/presenter-ui/src/components/library_modal.rs
+++ b/crates/presenter-ui/src/components/library_modal.rs
@@ -63,9 +63,10 @@ pub fn LibraryModals() -> impl IntoView {
         let op = op.clone();
         move |ev: web_sys::SubmitEvent| {
             ev.prevent_default();
-            // #571: re-entry guard — create is NOT idempotent, so a
-            // double-submit during the round-trip must not fire twice (the
-            // button is also disabled off this signal; belt and braces).
+            // #571: re-entry guard — this handler also runs in "create"
+            // mode, which is NOT idempotent, so a double-submit during the
+            // round-trip must not fire twice (the button is also disabled
+            // off this signal; belt and braces).
             if op.submitting.get_untracked() {
                 return;
             }

--- a/crates/presenter-ui/src/components/library_modal.rs
+++ b/crates/presenter-ui/src/components/library_modal.rs
@@ -63,6 +63,12 @@ pub fn LibraryModals() -> impl IntoView {
         let op = op.clone();
         move |ev: web_sys::SubmitEvent| {
             ev.prevent_default();
+            // #571: re-entry guard — create is NOT idempotent, so a
+            // double-submit during the round-trip must not fire twice (the
+            // button is also disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let name = name_value.get_untracked().trim().to_string();
             if name.is_empty() {
                 return;
@@ -222,6 +228,10 @@ pub fn LibraryModals() -> impl IntoView {
         move |_| crate::components::modal::close_modal(&op)
     };
 
+    // #571: disable the mutating buttons while a request is in flight.
+    let submitting_sig = op.submitting;
+    let is_submitting = move || submitting_sig.get();
+
     view! {
         // Library list modal
         <div class="operator__library-modal" data-role="library-modal"
@@ -342,13 +352,16 @@ pub fn LibraryModals() -> impl IntoView {
                             class="operator__library-edit-delete"
                             data-role="library-edit-delete"
                             style:display=move || if edit_mode() == "edit" { "inline-block" } else { "none" }
+                            prop:disabled=is_submitting
                             on:click=on_delete
                         >"Delete library"</button>
                         <div class="operator__library-edit-actions">
                             <button type="button" data-role="library-edit-cancel"
                                 on:click=on_cancel
                             >"Cancel"</button>
-                            <button type="submit" data-role="library-edit-save">"Save changes"</button>
+                            <button type="submit" data-role="library-edit-save"
+                                prop:disabled=is_submitting
+                            >"Save changes"</button>
                         </div>
                     </footer>
                 </form>

--- a/crates/presenter-ui/src/components/playlist_modal.rs
+++ b/crates/presenter-ui/src/components/playlist_modal.rs
@@ -61,6 +61,12 @@ pub fn PlaylistModals() -> impl IntoView {
         let op = op.clone();
         move |ev: web_sys::SubmitEvent| {
             ev.prevent_default();
+            // #571: re-entry guard — create is NOT idempotent, so a
+            // double-submit during the round-trip must not fire twice (the
+            // button is also disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let name = name_value.get_untracked().trim().to_string();
             if name.is_empty() {
                 return;
@@ -193,6 +199,10 @@ pub fn PlaylistModals() -> impl IntoView {
         move |_| crate::components::modal::close_modal(&op)
     };
 
+    // #571: disable the mutating buttons while a request is in flight.
+    let submitting_sig = op.submitting;
+    let is_submitting = move || submitting_sig.get();
+
     view! {
         // Playlist list modal
         <div class="operator__playlist-modal" data-role="playlist-modal"
@@ -310,13 +320,16 @@ pub fn PlaylistModals() -> impl IntoView {
                             class="operator__library-edit-delete"
                             data-role="playlist-edit-delete"
                             style:display=move || if edit_mode() == "edit" { "inline-block" } else { "none" }
+                            prop:disabled=is_submitting
                             on:click=on_delete
                         >"Delete playlist"</button>
                         <div class="operator__library-edit-actions">
                             <button type="button" data-role="playlist-edit-cancel"
                                 on:click=on_cancel
                             >"Cancel"</button>
-                            <button type="submit" data-role="playlist-edit-save">"Save changes"</button>
+                            <button type="submit" data-role="playlist-edit-save"
+                                prop:disabled=is_submitting
+                            >"Save changes"</button>
                         </div>
                     </footer>
                 </form>

--- a/crates/presenter-ui/src/components/playlist_modal.rs
+++ b/crates/presenter-ui/src/components/playlist_modal.rs
@@ -61,9 +61,10 @@ pub fn PlaylistModals() -> impl IntoView {
         let op = op.clone();
         move |ev: web_sys::SubmitEvent| {
             ev.prevent_default();
-            // #571: re-entry guard — create is NOT idempotent, so a
-            // double-submit during the round-trip must not fire twice (the
-            // button is also disabled off this signal; belt and braces).
+            // #571: re-entry guard — this handler also runs in "create"
+            // mode, which is NOT idempotent, so a double-submit during the
+            // round-trip must not fire twice (the button is also disabled
+            // off this signal; belt and braces).
             if op.submitting.get_untracked() {
                 return;
             }

--- a/crates/presenter-ui/src/components/presentation_modal.rs
+++ b/crates/presenter-ui/src/components/presentation_modal.rs
@@ -261,6 +261,12 @@ pub fn PresentationModals() -> impl IntoView {
     let on_create_blank = {
         let op = op.clone();
         move |_| {
+            // #571: re-entry guard — create is NOT idempotent, so a
+            // double-click during the round-trip must not fire twice (the
+            // button is also disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let lib_id = match ctx.selected_library_id.get_untracked() {
                 Some(id) => id,
                 None => return,
@@ -321,6 +327,12 @@ pub fn PresentationModals() -> impl IntoView {
     let on_paste_confirm = {
         let op = op.clone();
         move |_| {
+            // #571: re-entry guard — create is NOT idempotent, so a
+            // double-click during the round-trip must not fire twice (the
+            // button is also disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let lib_id = match ctx.selected_library_id.get_untracked() {
                 Some(id) => id,
                 None => return,
@@ -394,6 +406,12 @@ pub fn PresentationModals() -> impl IntoView {
     let on_import_confirm = {
         let op = op.clone();
         move |_| {
+            // #571: re-entry guard — create is NOT idempotent, so a
+            // double-click during the round-trip must not fire twice (the
+            // button is also disabled off this signal; belt and braces).
+            if op.submitting.get_untracked() {
+                return;
+            }
             let lib_id = match ctx.selected_library_id.get_untracked() {
                 Some(id) => id,
                 None => return,
@@ -492,8 +510,10 @@ pub fn PresentationModals() -> impl IntoView {
         let libraries = ctx.libraries;
         move || libraries.get()
     };
-    // Disable the edit-modal's mutating buttons while a request is in
-    // flight — copy is not idempotent, so a double-click must not fire twice.
+    // Disable the edit-modal's AND create-modal's mutating buttons while a
+    // request is in flight — none of these actions are idempotent (copy,
+    // create blank/paste/import), so a double-click must not fire twice
+    // (#571 extends this from the edit modal, fixed in #570, to create).
     let submitting_sig = op.submitting;
     let is_submitting = move || submitting_sig.get();
 
@@ -602,6 +622,7 @@ pub fn PresentationModals() -> impl IntoView {
                             style:display=move || if create_step.get() == "options" { "flex" } else { "none" }
                         >
                             <button type="button" class="operator__create-option" data-role="presentation-create-blank"
+                                prop:disabled=is_submitting
                                 on:click=on_create_blank
                             >
                                 <span class="operator__create-option-label">"Blank"</span>
@@ -637,6 +658,7 @@ pub fn PresentationModals() -> impl IntoView {
                                     on:click=move |_| create_step.set("options".to_string())
                                 >"Back"</button>
                                 <button type="button" data-role="presentation-create-paste-confirm"
+                                    prop:disabled=is_submitting
                                     on:click=on_paste_confirm
                                 >"Create"</button>
                             </div>
@@ -652,6 +674,7 @@ pub fn PresentationModals() -> impl IntoView {
                                     on:click=move |_| create_step.set("options".to_string())
                                 >"Back"</button>
                                 <button type="button" data-role="presentation-create-import-confirm"
+                                    prop:disabled=is_submitting
                                     on:click=on_import_confirm
                                 >"Import"</button>
                             </div>

--- a/crates/presenter-ui/src/pages/operator.rs
+++ b/crates/presenter-ui/src/pages/operator.rs
@@ -84,6 +84,43 @@ pub fn OperatorPage(#[prop(default = String::new())] initial_view: String) -> im
         });
     }
 
+    // #574: on a WS RECONNECT (not the very first connect — that's already
+    // covered by load_initial_data below), re-fetch libraries/playlists/
+    // presentations. A server restart (a deploy) always drops this socket;
+    // whatever changed on the other clients while it was down never
+    // reaches this tab as a broadcast, so a plain reconnect alone would
+    // leave stale/blank lists forever (the 2026-07-24 SNV incident).
+    {
+        let libraries = ctx.libraries;
+        let playlists = ctx.playlists;
+        let presentations = ctx.presentations;
+        let selected_library_id = ctx.selected_library_id;
+        let connected_before = std::cell::Cell::new(false);
+        Effect::new(move || {
+            let state = ws_state.get();
+            if state == ws::WsState::Connected {
+                if connected_before.get() {
+                    leptos::task::spawn_local(async move {
+                        if let Ok(libs) = crate::api::libraries::list_libraries().await {
+                            libraries.set(libs);
+                        }
+                        if let Ok(pls) = crate::api::playlists::list_playlists().await {
+                            playlists.set(pls);
+                        }
+                        if let Some(lib_id) = selected_library_id.get_untracked() {
+                            if let Ok(pres) =
+                                crate::api::libraries::list_presentations(&lib_id).await
+                            {
+                                presentations.set(pres);
+                            }
+                        }
+                    });
+                }
+                connected_before.set(true);
+            }
+        });
+    }
+
     // Dispatch WS events
     setup_ws_dispatch(last_event, &ctx);
 

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -38,6 +38,37 @@ body.operator {
   --operator-line-line-height: 1.35;
 }
 
+/* #574: prominent banner shown when the server was redeployed under an
+   open operator tab — fixed above everything (including the sticky
+   header) so it is impossible to miss regardless of scroll position. */
+.operator__version-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: #b45309;
+  color: #fffbeb;
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+}
+
+.operator__version-banner button {
+  background: #fffbeb;
+  color: #78350f;
+  border: none;
+  border-radius: 6px;
+  padding: 0.25rem 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .operator__header {
   display: flex;
   align-items: flex-start;

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -46,7 +46,10 @@ body.operator {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 200;
+  /* Must outrank every modal overlay (library/playlist/presentation edit
+     modals sit at 1200/1300) — a deploy during an open modal must still
+     show the reload banner on top, not behind the modal backdrop. */
+  z-index: 2000;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/tests/e2e/operator-version-recovery.spec.ts
+++ b/tests/e2e/operator-version-recovery.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * #574: an operator tab left open across a deploy must recover on its own.
+ *
+ * Incident (2026-07-24, SNV prod): the morning deploy restarted
+ * `presenter.service` under an operator tab open since before the deploy.
+ * The stale in-tab WASM app rendered the worship left panel WITHOUT library
+ * names until a manual reload. Fix: (1) the operator polls /healthz
+ * periodically and shows a one-click "reload" banner on a version mismatch
+ * against the version this tab actually loaded with, and (2) on WS
+ * reconnect (a server restart always drops the socket) it re-fetches
+ * libraries/playlists/presentations so a change that happened while
+ * disconnected is never left stale/blank.
+ *
+ * Each test manages its OWN dedicated server instance (stopped/restarted
+ * mid-test), separate from the shared-server pattern other spec files use.
+ */
+
+import { test, expect } from "@playwright/test";
+import { spawnSync } from "child_process";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+test.describe.configure({ timeout: 180_000 });
+
+test("shows a one-click reload banner when the server version changes under an open tab (#574)", async ({
+  page,
+}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  await refreshDevData(config.dbUrl);
+  const server = await startTestServer(config.port, config.dbUrl);
+
+  try {
+    // Pass the REAL /healthz response through for the first few seconds
+    // (covers this tab's own initial-load fetches), then start reporting a
+    // DIFFERENT version — simulating a deploy that happened while this tab
+    // stayed open. Gated on elapsed time, not call count: the operator page
+    // fires more than one independent /healthz fetch at mount (the header
+    // badge + the shared VersionLabel footer), so a call-count gate would
+    // be racy.
+    const testStartedAt = Date.now();
+    const GRACE_MS = 3_000;
+    await page.route("**/healthz", async (route) => {
+      const response = await route.fetch();
+      if (Date.now() - testStartedAt < GRACE_MS) {
+        await route.fulfill({ response });
+        return;
+      }
+      const body = await response.json();
+      body.version = `${body.version}-simulated-newer`;
+      await route.fulfill({ response, json: body });
+    });
+
+    await page.goto(`${config.baseURL}/ui/operator`);
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
+      timeout: 30_000,
+    });
+    await page.waitForSelector('[data-role="library-item"]', {
+      timeout: 30_000,
+    });
+
+    // No banner immediately after load (still within the grace window /
+    // before the first poll tick observes a mismatch).
+    await expect(
+      page.locator('[data-role="version-update-banner"]'),
+    ).toHaveCount(0);
+
+    // The periodic poll must observe the mismatch and show the banner.
+    await expect(
+      page.locator('[data-role="version-update-banner"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Clicking Reload actually reloads the page (one-click recovery).
+    const navigated = page.waitForEvent("load");
+    await page.locator('[data-role="version-update-reload"]').click();
+    await navigated;
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("WS reconnect after a server restart refreshes libraries without a page reload (#574)", async ({
+  page,
+}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  await refreshDevData(config.dbUrl);
+  let server: ServerHandle | undefined = await startTestServer(
+    config.port,
+    config.dbUrl,
+  );
+
+  try {
+    const createResp = await page.request.post(
+      new URL("/libraries", config.baseURL).toString(),
+      { data: { name: `WsReconnect${Date.now()}` } },
+    );
+    expect(createResp.ok()).toBeTruthy();
+    const library: { id: string; name: string } = await createResp.json();
+
+    await page.goto(`${config.baseURL}/ui/operator`);
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
+      timeout: 30_000,
+    });
+    await page.waitForFunction(
+      () => (window as any).__presenterLiveConnected?.() === true,
+      { timeout: 15_000 },
+    );
+
+    // Kill the server — the tab's WS drops for real (not simulated).
+    await stopServer(server);
+    server = undefined;
+    await page.waitForFunction(
+      () => (window as any).__presenterLiveConnected?.() === false,
+      { timeout: 15_000 },
+    );
+
+    // While the server is down, rename the library DIRECTLY in the sqlite
+    // file — this change can never reach the tab via a live broadcast
+    // (nothing is running to send one). Only a post-reconnect REFETCH can
+    // ever show it; stale locally-retained state would keep the OLD name.
+    const dbPath = config.dbUrl.replace(/^sqlite:\/\//, "");
+    const renamedTo = `WsReconnectRenamed${Date.now()}`;
+    const sql = spawnSync("sqlite3", [
+      dbPath,
+      `UPDATE libraries SET name = '${renamedTo}', search_name = '${renamedTo.toLowerCase()}' WHERE id = '${library.id}';`,
+    ]);
+    expect(sql.status, sql.stderr.toString()).toBe(0);
+
+    // Restart the SAME server on the SAME port + DB file — the client's
+    // own reconnect loop (2s delay, see crates/presenter-ui/src/ws/mod.rs)
+    // picks it back up with NO page reload.
+    server = await startTestServer(config.port, config.dbUrl);
+    await page.waitForFunction(
+      () => (window as any).__presenterLiveConnected?.() === true,
+      { timeout: 15_000 },
+    );
+
+    // The renamed library must show up WITHOUT a page reload.
+    await page.locator('[data-role="library-more"]').click();
+    await expect(
+      page.locator(
+        `[data-role="library-row"][data-library-id="${library.id}"] .operator__list-label`,
+      ),
+    ).toHaveText(renamedTo, { timeout: 15_000 });
+  } finally {
+    await stopServer(server);
+  }
+});

--- a/tests/e2e/wasm-presentation-crud.spec.ts
+++ b/tests/e2e/wasm-presentation-crud.spec.ts
@@ -424,6 +424,47 @@ Multiple lines here`;
     await page.keyboard.press("Escape");
   });
 
+  // #571: op.submitting is set by the create handlers but was never READ by
+  // any button — nothing actually prevented a double-submit during the
+  // network round-trip. A double-click on the non-idempotent "create blank"
+  // action must yield exactly ONE presentation, never two.
+  test("double-click create blank yields exactly one presentation (#571)", async ({
+    page,
+  }) => {
+    await selectLibrary(page);
+
+    const uniqueName = `DblClickBlank${Date.now()}`;
+
+    await page
+      .locator('[data-view-panel="worship"] [data-role="presentation-create"]')
+      .click();
+    await page.waitForFunction(
+      () =>
+        document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 5_000 },
+    );
+
+    await page.locator('[data-role="presentation-create-name"]').fill(uniqueName);
+
+    // The second click must be swallowed by the re-entry guard AND the
+    // disabled button — never create a second presentation.
+    await page.locator('[data-role="presentation-create-blank"]').dblclick();
+
+    await page.waitForFunction(
+      () =>
+        !document.querySelector(
+          '[data-role="presentation-create-modal"][data-open="true"]',
+        ),
+      { timeout: 10_000 },
+    );
+
+    await expect(
+      page.locator('[data-role="presentation-item"]', { hasText: uniqueName }),
+    ).toHaveCount(1, { timeout: 10_000 });
+  });
+
   // Regression guard for issue #275 follow-up: full pipeline on a
   // spevnik song export must produce the right name + correctly
   // chunked slides + empty bookends.


### PR DESCRIPTION
## Summary

Bundles three independent bug fixes (all validated STILL_VALID 2026-07-24):

- **#575** — `AbleSetLibraryCache` was invalidated ONLY by `update_ableset_settings`.
  Every other path that changes which presentations exist, their names, or which
  library they belong to (create/rename/delete/copy presentation, restore,
  library rename/delete, sync-apply) left the cache resolving stale/missing ids
  forever — the 2026-07-24 SNV incident (deleted song 010 kept resolving, new
  songs 163/164 never did, until AbleSet settings were re-saved verbatim).
  Fix: `nudge_sync()` (now async) and `drop_presentation_caches()` both
  invalidate the AbleSet cache; `rename_library`/`delete_library` invalidate it
  directly.

- **#571** — `op.submitting` was set by every modal submit handler but read by
  no button outside the presentation-edit modal (#570) — nothing prevented a
  double-submit during the network round-trip. Fix: wired `prop:disabled` +
  re-entry guards in `library_modal.rs`, `playlist_modal.rs`, and the
  presentation CREATE panel (blank/paste/import), mirroring the `on_copy`
  pattern from #570.

- **#574** — An operator tab left open across a deploy had no way to detect a
  server version change, and silently misbehaved with stale WASM (the
  2026-07-24 SNV incident: the worship left panel rendered without library
  names after a deploy restarted `presenter.service` under an open tab). Fix:
  the operator polls `/healthz` periodically and shows a one-click "New
  version — reload" banner on a mismatch against the version this tab loaded
  with; on a WS reconnect (a server restart always drops the socket) it
  re-fetches libraries/playlists/presentations so a change missed while
  disconnected is never left stale.

## Regression tests (RED before GREEN, each in its own commit pair)

- #575: `crates/presenter-server/src/state/tests.rs` —
  `ableset_cache_invalidates_after_presentation_create_delete_rename`,
  `ableset_cache_invalidates_after_library_rename`;
  `crates/presenter-server/src/state/sync_integration_tests.rs` —
  `sync_apply_invalidates_the_ableset_cache_on_the_pulling_side`.
  RED on `4dcc14b4`, GREEN on `7c24a585`.
- #571: `tests/e2e/wasm-presentation-crud.spec.ts` —
  `double-click create blank yields exactly one presentation (#571)`.
  RED on `355000b2` (reproduced live: 2 presentations), GREEN on `46ca3cad`.
- #574: `tests/e2e/operator-version-recovery.spec.ts` — both tests.
  RED on `ca3edaff` (reproduced live), GREEN on `d031078a`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
- [x] `cargo test --workspace` (484+ tests, presenter-server full suite green)
- [x] `crates/presenter-ui`: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test --lib` (262 passed)
- [x] `bash scripts/dev/quality-check.sh --strict --against origin/main` (exit 0)
- [x] E2E: `wasm-presentation-crud.spec.ts` (8/8), `presentation-copy.spec.ts` +
  `wasm-modals.spec.ts` + `wasm-playlist-operations.spec.ts` (20/20 — modal
  regression check), `operator-version-recovery.spec.ts` (2/2),
  `wasm-operator-smoke.spec.ts` + `operator-stale-playlist-restore.spec.ts`
  (10/10 — no console errors regression check)
- [ ] CI (dev pipeline) — full suite incl. self-hosted e2e-ndi lane

Closes #575
Closes #571
Closes #574
