### PR TITLE
fix(sync): soft-delete libraries so a deleted library never resurrects (#578)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -98,6 +98,18 @@ To validate a stage/UI change with the real Playwright specs before pushing
    `WorshipSnv`), `.stage__bible-text`/`.stage__bible-reference` for a triggered
    verse (set `POST /stage/layout {code:"bible"}` first so the mirror renders it).
 
+### Proving RED→GREEN locally with a real rebuild, not just commit order (#568/#569)
+
+`regression-test-first` requires RED before GREEN in commit order — but you can go one step
+further and actually PROVE the RED failure locally before committing: `git stash push -- <the fix
+files, NOT the new test files>` (leaves the new spec(s) staged/committed, reverts only the
+production code), rebuild WASM+server (steps 2–3), run the new spec(s) and confirm they fail for
+the RIGHT reason, then `git stash pop`, rebuild again, and confirm green. Costs ~2 extra
+build-and-test cycles (~15 min combined on this box) but catches two real classes of mistakes
+cheaply: (1) a test that can't actually fail (a tautology, or testing the wrong thing) stays green
+even with the fix reverted; (2) a fix so complete you forgot to also verify the OLD behavior was
+real (confirms you're not just adding a passing assertion to already-working code).
+
 ### GOTCHA — a stale/ambiguous `target/release/presenter-server` silently shadows your fresh fix (#558)
 
 `startTestServer` picks the NEWER of `target/debug/presenter-server` /

--- a/.claude/skills/ndi/SKILL.md
+++ b/.claude/skills/ndi/SKILL.md
@@ -442,3 +442,29 @@ impossible error — that exact mistake shipped once. The blindness the server r
 finder thread exits and the list stays empty forever) or it simply has not completed its first
 ~5 s scan yet (every restart). Ask `NdiManager::discovery_snapshot() -> Option<Vec<..>>`, which
 is `None` until the finder has published a scan.
+
+## Testing the `<video>` play/pause lifecycle without a live NDI source (#568)
+
+To E2E-test playback-recovery logic (a pause/ended/suspend listener, an autoplay retry) with NO
+NDI SDK/GPU needed: activate a not-producing bogus source (mounts `<video data-role="ndi-video">`
+with no real stream, per the "Deterministic stage-NDI E2E" pattern above), then bypass WHEP
+entirely by assigning a synthetic `canvas.captureStream(fps)` MediaStream directly onto that
+`<video>` element's `srcObject` from `page.evaluate` — repaint the canvas on an interval so the
+captured track has real frame changes. This produces a genuinely playing/pausable element your
+guard code reacts to exactly like a real stream, on any runner (`stage-ndi-playback-guard.spec.ts`).
+
+**A fast-reacting guard makes "confirm it paused" itself flaky — assert the EVENT, not the
+boolean.** If your fix makes the element recover from `pause()` near-instantly, a
+`expect.poll(() => video.paused).toBe(true)` sanity check can miss the brief paused window
+entirely (the poll only ever samples `false`). Attach a one-shot `pause` event listener that
+flips a flag BEFORE calling `.pause()`, and poll that flag instead — a discrete fact, not a
+racing sample of a fast-changing state.
+
+**Verify a `-webkit-media-controls*` CSS suppression rule via CSSOM, not `getComputedStyle`.**
+`getComputedStyle(el, '::-webkit-media-controls-overlay-play-button')` resolves inconsistently
+across headless Chromium builds for internal UA pseudo-elements. Instead, walk
+`document.styleSheets` → `CSSStyleRule`s whose `selectorText` contains `media-controls`, strip the
+`::-webkit-media-controls*` suffix from each comma-separated selector, and check
+`element.matches(strippedSelector)` + `rule.style.getPropertyValue('display') === 'none'`. This
+deterministically proves the rule's SELECTOR reaches the element — which is what #568 actually
+broke (the rule existed, it just didn't target two of the three stage layouts' video elements).

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -167,6 +167,19 @@ Connection/status indicators (Resolume chips etc.) live in the TOP brand/surface
 (`.operator__brand-nav`, next to the Stage/Camera/Tablet/Timer links), never next to the
 Stage Output controls in `operator__header-right`.
 
+## `(pointer: coarse)` CSS/JS scoping needs `hasTouch: true` in Playwright to test (#569)
+
+A touch-only UI behavior (a CSS `@media (pointer: coarse)` rule, or a JS
+`matchMedia("(pointer: coarse)")` gate — e.g. "only force-rotate / only auto-fullscreen on a real
+phone/tablet, never on a desktop browser window") needs the `(pointer: coarse)` media feature to
+actually MATCH in a test. Playwright/Chromium only reports a coarse pointer when the **browser
+context** declares touch support — a plain viewport resize (`setViewportSize`) does NOT do this;
+by default every Playwright context reports a FINE (mouse/trackpad) pointer regardless of window
+shape. Use `test.use({ hasTouch: true })` (works inside a nested `test.describe` block, doesn't
+disturb the file's top-level `beforeAll`/`afterAll`) to emulate a real touch device, and keep a
+SEPARATE test with the default (no `hasTouch`) context to prove the desktop/fine-pointer case is
+correctly left untouched — one test per side of the gate, not one test assuming both.
+
 ## `env!("CARGO_PKG_VERSION")` is USELESS here for server-version comparison (#574)
 
 `presenter-ui` has its OWN unrelated Cargo.toml `version` (e.g. `0.1.43` — bumped

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.206"
+version = "0.4.207"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-migration/src/lib.rs
+++ b/crates/presenter-migration/src/lib.rs
@@ -20,6 +20,7 @@ mod m20260629_000001_add_stage_active_entry_index;
 mod m20260702_000001_create_slide_stage_layouts;
 mod m20260715_000001_add_presentation_sync_columns;
 mod m20260717_000001_add_resolume_active_port;
+mod m20260725_000001_add_library_sync_columns;
 
 pub struct Migrator;
 
@@ -44,6 +45,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260702_000001_create_slide_stage_layouts::Migration),
             Box::new(m20260715_000001_add_presentation_sync_columns::Migration),
             Box::new(m20260717_000001_add_resolume_active_port::Migration),
+            Box::new(m20260725_000001_add_library_sync_columns::Migration),
         ]
     }
 }

--- a/crates/presenter-migration/src/m20260725_000001_add_library_sync_columns.rs
+++ b/crates/presenter-migration/src/m20260725_000001_add_library_sync_columns.rs
@@ -1,0 +1,265 @@
+//! #578 library sync: adds `updated_at` (LWW clock), `sync_id` (cross-instance
+//! identity, random-UUID backfill — peers converge via the name-match adopt on
+//! first sync), and `deleted_at` (soft-delete tombstone) to `libraries`,
+//! mirroring the #555 presentation sync columns. Without these a
+//! library-cascade delete hard-removed presentations with no tombstone, so the
+//! peer's still-live copy resurrected the whole library+song on the next sync
+//! cycle (a permanent loop). It also replaces the plain `UNIQUE(name)` index
+//! with a PARTIAL unique over LIVE rows only, so a tombstoned library can keep
+//! its name without blocking a same-named live library.
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+async fn column_missing<C: ConnectionTrait>(db: &C, column: &str) -> Result<bool, DbErr> {
+    let sql =
+        format!("SELECT COUNT(*) AS cnt FROM pragma_table_info('libraries') WHERE name='{column}'");
+    let row = db
+        .query_one(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            sql,
+        ))
+        .await?;
+    Ok(row
+        .map(|r| r.try_get::<i32>("", "cnt").unwrap_or(0) == 0)
+        .unwrap_or(true))
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // 1. updated_at — nullable at DB level (SQLite can't ADD NOT NULL
+        //    without a default), backfilled to `now`, and always set by every
+        //    insert/mutation going forward so no NULL row ever exists (the
+        //    entity type is NOT NULL). Same S8 split as the presentation
+        //    migration: the ADD COLUMN is column-gated (idempotent), but the
+        //    backfill UPDATE always runs, keyed on DATA state
+        //    (`updated_at IS NULL`), so a crash between ADD COLUMN and the
+        //    backfill can never strand NULL rows once the column exists.
+        if column_missing(db, "updated_at").await? {
+            db.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "ALTER TABLE libraries ADD COLUMN updated_at TEXT",
+            ))
+            .await?;
+        }
+        let now = chrono::Utc::now().to_rfc3339();
+        db.execute(Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE libraries SET updated_at = ? WHERE updated_at IS NULL",
+            [now.into()],
+        ))
+        .await?;
+
+        // 2. deleted_at — the soft-delete tombstone marker, genuinely
+        //    nullable, no backfill.
+        if column_missing(db, "deleted_at").await? {
+            db.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "ALTER TABLE libraries ADD COLUMN deleted_at TEXT",
+            ))
+            .await?;
+        }
+
+        // 3. sync_id — cross-instance identity. Backfilled with a fresh random
+        //    UUID per library (per the settled design); two independently
+        //    migrated peers get DIFFERENT ids for the same-named library and
+        //    converge on first sync via `apply_sync_library`'s name-match
+        //    adopt. Same S8 data-gated backfill (`sync_id IS NULL`) so a
+        //    rerun after a crash finishes any stranded rows.
+        if column_missing(db, "sync_id").await? {
+            db.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "ALTER TABLE libraries ADD COLUMN sync_id TEXT",
+            ))
+            .await?;
+        }
+        let rows = db
+            .query_all(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT id FROM libraries WHERE sync_id IS NULL",
+            ))
+            .await?;
+        for row in rows {
+            let id: String = row.try_get("", "id")?;
+            db.execute(Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Sqlite,
+                "UPDATE libraries SET sync_id = ? WHERE id = ? AND sync_id IS NULL",
+                [uuid::Uuid::new_v4().to_string().into(), id.into()],
+            ))
+            .await?;
+        }
+
+        // Unique index on sync_id — one row per identity (mirrors
+        // idx_presentations_sync_id). Idempotent.
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_libraries_sync_id ON libraries(sync_id)",
+        ))
+        .await?;
+
+        // Replace the plain UNIQUE(name) index with a PARTIAL unique over LIVE
+        // (deleted_at IS NULL) rows only. A soft-deleted library keeps its
+        // name occupied; a plain UNIQUE would then block re-creating or
+        // adopting a same-named live library. The partial index preserves the
+        // "one LIVE library per name" invariant that `upsert_library` /
+        // `create_library` rely on while allowing any number of tombstones.
+        // Both statements are idempotent (IF EXISTS / IF NOT EXISTS).
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "DROP INDEX IF EXISTS idx_libraries_name_unique",
+        ))
+        .await?;
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_libraries_name_live_unique \
+             ON libraries(name) WHERE deleted_at IS NULL",
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Non-destructive additive migration; SQLite pre-3.35 has no DROP COLUMN. No-op.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{Database, DatabaseConnection};
+    use sea_orm_migration::SchemaManager;
+
+    async fn setup_pre_migration_db() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.expect("connect");
+        for sql in [
+            "CREATE TABLE libraries (id TEXT PRIMARY KEY, name TEXT NOT NULL, \
+             search_name TEXT NOT NULL, created_at TEXT NOT NULL)",
+            "CREATE UNIQUE INDEX idx_libraries_name_unique ON libraries(name)",
+            "INSERT INTO libraries VALUES \
+             ('lib1', 'Songs', 'songs', '2026-01-01T00:00:00+00:00'), \
+             ('lib2', 'Hymns', 'hymns', '2026-01-02T00:00:00+00:00')",
+        ] {
+            db.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                sql,
+            ))
+            .await
+            .expect("seed");
+        }
+        db
+    }
+
+    async fn rows(db: &DatabaseConnection) -> Vec<(String, Option<String>, Option<String>)> {
+        let rows = db
+            .query_all(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT id, updated_at, sync_id FROM libraries ORDER BY id",
+            ))
+            .await
+            .expect("select");
+        rows.into_iter()
+            .map(|r| {
+                (
+                    r.try_get::<String>("", "id").expect("id"),
+                    r.try_get::<Option<String>>("", "updated_at")
+                        .expect("updated_at"),
+                    r.try_get::<Option<String>>("", "sync_id").expect("sync_id"),
+                )
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn backfills_columns_and_is_idempotent() {
+        let db = setup_pre_migration_db().await;
+        let manager = SchemaManager::new(&db);
+
+        Migration.up(&manager).await.expect("first up");
+
+        let after = rows(&db).await;
+        assert_eq!(after.len(), 2);
+        let mut sync_ids = std::collections::HashSet::new();
+        for (id, updated, sync_id) in &after {
+            assert!(updated.is_some(), "{id}: updated_at backfilled");
+            let sid = sync_id.as_ref().expect("sync_id backfilled");
+            assert!(!sid.is_empty(), "{id}: sync_id non-empty");
+            assert!(sync_ids.insert(sid.clone()), "{id}: sync_id unique");
+        }
+
+        // Re-running must change nothing (idempotent ADD COLUMN + data-gated backfill).
+        let before = rows(&db).await;
+        Migration.up(&manager).await.expect("second up");
+        assert_eq!(before, rows(&db).await, "second run changed nothing");
+    }
+
+    #[tokio::test]
+    async fn interrupted_backfill_is_completed_by_a_rerun() {
+        // S8 regression: the backfill must be keyed on DATA state, not on
+        // whether the column already exists — a crash between ADD COLUMN and
+        // the backfill must be finished by a rerun.
+        let db = setup_pre_migration_db().await;
+        let manager = SchemaManager::new(&db);
+        Migration.up(&manager).await.expect("first up");
+
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE libraries SET updated_at = NULL, sync_id = NULL WHERE id = 'lib2'",
+        ))
+        .await
+        .expect("simulate a crash that stranded lib2 mid-backfill");
+
+        Migration.up(&manager).await.expect("second up (resumed)");
+
+        let after = rows(&db).await;
+        let lib2 = after.iter().find(|r| r.0 == "lib2").expect("lib2");
+        assert!(lib2.1.is_some(), "a rerun finishes the updated_at backfill");
+        assert!(
+            lib2.2.as_ref().is_some_and(|s| !s.is_empty()),
+            "a rerun finishes the sync_id backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_name_unique_allows_a_tombstone_beside_a_live_row() {
+        let db = setup_pre_migration_db().await;
+        let manager = SchemaManager::new(&db);
+        Migration.up(&manager).await.expect("up");
+
+        // Tombstone lib1 ("Songs"), then a fresh LIVE "Songs" must be allowed
+        // (the OLD plain UNIQUE(name) would reject this).
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE libraries SET deleted_at = '2026-02-01T00:00:00+00:00' WHERE id = 'lib1'",
+        ))
+        .await
+        .expect("tombstone lib1");
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "INSERT INTO libraries (id, name, search_name, created_at, updated_at, sync_id) VALUES \
+             ('lib3', 'Songs', 'songs', '2026-02-02T00:00:00+00:00', \
+              '2026-02-02T00:00:00+00:00', 'sid-3')",
+        ))
+        .await
+        .expect("a fresh live 'Songs' beside the tombstone must be allowed");
+
+        // But two LIVE rows with the same name must still be rejected.
+        let dup = db
+            .execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "INSERT INTO libraries (id, name, search_name, created_at, updated_at, sync_id) \
+                 VALUES ('lib4', 'Songs', 'songs', '2026-02-03T00:00:00+00:00', \
+                 '2026-02-03T00:00:00+00:00', 'sid-4')",
+            ))
+            .await;
+        assert!(
+            dup.is_err(),
+            "a second LIVE 'Songs' must still violate the partial unique index"
+        );
+    }
+}

--- a/crates/presenter-persistence/src/entities.rs
+++ b/crates/presenter-persistence/src/entities.rs
@@ -10,6 +10,10 @@ pub mod library {
         pub name: String,
         pub search_name: String,
         pub created_at: DateTimeWithTimeZone,
+        // #578 library sync (mirrors the #555 presentation sync columns):
+        pub updated_at: DateTimeWithTimeZone,
+        pub sync_id: String,
+        pub deleted_at: Option<DateTimeWithTimeZone>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/presenter-persistence/src/lib.rs
+++ b/crates/presenter-persistence/src/lib.rs
@@ -28,6 +28,6 @@ mod repository;
 
 pub use audit::{ResolumePushAuditEntry, SettingsAuditEntry, SettingsAuditSource};
 pub use repository::{
-    sync_should_apply, DatabaseSettings, Repository, SyncApplyOutcome, SyncManifestRow,
-    SyncPresentation, TrashedPresentation, PRUNE_HORIZON,
+    sync_should_apply, DatabaseSettings, Repository, SyncApplyOutcome, SyncLibraryManifestRow,
+    SyncManifestRow, SyncPresentation, TrashedPresentation, PRUNE_HORIZON,
 };

--- a/crates/presenter-persistence/src/repository/library.rs
+++ b/crates/presenter-persistence/src/repository/library.rs
@@ -8,8 +8,9 @@ use presenter_core::{
     PresentationSummary,
 };
 use sea_orm::{
-    sea_query::OnConflict, ActiveModelTrait, ColumnTrait, DatabaseTransaction, EntityTrait,
-    IntoActiveModel, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
+    sea_query::{Expr, OnConflict},
+    ColumnTrait, DatabaseTransaction, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait,
 };
 use std::collections::{HashMap, HashSet};
 use tracing::instrument;
@@ -109,6 +110,11 @@ impl Repository {
             name: Set(library.name.clone()),
             search_name: Set(fold_query(&library.name)),
             created_at: Set(Utc::now().into()),
+            // #578: a re-import creates a live library with a fresh sync
+            // identity; it converges with the peer via the name-match adopt.
+            updated_at: Set(Utc::now().into()),
+            sync_id: Set(uuid::Uuid::new_v4().to_string()),
+            deleted_at: Set(None),
         };
         library::Entity::insert(lib_model).exec(&txn).await?;
 
@@ -143,6 +149,11 @@ impl Repository {
             name: Set(name.to_string()),
             search_name: Set(fold_query(name)),
             created_at: Set(Utc::now().into()),
+            // #578: a freshly created library is a live, brand-new sync
+            // identity — it converges with the peer via the name-match adopt.
+            updated_at: Set(Utc::now().into()),
+            sync_id: Set(uuid::Uuid::new_v4().to_string()),
+            deleted_at: Set(None),
         };
 
         library::Entity::insert(model).exec(&txn).await?;
@@ -155,27 +166,92 @@ impl Repository {
     #[instrument(skip_all)]
     pub async fn rename_library(&self, library_id: LibraryId, name: &str) -> anyhow::Result<()> {
         let id = library_id.to_string();
-        let mut model = library::Entity::find_by_id(id.clone())
-            .one(&self.db)
-            .await?
-            .ok_or_else(|| anyhow!("library not found"))?
-            .into_active_model();
-        model.name = Set(name.to_string());
-        model.search_name = Set(fold_query(name));
-        model.update(&self.db).await?;
+        // #578: bump `updated_at` in the SAME statement as the rename so the
+        // change propagates to the peer under LWW (mirrors rename_presentation
+        // — one atomic write, no separate touch that a concurrent sync apply
+        // could interleave with). Only a LIVE library can be renamed.
+        let result = library::Entity::update_many()
+            .col_expr(library::Column::Name, Expr::value(name))
+            .col_expr(library::Column::SearchName, Expr::value(fold_query(name)))
+            .col_expr(
+                library::Column::UpdatedAt,
+                Expr::value(Utc::now().to_rfc3339()),
+            )
+            .filter(library::Column::Id.eq(id))
+            .filter(library::Column::DeletedAt.is_null())
+            .exec(&self.db)
+            .await?;
+        if result.rows_affected == 0 {
+            return Err(anyhow!("library not found"));
+        }
         Ok(())
     }
 
     #[instrument(skip_all)]
     pub async fn delete_library(&self, library_id: LibraryId) -> anyhow::Result<()> {
+        use crate::entities::{playlist_entry, slide_stage_layout};
         let id = library_id.to_string();
-        let result = library::Entity::delete_by_id(id).exec(&self.db).await?;
-        if result.rows_affected == 0 {
+        // #578: SOFT delete. The library row AND all its live presentations are
+        // tombstoned in ONE transaction, so the deletion syncs like any edit
+        // under LWW and never resurrects from the peer's still-live copy. The
+        // library row is NEVER hard-deleted → the FK ON DELETE CASCADE never
+        // fires → the presentation tombstones survive (that survival is what
+        // lets the peer's next cycle see the newer tombstone and converge,
+        // instead of re-creating the song from its own still-live copy).
+        let txn = self.db.begin().await?;
+        let now = Utc::now().to_rfc3339();
+
+        let lib_result = library::Entity::update_many()
+            .col_expr(library::Column::DeletedAt, Expr::value(now.clone()))
+            .col_expr(library::Column::UpdatedAt, Expr::value(now.clone()))
+            .filter(library::Column::Id.eq(id.clone()))
+            .filter(library::Column::DeletedAt.is_null())
+            .exec(&txn)
+            .await?;
+        if lib_result.rows_affected == 0 {
+            // Missing (or already-deleted) library → NotFound; the router maps
+            // this exact message to 404 instead of a 500 (#578).
             return Err(anyhow!("library not found"));
         }
-        // #515: the FK cascade removed the library's slides — sweep their
-        // stage-layout marker rows (no FK on slide_stage_layouts).
-        self.prune_orphan_slide_stage_layouts().await?;
+
+        // The ids of the LIVE presentations we're about to tombstone — needed
+        // to scope the playlist-entry + stage-layout cleanup below (mirrors
+        // delete_presentation's per-song semantics, done set-wise).
+        let live_presentation_ids: Vec<String> = presentation_entity::Entity::find()
+            .select_only()
+            .column(presentation_entity::Column::Id)
+            .filter(presentation_entity::Column::LibraryId.eq(id.clone()))
+            .filter(presentation_entity::Column::DeletedAt.is_null())
+            .into_tuple()
+            .all(&txn)
+            .await?;
+
+        if !live_presentation_ids.is_empty() {
+            presentation_entity::Entity::update_many()
+                .col_expr(
+                    presentation_entity::Column::DeletedAt,
+                    Expr::value(now.clone()),
+                )
+                .col_expr(presentation_entity::Column::UpdatedAt, Expr::value(now))
+                .filter(presentation_entity::Column::LibraryId.eq(id))
+                .filter(presentation_entity::Column::DeletedAt.is_null())
+                .exec(&txn)
+                .await?;
+
+            // A deleted song leaves every playlist (mirrors delete_presentation).
+            playlist_entry::Entity::delete_many()
+                .filter(playlist_entry::Column::PresentationId.is_in(live_presentation_ids.clone()))
+                .exec(&txn)
+                .await?;
+
+            // #515 stage-layout markers go with the (now-hidden) songs.
+            slide_stage_layout::Entity::delete_many()
+                .filter(slide_stage_layout::Column::PresentationId.is_in(live_presentation_ids))
+                .exec(&txn)
+                .await?;
+        }
+
+        txn.commit().await?;
         Ok(())
     }
 
@@ -183,8 +259,10 @@ impl Repository {
     /// Optimized to use 3 queries total instead of 1 + n + (n*m) queries.
     #[instrument(skip_all)]
     pub async fn fetch_libraries(&self) -> anyhow::Result<Vec<Library>> {
-        // Query 1: Fetch all libraries
+        // Query 1: Fetch all LIVE libraries (#578: tombstoned libraries are
+        // hidden from every list/fetch, exactly like trashed presentations).
         let libraries = library::Entity::find()
+            .filter(library::Column::DeletedAt.is_null())
             .order_by_asc(library::Column::Name)
             .all(&self.db)
             .await?;
@@ -315,8 +393,9 @@ impl Repository {
         &self,
         filter: Option<&str>,
     ) -> anyhow::Result<Vec<LibrarySummary>> {
-        // Query 1: Fetch libraries (with optional filter)
-        let mut query = library::Entity::find();
+        // Query 1: Fetch LIVE libraries (with optional filter). #578: a
+        // tombstoned library never appears in a summary listing.
+        let mut query = library::Entity::find().filter(library::Column::DeletedAt.is_null());
         if let Some(filter) = filter {
             let pattern = format!("%{}%", sanitize_like_input(filter));
             query = query.filter(library::Column::Name.like(pattern));

--- a/crates/presenter-persistence/src/repository/library_sync.rs
+++ b/crates/presenter-persistence/src/repository/library_sync.rs
@@ -1,0 +1,184 @@
+//! #578 library sync: the library manifest read + the LWW apply of one peer
+//! library row + the tombstone prune. A library has no "content" to fetch
+//! (just its name), so — unlike a presentation — the manifest row carries
+//! everything the apply needs. Mirrors `apply_sync_presentation`'s
+//! sync_id-match → adopt-by-name → create-or-skip shape under the SAME
+//! `sync_should_apply` LWW gate, so library deletes + renames converge across
+//! the PP<->SNV pair and a deleted library never resurrects.
+use super::sync_apply::{sync_should_apply, SyncApplyOutcome};
+use super::Repository;
+use crate::entities::library;
+use chrono::{DateTime, Utc};
+use presenter_core::search::fold_query;
+use sea_orm::{
+    sea_query::Expr, ColumnTrait, DatabaseTransaction, EntityTrait, QueryFilter, Set,
+    TransactionTrait,
+};
+use tracing::{info, instrument};
+
+/// One library manifest row — identity + name + timestamps, ALL libraries
+/// including tombstoned (mirrors `SyncManifestRow` for presentations, so a
+/// tombstone propagates instead of the library silently vanishing from the
+/// wire).
+#[derive(Debug, Clone)]
+pub struct SyncLibraryManifestRow {
+    pub sync_id: String,
+    pub name: String,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl Repository {
+    #[instrument(skip_all)]
+    pub async fn list_library_sync_manifest(&self) -> anyhow::Result<Vec<SyncLibraryManifestRow>> {
+        let rows = library::Entity::find().all(&self.db).await?;
+        Ok(rows
+            .into_iter()
+            .map(|l| SyncLibraryManifestRow {
+                sync_id: l.sync_id,
+                name: l.name,
+                updated_at: l.updated_at.into(),
+                deleted_at: l.deleted_at.map(Into::into),
+            })
+            .collect())
+    }
+
+    /// Apply one peer library row under LWW (#578). Returns the outcome so the
+    /// caller can count applied rows and evict caches when something changed.
+    #[instrument(skip_all, fields(sync_id = %incoming.sync_id, name = %incoming.name))]
+    pub async fn apply_sync_library(
+        &self,
+        incoming: &SyncLibraryManifestRow,
+    ) -> anyhow::Result<SyncApplyOutcome> {
+        let txn = self.db.begin().await?;
+
+        // 1. Match by sync_id — the authoritative identity, independent of name
+        //    (so a peer rename applies in place, preserving the local id and
+        //    every presentation.library_id FK pointing at it).
+        if let Some(existing) = library::Entity::find()
+            .filter(library::Column::SyncId.eq(incoming.sync_id.clone()))
+            .one(&txn)
+            .await?
+        {
+            let local: DateTime<Utc> = existing.updated_at.into();
+            if !sync_should_apply(
+                incoming.updated_at,
+                incoming.deleted_at.is_some(),
+                Some(local),
+            ) {
+                txn.commit().await?;
+                return Ok(SyncApplyOutcome::SkippedNotNewer);
+            }
+            Self::write_library_row(&txn, &existing.id, incoming).await?;
+            txn.commit().await?;
+            info!("sync library updated");
+            return Ok(SyncApplyOutcome::Updated);
+        }
+
+        // 2. Adopt-by-name: a LIVE local library with an unknown sync_id but the
+        //    same name — two peers that independently created the library (each
+        //    with its own backfilled random sync_id) converge here on first
+        //    sync. ONLY for a LIVE incoming: a peer TOMBSTONE with an unknown
+        //    sync_id must never reach across and trash a live same-named local
+        //    library (mirrors the presentation adopt-by-name Decision B). A
+        //    tombstone falls through to step 3, which creates its own separate
+        //    tombstoned row instead.
+        if incoming.deleted_at.is_none() {
+            if let Some(existing) = Self::find_live_library_by_name(&txn, &incoming.name).await? {
+                let local: DateTime<Utc> = existing.updated_at.into();
+                if !sync_should_apply(incoming.updated_at, false, Some(local)) {
+                    // Local wins; the peer will adopt OUR sync_id when it pulls us.
+                    txn.commit().await?;
+                    return Ok(SyncApplyOutcome::SkippedNotNewer);
+                }
+                Self::write_library_row(&txn, &existing.id, incoming).await?;
+                txn.commit().await?;
+                info!("sync library adopted-by-name");
+                return Ok(SyncApplyOutcome::AdoptedByName);
+            }
+        }
+
+        // 3. Unknown sync_id → create-or-skip, gated on the SAME prune-horizon
+        //    tombstone-age rule as presentations (`sync_should_apply`'s None
+        //    branch): a genuinely-pruned tombstone (older than the horizon) is
+        //    never resurrected as a fresh trashed row; a recent tombstone or
+        //    any live entry is created with the peer's identity + timestamps.
+        if !sync_should_apply(incoming.updated_at, incoming.deleted_at.is_some(), None) {
+            txn.commit().await?;
+            return Ok(SyncApplyOutcome::SkippedNotNewer);
+        }
+        library::Entity::insert(library::ActiveModel {
+            id: Set(uuid::Uuid::new_v4().to_string()),
+            name: Set(incoming.name.clone()),
+            search_name: Set(fold_query(&incoming.name)),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(incoming.updated_at.into()),
+            sync_id: Set(incoming.sync_id.clone()),
+            deleted_at: Set(incoming.deleted_at.map(Into::into)),
+        })
+        .exec(&txn)
+        .await?;
+        txn.commit().await?;
+        info!("sync library created");
+        Ok(SyncApplyOutcome::Created)
+    }
+
+    /// The single LIVE (non-tombstoned) local library with this name, if any —
+    /// the partial name-unique index guarantees at most one, so `.one()` is
+    /// unambiguous here (unlike presentations, which can have same-name twins).
+    async fn find_live_library_by_name(
+        txn: &DatabaseTransaction,
+        name: &str,
+    ) -> anyhow::Result<Option<library::Model>> {
+        Ok(library::Entity::find()
+            .filter(library::Column::Name.eq(name.to_string()))
+            .filter(library::Column::DeletedAt.is_null())
+            .one(txn)
+            .await?)
+    }
+
+    /// Update a local library row IN PLACE (preserving its id — and thus every
+    /// `presentation.library_id` FK pointing at it): name, search_name, sync_id
+    /// (adopt), deleted_at, and the PEER's `updated_at` (never `now()` — an
+    /// applied change is not a new local edit, which is what prevents an
+    /// echo/ping-pong loop).
+    async fn write_library_row(
+        txn: &DatabaseTransaction,
+        local_id: &str,
+        incoming: &SyncLibraryManifestRow,
+    ) -> anyhow::Result<()> {
+        use library::Column;
+        let deleted = incoming
+            .deleted_at
+            .map(|d| Expr::value(d.to_rfc3339()))
+            .unwrap_or_else(|| Expr::value(Option::<String>::None));
+        library::Entity::update_many()
+            .col_expr(Column::Name, Expr::value(incoming.name.clone()))
+            .col_expr(Column::SearchName, Expr::value(fold_query(&incoming.name)))
+            .col_expr(Column::SyncId, Expr::value(incoming.sync_id.clone()))
+            .col_expr(
+                Column::UpdatedAt,
+                Expr::value(incoming.updated_at.to_rfc3339()),
+            )
+            .col_expr(Column::DeletedAt, deleted)
+            .filter(Column::Id.eq(local_id))
+            .exec(txn)
+            .await?;
+        Ok(())
+    }
+
+    /// Hard-delete libraries tombstoned longer than `retain`. The FK
+    /// ON DELETE CASCADE removes any presentations still under them (all
+    /// already tombstoned) + their slides. Returns rows removed. Mirrors
+    /// `prune_deleted_presentations`, driven by the SAME `PRUNE_HORIZON`.
+    #[instrument(skip_all)]
+    pub async fn prune_deleted_libraries(&self, retain: chrono::Duration) -> anyhow::Result<u64> {
+        let cutoff = (Utc::now() - retain).to_rfc3339();
+        let res = library::Entity::delete_many()
+            .filter(library::Column::DeletedAt.is_not_null())
+            .filter(library::Column::DeletedAt.lt(cutoff))
+            .exec(&self.db)
+            .await?;
+        Ok(res.rows_affected)
+    }
+}

--- a/crates/presenter-persistence/src/repository/library_sync_tests.rs
+++ b/crates/presenter-persistence/src/repository/library_sync_tests.rs
@@ -1,0 +1,291 @@
+//! #578 unit tests for the library-sync machinery: `apply_sync_library`'s LWW
+//! (sync_id match → adopt-by-name → create-or-skip), the prune, and
+//! `rename_library`'s updated_at bump.
+use super::Repository;
+use crate::entities::library;
+use crate::{SyncApplyOutcome, SyncLibraryManifestRow};
+use chrono::{Duration, Utc};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+async fn repo() -> Repository {
+    Repository::connect_in_memory()
+        .await
+        .expect("in-memory repo")
+}
+
+/// The stored `(sync_id, updated_at, deleted_at)` for the single LIVE-or-not
+/// library row with this name (fails if there are 0 or 2+).
+async fn library_row_by_name(repo: &Repository, name: &str) -> library::Model {
+    library::Entity::find()
+        .filter(library::Column::Name.eq(name.to_string()))
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .expect("library row exists")
+}
+
+fn incoming(
+    sync_id: &str,
+    name: &str,
+    minutes_from_now: i64,
+    deleted: bool,
+) -> SyncLibraryManifestRow {
+    let ts = Utc::now() + Duration::minutes(minutes_from_now);
+    SyncLibraryManifestRow {
+        sync_id: sync_id.to_string(),
+        name: name.to_string(),
+        updated_at: ts,
+        deleted_at: deleted.then_some(ts),
+    }
+}
+
+#[tokio::test]
+async fn create_from_unknown_live_sync_id() {
+    let repo = repo().await;
+    let outcome = repo
+        .apply_sync_library(&incoming("peer-1", "Songs", 0, false))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::Created);
+    let libs = repo.fetch_libraries().await.unwrap();
+    assert_eq!(libs.len(), 1);
+    assert_eq!(libs[0].name, "Songs");
+    assert_eq!(library_row_by_name(&repo, "Songs").await.sync_id, "peer-1");
+}
+
+#[tokio::test]
+async fn rename_in_place_by_sync_id_preserves_id_and_presentations() {
+    let repo = repo().await;
+    let lib = repo.create_library("Old Name").await.unwrap();
+    repo.create_presentation(lib.id, "Song", None)
+        .await
+        .unwrap();
+    let sid = library_row_by_name(&repo, "Old Name").await.sync_id;
+
+    let outcome = repo
+        .apply_sync_library(&incoming(&sid, "New Name", 1, false))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::Updated);
+
+    let libs = repo.fetch_libraries().await.unwrap();
+    assert_eq!(libs.len(), 1);
+    assert_eq!(libs[0].name, "New Name", "rename applied in place");
+    assert_eq!(libs[0].id, lib.id, "the local id (and its FK) is preserved");
+    assert_eq!(
+        libs[0].presentations.len(),
+        1,
+        "the presentation stays attached across the rename"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_by_sync_id_hides_the_library() {
+    let repo = repo().await;
+    let lib = repo.create_library("Songs").await.unwrap();
+    let sid = library_row_by_name(&repo, "Songs").await.sync_id;
+
+    let outcome = repo
+        .apply_sync_library(&incoming(&sid, "Songs", 1, true))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::Updated);
+    assert!(
+        repo.fetch_libraries().await.unwrap().is_empty(),
+        "the tombstoned library is hidden from the live listing"
+    );
+    // The row survives as a tombstone (still in the sync manifest).
+    let row = library_row_by_name(&repo, "Songs").await;
+    assert_eq!(row.id, lib.id.to_string());
+    assert!(row.deleted_at.is_some());
+}
+
+#[tokio::test]
+async fn adopt_by_name_converges_two_independently_created_libraries() {
+    let repo = repo().await;
+    repo.create_library("Songs").await.unwrap();
+    let local_sid = library_row_by_name(&repo, "Songs").await.sync_id;
+
+    // The peer's "Songs" (a DIFFERENT random sync_id, newer) adopts onto ours.
+    let outcome = repo
+        .apply_sync_library(&incoming("peer-songs", "Songs", 1, false))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::AdoptedByName);
+
+    let row = library_row_by_name(&repo, "Songs").await;
+    assert_eq!(
+        row.sync_id, "peer-songs",
+        "local adopted the peer's sync_id"
+    );
+    assert_ne!(row.sync_id, local_sid);
+    assert_eq!(
+        repo.fetch_libraries().await.unwrap().len(),
+        1,
+        "no duplicate library created — adopted in place"
+    );
+}
+
+#[tokio::test]
+async fn a_peer_tombstone_never_adopts_a_live_same_name_library() {
+    // Decision B: a tombstone with an UNKNOWN sync_id must never reach across
+    // and trash a live same-named local library — two sites can independently
+    // hold different libraries that share a name.
+    let repo = repo().await;
+    let lib = repo.create_library("Songs").await.unwrap();
+    let local_sid = library_row_by_name(&repo, "Songs").await.sync_id;
+
+    let outcome = repo
+        .apply_sync_library(&incoming("peer-other", "Songs", 1, true))
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome,
+        SyncApplyOutcome::Created,
+        "a tombstone with an unknown sync_id creates its OWN separate trashed row"
+    );
+
+    // Our live "Songs" is untouched (still live, still our sync_id).
+    let libs = repo.fetch_libraries().await.unwrap();
+    assert_eq!(libs.len(), 1);
+    assert_eq!(
+        libs[0].id, lib.id,
+        "the live library is not trashed by the peer tombstone"
+    );
+    let rows = library::Entity::find()
+        .filter(library::Column::Name.eq("Songs".to_string()))
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "one live row + one separate tombstone row");
+    let live = rows.iter().find(|r| r.deleted_at.is_none()).unwrap();
+    assert_eq!(live.sync_id, local_sid, "the live row keeps our identity");
+}
+
+#[tokio::test]
+async fn a_recent_unknown_tombstone_is_created_as_trashed() {
+    // A fresh/re-provisioned peer's first sync must materialize a recently
+    // trashed library it never held, so trash contents converge (#558 R2).
+    let repo = repo().await;
+    let outcome = repo
+        .apply_sync_library(&incoming("peer-trash", "Retired", -1, true))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::Created);
+    assert!(
+        repo.fetch_libraries().await.unwrap().is_empty(),
+        "it's created in the trashed state — hidden from the live listing"
+    );
+    assert!(
+        repo.list_library_sync_manifest()
+            .await
+            .unwrap()
+            .iter()
+            .any(|l| l.name == "Retired" && l.deleted_at.is_some()),
+        "the tombstone exists in the manifest so it converges with the peer"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_tombstone_older_than_the_prune_horizon_is_never_resurrected() {
+    let repo = repo().await;
+    let mut old = incoming("peer-gone", "Ancient", 0, true);
+    let ts = Utc::now() - Duration::days(40);
+    old.updated_at = ts;
+    old.deleted_at = Some(ts);
+    let outcome = repo.apply_sync_library(&old).await.unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::SkippedNotNewer);
+    assert!(
+        repo.list_library_sync_manifest().await.unwrap().is_empty(),
+        "an already-pruned tombstone must never be resurrected as a fresh row"
+    );
+}
+
+#[tokio::test]
+async fn skips_when_local_is_newer() {
+    let repo = repo().await;
+    repo.create_library("Songs").await.unwrap();
+    let sid = library_row_by_name(&repo, "Songs").await.sync_id;
+    // A peer edit OLDER than our local row must be skipped.
+    let outcome = repo
+        .apply_sync_library(&incoming(&sid, "Stale", -1, false))
+        .await
+        .unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::SkippedNotNewer);
+    assert_eq!(
+        library_row_by_name(&repo, "Songs").await.name,
+        "Songs",
+        "a stale peer edit did not overwrite the newer local name"
+    );
+}
+
+#[tokio::test]
+async fn rename_library_bumps_updated_at_for_propagation() {
+    let repo = repo().await;
+    let lib = repo.create_library("Before").await.unwrap();
+    let before = library_row_by_name(&repo, "Before").await.updated_at;
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    repo.rename_library(lib.id, "After").await.unwrap();
+    let after = library_row_by_name(&repo, "After").await;
+    assert!(
+        after.updated_at > before,
+        "rename must bump updated_at so the change propagates under LWW"
+    );
+}
+
+#[tokio::test]
+async fn rename_and_delete_missing_library_error() {
+    let repo = repo().await;
+    let missing = presenter_core::LibraryId::new();
+    assert!(repo.rename_library(missing, "x").await.is_err());
+    assert!(
+        repo.delete_library(missing).await.is_err(),
+        "delete of a missing library errors (the router maps it to 404)"
+    );
+}
+
+#[tokio::test]
+async fn prune_removes_only_old_tombstones() {
+    let repo = repo().await;
+    // A live library, plus a recent tombstone (via apply). The old tombstone
+    // is inserted DIRECTLY — `apply_sync_library` refuses to materialize a
+    // tombstone older than the horizon (that's a separate test), so we seed
+    // the genuinely-old trashed row straight into the DB for the prune check.
+    repo.create_library("Live").await.unwrap();
+    use sea_orm::Set;
+    let old_ts = Utc::now() - Duration::days(40);
+    library::Entity::insert(library::ActiveModel {
+        id: Set(uuid::Uuid::new_v4().to_string()),
+        name: Set("OldTrash".into()),
+        search_name: Set("oldtrash".into()),
+        created_at: Set(old_ts.into()),
+        updated_at: Set(old_ts.into()),
+        sync_id: Set("old-trash".into()),
+        deleted_at: Set(Some(old_ts.into())),
+    })
+    .exec(&repo.db)
+    .await
+    .unwrap();
+    repo.apply_sync_library(&incoming("recent", "RecentTrash", 0, true))
+        .await
+        .unwrap();
+
+    let pruned = repo
+        .prune_deleted_libraries(Duration::days(30))
+        .await
+        .unwrap();
+    assert_eq!(pruned, 1, "only the >30d tombstone is pruned");
+    let names: Vec<String> = repo
+        .list_library_sync_manifest()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|l| l.name)
+        .collect();
+    assert!(names.contains(&"Live".to_string()));
+    assert!(names.contains(&"RecentTrash".to_string()));
+    assert!(
+        !names.contains(&"OldTrash".to_string()),
+        "old tombstone pruned"
+    );
+}

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -2,6 +2,9 @@ mod audit;
 mod bible;
 mod group_color;
 mod library;
+mod library_sync;
+#[cfg(test)]
+mod library_sync_tests;
 mod playlist;
 mod presentation;
 #[cfg(test)]
@@ -26,6 +29,7 @@ mod sync_trash_tests;
 mod tests;
 mod util;
 
+pub use library_sync::SyncLibraryManifestRow;
 pub use sync::{SyncManifestRow, SyncPresentation, TrashedPresentation};
 pub use sync_apply::{sync_should_apply, SyncApplyOutcome, PRUNE_HORIZON};
 

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -120,7 +120,18 @@ impl Repository {
                 info!("sync skip (not newer)");
                 return Ok((SyncApplyOutcome::SkippedNotNewer, None));
             }
-            let library_id = Self::ensure_library(&txn, &incoming.library_name).await?;
+            // #578: a TOMBSTONE keeps the presentation under its EXISTING
+            // library — never ensure/create a live library for a row being
+            // trashed. When the peer deleted the whole library, the local
+            // library is being tombstoned in the SAME cycle (library recon
+            // runs first), so `ensure_library`'s live-only lookup would miss
+            // it and create a fresh EMPTY LIVE library shell to hold the
+            // tombstone. Only a LIVE apply (re)attaches to the peer's library.
+            let library_id = if incoming.deleted_at.is_some() {
+                existing.library_id.clone()
+            } else {
+                Self::ensure_library(&txn, &incoming.library_name).await?
+            };
             Self::write_synced_row(&txn, &existing.id, &library_id, incoming).await?;
             txn.commit().await?;
             info!("sync updated");
@@ -175,8 +186,14 @@ impl Repository {
         conn: &C,
         library_name: &str,
     ) -> anyhow::Result<Option<String>> {
+        // #578: only a LIVE (non-tombstoned) library is a valid attachment
+        // target for a synced presentation. If the local same-named library
+        // is soft-deleted, `ensure_library` creates a fresh live one rather
+        // than reviving a tombstone (the partial name-unique index allows a
+        // live row beside the tombstone).
         Ok(library::Entity::find()
             .filter(library::Column::Name.eq(library_name.to_string()))
+            .filter(library::Column::DeletedAt.is_null())
             .one(conn)
             .await?
             .map(|l| l.id))
@@ -291,6 +308,48 @@ impl Repository {
             name: Set(library_name.to_string()),
             search_name: Set(fold_query(library_name)),
             created_at: Set(Utc::now().into()),
+            // #578: a library implicitly created to hold a synced presentation
+            // is live with a fresh sync identity; the library manifest sync
+            // converges that identity with the peer via the name-match adopt.
+            updated_at: Set(Utc::now().into()),
+            sync_id: Set(uuid::Uuid::new_v4().to_string()),
+            deleted_at: Set(None),
+        })
+        .exec(txn)
+        .await?;
+        Ok(id)
+    }
+
+    /// #578: resolve a library id for a brand-new TOMBSTONED presentation
+    /// WITHOUT creating an empty LIVE library shell. Attach to any existing
+    /// same-named library (live preferred, then tombstoned); if none exists,
+    /// create a TOMBSTONED library (its identity converges separately via the
+    /// peer's library manifest). Used only by `apply_unknown_sync_id` for a
+    /// tombstone — a live entry keeps using `ensure_library`.
+    async fn ensure_library_for_tombstone(
+        txn: &sea_orm::DatabaseTransaction,
+        library_name: &str,
+    ) -> anyhow::Result<String> {
+        // order_by DeletedAt ASC → live rows (NULL sorts first in SQLite) win
+        // over a tombstoned same-named row when both exist.
+        if let Some(row) = library::Entity::find()
+            .filter(library::Column::Name.eq(library_name.to_string()))
+            .order_by_asc(library::Column::DeletedAt)
+            .one(txn)
+            .await?
+        {
+            return Ok(row.id);
+        }
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now();
+        library::Entity::insert(library::ActiveModel {
+            id: Set(id.clone()),
+            name: Set(library_name.to_string()),
+            search_name: Set(fold_query(library_name)),
+            created_at: Set(now.into()),
+            updated_at: Set(now.into()),
+            sync_id: Set(uuid::Uuid::new_v4().to_string()),
+            deleted_at: Set(Some(now.into())),
         })
         .exec(txn)
         .await?;
@@ -385,7 +444,16 @@ impl Repository {
             info!("sync skip (unknown tombstone past prune horizon)");
             return Ok((SyncApplyOutcome::SkippedNotNewer, None));
         }
-        let library_id = Self::ensure_library(txn, &incoming.library_name).await?;
+        // #578: a brand-new TOMBSTONE (a fresh peer's recently-trashed song we
+        // never held) must NOT spin up a fresh EMPTY LIVE library shell —
+        // attach it to any existing same-named library (live or tombstoned),
+        // or, if none exists, a TOMBSTONED library. A LIVE entry ensures a
+        // live library as before.
+        let library_id = if incoming.deleted_at.is_some() {
+            Self::ensure_library_for_tombstone(txn, &incoming.library_name).await?
+        } else {
+            Self::ensure_library(txn, &incoming.library_name).await?
+        };
         let new_id = uuid::Uuid::new_v4().to_string();
         presentation_entity::Entity::insert(presentation_entity::ActiveModel {
             id: Set(new_id.clone()),

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -646,7 +646,14 @@ async fn rename_library_updates_name() {
 }
 
 #[tokio::test]
-async fn delete_library_removes_presentations_and_slides() {
+async fn delete_library_soft_deletes_library_and_its_presentations() {
+    // #578: `delete_library` used to HARD-delete the library and cascade its
+    // presentations + slides away with no sync tombstone — the peer's
+    // still-live copy then resurrected them on the next sync cycle. It now
+    // SOFT-deletes: the library row AND each live presentation are tombstoned
+    // (never hard-removed), so the deletion propagates under LWW and the
+    // tombstones survive in the sync manifests. This test was rewritten from
+    // the old hard-delete assertions to lock the new soft-delete semantics.
     let repo = Repository::connect_in_memory().await.unwrap();
     let library = sample_library();
     let presentation = library.presentations[0].clone();
@@ -654,14 +661,61 @@ async fn delete_library_removes_presentations_and_slides() {
 
     repo.delete_library(library.id).await.unwrap();
 
-    let libraries = repo.fetch_libraries().await.unwrap();
-    assert!(libraries.is_empty());
+    // Hidden from every LIVE listing…
+    assert!(
+        repo.fetch_libraries().await.unwrap().is_empty(),
+        "the tombstoned library is hidden from the live listing"
+    );
+    assert!(
+        repo.fetch_presentation_detail(presentation.id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the tombstoned presentation is hidden from detail fetches"
+    );
 
-    let detail = repo
-        .fetch_presentation_detail(presentation.id)
+    // …but the library row SURVIVES as a tombstone (not hard-deleted).
+    let lib_row = repo
+        .list_library_sync_manifest()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.name == "Default")
+        .expect("the library row survives as a tombstone in the manifest");
+    assert!(
+        lib_row.deleted_at.is_some(),
+        "the library row is tombstoned, not hard-deleted"
+    );
+
+    // …and each presentation SURVIVES as a tombstone in the sync manifest —
+    // that survival is exactly what lets the peer converge on the deletion
+    // instead of resurrecting the song from its own still-live copy.
+    let pres_row = repo
+        .list_sync_manifest()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|p| p.name == presentation.name)
+        .expect("the presentation survives as a tombstone in the sync manifest");
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "the presentation is tombstoned, not hard-deleted"
+    );
+
+    // Slides are preserved behind the tombstone (not cascaded away), so the
+    // content stays restorable.
+    use crate::entities::slide as slide_entity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    let surviving_slides = slide_entity::Entity::find()
+        .filter(slide_entity::Column::PresentationId.eq(presentation.id.to_string()))
+        .all(&repo.db)
         .await
         .unwrap();
-    assert!(detail.is_none());
+    assert_eq!(
+        surviving_slides.len(),
+        2,
+        "the presentation's slides survive the soft delete"
+    );
 }
 
 #[tokio::test]

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -288,6 +288,13 @@ pub fn build_router(state: AppState) -> Router {
         // registered before the dynamic /presentations/{id} route so matchit
         // does not swallow it (same lesson as /integrations/video-sources/status).
         .route("/sync/manifest", get(sync::get_sync_manifest))
+        // #578: library identities (rename + tombstone) — a separate manifest
+        // (a library has no content to fetch). An OLD peer without this route
+        // 404s; the pulling side degrades gracefully (skips library recon).
+        .route(
+            "/sync/libraries/manifest",
+            get(sync::get_sync_library_manifest),
+        )
         .route(
             "/sync/presentations/{sync_id}",
             get(sync::get_sync_presentation),

--- a/crates/presenter-server/src/router/sync.rs
+++ b/crates/presenter-server/src/router/sync.rs
@@ -9,7 +9,8 @@ use tracing::instrument;
 
 use super::AppError;
 use crate::state::sync::{
-    SyncManifestEntryDto, SyncPresentationDto, SyncStatus, TrashedPresentationDto,
+    SyncLibraryManifestEntryDto, SyncManifestEntryDto, SyncPresentationDto, SyncStatus,
+    TrashedPresentationDto,
 };
 use crate::state::AppState;
 use presenter_core::PresentationId;
@@ -24,6 +25,23 @@ pub(super) async fn get_sync_manifest(
             .map(|r| SyncManifestEntryDto {
                 sync_id: r.sync_id,
                 library_name: r.library_name,
+                name: r.name,
+                updated_at: r.updated_at,
+                deleted_at: r.deleted_at,
+            })
+            .collect(),
+    ))
+}
+
+#[instrument(skip_all)]
+pub(super) async fn get_sync_library_manifest(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<SyncLibraryManifestEntryDto>>, AppError> {
+    let rows = state.repository().list_library_sync_manifest().await?;
+    Ok(Json(
+        rows.into_iter()
+            .map(|r| SyncLibraryManifestEntryDto {
+                sync_id: r.sync_id,
                 name: r.name,
                 updated_at: r.updated_at,
                 deleted_at: r.deleted_at,

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -271,6 +271,56 @@ impl AppState {
         });
     }
 
+    /// Periodically hard-delete trash older than PRUNE_HORIZON — songs
+    /// (#555) then, on the SAME horizon, soft-deleted libraries (#578). Low
+    /// frequency (every 6h); months of use must not grow the tables unbounded.
+    /// #558 round-3 T8: PRUNE_HORIZON is the SAME constant `sync_apply.rs` uses
+    /// to distinguish a fresh unknown tombstone from an already-pruned one —
+    /// one shared source so the two can never drift apart. Extracted from
+    /// `spawn_background_tasks` to keep that fn under the 120-line gate (#578).
+    fn spawn_trash_prune_task(&self) {
+        let prune_state = self.clone();
+        tokio::spawn(async move {
+            let mut ticker = interval(TokioDuration::from_secs(6 * 3600));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                match prune_state
+                    .repository
+                    .prune_deleted_presentations(PRUNE_HORIZON)
+                    .await
+                {
+                    // #558 round-4 U7: log the horizon's actual VALUE (days),
+                    // not the Rust constant's name — a log reader can't look it up.
+                    Ok(n) if n > 0 => tracing::info!(
+                        pruned = n,
+                        horizon_days = PRUNE_HORIZON.num_days(),
+                        "pruned trashed songs older than the prune horizon"
+                    ),
+                    Ok(_) => {}
+                    Err(err) => warn!(?err, "trash prune failed"),
+                }
+                // #578: soft-deleted LIBRARIES age out on the SAME horizon.
+                // Runs AFTER the presentation prune so a still-live song in a
+                // to-be-pruned library is already tombstoned; the library
+                // hard-delete's FK cascade then clears whatever remains.
+                match prune_state
+                    .repository
+                    .prune_deleted_libraries(PRUNE_HORIZON)
+                    .await
+                {
+                    Ok(n) if n > 0 => tracing::info!(
+                        pruned = n,
+                        horizon_days = PRUNE_HORIZON.num_days(),
+                        "pruned trashed libraries older than the prune horizon"
+                    ),
+                    Ok(_) => {}
+                    Err(err) => warn!(?err, "library trash prune failed"),
+                }
+            }
+        });
+    }
+
     fn spawn_background_tasks(&self) {
         let timers_state = self.clone();
         tokio::spawn(async move {
@@ -299,55 +349,7 @@ impl AppState {
             }
         });
 
-        // #555: songs trashed longer than PRUNE_HORIZON are pruned for good.
-        // Low frequency — months of use must not grow the table unbounded.
-        // #558 round-3 T8: PRUNE_HORIZON is the SAME constant `sync_apply.rs`
-        // uses to distinguish a fresh unknown tombstone from an
-        // already-pruned one — one shared source so the two can never
-        // drift apart.
-        let prune_state = self.clone();
-        tokio::spawn(async move {
-            let mut ticker = interval(TokioDuration::from_secs(6 * 3600));
-            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-            loop {
-                ticker.tick().await;
-                match prune_state
-                    .repository
-                    .prune_deleted_presentations(PRUNE_HORIZON)
-                    .await
-                {
-                    Ok(n) if n > 0 => {
-                        // #558 round-4 U7: log the horizon's actual VALUE
-                        // (days), not the Rust constant's name — a log
-                        // reader has no way to look up `PRUNE_HORIZON`.
-                        tracing::info!(
-                            pruned = n,
-                            horizon_days = PRUNE_HORIZON.num_days(),
-                            "pruned trashed songs older than the prune horizon"
-                        );
-                    }
-                    Ok(_) => {}
-                    Err(err) => warn!(?err, "trash prune failed"),
-                }
-                // #578: soft-deleted LIBRARIES age out on the SAME horizon.
-                // Runs AFTER the presentation prune so a still-live song in a
-                // to-be-pruned library is already tombstoned; the library
-                // hard-delete's FK cascade then clears whatever remains.
-                match prune_state
-                    .repository
-                    .prune_deleted_libraries(PRUNE_HORIZON)
-                    .await
-                {
-                    Ok(n) if n > 0 => tracing::info!(
-                        pruned = n,
-                        horizon_days = PRUNE_HORIZON.num_days(),
-                        "pruned trashed libraries older than the prune horizon"
-                    ),
-                    Ok(_) => {}
-                    Err(err) => warn!(?err, "library trash prune failed"),
-                }
-            }
-        });
+        self.spawn_trash_prune_task();
 
         // NDI auto-reconnect: if a source is marked active in DB but no stream
         // is running, retry activation every 30 seconds. Handles the case where

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -329,6 +329,23 @@ impl AppState {
                     Ok(_) => {}
                     Err(err) => warn!(?err, "trash prune failed"),
                 }
+                // #578: soft-deleted LIBRARIES age out on the SAME horizon.
+                // Runs AFTER the presentation prune so a still-live song in a
+                // to-be-pruned library is already tombstoned; the library
+                // hard-delete's FK cascade then clears whatever remains.
+                match prune_state
+                    .repository
+                    .prune_deleted_libraries(PRUNE_HORIZON)
+                    .await
+                {
+                    Ok(n) if n > 0 => tracing::info!(
+                        pruned = n,
+                        horizon_days = PRUNE_HORIZON.num_days(),
+                        "pruned trashed libraries older than the prune horizon"
+                    ),
+                    Ok(_) => {}
+                    Err(err) => warn!(?err, "library trash prune failed"),
+                }
             }
         });
 

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -34,17 +34,22 @@ impl AppState {
 
     pub async fn rename_library(&self, library_id: LibraryId, name: &str) -> anyhow::Result<()> {
         self.repository.rename_library(library_id, name).await?;
-        // #575: a rename can change whether this library matches the
-        // AbleSet-tracked library name.
-        self.invalidate_ableset_cache().await;
+        // #578: a library rename is a local edit that must propagate to the
+        // peer under LWW → nudge the sync loop. nudge_sync ALSO invalidates the
+        // resolved AbleSet cache (#575: a rename can change whether this
+        // library matches the AbleSet-tracked name), so no separate call.
+        self.nudge_sync().await;
         Ok(())
     }
 
     pub async fn delete_library(&self, library_id: LibraryId) -> anyhow::Result<()> {
         self.repository.delete_library(library_id).await?;
-        // #575: deleting a library cascades its presentations away — any
-        // resolved AbleSet entries pointing at them must not survive.
-        self.invalidate_ableset_cache().await;
+        // #578: a library delete now soft-deletes (tombstones) the library +
+        // its songs so the deletion propagates to the peer instead of
+        // resurrecting → nudge the sync loop. nudge_sync also invalidates the
+        // resolved AbleSet cache (#575: the now-hidden songs must not survive
+        // as resolved entries).
+        self.nudge_sync().await;
         Ok(())
     }
 

--- a/crates/presenter-server/src/state/sync.rs
+++ b/crates/presenter-server/src/state/sync.rs
@@ -51,6 +51,30 @@ impl From<SyncPresentationDto> for SyncPresentation {
     }
 }
 
+/// #578 library-sync wire DTO — a library has no content to fetch, so the
+/// manifest row carries everything the apply needs. camelCase, and (like the
+/// other sync DTOs) NO `deny_unknown_fields`, so a future additive field never
+/// 422s an older peer mid-rollout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncLibraryManifestEntryDto {
+    pub sync_id: String,
+    pub name: String,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl From<SyncLibraryManifestEntryDto> for presenter_persistence::SyncLibraryManifestRow {
+    fn from(d: SyncLibraryManifestEntryDto) -> Self {
+        presenter_persistence::SyncLibraryManifestRow {
+            sync_id: d.sync_id,
+            name: d.name,
+            updated_at: d.updated_at,
+            deleted_at: d.deleted_at,
+        }
+    }
+}
+
 /// Trash row for the settings UI.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -532,6 +556,14 @@ pub(crate) async fn run_sync_cycle_with_clients(
 ) -> anyhow::Result<(usize, usize, usize)> {
     let repo = state.repository();
 
+    // #578: reconcile library identities (rename + tombstone propagation)
+    // FIRST — before presentations — so a synced presentation attaches by name
+    // to a library whose name/tombstone state already matches the peer.
+    // Best-effort and isolated (see `reconcile_libraries`): degrading here
+    // never blocks the presentation tombstones that actually fix the
+    // resurrection loop.
+    let libraries_applied = reconcile_libraries(state, manifest_client, peer_url).await;
+
     // Index our local identities → updated_at for the LWW gate.
     let local = repo.list_sync_manifest().await?;
     let mut local_map = std::collections::HashMap::new();
@@ -574,11 +606,71 @@ pub(crate) async fn run_sync_cycle_with_clients(
         )
         .await?;
     }
-    if applied > 0 {
-        // Synced-in changes must be visible to this instance's own UI/caches.
+    if applied > 0 || libraries_applied > 0 {
+        // Synced-in changes — songs OR library renames/tombstones (#578) —
+        // must be visible to this instance's own UI/caches, incl. the AbleSet
+        // resolved-name cache (#575) that `drop_presentation_caches` clears.
         state.drop_presentation_caches().await;
     }
     Ok((pulled, applied, errors))
+}
+
+/// #578: reconcile the peer's library identities (rename + tombstone
+/// propagation) under LWW. Best-effort and fully ISOLATED — a missing endpoint
+/// (an OLD peer during rollout skew answers 404), a decode failure, or any
+/// single-library apply error is logged and skipped, NEVER aborting the whole
+/// cycle. This is safe because the presentation-level tombstones (from
+/// `delete_library` soft-deleting each song) already fix the resurrection loop
+/// through the EXISTING presentation manifest with zero library-sync support;
+/// library sync only adds library-row rename + tombstone convergence on top.
+/// Returns the number of libraries actually written.
+async fn reconcile_libraries(state: &AppState, client: &reqwest::Client, peer_url: &str) -> usize {
+    let resp = match client
+        .get(format!("{peer_url}/sync/libraries/manifest"))
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(err) => {
+            warn!(
+                ?err,
+                "sync: library manifest fetch failed — skipping library reconciliation"
+            );
+            return 0;
+        }
+    };
+    if !resp.status().is_success() {
+        // An OLD peer (rollout skew) has no such endpoint → 404. Not an error.
+        info!(
+            status = %resp.status(),
+            "sync: peer has no library manifest (older peer?) — skipping library reconciliation"
+        );
+        return 0;
+    }
+    let manifest: Vec<SyncLibraryManifestEntryDto> = match resp.json().await {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            warn!(
+                ?err,
+                "sync: library manifest decode failed — skipping library reconciliation"
+            );
+            return 0;
+        }
+    };
+    let repo = state.repository();
+    let mut applied = 0usize;
+    for entry in manifest {
+        let incoming: presenter_persistence::SyncLibraryManifestRow = entry.into();
+        match repo.apply_sync_library(&incoming).await {
+            Ok(outcome) if outcome.wrote() => applied += 1,
+            Ok(_) => {}
+            Err(err) => warn!(
+                ?err,
+                "sync: single-library apply failed — continuing with the next library"
+            ),
+        }
+    }
+    applied
 }
 
 /// Process ONE manifest entry within `run_sync_cycle_with_clients`'s loop —

--- a/crates/presenter-server/src/state/sync_integration_tests.rs
+++ b/crates/presenter-server/src/state/sync_integration_tests.rs
@@ -847,3 +847,55 @@ async fn sync_apply_invalidates_the_ableset_cache_on_the_pulling_side() {
         "resolved id must be the newly synced-in presentation"
     );
 }
+
+#[tokio::test]
+async fn deleting_a_library_does_not_resurrect_via_sync() {
+    // #578 RED: `delete_library` used to HARD-delete the library row and
+    // cascade its presentations away with NO sync tombstone. The peer still
+    // held a LIVE copy, so the very next reverse sync cycle saw a sync_id the
+    // deleting side no longer held (`sync_should_apply`'s `local: None`
+    // branch) and RE-CREATED the whole library + song — a permanent
+    // resurrection loop (delete again, resurrect again, forever). The fix
+    // SOFT-deletes (tombstones) both the library and its presentations so the
+    // deletion propagates under LWW and never resurrects. Before the fix this
+    // fails at the "not resurrected" assert: A's pull of B's still-live copy
+    // recreates the song.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+    let b_url = serve(b.clone()).await;
+    let (lib_id, _pres_id) = make_song(&a, "Songs", "Amazing Grace").await;
+
+    // B pulls A → B holds a LIVE copy of the song (stored with A's timestamp,
+    // no echo).
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert!(
+        find_song(&b.libraries().await.unwrap(), "Amazing Grace").is_some(),
+        "B must import the song created on A"
+    );
+
+    // Delete the whole library on A (a strictly-later timestamp than B's copy).
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    a.delete_library(lib_id).await.unwrap();
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "Amazing Grace").is_none(),
+        "the song is gone on A right after the library delete"
+    );
+
+    // A pulls B's still-live copy back. TODAY this resurrects the library +
+    // song on A (RED). After the fix, A holds a strictly-NEWER tombstone for
+    // that sync_id, so LWW skips it.
+    run_sync_cycle(&a, &b_url, &client()).await.unwrap();
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "Amazing Grace").is_none(),
+        "a library deleted on A must NOT be resurrected from B's still-live copy"
+    );
+
+    // And the deletion must PROPAGATE to B: B pulls A's presentation tombstone
+    // and hides the song too.
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert!(
+        find_song(&b.libraries().await.unwrap(), "Amazing Grace").is_none(),
+        "the library deletion must propagate to B via the presentation tombstone"
+    );
+}

--- a/crates/presenter-server/src/state/sync_integration_tests.rs
+++ b/crates/presenter-server/src/state/sync_integration_tests.rs
@@ -899,3 +899,76 @@ async fn deleting_a_library_does_not_resurrect_via_sync() {
         "the library deletion must propagate to B via the presentation tombstone"
     );
 }
+
+#[tokio::test]
+async fn library_rename_propagates_across_sync() {
+    // #578: a library rename bumps updated_at and propagates under LWW. Library
+    // identity converges on the FIRST sync (reconcile_libraries creates B's
+    // library carrying A's sync_id, before the presentation's ensure_library),
+    // so a later rename matches by sync_id and applies IN PLACE — no duplicate
+    // library, the song stays attached.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+    let (lib_id, _id) = make_song(&a, "Songs", "S").await;
+
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert!(
+        b.libraries()
+            .await
+            .unwrap()
+            .iter()
+            .any(|l| l.name == "Songs"),
+        "B holds the library after the first sync"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    a.rename_library(lib_id, "Gospel").await.unwrap();
+
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    let libs = b.libraries().await.unwrap();
+    assert_eq!(
+        libs.iter().filter(|l| l.name == "Gospel").count(),
+        1,
+        "the rename applied in place — exactly one 'Gospel', no duplicate"
+    );
+    assert!(
+        !libs.iter().any(|l| l.name == "Songs"),
+        "the old library name is gone on B"
+    );
+    assert!(
+        find_song(&libs, "S").is_some(),
+        "the song stayed attached across the library rename"
+    );
+}
+
+#[tokio::test]
+async fn library_delete_propagates_the_library_tombstone_to_the_peer() {
+    // #578: deleting a library on A hides the library ROW on B too (the library
+    // tombstone converges via /sync/libraries/manifest), not just the song.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+    let (lib_id, _id) = make_song(&a, "Songs", "S").await;
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert!(b
+        .libraries()
+        .await
+        .unwrap()
+        .iter()
+        .any(|l| l.name == "Songs"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    a.delete_library(lib_id).await.unwrap();
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+
+    let libs = b.libraries().await.unwrap();
+    assert!(
+        !libs.iter().any(|l| l.name == "Songs"),
+        "the deleted library's row is hidden on the peer (library tombstone propagated)"
+    );
+    assert!(
+        find_song(&libs, "S").is_none(),
+        "and its song is hidden on the peer too"
+    );
+}

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -417,3 +417,42 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
   v0.4.205. Post-release bump to 0.4.206 (`e9832cc3`) needed a `git merge origin/main` first (dev was
   1 commit behind main's own merge commit — Branch Sync Check failure, fixed by syncing before the
   second push, `2cb00531`). Playbook doc-only follow-up `d1898a3d` (deploy + ui skills).
+
+## 2026-07-25 — #568 (stage NDI play-arrow overlay) + #569 (tablet orientation lock) (PR #579, v0.4.206)
+
+- **#568** native play-arrow overlay on stage NDI video. Two root causes: (a) the June #476 CSS
+  suppression (`::-webkit-media-controls*`) only targeted `.stage-ndi__video` (ndi-fullscreen layout)
+  — `.stage-timer__ndi`/`.stage-api__ndi` had none; (b) nothing re-initiated playback once the
+  `<video>` ended up paused. RED `c0690e3d` (new `stage-ndi-playback-guard.spec.ts`, verified by
+  literally `git stash`-ing the fix + rebuilding: 5/6 assertions failed) → GREEN `8e30b1a3`: CSS
+  generalized to `[data-role="ndi-video"]` (covers all 3 layouts); new
+  `ndi_playback_guard.rs` installs a bounded pause/ended/suspend/visibilitychange `.play()` replay
+  guard (max 5 attempts/30s, then defers to the existing frame-based Watchdog) once per `<NdiVideo>`
+  mount.
+- **#569** tablet UI (`/ui/tablet`) rotated with phone position despite the phone's OS rotate-lock.
+  Validator rescope: a PWA scaffold already existed (2026-03) but `manifest.json` had
+  `"orientation":"any"`. RED `0fe26fde` (new `tablet-orientation-lock.spec.ts`) → GREEN `b9ab00de`:
+  manifest → `"landscape"`; new `tablet_orientation.rs` first-tap fullscreen +
+  `screen.orientation.lock("landscape")` gesture (plain-tab flow); CSS
+  `@media (orientation:portrait)` counter-rotation fallback in `tablet.css` (algebraically derived
+  transform, verified via viewport emulation — no real phone reachable from this dev box).
+- **Deep-review fixup** `c4559e61` (dispatched `general-purpose` reviewer, `requesting-code-review`
+  skill): scoped BOTH the CSS fallback and the JS gesture to `(pointer: coarse)` (a narrow desktop
+  browser window must never get force-rotated/fullscreen-prompted — new touch-emulated
+  (`hasTouch: true`) + desktop-fine-pointer E2E tests prove both sides); added a `@video-codec`-tagged
+  test (real Chrome, `--autoplay-policy=user-gesture-required`) proving the replay guard survives
+  REAL autoplay enforcement, not just Playwright's relaxed default; extracted a shared
+  `play_and_log()` helper (removed ~10 duplicated lines between `attach_ontrack` and the new guard);
+  corrected "rolling window" → "fixed window that resets" in comments (implementation detail, not a
+  behavior change); commented on #569 documenting the intentional install-nudge-UX deferral (a
+  validator rescope item not required by any acceptance criterion).
+- One bundled PR (dev→main #579, Closes #568 #569), merged `69204948`. Main Deploy green → SNV
+  verified v0.4.206 live (Playwright: CSS suppression rule matches on all 3 layouts, pause→replay
+  recovery proven with a `canvas.captureStream()` synthetic stream, manifest `orientation:landscape`
+  served, version label v0.4.206 in DOM, 0 console errors — the real "cg" production source was
+  restored immediately after each throwaway-source check). GitHub Release v0.4.206 → `release.yml`
+  deploy-pp succeeded (no #469 recurrence) → PP verified v0.4.206. Post-release bump to 0.4.207
+  (`68400feb`).
+- **UNVERIFIED** (both issues): real stagebox TV / real phone confirmation — no physical device
+  reachable from this dev box. Playwright-verified on the live prod DOM instead; flagged for the
+  user's next in-person look.


### PR DESCRIPTION
## Library delete no longer resurrects across PP↔SNV sync (#578)

`delete_library` hard-deleted the library row and cascaded its presentations
away with **no sync tombstone**, so the peer instance's still-live copy
re-created the whole library+song on the next sync cycle — a permanent
resurrection loop (delete again → resurrect again, forever).

### Fix (settled design "shape 2")
- **Migration `m20260725_000001_add_library_sync_columns`**: libraries gain
  `sync_id` / `updated_at` / `deleted_at` (mirrors the #555 presentation sync
  columns; idempotent, data-gated backfill). Replaces the plain `UNIQUE(name)`
  index with a **partial** `UNIQUE(name) WHERE deleted_at IS NULL` (so a
  tombstoned library keeps its name without blocking a live same-named one) +
  a unique `sync_id` index.
- **`delete_library` is now a SOFT delete**: one transaction tombstones the
  library row **and** every live presentation under it (playlist-entry +
  stage-layout cleanup), never hard-deletes → the FK cascade never fires → the
  presentation tombstones survive → the peer converges on the deletion instead
  of resurrecting. Missing library → 404 (was 500).
- **Library rename + tombstone propagate** via a new
  `GET /sync/libraries/manifest` + `apply_sync_library` (LWW: sync_id-match →
  live name-match adopt → create-or-skip on the shared `PRUNE_HORIZON`),
  reconciled **before** presentations each cycle and **404-tolerant** for
  rollout skew (an older peer without the endpoint degrades gracefully; the
  presentation tombstones fix the resurrection with zero library-sync support).
- A presentation **tombstone keeps its existing `library_id`** (no empty
  live-library shell on the receiving side). Soft-deleted libraries age out on
  the same 30-day prune tick. Library queries filter `deleted_at IS NULL`.

### Tests (RED → GREEN)
- RED: `deleting_a_library_does_not_resurrect_via_sync` (failed on old code at
  the "must NOT be resurrected" assert).
- GREEN + new: `library_rename_propagates_across_sync`,
  `library_delete_propagates_the_library_tombstone_to_the_peer`, the
  `library_sync_tests` unit suite (LWW / adopt / tombstone-horizon / prune /
  404), the migration tests, and the rewritten `delete_library` semantics test.
- Local: cargo fmt/clippy clean, `quality-check.sh --strict` green,
  persistence 116 + migration 17 + server 487 tests pass, Playwright
  song-trash/presentations/wasm-modals 11 pass. Dev deploy verified: v0.4.207,
  `/sync/libraries/manifest` live with backfilled sync_ids.

Follow-up filed: #580 (a rare concurrent library-delete-vs-song-create race —
not the fixed loop).

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
