### PR TITLE
Suppress stage NDI play-arrow overlay (#568) + lock tablet orientation (#569)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -245,6 +245,35 @@ healthy locally:** `systemctl status cloudflared` (daemon up?) → `journalctl -
 HTTP/2 drop-in above, and re-verify — don't chase the app/service layer when the daemon logs show
 the tunnel itself never reconnecting.
 
+## Post-deploy live verification on SNV/PP: NEVER delete a test library via `/libraries/{id}` (#578)
+
+When you create a throwaway test library+presentation on SNV or PP to verify a live fix,
+clean it up by deleting the **presentation** (`DELETE /presentations/{id}` — soft-delete,
+tombstoned, propagates the deletion through the #555 sync loop) and only THEN, if you
+want, the now-empty library. **Never delete the library first/only** — `delete_library`
+does a plain hard `Entity::delete_by_id` with NO sync tombstone (pre-existing bug, filed
+as #578), so if the peer (PP<->SNV) already pulled a copy of that presentation in the
+~30s since you created it, the very next sync cycle sees "we never held this" on the
+side that just hard-deleted it and RESURRECTS the whole library+presentation from the
+peer — repeatably, forever, no matter how many times you delete the library again. Live
+incident (2026-07-24/25, verifying #575/#571/#574): a canary library round-tripped
+resurrection twice before switching to presentation-level delete converged it for good.
+If you're left with an empty, obviously-test-named library shell on either side, that's
+the safe end state — leave it (deleting it again just risks re-triggering the loop if
+either side still holds a live copy of anything under that name).
+
+## `cargo test --workspace 2>&1 | tail -N` SWALLOWS a real test failure's exit code
+
+The exit code of a bash pipeline is the LAST command's (`tail`'s, which is almost always
+0) — not `cargo test`'s. Piping a live `cargo test` run through `tail` for a shorter
+paste ALSO throws away the real pass/fail signal; a failing suite silently reports
+`EXIT_CODE: 0`. Redirect to a file instead and check the exit code of the redirect
+itself, then `grep -n "^test result:\|FAILED"` the file afterward:
+```bash
+cargo test --workspace > /tmp/full_test.log 2>&1; echo "EXIT: $?"
+grep -n "^test result:\|FAILED" /tmp/full_test.log
+```
+
 ## CLIProxyAPI Login Flow
 
 Use `cli-proxy-api -claude-login -no-browser` with callback URL paste.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -166,3 +166,15 @@ Related JSON-shape gotcha: `SlideText` serializes as an object — assert
 Connection/status indicators (Resolume chips etc.) live in the TOP brand/surface-nav row
 (`.operator__brand-nav`, next to the Stage/Camera/Tablet/Timer links), never next to the
 Stage Output controls in `operator__header-right`.
+
+## `env!("CARGO_PKG_VERSION")` is USELESS here for server-version comparison (#574)
+
+`presenter-ui` has its OWN unrelated Cargo.toml `version` (e.g. `0.1.43` — bumped
+independently of the workspace's `0.4.x`, since the crate is workspace-`exclude`d, see
+the deploy skill). `env!("CARGO_PKG_VERSION")` inside `presenter-ui` compiles to THAT
+number, never the server's real version — `info_popover.rs` already does this (a
+pre-existing, out-of-scope display quirk, left alone in #574). Do NOT reach for
+`env!("CARGO_PKG_VERSION")` to detect "did the server get redeployed under this open
+tab" — it would mismatch on every single load. Instead capture the baseline from the
+tab's OWN first `/healthz` response (`header.rs`'s `known_version` signal) and compare
+LATER polls against that captured value, never against a build-time constant.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.205"
+version = "0.4.206"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router/tablet_pwa.rs
+++ b/crates/presenter-server/src/router/tablet_pwa.rs
@@ -14,7 +14,13 @@ pub async fn tablet_manifest() -> impl IntoResponse {
         "start_url": "/ui/tablet",
         "scope": "/ui/tablet",
         "display": "standalone",
-        "orientation": "any",
+        // #569: the tablet UI has one design orientation (landscape) and must
+        // never flip with phone position. An installed/standalone PWA honors
+        // this manifest field directly; the plain-browser-tab flow (not
+        // installed) is covered separately by a first-tap fullscreen +
+        // screen.orientation.lock() attempt plus a CSS counter-rotation
+        // fallback (see tablet_orientation.rs / tablet.css).
+        "orientation": "landscape",
         "background_color": "#0f172a",
         "theme_color": "#0f172a",
         "icons": [

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.205"
+version = "0.4.206"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/stage/mod.rs
+++ b/crates/presenter-ui/src/components/stage/mod.rs
@@ -9,6 +9,7 @@ mod ndi_frame_stats;
 pub mod ndi_fullscreen;
 mod ndi_health_ticker;
 mod ndi_ice;
+mod ndi_playback_guard;
 mod ndi_profile;
 mod ndi_reload_guard;
 pub mod ndi_video;

--- a/crates/presenter-ui/src/components/stage/ndi_playback_guard.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_playback_guard.rs
@@ -2,10 +2,15 @@
 //!
 //! Android TV / weak-WebView browsers draw a big native "start playback"
 //! overlay over a `<video>` element the moment it sits in a PAUSED state —
-//! whether that's a rejected autoplay `.play()`, a WHEP stream that stalls
-//! mid-session (`pause`/`suspend`/`ended` fire on the element even though
-//! playback SHOULD continue), or the page/app returning from background
-//! (Android TV WebViews often suspend/resume without ever firing `pause`).
+//! a WHEP stream that stalls mid-session (`pause`/`suspend`/`ended` fire on
+//! the element even though playback SHOULD continue), or the page/app
+//! returning from background (Android TV WebViews often suspend/resume
+//! without ever firing `pause`). A rejected INITIAL autoplay `.play()` (the
+//! ticket's #1 named cause) is covered indirectly: `attach_ontrack`
+//! (`ndi_video.rs`) already asserts `muted` before that first `.play()`, and
+//! if a genuine rejection ever leaves the element paused, the browser itself
+//! typically follows with a `pause` event — this guard's `pause` listener
+//! then re-asserts `muted` and retries, same as any other stall.
 //! CSS suppression (`stage.css`) hides the affordance as defense-in-depth, but
 //! the root cause is that nothing re-initiates playback — so the element can
 //! sit paused indefinitely. This module detects the pause and re-calls
@@ -24,15 +29,23 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 use super::ndi_watchdog::now_ms;
 
-/// At most this many `.play()` replay attempts within any rolling
-/// `RETRY_WINDOW_MS` window. Beyond that, this guard stops trying and lets the
-/// frame-based `Watchdog` escalate instead — a source that is truly dead needs
-/// a RECONNECT, not a tighter replay loop hammering `.play()`.
+/// At most this many `.play()` replay attempts within any `RETRY_WINDOW_MS`
+/// window. Beyond that, this guard stops trying and lets the frame-based
+/// `Watchdog` escalate instead — a source that is truly dead needs a
+/// RECONNECT, not a tighter replay loop hammering `.play()`.
+///
+/// Note: `RetryWindow` is a FIXED window that resets once fully elapsed, not
+/// a true sliding window — a burst straddling the boundary (attempts just
+/// before reset, more just after) can allow up to `2×MAX_RETRIES_PER_WINDOW`
+/// in a short span. Acceptable here: the frame-based `Watchdog` is the real
+/// backstop for a persistently-broken source, so this budget only needs to
+/// be "roughly bounded," not exact.
 pub(crate) const MAX_RETRIES_PER_WINDOW: usize = 5;
 pub(crate) const RETRY_WINDOW_MS: f64 = 30_000.0;
 
-/// Rolling-window bookkeeping for the bounded replay retries. Pure state, no
-/// DOM — kept separate from the DOM wiring so the decision logic is
+/// Fixed-window bookkeeping for the bounded replay retries (see the
+/// `MAX_RETRIES_PER_WINDOW` note on the fixed-vs-rolling distinction). Pure
+/// state, no DOM — kept separate from the DOM wiring so the decision logic is
 /// unit-testable without a browser.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RetryWindow {
@@ -51,10 +64,10 @@ impl RetryWindow {
 
 /// Decide whether a pause/ended/suspend/visibility-restore event observed at
 /// `now_ms` should trigger another `.play()` attempt, advancing `state`'s
-/// rolling-window bookkeeping. A window with no activity for
-/// `RETRY_WINDOW_MS` resets the attempt counter — a source that recovered and
-/// later blips again gets a fresh budget rather than staying permanently
-/// capped by an old failure streak. Pure + unit-tested.
+/// fixed-window bookkeeping. A window with no activity for `RETRY_WINDOW_MS`
+/// resets the attempt counter — a source that recovered and later blips
+/// again gets a fresh budget rather than staying permanently capped by an
+/// old failure streak. Pure + unit-tested.
 pub(crate) fn should_attempt_replay(state: &mut RetryWindow, now_ms: f64) -> bool {
     if now_ms - state.window_start_ms >= RETRY_WINDOW_MS {
         state.attempts = 0;
@@ -112,7 +125,7 @@ pub(crate) fn install(video: &HtmlVideoElement) {
     }
 }
 
-/// If `video` is actually paused and the rolling-window budget allows it,
+/// If `video` is actually paused and the fixed-window budget allows it,
 /// re-assert `muted` (matches `attach_ontrack`'s Chrome-autoplay-policy fix —
 /// a stream reassigned or renegotiated could reset the live `muted` property)
 /// and re-call `.play()`. Silently no-ops when the element isn't paused (nothing
@@ -135,18 +148,25 @@ fn replay_if_within_budget(
         return;
     }
     video.set_muted(true);
+    play_and_log(video, format!("ndi_playback_guard: replay after {source}"));
+}
+
+/// Call `.play()` on `video` and log (WARN, never propagated) if the returned
+/// promise rejects or the call itself throws. Shared by `ndi_video.rs`'s
+/// initial `attach_ontrack` play and this module's replay above — both need
+/// identical "fire, await, log on failure" handling, and duplicating it was
+/// flagged in review (PR #579).
+pub(crate) fn play_and_log(video: &HtmlVideoElement, context: String) {
     match video.play() {
         Ok(promise) => {
             spawn_local(async move {
                 if let Err(e) = JsFuture::from(promise).await {
-                    leptos::logging::warn!(
-                        "ndi_playback_guard: replay after {source} rejected: {e:?}"
-                    );
+                    leptos::logging::warn!("{context}: play() rejected: {e:?}");
                 }
             });
         }
         Err(e) => {
-            leptos::logging::warn!("ndi_playback_guard: replay after {source} threw: {e:?}");
+            leptos::logging::warn!("{context}: play() threw: {e:?}");
         }
     }
 }

--- a/crates/presenter-ui/src/components/stage/ndi_playback_guard.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_playback_guard.rs
@@ -1,0 +1,205 @@
+//! Bounded playback-recovery guard for `NdiVideo`'s `<video>` element (#568).
+//!
+//! Android TV / weak-WebView browsers draw a big native "start playback"
+//! overlay over a `<video>` element the moment it sits in a PAUSED state —
+//! whether that's a rejected autoplay `.play()`, a WHEP stream that stalls
+//! mid-session (`pause`/`suspend`/`ended` fire on the element even though
+//! playback SHOULD continue), or the page/app returning from background
+//! (Android TV WebViews often suspend/resume without ever firing `pause`).
+//! CSS suppression (`stage.css`) hides the affordance as defense-in-depth, but
+//! the root cause is that nothing re-initiates playback — so the element can
+//! sit paused indefinitely. This module detects the pause and re-calls
+//! `.play()` immediately, bounded so a persistently-broken source doesn't spin
+//! `.play()` forever: the existing frame-based `Watchdog` (`ndi_watchdog.rs`)
+//! already escalates — reconnect, then a last-resort page reload — for a
+//! source that truly cannot recover, so this guard backs off and defers to it
+//! rather than retrying without limit.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use leptos::wasm_bindgen::{closure::Closure, JsCast};
+use leptos::web_sys::HtmlVideoElement;
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+
+use super::ndi_watchdog::now_ms;
+
+/// At most this many `.play()` replay attempts within any rolling
+/// `RETRY_WINDOW_MS` window. Beyond that, this guard stops trying and lets the
+/// frame-based `Watchdog` escalate instead — a source that is truly dead needs
+/// a RECONNECT, not a tighter replay loop hammering `.play()`.
+pub(crate) const MAX_RETRIES_PER_WINDOW: usize = 5;
+pub(crate) const RETRY_WINDOW_MS: f64 = 30_000.0;
+
+/// Rolling-window bookkeeping for the bounded replay retries. Pure state, no
+/// DOM — kept separate from the DOM wiring so the decision logic is
+/// unit-testable without a browser.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetryWindow {
+    attempts: usize,
+    window_start_ms: f64,
+}
+
+impl RetryWindow {
+    pub(crate) fn new(now_ms: f64) -> Self {
+        Self {
+            attempts: 0,
+            window_start_ms: now_ms,
+        }
+    }
+}
+
+/// Decide whether a pause/ended/suspend/visibility-restore event observed at
+/// `now_ms` should trigger another `.play()` attempt, advancing `state`'s
+/// rolling-window bookkeeping. A window with no activity for
+/// `RETRY_WINDOW_MS` resets the attempt counter — a source that recovered and
+/// later blips again gets a fresh budget rather than staying permanently
+/// capped by an old failure streak. Pure + unit-tested.
+pub(crate) fn should_attempt_replay(state: &mut RetryWindow, now_ms: f64) -> bool {
+    if now_ms - state.window_start_ms >= RETRY_WINDOW_MS {
+        state.attempts = 0;
+        state.window_start_ms = now_ms;
+    }
+    if state.attempts >= MAX_RETRIES_PER_WINDOW {
+        return false;
+    }
+    state.attempts += 1;
+    true
+}
+
+/// Install the bounded pause/ended/suspend/visibility-restore replay guard on
+/// `video`. Attaches listeners for the element's lifetime — one `<video>` per
+/// `NdiVideo` mount; reconnects reuse the same element (see `ndi_video.rs`),
+/// so this is called ONCE per mount, not per WHEP session.
+///
+/// The closures are intentionally `forget()`-leaked into JS, same rationale as
+/// `install_pagehide_teardown` in `ndi_video.rs`: one bounded set per
+/// `NdiVideo` mount lifetime, each capturing only a cloned `HtmlVideoElement` +
+/// a shared `Rc<RefCell<RetryWindow>>` (a few dozen bytes) — negligible next
+/// to a page-load-scoped stage display, and released with everything else
+/// when the page unloads/reloads.
+pub(crate) fn install(video: &HtmlVideoElement) {
+    let state = Rc::new(RefCell::new(RetryWindow::new(now_ms())));
+
+    for event_name in ["pause", "ended", "suspend"] {
+        let video_clone = video.clone();
+        let state_clone = Rc::clone(&state);
+        let cb = Closure::<dyn FnMut()>::new(move || {
+            replay_if_within_budget(&video_clone, &state_clone, event_name);
+        });
+        let _ = video.add_event_listener_with_callback(event_name, cb.as_ref().unchecked_ref());
+        cb.forget();
+    }
+
+    // The page/app returning to the foreground (Android TV WebViews often
+    // suspend/resume without firing pause/suspend/ended of their own) can
+    // leave the element paused with no element-level event at all — recheck
+    // on every visibility restore. `replay_if_within_budget` itself checks
+    // `video.paused()` first, so a visibility flip while genuinely playing is
+    // a cheap no-op.
+    if let Some(document) = leptos::web_sys::window().and_then(|w| w.document()) {
+        let video_clone = video.clone();
+        let state_clone = Rc::clone(&state);
+        let document_for_check = document.clone();
+        let cb = Closure::<dyn FnMut()>::new(move || {
+            if !document_for_check.hidden() {
+                replay_if_within_budget(&video_clone, &state_clone, "visibilitychange");
+            }
+        });
+        let _ = document
+            .add_event_listener_with_callback("visibilitychange", cb.as_ref().unchecked_ref());
+        cb.forget();
+    }
+}
+
+/// If `video` is actually paused and the rolling-window budget allows it,
+/// re-assert `muted` (matches `attach_ontrack`'s Chrome-autoplay-policy fix —
+/// a stream reassigned or renegotiated could reset the live `muted` property)
+/// and re-call `.play()`. Silently no-ops when the element isn't paused (nothing
+/// to recover) or the retry budget is exhausted (logs once, defers to the
+/// frame-based Watchdog).
+fn replay_if_within_budget(
+    video: &HtmlVideoElement,
+    state: &Rc<RefCell<RetryWindow>>,
+    source: &'static str,
+) {
+    if !video.paused() {
+        return;
+    }
+    let should_retry = should_attempt_replay(&mut state.borrow_mut(), now_ms());
+    if !should_retry {
+        leptos::logging::warn!(
+            "ndi_playback_guard: {source} exceeded {MAX_RETRIES_PER_WINDOW} replay \
+             attempts in {RETRY_WINDOW_MS}ms — leaving recovery to the frame watchdog"
+        );
+        return;
+    }
+    video.set_muted(true);
+    match video.play() {
+        Ok(promise) => {
+            spawn_local(async move {
+                if let Err(e) = JsFuture::from(promise).await {
+                    leptos::logging::warn!(
+                        "ndi_playback_guard: replay after {source} rejected: {e:?}"
+                    );
+                }
+            });
+        }
+        Err(e) => {
+            leptos::logging::warn!("ndi_playback_guard: replay after {source} threw: {e:?}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_attempt_replay, RetryWindow, MAX_RETRIES_PER_WINDOW, RETRY_WINDOW_MS};
+
+    #[test]
+    fn allows_up_to_the_cap_within_one_window() {
+        let mut state = RetryWindow::new(0.0);
+        for i in 0..MAX_RETRIES_PER_WINDOW {
+            assert!(
+                should_attempt_replay(&mut state, i as f64 * 10.0),
+                "attempt {i} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_beyond_the_cap_within_the_same_window() {
+        let mut state = RetryWindow::new(0.0);
+        for i in 0..MAX_RETRIES_PER_WINDOW {
+            assert!(should_attempt_replay(&mut state, i as f64 * 10.0));
+        }
+        // The (MAX+1)th attempt, still well inside the 30s window, must be
+        // rejected — this is the bound that stops an infinite `.play()` spin.
+        assert!(!should_attempt_replay(&mut state, 100.0));
+        assert!(!should_attempt_replay(&mut state, RETRY_WINDOW_MS - 1.0));
+    }
+
+    #[test]
+    fn resets_the_budget_once_the_window_elapses() {
+        let mut state = RetryWindow::new(0.0);
+        for i in 0..MAX_RETRIES_PER_WINDOW {
+            assert!(should_attempt_replay(&mut state, i as f64 * 10.0));
+        }
+        assert!(!should_attempt_replay(&mut state, RETRY_WINDOW_MS - 1.0));
+        // A blip AFTER the rolling window has fully elapsed gets a fresh
+        // budget — a source that recovered and stayed healthy for 30s+
+        // should not stay permanently capped by an old failure streak.
+        assert!(should_attempt_replay(&mut state, RETRY_WINDOW_MS + 1.0));
+    }
+
+    #[test]
+    fn budget_is_exactly_max_retries_not_off_by_one() {
+        let mut state = RetryWindow::new(0.0);
+        let mut allowed = 0;
+        for i in 0..(MAX_RETRIES_PER_WINDOW * 3) {
+            if should_attempt_replay(&mut state, i as f64) {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, MAX_RETRIES_PER_WINDOW);
+    }
+}

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -712,21 +712,7 @@ fn attach_ontrack(pc: &RtcPeerConnection, video: &HtmlVideoElement) {
 
             // Programmatic `.play()` is then permitted on muted + playsinline
             // video without user interaction.
-            let play_promise = video_clone.play();
-            match play_promise {
-                Ok(promise) => {
-                    spawn_local(async move {
-                        if let Err(e) = JsFuture::from(promise).await {
-                            leptos::logging::warn!(
-                                "video.play() rejected by browser autoplay policy: {e:?}"
-                            );
-                        }
-                    });
-                }
-                Err(e) => {
-                    leptos::logging::warn!("video.play() threw: {e:?}");
-                }
-            }
+            super::ndi_playback_guard::play_and_log(&video_clone, "attach_ontrack".to_string());
         }
     });
     pc.set_ontrack(Some(ontrack.as_ref().unchecked_ref()));

--- a/crates/presenter-ui/src/components/stage/ndi_video.rs
+++ b/crates/presenter-ui/src/components/stage/ndi_video.rs
@@ -169,6 +169,12 @@ pub fn NdiVideo(source_id: String, #[prop(optional)] class: Option<&'static str>
     let stage_signal_setters_for_effect = stage_signal_setters;
     Effect::new(move |_| {
         let Some(video) = video_ref.get() else { return };
+        // #568: bounded pause/ended/suspend/visibility-restore replay guard —
+        // installed ONCE per <NdiVideo> mount (the element persists across
+        // every reconnect cycle below), independent of the WHEP session
+        // state, so it also covers a stream reassigned onto this element by
+        // any means. See ndi_playback_guard.rs for the bounded-retry rationale.
+        super::ndi_playback_guard::install(&video);
         let source_id = source_id_for_effect.clone();
         let cancelled = Arc::clone(&cancelled_for_effect);
         let stage_signal_setters = stage_signal_setters_for_effect.clone();

--- a/crates/presenter-ui/src/pages/mod.rs
+++ b/crates/presenter-ui/src/pages/mod.rs
@@ -8,3 +8,4 @@ pub mod operator;
 pub mod settings;
 pub mod stage;
 pub mod tablet;
+mod tablet_orientation;

--- a/crates/presenter-ui/src/pages/tablet.rs
+++ b/crates/presenter-ui/src/pages/tablet.rs
@@ -28,6 +28,12 @@ pub fn TabletPage() -> impl IntoView {
     // Register service worker
     register_service_worker();
 
+    // #569: attempt to lock the UI to a fixed orientation on the first tap
+    // (no-op on an already-landscape viewport, incl. desktop E2E runs). The
+    // CSS media-query fallback in tablet.css covers browsers where the lock
+    // is unsupported or the gesture never fires.
+    super::tablet_orientation::install_orientation_lock_gesture();
+
     // Connect WebSocket
     let (ws_state, last_event) = ws::use_live_websocket("tablet");
 

--- a/crates/presenter-ui/src/pages/tablet_orientation.rs
+++ b/crates/presenter-ui/src/pages/tablet_orientation.rs
@@ -11,11 +11,14 @@
 //! fires, is denied, or is unsupported — see that file for the full picture.
 
 /// Install a ONE-SHOT `pointerdown` listener: on the first tap, if the page is
-/// currently portrait, request fullscreen then lock the orientation to
-/// landscape. Removes itself after the first tap regardless of outcome —
-/// never nags on every subsequent tap. A no-op when the viewport is already
-/// landscape (nothing to fix — this also keeps it inert on desktop-sized E2E
-/// runs, which never resize to portrait).
+/// currently portrait AND on a touch device, request fullscreen then lock the
+/// orientation to landscape. Removes itself after the first tap regardless of
+/// outcome — never nags on every subsequent tap. A no-op when the viewport is
+/// already landscape (nothing to fix — this also keeps it inert on
+/// desktop-sized E2E runs, which never resize to portrait), or when the
+/// primary pointer is fine (mouse/trackpad) — a desktop user with a
+/// narrow/portrait-shaped browser window must never get an unsolicited
+/// fullscreen + orientation-lock attempt (review finding, PR #579).
 ///
 /// Every promise is explicitly caught: an unsupported/denied lock (iOS
 /// Safari, a browser that refuses fullscreen) must never surface as an
@@ -30,6 +33,9 @@ const ORIENTATION_LOCK_GESTURE_JS: &str = r#"
         document.removeEventListener("pointerdown", attempt, true);
         if (window.innerWidth >= window.innerHeight) {
             return; // already landscape — nothing to fix
+        }
+        if (!window.matchMedia || !window.matchMedia("(pointer: coarse)").matches) {
+            return; // not a touch device — never force fullscreen/lock on desktop
         }
         var el = document.documentElement;
         var entered = el.requestFullscreen

--- a/crates/presenter-ui/src/pages/tablet_orientation.rs
+++ b/crates/presenter-ui/src/pages/tablet_orientation.rs
@@ -1,0 +1,52 @@
+//! First-tap orientation-lock gesture for the tablet UI (#569).
+//!
+//! `screen.orientation.lock()` is only honored inside a fullscreen context,
+//! and is unsupported entirely on iOS Safari — so the plain-browser-tab flow
+//! (not installed as a PWA) needs a one-time user gesture to request both.
+//! Split out of `tablet.rs` to keep that file under the size cap.
+//!
+//! This is ONE layer of the fix; the CSS counter-rotation fallback in
+//! `tablet.css` (`@media (orientation: portrait)`) is what actually guarantees
+//! the "never flips with phone position" requirement when this gesture never
+//! fires, is denied, or is unsupported — see that file for the full picture.
+
+/// Install a ONE-SHOT `pointerdown` listener: on the first tap, if the page is
+/// currently portrait, request fullscreen then lock the orientation to
+/// landscape. Removes itself after the first tap regardless of outcome —
+/// never nags on every subsequent tap. A no-op when the viewport is already
+/// landscape (nothing to fix — this also keeps it inert on desktop-sized E2E
+/// runs, which never resize to portrait).
+///
+/// Every promise is explicitly caught: an unsupported/denied lock (iOS
+/// Safari, a browser that refuses fullscreen) must never surface as an
+/// unhandled-rejection console error — the CSS fallback covers that case.
+pub(crate) fn install_orientation_lock_gesture() {
+    let _ = js_sys::eval(ORIENTATION_LOCK_GESTURE_JS);
+}
+
+const ORIENTATION_LOCK_GESTURE_JS: &str = r#"
+(function () {
+    function attempt() {
+        document.removeEventListener("pointerdown", attempt, true);
+        if (window.innerWidth >= window.innerHeight) {
+            return; // already landscape — nothing to fix
+        }
+        var el = document.documentElement;
+        var entered = el.requestFullscreen
+            ? el.requestFullscreen()
+            : Promise.reject(new Error("Fullscreen API unavailable"));
+        Promise.resolve(entered)
+            .then(function () {
+                if (window.screen && window.screen.orientation && window.screen.orientation.lock) {
+                    return window.screen.orientation.lock("landscape");
+                }
+            })
+            .catch(function () {
+                // Unsupported or denied (iOS Safari, no fullscreen support,
+                // a user-activation edge case) — the CSS rotate-fallback in
+                // tablet.css covers this case, so there is nothing more to do.
+            });
+    }
+    document.addEventListener("pointerdown", attempt, true);
+})();
+"#;

--- a/crates/presenter-ui/styles/stage.css
+++ b/crates/presenter-ui/styles/stage.css
@@ -639,12 +639,18 @@ body.stage {
    autoplaying muted with frames flowing — desktop Chromium does not. The video
    IS playing (autoplay+muted+playsinline + explicit .play()); this only
    suppresses the UA media-control chrome so a clean fullscreen video shows on
-   the stage instead of a huge play-arrow. */
-.stage-ndi__video::-webkit-media-controls,
-.stage-ndi__video::-webkit-media-controls-enclosure,
-.stage-ndi__video::-webkit-media-controls-panel,
-.stage-ndi__video::-webkit-media-controls-overlay-play-button,
-.stage-ndi__video::-webkit-media-controls-start-playback-button {
+   the stage instead of a huge play-arrow.
+   #568: targets the [data-role="ndi-video"] attribute (set unconditionally by
+   <NdiVideo>, ndi_video.rs) rather than a single layout's class, so it covers
+   EVERY stage layout that mounts <NdiVideo> — ndi-fullscreen (.stage-ndi__video),
+   timer (.stage-timer__ndi), and api (.stage-api__ndi) — instead of only the
+   first one. A prior version of this rule targeted .stage-ndi__video alone,
+   which left the other two layouts showing the native play-arrow (#568). */
+[data-role="ndi-video"]::-webkit-media-controls,
+[data-role="ndi-video"]::-webkit-media-controls-enclosure,
+[data-role="ndi-video"]::-webkit-media-controls-panel,
+[data-role="ndi-video"]::-webkit-media-controls-overlay-play-button,
+[data-role="ndi-video"]::-webkit-media-controls-start-playback-button {
     display: none !important;
     -webkit-appearance: none;
     appearance: none;

--- a/crates/presenter-ui/styles/tablet.css
+++ b/crates/presenter-ui/styles/tablet.css
@@ -36,6 +36,41 @@ body.tablet {
   box-sizing: border-box;
 }
 
+/* #569: pure-CSS orientation-lock FALLBACK for the plain-browser-tab flow.
+   `screen.orientation.lock()` (attempted on the first tap — see
+   tablet_orientation.rs) only works inside a fullscreen context and is
+   unsupported entirely on iOS Safari, so a phone that never enters fullscreen
+   (or can't) still reports a PORTRAIT window. This media query rotates the
+   whole tablet UI 90° so it keeps rendering in its landscape design
+   orientation instead of flipping with phone position.
+
+   It is a fallback ONLY in effect, with no JS coordination needed: once
+   screen.orientation.lock("landscape") succeeds, the OS reports genuinely
+   landscape window dimensions, so this query simply stops matching on its
+   own. It also re-evaluates automatically on resize/orientationchange (a
+   media query, not a one-shot listener).
+
+   The transform math (verified algebraically, since no real phone is
+   reachable from a dev box — see #569 completion evidence): the box is
+   authored at the SWAPPED size (width=100vh, height=100vw — the actual
+   portrait viewport's height/width), pivoted at its own top-left corner
+   (transform-origin), translated up by its own full height, then rotated 90°
+   clockwise. That composition maps the box's four corners exactly onto
+   (0,0)-(100vw,100vh) — i.e. it fills the real portrait viewport edge to
+   edge with content that is internally composed as landscape (100vh x
+   100vw), pivoted into a phone-shaped screen. */
+@media screen and (orientation: portrait) {
+  body.tablet {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vh;
+    height: 100vw;
+    transform-origin: top left;
+    transform: rotate(90deg) translateY(-100%);
+  }
+}
+
 .tablet-header {
   display: flex;
   justify-content: space-between;

--- a/crates/presenter-ui/styles/tablet.css
+++ b/crates/presenter-ui/styles/tablet.css
@@ -58,8 +58,15 @@ body.tablet {
    clockwise. That composition maps the box's four corners exactly onto
    (0,0)-(100vw,100vh) — i.e. it fills the real portrait viewport edge to
    edge with content that is internally composed as landscape (100vh x
-   100vw), pivoted into a phone-shaped screen. */
-@media screen and (orientation: portrait) {
+   100vw), pivoted into a phone-shaped screen.
+
+   `(pointer: coarse)` scopes this to touch devices (review finding, PR #579):
+   without it, a desktop user with a narrow/portrait-shaped browser window (a
+   portrait external monitor, a docked side-panel browser) would get the
+   whole UI silently force-rotated too — a real device has ONLY a coarse
+   (touch) primary pointer, a desktop/laptop has a fine (mouse/trackpad) one,
+   regardless of window aspect ratio. */
+@media screen and (orientation: portrait) and (pointer: coarse) {
   body.tablet {
     position: fixed;
     top: 0;

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -385,3 +385,35 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
   hook, which raced against and lost to the real telemetry (expected; the hook targets no-live-stream
   E2E envs). 0 console errors/warnings.
 - Solo PR (dev→main #534, Closes #532), version 0.4.189.
+
+## Batch: #575 + #571 + #574 (2026-07-25)
+
+- **#575** AbleSet song cache never invalidated on presentation/library mutations (2026-07-24 SNV
+  incident). RED `4dcc14b4` (`state::tests::ableset_cache_invalidates_after_presentation_create_delete_rename`,
+  `ableset_cache_invalidates_after_library_rename`, `state::sync_integration_tests::sync_apply_invalidates_the_ableset_cache_on_the_pulling_side`)
+  → GREEN `7c24a585`: `nudge_sync()` (now async) + `drop_presentation_caches()` both invalidate
+  `caches.ableset`; `rename_library`/`delete_library` invalidate it directly too.
+- **#571** dead `op.submitting` double-submit guard outside the #570 presentation-edit modal. RED
+  `355000b2` (E2E `wasm-presentation-crud.spec.ts` double-click-create-blank, reproduced 2 presentations
+  live) → GREEN `46ca3cad`: `prop:disabled` + re-entry guards wired into `library_modal.rs`,
+  `playlist_modal.rs`, presentation CREATE panel (mirrors #570's `on_copy` pattern).
+- **#574** operator tab open across a deploy breaks silently (2026-07-24 SNV incident: worship panel
+  rendered without library names after a deploy). RED `ca3edaff` (new E2E spec
+  `operator-version-recovery.spec.ts`, both tests reproduced live) → GREEN `d031078a`: `header.rs` polls
+  `/healthz` every 15s vs. a tab-captured baseline (NOT `env!("CARGO_PKG_VERSION")` — presenter-ui's own
+  Cargo.toml version is unrelated) and shows a reload banner; `operator.rs` refetches
+  libraries/playlists/presentations on a genuine WS reconnect.
+- **Review fixup** `27192bf4`: adversarial code review (dispatched subagent) caught the #574 banner's
+  `z-index:200` sitting below modal overlays (1200/1300) — bumped to 2000; also tightened two
+  slightly-imprecise comments.
+- **Discovered + filed, NOT fixed here (genuinely out of scope):** #578 — `delete_library` hard-cascades
+  presentations with no sync tombstone, causing a resurrection loop across the PP<->SNV sync peer.
+  Found live during post-deploy verification (a throwaway test library on SNV kept resurrecting after
+  delete); pre-existing on `main` before this batch, confirmed via `git log -p`. Cleaned up by
+  soft-deleting the presentation (not the library) on both SNV and PP instead.
+- One bundled PR (dev→main #577, Closes #575 #571 #574), merged `e3e1d3e5`. Main Deploy green → SNV
+  verified v0.4.205 (DOM + Playwright, 0 console errors; #571 dbl-click canary proved live). GitHub
+  Release v0.4.205 → `release.yml` deploy-pp succeeded (no #469 recurrence this time) → PP verified
+  v0.4.205. Post-release bump to 0.4.206 (`e9832cc3`) needed a `git merge origin/main` first (dev was
+  1 commit behind main's own merge commit — Branch Sync Check failure, fixed by syncing before the
+  second push, `2cb00531`). Playbook doc-only follow-up `d1898a3d` (deploy + ui skills).

--- a/tests/e2e/stage-ndi-playback-guard.spec.ts
+++ b/tests/e2e/stage-ndi-playback-guard.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+// ─────────────────────────────────────────────────────────────────────────
+// #568 — the native browser play-arrow overlay must NEVER appear on the
+// stage NDI video, on ANY of the three stage layouts that mount <NdiVideo>
+// (ndi-fullscreen, timer, api). Two root causes fixed:
+//
+// 1. The prior CSS suppression (`::-webkit-media-controls*`) targeted only
+//    `.stage-ndi__video` (the ndi-fullscreen layout's class) — the timer
+//    and api layouts' own NdiVideo classes had NO suppression at all.
+// 2. Nothing re-initiated playback when the <video> element ended up in a
+//    paused state (play() rejection, a stalled WHEP stream, a
+//    background/foreground app-suspend cycle) — the browser then draws its
+//    native "start playback" overlay over a paused video.
+//
+// This runs on the standard GitHub-hosted `e2e` lane (no NDI SDK/GPU
+// needed): the CSS check only needs the stylesheet + the mounted <video>
+// element (no real stream), and the pause-recovery check bypasses WHEP
+// entirely by assigning a synthetic `canvas.captureStream()` MediaStream
+// directly onto the mounted element — so it forces a REAL playing→paused→
+// (guard fires)→playing cycle without needing a live NDI source.
+// ─────────────────────────────────────────────────────────────────────────
+
+test.describe.configure({ timeout: 180_000 });
+
+let server: ServerHandle | undefined;
+let baseURL = "";
+let dbUrl = "";
+let port = 0;
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  dbUrl = cfg.dbUrl;
+  port = cfg.port;
+  await refreshDevData(dbUrl);
+  server = await startTestServer(port, dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(server);
+  server = undefined;
+});
+
+/** Console noise expected on a host with no live NDI source/SDK: the WHEP
+ * POST is answered 503 (no SDK) / 204 (configured-but-not-producing, #431)
+ * and the client backs off quietly with a WARN — same allow-list used by the
+ * existing timer/api NDI specs. */
+const ALLOWED_CONSOLE_NOISE = [
+  /Failed to load resource.*\b(503|204)\b/i,
+  /WHEP (POST|connect)[^\n]*\b(503|204)\b/i,
+  /reconnect_loop.*connect_whep failed/i,
+];
+
+function collectConsoleNoise(page: Page): string[] {
+  const messages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() !== "error" && msg.type() !== "warning") return;
+    const text = msg.text();
+    if (!ALLOWED_CONSOLE_NOISE.some((re) => re.test(text))) {
+      messages.push(`[${msg.type()}] ${text}`);
+    }
+  });
+  page.on("pageerror", (err) => messages.push(`[pageerror] ${err.message}`));
+  return messages;
+}
+
+/** Create + activate a not-producing NDI source (no SDK on this runner →
+ * activate succeeds without ever starting a real pipeline), select the given
+ * stage layout, and open `/stage` ready + with `<video data-role="ndi-video">`
+ * mounted. Returns the created source id (caller cleans it up). */
+async function openStageWithNdiVideo(
+  page: Page,
+  layoutCode: string,
+  label: string,
+): Promise<string> {
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+    { failOnStatusCode: false },
+  );
+  await page.request.post(new URL("/stage/layout", baseURL).toString(), {
+    data: { code: layoutCode },
+  });
+
+  const created = await page.request.post(
+    new URL("/integrations/video-sources", baseURL).toString(),
+    { data: { label, ndiName: `BOGUS-${label}` } },
+  );
+  const source = await created.json();
+  await page.request.post(
+    new URL(
+      `/integrations/video-sources/${source.id}/activate`,
+      baseURL,
+    ).toString(),
+    { failOnStatusCode: false },
+  );
+
+  await page.goto(new URL("/stage", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+  await page.waitForSelector(`body[data-layout-code="${layoutCode}"]`, {
+    timeout: 10_000,
+  });
+  await page.waitForSelector('[data-role="ndi-video"]', { timeout: 15_000 });
+
+  return source.id as string;
+}
+
+async function deactivateAndDelete(page: Page, sourceId: string): Promise<void> {
+  await page.request.post(
+    new URL("/integrations/video-sources/deactivate", baseURL).toString(),
+    { failOnStatusCode: false },
+  );
+  await page.request.delete(
+    new URL(`/integrations/video-sources/${sourceId}`, baseURL).toString(),
+    { failOnStatusCode: false },
+  );
+}
+
+/** Find every `-webkit-media-controls*` CSS rule whose selector matches
+ * `videoSelector`'s element and returns `display: none`. Checking the actual
+ * stylesheet rule (rather than `getComputedStyle(el, '::pseudo')`, which some
+ * headless Chromium builds resolve inconsistently for internal UA
+ * pseudo-elements) deterministically proves the suppression rule REACHES this
+ * exact element — which is the thing #568 actually broke (the rule existed,
+ * it just didn't target the timer/api layouts' elements). */
+async function mediaControlsSuppressionApplies(
+  page: Page,
+  videoSelector: string,
+): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return false;
+    let matched = false;
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules: CSSRuleList;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue; // cross-origin stylesheet — not ours, skip
+      }
+      for (const rule of Array.from(rules)) {
+        if (!(rule instanceof CSSStyleRule)) continue;
+        if (!rule.selectorText.includes("media-controls")) continue;
+        const bases = rule.selectorText
+          .split(",")
+          .map((s) => s.trim().replace(/::-webkit-media-controls[a-z-]*/gi, ""))
+          .filter((s) => s.length > 0);
+        const targetsThisElement = bases.some((base) => {
+          try {
+            return el.matches(base);
+          } catch {
+            return false;
+          }
+        });
+        if (
+          targetsThisElement &&
+          rule.style.getPropertyValue("display").trim() === "none"
+        ) {
+          matched = true;
+        }
+      }
+    }
+    return matched;
+  }, videoSelector);
+}
+
+for (const layout of [
+  { code: "ndi-fullscreen", label: "PlaybackGuardFullscreen" },
+  { code: "timer", label: "PlaybackGuardTimer" },
+  { code: "api", label: "PlaybackGuardApi" },
+]) {
+  test(`native play-arrow overlay is suppressed on the ${layout.code} stage layout (#568)`, async ({
+    page,
+  }) => {
+    const consoleMessages = collectConsoleNoise(page);
+    const sourceId = await openStageWithNdiVideo(page, layout.code, layout.label);
+    try {
+      const suppressed = await mediaControlsSuppressionApplies(
+        page,
+        '[data-role="ndi-video"]',
+      );
+      expect(
+        suppressed,
+        `${layout.code}: no display:none -webkit-media-controls* rule targets [data-role="ndi-video"]`,
+      ).toBe(true);
+      expect(consoleMessages).toEqual([]);
+    } finally {
+      await deactivateAndDelete(page, sourceId);
+    }
+  });
+}
+
+test("NdiVideo replays a stalled stream after an external pause() within the bounded retry window (#568)", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleNoise(page);
+  const sourceId = await openStageWithNdiVideo(
+    page,
+    "ndi-fullscreen",
+    "PlaybackGuardReplay",
+  );
+
+  try {
+    // Bypass WHEP entirely: assign a synthetic canvas-captured MediaStream
+    // directly onto the mounted <video> element. This exercises the SAME
+    // pause/ended/suspend replay guard the real WHEP path uses (the guard is
+    // installed unconditionally per <NdiVideo> mount, independent of how the
+    // element got its srcObject), without needing a live NDI source or GPU.
+    await page.evaluate((sel) => {
+      const video = document.querySelector(sel) as HTMLVideoElement;
+      const canvas = document.createElement("canvas");
+      canvas.width = 16;
+      canvas.height = 16;
+      const ctx = canvas.getContext("2d")!;
+      let toggle = false;
+      ctx.fillStyle = "red";
+      ctx.fillRect(0, 0, 16, 16);
+      // Repaint periodically so the captured track has real frame changes —
+      // avoids any "static canvas" edge case in some Chromium versions.
+      const interval = setInterval(() => {
+        toggle = !toggle;
+        ctx.fillStyle = toggle ? "blue" : "red";
+        ctx.fillRect(0, 0, 16, 16);
+      }, 100);
+      (window as unknown as { __e2eGuardInterval?: number }).__e2eGuardInterval =
+        interval as unknown as number;
+      const stream = canvas.captureStream(10);
+      video.srcObject = stream;
+      video.muted = true;
+      return video.play();
+    }, '[data-role="ndi-video"]');
+
+    const isPaused = () =>
+      page.evaluate(
+        (sel) => (document.querySelector(sel) as HTMLVideoElement).paused,
+        '[data-role="ndi-video"]',
+      );
+
+    // Sanity: the synthetic stream is genuinely playing before we pause it.
+    await expect.poll(isPaused, { timeout: 10_000 }).toBe(false);
+
+    // Record the `pause` EVENT directly (a discrete fact) rather than polling
+    // the `paused` boolean for `true` — the fix under test reacts to `pause`
+    // so fast that a poll can miss the brief paused window entirely and only
+    // ever observe `false`, which would make this sanity check itself flaky.
+    await page.evaluate((sel) => {
+      const video = document.querySelector(sel) as HTMLVideoElement;
+      (window as unknown as { __e2ePauseSeen?: boolean }).__e2ePauseSeen = false;
+      video.addEventListener(
+        "pause",
+        () => {
+          (window as unknown as { __e2ePauseSeen?: boolean }).__e2ePauseSeen = true;
+        },
+        { once: true },
+      );
+    }, '[data-role="ndi-video"]');
+
+    // Force the exact bug condition: the element ends up paused (a rejected
+    // play(), a stalled stream, or — as simulated here — any external pause).
+    await page.evaluate(
+      (sel) => (document.querySelector(sel) as HTMLVideoElement).pause(),
+      '[data-role="ndi-video"]',
+    );
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { __e2ePauseSeen?: boolean }).__e2ePauseSeen), {
+        timeout: 5_000,
+      })
+      .toBe(true);
+
+    // The bounded replay guard (ndi_playback_guard.rs) must detect the
+    // `pause` event and re-call `.play()` — recovering WITHOUT any reload or
+    // reconnect. This is the #568 core fix: before it existed, the element
+    // stayed paused forever and the browser drew its native play-arrow.
+    await expect.poll(isPaused, { timeout: 5_000 }).toBe(false);
+
+    await page.evaluate(() => {
+      const w = window as unknown as { __e2eGuardInterval?: number };
+      if (w.__e2eGuardInterval) clearInterval(w.__e2eGuardInterval);
+    });
+
+    expect(consoleMessages).toEqual([]);
+  } finally {
+    await deactivateAndDelete(page, sourceId);
+  }
+});

--- a/tests/e2e/stage-ndi-playback-guard.spec.ts
+++ b/tests/e2e/stage-ndi-playback-guard.spec.ts
@@ -292,3 +292,82 @@ test("NdiVideo replays a stalled stream after an external pause() within the bou
     await deactivateAndDelete(page, sourceId);
   }
 });
+
+// #568 review follow-up (PR #579): the sibling test above proves the
+// pause/ended/suspend replay guard recovers from an EXPLICIT pause() call,
+// but Playwright's default `chromium` project disables Chrome's autoplay
+// policy entirely (see playwright.config.ts), so it can't prove the replay
+// still succeeds under REAL enforcement — the ticket's #1 named root cause
+// ("video.play() rejects (autoplay policy)... and no retry brings it back").
+// This re-runs the same playing→paused→recovered cycle under real Chrome
+// with `--autoplay-policy=user-gesture-required` (the `chrome-video`
+// project, `@video-codec` tag — same mechanism as the pre-existing
+// "NdiVideo actually starts playing (autoplay policy regression)" test in
+// ndi-webrtc.spec.ts), proving the guard's `set_muted(true)` + `.play()`
+// re-assertion (ndi_playback_guard.rs) genuinely survives strict policy
+// enforcement — a script-initiated replay is ONLY permitted at all because
+// it re-asserts `muted` first.
+test("NdiVideo replays a stalled stream after pause() under real Chrome autoplay-policy enforcement (#568) @video-codec", async ({
+  page,
+}) => {
+  const consoleMessages = collectConsoleNoise(page);
+  const sourceId = await openStageWithNdiVideo(
+    page,
+    "ndi-fullscreen",
+    "PlaybackGuardReplayStrictPolicy",
+  );
+
+  try {
+    await page.evaluate((sel) => {
+      const video = document.querySelector(sel) as HTMLVideoElement;
+      const canvas = document.createElement("canvas");
+      canvas.width = 16;
+      canvas.height = 16;
+      const ctx = canvas.getContext("2d")!;
+      let toggle = false;
+      ctx.fillStyle = "red";
+      ctx.fillRect(0, 0, 16, 16);
+      const interval = setInterval(() => {
+        toggle = !toggle;
+        ctx.fillStyle = toggle ? "blue" : "red";
+        ctx.fillRect(0, 0, 16, 16);
+      }, 100);
+      (window as unknown as { __e2eGuardInterval?: number }).__e2eGuardInterval =
+        interval as unknown as number;
+      const stream = canvas.captureStream(10);
+      video.srcObject = stream;
+      video.muted = true;
+      return video.play();
+    }, '[data-role="ndi-video"]');
+
+    const isPaused = () =>
+      page.evaluate(
+        (sel) => (document.querySelector(sel) as HTMLVideoElement).paused,
+        '[data-role="ndi-video"]',
+      );
+
+    // Under REAL Chrome with --autoplay-policy=user-gesture-required, a
+    // programmatic play() on a NON-muted element would reject — this first
+    // poll proves the initial muted play() succeeds even under strict
+    // enforcement (mirrors attach_ontrack's production behavior).
+    await expect.poll(isPaused, { timeout: 10_000 }).toBe(false);
+
+    await page.evaluate(
+      (sel) => (document.querySelector(sel) as HTMLVideoElement).pause(),
+      '[data-role="ndi-video"]',
+    );
+
+    // The guard's replay must recover even here — proving the fix holds
+    // under real policy enforcement, not just Playwright's relaxed default.
+    await expect.poll(isPaused, { timeout: 5_000 }).toBe(false);
+
+    await page.evaluate(() => {
+      const w = window as unknown as { __e2eGuardInterval?: number };
+      if (w.__e2eGuardInterval) clearInterval(w.__e2eGuardInterval);
+    });
+
+    expect(consoleMessages).toEqual([]);
+  } finally {
+    await deactivateAndDelete(page, sourceId);
+  }
+});

--- a/tests/e2e/tablet-orientation-lock.spec.ts
+++ b/tests/e2e/tablet-orientation-lock.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import {
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+// ─────────────────────────────────────────────────────────────────────────
+// #569 — the tablet UI (`/ui/tablet`) must stay pinned to a single
+// orientation and never flip with phone position, even in the plain
+// browser-tab flow (not installed as a PWA).
+//
+// Three layers:
+//   1. The PWA manifest declares `"orientation": "landscape"` (was "any") —
+//      honored automatically by an installed/standalone PWA.
+//   2. A first-tap gesture (tablet_orientation.rs) attempts fullscreen +
+//      `screen.orientation.lock("landscape")` for the plain-tab flow. Real
+//      fullscreen/orientation-lock behavior is environment-dependent
+//      (headless Chromium, no real screen) and not meaningfully assertable
+//      here — the CSS fallback below is what's E2E-verifiable and is the
+//      layer that actually guarantees the "never flips" requirement when
+//      the lock is unsupported/denied/never attempted.
+//   3. A pure CSS `@media (orientation: portrait)` fallback (tablet.css)
+//      rotates the whole UI 90° so it keeps rendering in its landscape
+//      design orientation regardless of the physical/window orientation.
+//      This re-evaluates automatically on viewport resize — exactly what
+//      Playwright's `setViewportSize` triggers — so it's fully testable via
+//      viewport emulation without a real phone.
+// ─────────────────────────────────────────────────────────────────────────
+
+test.describe.configure({ timeout: 180_000 });
+
+let serverHandle: ServerHandle | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({}, testInfo) => {
+  const cfg = deriveTestConfig(testInfo);
+  baseURL = cfg.baseURL;
+  await refreshDevData(cfg.dbUrl);
+  serverHandle = await startTestServer(cfg.port, cfg.dbUrl, cfg.oscPort);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+test("tablet manifest declares a fixed landscape orientation (#569)", async ({
+  request,
+}) => {
+  const response = await request.get(
+    new URL("/ui/tablet/manifest.json", baseURL).toString(),
+  );
+  expect(response.ok()).toBeTruthy();
+  const manifest = await response.json();
+  expect(manifest.orientation).toBe("landscape");
+});
+
+test("tablet UI counter-rotates to stay landscape when the window is portrait, and does not when it's landscape (#569)", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  // Start landscape (a typical tablet/desktop shape) — the fallback rotation
+  // must NOT be active here; this is the everyday, already-correct case.
+  await page.setViewportSize({ width: 900, height: 500 });
+  await page.goto(new URL("/ui/tablet", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', {
+    timeout: 30_000,
+  });
+
+  const body = page.locator("body.tablet");
+  await expect(body).toBeAttached();
+
+  const readTransform = () =>
+    body.evaluate((el) => window.getComputedStyle(el).transform);
+  const readPosition = () =>
+    body.evaluate((el) => window.getComputedStyle(el).position);
+
+  await expect.poll(readTransform).toBe("none");
+
+  // Rotate to a portrait phone shape (a physically-rotated phone with no
+  // orientation lock active — the exact bug condition: the UI must NOT
+  // follow this rotation). The media query re-evaluates automatically.
+  await page.setViewportSize({ width: 400, height: 800 });
+  await expect.poll(readTransform).not.toBe("none");
+  expect(await readPosition()).toBe("fixed");
+
+  // Rotate back to landscape (phone turned back) — the fallback must
+  // disengage cleanly, proving this is a live, bounded, reversible rule and
+  // not a one-shot state that gets stuck.
+  await page.setViewportSize({ width: 900, height: 500 });
+  await expect.poll(readTransform).toBe("none");
+
+  expect(consoleMessages).toEqual([]);
+});

--- a/tests/e2e/tablet-orientation-lock.spec.ts
+++ b/tests/e2e/tablet-orientation-lock.spec.ts
@@ -58,19 +58,69 @@ test("tablet manifest declares a fixed landscape orientation (#569)", async ({
   expect(manifest.orientation).toBe("landscape");
 });
 
-test("tablet UI counter-rotates to stay landscape when the window is portrait, and does not when it's landscape (#569)", async ({
+// A real phone/tablet has a COARSE (touch) primary pointer — Playwright only
+// makes `(pointer: coarse)` match when the browser context declares touch
+// support, so this test explicitly emulates one (review finding, PR #579:
+// the fallback is scoped to `(pointer: coarse)` so a desktop user with a
+// narrow/portrait-shaped browser window is never force-rotated — see the
+// sibling test below for that case).
+test.describe("touch device (pointer: coarse)", () => {
+  test.use({ hasTouch: true });
+
+  test("tablet UI counter-rotates to stay landscape when the window is portrait, and does not when it's landscape (#569)", async ({
+    page,
+  }) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+
+    // Start landscape (a typical tablet shape) — the fallback rotation must
+    // NOT be active here; this is the everyday, already-correct case.
+    await page.setViewportSize({ width: 900, height: 500 });
+    await page.goto(new URL("/ui/tablet", baseURL).toString());
+    await page.waitForSelector('body[data-wasm-ready="true"]', {
+      timeout: 30_000,
+    });
+
+    const body = page.locator("body.tablet");
+    await expect(body).toBeAttached();
+
+    const readTransform = () =>
+      body.evaluate((el) => window.getComputedStyle(el).transform);
+    const readPosition = () =>
+      body.evaluate((el) => window.getComputedStyle(el).position);
+
+    await expect.poll(readTransform).toBe("none");
+
+    // Rotate to a portrait phone shape (a physically-rotated phone with no
+    // orientation lock active — the exact bug condition: the UI must NOT
+    // follow this rotation). The media query re-evaluates automatically.
+    await page.setViewportSize({ width: 400, height: 800 });
+    await expect.poll(readTransform).not.toBe("none");
+    expect(await readPosition()).toBe("fixed");
+
+    // Rotate back to landscape (phone turned back) — the fallback must
+    // disengage cleanly, proving this is a live, bounded, reversible rule
+    // and not a one-shot state that gets stuck.
+    await page.setViewportSize({ width: 900, height: 500 });
+    await expect.poll(readTransform).toBe("none");
+
+    expect(consoleMessages).toEqual([]);
+  });
+});
+
+// Desktop browsers report a FINE (mouse/trackpad) primary pointer regardless
+// of window aspect ratio. A narrow/portrait-shaped desktop browser window
+// (e.g. a portrait external monitor, a docked side-panel browser) must NOT
+// get the tablet UI force-rotated — that would be a real, if unlikely,
+// regression of the "no regression on desktop" requirement.
+test("desktop (fine pointer) with a portrait-shaped window is NOT rotated (#569)", async ({
   page,
 }) => {
-  const consoleMessages: string[] = [];
-  page.on("console", (msg) => {
-    if (msg.type() === "error" || msg.type() === "warning") {
-      consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
-    }
-  });
-
-  // Start landscape (a typical tablet/desktop shape) — the fallback rotation
-  // must NOT be active here; this is the everyday, already-correct case.
-  await page.setViewportSize({ width: 900, height: 500 });
+  await page.setViewportSize({ width: 400, height: 800 });
   await page.goto(new URL("/ui/tablet", baseURL).toString());
   await page.waitForSelector('body[data-wasm-ready="true"]', {
     timeout: 30_000,
@@ -78,26 +128,8 @@ test("tablet UI counter-rotates to stay landscape when the window is portrait, a
 
   const body = page.locator("body.tablet");
   await expect(body).toBeAttached();
-
-  const readTransform = () =>
-    body.evaluate((el) => window.getComputedStyle(el).transform);
-  const readPosition = () =>
-    body.evaluate((el) => window.getComputedStyle(el).position);
-
-  await expect.poll(readTransform).toBe("none");
-
-  // Rotate to a portrait phone shape (a physically-rotated phone with no
-  // orientation lock active — the exact bug condition: the UI must NOT
-  // follow this rotation). The media query re-evaluates automatically.
-  await page.setViewportSize({ width: 400, height: 800 });
-  await expect.poll(readTransform).not.toBe("none");
-  expect(await readPosition()).toBe("fixed");
-
-  // Rotate back to landscape (phone turned back) — the fallback must
-  // disengage cleanly, proving this is a live, bounded, reversible rule and
-  // not a one-shot state that gets stuck.
-  await page.setViewportSize({ width: 900, height: 500 });
-  await expect.poll(readTransform).toBe("none");
-
-  expect(consoleMessages).toEqual([]);
+  const transform = await body.evaluate(
+    (el) => window.getComputedStyle(el).transform,
+  );
+  expect(transform).toBe("none");
 });


### PR DESCRIPTION
## Summary

- **#568** — the native browser play-arrow overlay could appear on stage NDI video. Root causes: (1) the `::-webkit-media-controls*` CSS suppression only targeted the ndi-fullscreen layout's class, leaving the timer and api layouts unsuppressed; (2) nothing re-initiated playback when the `<video>` element ended up paused (rejected autoplay, a stalled WHEP stream, a background/foreground app-suspend). Fixed by generalizing the CSS suppression to the `[data-role="ndi-video"]` attribute (present on all three layouts) and adding a bounded pause/ended/suspend/visibility-restore replay guard (`ndi_playback_guard.rs`).
- **#569** — the tablet UI (`/ui/tablet`) rotated with phone position even with the phone's system rotation lock enabled. Fixed the PWA manifest (`orientation: "any"` → `"landscape"`), added a first-tap fullscreen + `screen.orientation.lock("landscape")` gesture for the plain-browser-tab flow, and a pure-CSS `@media (orientation: portrait)` counter-rotation fallback that guarantees the fixed orientation even when the lock is unsupported/denied/never attempted.

Closes #568
Closes #569

## Test plan

- [x] `cd crates/presenter-ui && cargo test --lib` — 266 passed (incl. 4 new `ndi_playback_guard` unit tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cd crates/presenter-ui && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` / `cd crates/presenter-ui && cargo fmt --check` — clean
- [x] RED→GREEN proven locally for both issues (stashed the fix, rebuilt, confirmed 5/6 new E2E assertions failed; restored the fix, rebuilt, confirmed all 6 pass)
- [x] `npx playwright test tests/e2e/stage-ndi-playback-guard.spec.ts tests/e2e/tablet-orientation-lock.spec.ts` — 6 passed
- [x] Regression sweep of related existing NDI/tablet specs — all green (see evidence block)
- [ ] CI (this PR)

🤖 Generated with autopilot-worker
