### PR TITLE
Release v0.4.208: #578 review gaps (search tombstone filter, 404, favorites cleanup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.207"
+version = "0.4.208"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/library.rs
+++ b/crates/presenter-persistence/src/repository/library.rs
@@ -233,7 +233,7 @@ impl Repository {
                     Expr::value(now.clone()),
                 )
                 .col_expr(presentation_entity::Column::UpdatedAt, Expr::value(now))
-                .filter(presentation_entity::Column::LibraryId.eq(id))
+                .filter(presentation_entity::Column::LibraryId.eq(id.clone()))
                 .filter(presentation_entity::Column::DeletedAt.is_null())
                 .exec(&txn)
                 .await?;
@@ -250,6 +250,17 @@ impl Repository {
                 .exec(&txn)
                 .await?;
         }
+
+        // #578 review gap: a soft-deleted library's favorite row was left
+        // dangling — the library is hidden from every list/fetch, but its
+        // `library_favorites` row (and thus its favorite status) survived,
+        // so a NEW library that later reused the same id (extremely
+        // unlikely but not impossible) — or a stale client still holding
+        // the id — could see a phantom favorite. Delete it in the same
+        // transaction as the tombstone, same as the cascade cleanups above.
+        library_favorite::Entity::delete_by_id(id)
+            .exec(&txn)
+            .await?;
 
         txn.commit().await?;
         Ok(())

--- a/crates/presenter-persistence/src/repository/search.rs
+++ b/crates/presenter-persistence/src/repository/search.rs
@@ -91,6 +91,9 @@ impl Repository {
 
         let library_models = library::Entity::find()
             .filter(library_condition)
+            // #578 review gap: a tombstoned library must never surface in
+            // search, exactly like a trashed presentation/slide.
+            .filter(library::Column::DeletedAt.is_null())
             .order_by_asc(library::Column::Name)
             .limit(ctx.remaining() as u64)
             .all(&self.db)

--- a/crates/presenter-persistence/src/repository/search_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/search_trash_tests.rs
@@ -54,3 +54,40 @@ async fn trashed_song_lyrics_are_not_searchable() {
         "a trashed song's lyrics must never surface in search results, got: {after:?}"
     );
 }
+
+#[tokio::test]
+async fn trashed_library_is_not_searchable_by_name() {
+    // #578 review gap: `delete_library` now soft-deletes the library row
+    // itself (tombstone, not hard-delete) so the deletion syncs correctly —
+    // but `search_libraries` never gained a `deleted_at IS NULL` filter, so
+    // a tombstoned library still matched by NAME and surfaced as a
+    // Library-kind search result even though it is hidden from
+    // `fetch_libraries` / `list_library_summaries`.
+    let repo = repo().await;
+    let library = Library::new("VeryUniqueLibraryName", Vec::new()).unwrap();
+    let library_id = library.id;
+    repo.upsert_library(&library).await.unwrap();
+
+    // Sanity: searchable while live.
+    let before = repo
+        .search_presenter("VeryUniqueLibraryName", 10)
+        .await
+        .unwrap();
+    assert!(
+        before
+            .iter()
+            .any(|r| matches!(r.kind, SearchResultKind::Library)),
+        "the live library must be searchable by name"
+    );
+
+    repo.delete_library(library_id).await.unwrap();
+
+    let after = repo
+        .search_presenter("VeryUniqueLibraryName", 10)
+        .await
+        .unwrap();
+    assert!(
+        after.is_empty(),
+        "a tombstoned library must never surface in search results, got: {after:?}"
+    );
+}

--- a/crates/presenter-persistence/src/repository/tests.rs
+++ b/crates/presenter-persistence/src/repository/tests.rs
@@ -719,6 +719,47 @@ async fn delete_library_soft_deletes_library_and_its_presentations() {
 }
 
 #[tokio::test]
+async fn delete_library_removes_its_favorite_row() {
+    // #578 review gap: soft-deleting a library left its `library_favorites`
+    // row dangling — the library disappears from every list/fetch, but the
+    // favorite marker itself was never cleaned up.
+    let repo = Repository::connect_in_memory().await.unwrap();
+    let library = sample_library();
+    repo.upsert_library(&library).await.unwrap();
+    repo.set_library_favorite(library.id, true).await.unwrap();
+
+    assert!(
+        repo.list_library_favorites()
+            .await
+            .unwrap()
+            .contains(&library.id),
+        "sanity: the library is favorited before delete"
+    );
+
+    repo.delete_library(library.id).await.unwrap();
+
+    assert!(
+        !repo
+            .list_library_favorites()
+            .await
+            .unwrap()
+            .contains(&library.id),
+        "a deleted library must not remain in the favorites list"
+    );
+
+    use crate::entities::library_favorite;
+    use sea_orm::EntityTrait;
+    assert!(
+        library_favorite::Entity::find_by_id(library.id.to_string())
+            .one(&repo.db)
+            .await
+            .unwrap()
+            .is_none(),
+        "the favorite row itself must be deleted, not just filtered out"
+    );
+}
+
+#[tokio::test]
 async fn replace_presentation_slides_overwrites_rows() {
     let repo = Repository::connect_in_memory().await.unwrap();
     let library = sample_library();

--- a/crates/presenter-server/src/router/libraries.rs
+++ b/crates/presenter-server/src/router/libraries.rs
@@ -98,7 +98,20 @@ pub(super) async fn delete_library(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    state.delete_library(LibraryId::from_uuid(id)).await?;
+    state
+        .delete_library(LibraryId::from_uuid(id))
+        .await
+        .map_err(|err| {
+            // EXACT match on the repository's refusal message — a substring
+            // test would mis-map any internal error that happens to contain
+            // "not found" to a client error (mirrors copy_presentation's
+            // mapping in presentations.rs). #578 review gap: a missing or
+            // already-deleted library used to fall through to 500.
+            match err.to_string().as_str() {
+                "library not found" => AppError::not_found("library not found"),
+                _ => err.into(),
+            }
+        })?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -798,6 +798,75 @@ async fn delete_library_endpoint_removes_library() {
 }
 
 #[tokio::test]
+async fn delete_library_endpoint_missing_library_returns_404() {
+    // #578 review gap: `delete_library`'s repository error ("library not
+    // found") had no exact-match mapping in the router, so it fell through
+    // the default `AppError::from(anyhow::Error)` conversion to 500 —
+    // instead of 404, the pattern already used by copy_presentation for its
+    // own "not found" refusals.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let create_body = serde_json::json!({ "name": "Disposable2" }).to_string();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/libraries")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: Library = serde_json::from_slice(&bytes).unwrap();
+
+    // First delete succeeds.
+    let first_delete = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/libraries/{}", created.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_delete.status(), StatusCode::NO_CONTENT);
+
+    // Second delete of the now-tombstoned library must be 404, not 500.
+    let second_delete = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/libraries/{}", created.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_delete.status(), StatusCode::NOT_FOUND);
+
+    // A library id that never existed must also be 404.
+    let random_id = uuid::Uuid::new_v4();
+    let unknown_delete = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/libraries/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unknown_delete.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn create_playlist_endpoint_supports_dashboard_flag() {
     let app = build_router(AppState::in_memory().await.unwrap());
     let create_body = serde_json::json!({


### PR DESCRIPTION
## Summary
Adversarial review of #581 (soft-delete libraries, #578) found 3 in-diff gaps, fixed here with RED-before-GREEN regression tests:

- `search_libraries` never filtered `deleted_at IS NULL` — a tombstoned library still matched by name in `/search`.
- `DELETE /libraries/{id}` on a missing/already-deleted library returned 500 instead of 404 (an explicit #578 requirement).
- Soft-deleting a library left its `library_favorites` row dangling instead of cleaning it up in the same transaction.

Bumps version 0.4.207 → 0.4.208.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -W clippy::all`
- [x] `cargo test -p presenter-persistence` (118 passed)
- [x] `cargo test -p presenter-server` (488 passed)
- [x] `cargo build --release -p presenter-server`
- [x] CI green on dev (Pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
