### PR TITLE
fix(sync): #580 library-delete race + chore(build): #585 disable incremental compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,13 @@
 # SOTA 2025 Cargo build configuration
 
 [build]
-# Enable incremental compilation
-incremental = true
+# #585: incremental compilation disabled — the `incremental/` scratch cache
+# grew to 29 GB on dev2 for a Tier-1 (local-build) machine dominated by full
+# `cargo test` / `cargo clippy --all-targets` sweeps and build-ui.sh, where
+# incremental buys little wall-clock but costs real disk (also shared with
+# bakerion-ai's own target/ on the same disk). See .claude/skills/deploy for
+# the purge one-liner + disk-size expectations.
+incremental = false
 
 # Use LLD linker for faster linking on Linux
 [target.x86_64-unknown-linux-gnu]
@@ -11,7 +16,10 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 # Environment variables for build
 [env]
-CARGO_INCREMENTAL = "1"
+# #585: an env var overrides [build]/[profile] settings, so this must stay
+# in lockstep with `incremental = false` above — never re-enable one without
+# the other.
+CARGO_INCREMENTAL = "0"
 
 # Alias definitions for common tasks
 [alias]
@@ -33,7 +41,10 @@ doc-open = "doc --open --no-deps"
 [profile.dev]
 opt-level = 0
 debug = true
-incremental = true
+# #585: an explicit per-profile `incremental` setting takes precedence over
+# [build] incremental above — both must say false, or dev/test/clippy builds
+# (all profile.dev-derived) would keep incremental ON regardless.
+incremental = false
 
 [profile.dev.package."*"]
 opt-level = 2  # Optimize dependencies even in dev

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,12 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 [env]
 # #585: an env var overrides [build]/[profile] settings, so this must stay
 # in lockstep with `incremental = false` above — never re-enable one without
-# the other.
-CARGO_INCREMENTAL = "0"
+# the other. `force = true` is required: a plain `KEY = "value"` [env] entry
+# only applies when the process environment does NOT already define the
+# variable (Cargo config reference) — without force, a shell that happens to
+# export CARGO_INCREMENTAL would silently win over this config and defeat
+# the whole point of this fix.
+CARGO_INCREMENTAL = { value = "0", force = true }
 
 # Alias definitions for common tasks
 [alias]

--- a/.claude/skills/database/SKILL.md
+++ b/.claude/skills/database/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: database
+description: Presenter database policy — schema-change/migration rules, deploy safety and backups, settings audit log, manual import workflow, and ProPresenter library management. Use when adding a migration, changing schema, running the Import Data workflow, or touching settings persistence.
+---
+
+# Database Policy
+
+## Schema Changes (Pre-release)
+
+Schema is mutable during pre-release:
+
+1. **New columns:** Add an incremental migration (e.g., `m20260408_000001_add_column.rs`) that uses `ALTER TABLE ADD COLUMN` with an idempotent guard (check `pragma_table_info` first). Register it in `lib.rs`. This ensures existing databases are upgraded automatically on startup.
+2. **New tables:** May be added to the initial migration (uses `if_not_exists()`) or as an incremental migration.
+3. **Destructive schema changes** (column renames, type changes): Add an incremental migration. If data must be re-imported, manually trigger the Import Data workflow after deploy.
+4. The server auto-migrates on startup via `Repository::connect()`
+
+## Deploy Safety
+
+- Deploys NEVER delete the database — only binaries and service files are updated
+- Database is backed up automatically before each deploy (5 retained in `backups/`)
+- Imports happen only via the explicit Import Data workflow. Deploys never touch the database.
+- New server installations start with an empty libraries table. Run the Import Data workflow once after first deploy to populate it.
+
+## Settings Audit Log
+
+All settings writes (ableset, osc, resolume hosts, android stage displays, video sources) are recorded in `settings_audit` (append-only). Each entry captures:
+
+- `setting_table`, `setting_id` — which row changed
+- `source` — `http_setter` | `companion_setter` | `startup_default` | `schema_migration`
+- `actor` — caller IP (from `X-Forwarded-For` or `X-Real-IP`) or `"system"` / `"companion"`
+- `before_json`, `after_json` — full row state before and after
+
+Query: `GET /integrations/audit?table=<name>&settingId=<id>&since=<rfc3339>&limit=<n>`.
+
+Startup MUST be read-only against settings tables. The only allowed startup write is creating a singleton row if missing (with `source=startup_default`). A second startup on an unchanged DB produces zero new audit rows — enforced by the regression test in `crates/presenter-persistence/src/repository/tests.rs::second_startup_writes_no_audit_rows`.
+
+## Manual Import
+
+To re-import source data (ProPresenter libraries, Bibles):
+
+1. Go to Actions > "Import Data" > Run workflow
+2. Select environment (dev/production) and import type
+3. Default mode (`--keep`) preserves existing data
+4. `--purge` mode replaces all libraries (WARNING: destroys playlists via FK cascade)
+
+## Library Management
+
+ProPresenter libraries are stored in `data/libraries/` as the single source of truth.
+
+**To update songs:**
+
+1. Export from ProPresenter on Mac
+2. Copy `.pro` files to `data/libraries/<LIBRARY_NAME>/`
+3. Commit and push to dev
+4. Deploy syncs libraries to servers via `rsync`
+5. Run Import Data workflow if needed
+
+Deploy workflows automatically sync `data/libraries/` to `/opt/presenter*/libraries/` on target servers.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -42,6 +42,47 @@ Build order matters (WASM embedded into server at compile time via `include_dir!
 
 5. **Verify**: `curl http://10.77.8.134:8080/healthz`
 
+## Disk budget — incremental compilation disabled (#585)
+
+`target/` dirs grew to **55 GB** on dev2 (41 GB workspace `target/` + 14 GB
+`crates/presenter-ui/target/`, 84% disk usage), **29 GB of it pure
+`incremental/` scratch cache** (20 GB `target/debug/incremental` + 5.0 GB
+`crates/presenter-ui/target/debug/incremental` + 4.3 GB
+`crates/presenter-ui/target/wasm32-unknown-unknown/{debug,release}/incremental`).
+Incremental compilation only pays off on repeated small edits to the SAME
+crate — our local runs are dominated by full `cargo test` / `cargo clippy
+--all-targets` sweeps and `build-ui.sh`, where it added disk + I/O for
+little wall-clock benefit (and this disk is shared with bakerion-ai's own
+`target/`).
+
+**Fixed as of v0.4.209**: `incremental = false` in BOTH `[build]` and
+`[profile.dev]` of the repo-root `.cargo/config.toml` (a profile-level
+`incremental` setting overrides `[build]`'s, so both must agree — and
+`CARGO_INCREMENTAL` in `[env]` must match too, since an env var overrides
+config/profile settings), plus the identical `[build]`/`[env]` pair in
+`crates/presenter-ui/.cargo/config.toml` (that crate is OUTSIDE the
+workspace — own `Cargo.lock`, own `target/` — so the root config never
+reaches it). Verified locally: a full `cargo test --workspace` +
+`bash scripts/build-ui.sh` after purging leaves `incremental/` either
+absent or an EMPTY 4 KB placeholder dir (cargo/trunk still `mkdir`s the
+slot; it just never writes cache content into it) under every `target/`
+tree — no more multi-GB growth.
+
+**Purge one-liner** (safe any time — these are pure scratch caches, never
+committed source, and Cargo regenerates whatever it still needs):
+```bash
+rm -rf target/debug/incremental target/release/incremental \
+  crates/presenter-ui/target/debug/incremental \
+  crates/presenter-ui/target/release/incremental \
+  crates/presenter-ui/target/wasm32-unknown-unknown/debug/incremental \
+  crates/presenter-ui/target/wasm32-unknown-unknown/release/incremental
+```
+Check current disk budget: `df -h /` and `du -sh target crates/presenter-ui/target`.
+If `target/` disk usage is climbing again despite the fix, suspect a NEW
+per-profile `incremental = true` override slipping into either
+`.cargo/config.toml` before reaching for the purge — the setting, not the
+purge, is the actual fix; purging just reclaims space already spent.
+
 ### Local WASM build — use `scripts/build-ui.sh`, NOT plain `trunk build` (#465 resolved)
 
 The local WASM build **works** — via `scripts/build-ui.sh`. The #465 symptom

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -257,22 +257,32 @@ healthy locally:** `systemctl status cloudflared` (daemon up?) → `journalctl -
 HTTP/2 drop-in above, and re-verify — don't chase the app/service layer when the daemon logs show
 the tunnel itself never reconnecting.
 
-## Post-deploy live verification on SNV/PP: NEVER delete a test library via `/libraries/{id}` (#578)
+## `delete_library` resurrection bug — FIXED as of v0.4.207/#578 (was previously live)
 
-When you create a throwaway test library+presentation on SNV or PP to verify a live fix,
-clean it up by deleting the **presentation** (`DELETE /presentations/{id}` — soft-delete,
-tombstoned, propagates the deletion through the #555 sync loop) and only THEN, if you
-want, the now-empty library. **Never delete the library first/only** — `delete_library`
-does a plain hard `Entity::delete_by_id` with NO sync tombstone (pre-existing bug, filed
-as #578), so if the peer (PP<->SNV) already pulled a copy of that presentation in the
-~30s since you created it, the very next sync cycle sees "we never held this" on the
-side that just hard-deleted it and RESURRECTS the whole library+presentation from the
-peer — repeatably, forever, no matter how many times you delete the library again. Live
-incident (2026-07-24/25, verifying #575/#571/#574): a canary library round-tripped
-resurrection twice before switching to presentation-level delete converged it for good.
-If you're left with an empty, obviously-test-named library shell on either side, that's
-the safe end state — leave it (deleting it again just risks re-triggering the loop if
-either side still holds a live copy of anything under that name).
+Historical note: before #578 landed, `DELETE /libraries/{id}` did a plain hard
+`Entity::delete_by_id` with NO sync tombstone — deleting a library that the peer
+(PP<->SNV) had already pulled a copy of could resurrect it forever on the next sync
+cycle. **This is fixed since v0.4.207**: `delete_library` now SOFT-deletes the library
+row AND its live presentations in one transaction (`repository/library.rs`), so the
+deletion propagates like any other edit under LWW. It is now safe to delete a library
+directly via `/libraries/{id}` for cleanup — no more presentation-first workaround
+needed. (v0.4.208 also closed the 3 review gaps found on that fix: search no longer
+surfaces a tombstoned library by name, a missing/already-deleted library 404s instead
+of 500, and the library's favorite row is cleaned up on delete — see #578 comments.)
+
+## `cargo test -p presenter-server --lib <test>` FAILS — it's a binary-only crate
+
+`presenter-server`'s `Cargo.toml` has no `[lib]` section and no `src/lib.rs` — only
+`src/main.rs`. Running `cargo test -p presenter-server --lib <path>` errors immediately
+with `error: no library targets found in package` (no compile, no test run — a fast
+false negative that looks like "the test doesn't exist"). Use `--bin presenter-server`
+instead:
+```bash
+cargo test -p presenter-server --bin presenter-server router::tests::my_test -- --nocapture
+```
+A bare `cargo test -p presenter-server` (no `--lib`/`--bin`) also works — cargo infers
+the single binary target. Only add `--bin presenter-server` when you need to pass a
+specific test-name filter alongside other flags.
 
 ## `cargo test --workspace 2>&1 | tail -N` SWALLOWS a real test failure's exit code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Runner management, GPU wedge, probe cleanup | `.claude/skills/ci/SKILL.md` |
 | Local build/deploy workflow, CLIProxyAPI login | `.claude/skills/deploy/SKILL.md` |
 | Leptos/WASM frontend gotchas (view! macro, keyed `<For>`) | `.claude/skills/ui/SKILL.md` |
+| Database schema, migrations, settings audit, library import | `.claude/skills/database/SKILL.md` |
 
 ## Always-Rules
 
@@ -99,23 +100,7 @@ The local runner does NOT compile Rust — it only runs pre-built artifacts down
 
 **Deploy workflows** use SSH from the local runner to application hosts (`10.77.9.205` for production, `10.77.8.134` for dev, `companion-pp.lan` for PP releases).
 
-#### Runner Management
-
-```bash
-# Check runner status (runs locally — same machine as dev)
-cd ~/actions-runner && sudo ./svc.sh status
-
-# View runner logs
-sudo journalctl -u actions.runner.zbynekdrlik-presenter.presenter-local -f
-
-# Restart runner
-cd ~/actions-runner && sudo ./svc.sh stop && sudo ./svc.sh start
-
-# Re-register (requires fresh token)
-gh api -X POST repos/zbynekdrlik/presenter/actions/runners/registration-token --jq '.token'
-cd ~/actions-runner && ./config.sh --url https://github.com/zbynekdrlik/presenter --token "$TOKEN" --name presenter-local --labels self-hosted,local
-sudo ./svc.sh install && sudo ./svc.sh start
-```
+Runner management commands (status, restart, re-register) live in the ci skill — see the Playbook Router.
 
 ### Workflows
 
@@ -282,93 +267,15 @@ crates/
 
 ---
 
-## Database Policy
-
-### Schema Changes (Pre-release)
-
-Schema is mutable during pre-release:
-
-1. **New columns:** Add an incremental migration (e.g., `m20260408_000001_add_column.rs`) that uses `ALTER TABLE ADD COLUMN` with an idempotent guard (check `pragma_table_info` first). Register it in `lib.rs`. This ensures existing databases are upgraded automatically on startup.
-2. **New tables:** May be added to the initial migration (uses `if_not_exists()`) or as an incremental migration.
-3. **Destructive schema changes** (column renames, type changes): Add an incremental migration. If data must be re-imported, manually trigger the Import Data workflow after deploy.
-4. The server auto-migrates on startup via `Repository::connect()`
-
-### Deploy Safety
-
-- Deploys NEVER delete the database — only binaries and service files are updated
-- Database is backed up automatically before each deploy (5 retained in `backups/`)
-- Imports happen only via the explicit Import Data workflow. Deploys never touch the database.
-- New server installations start with an empty libraries table. Run the Import Data workflow once after first deploy to populate it.
-
-### Settings Audit Log
-
-All settings writes (ableset, osc, resolume hosts, android stage displays, video sources) are recorded in `settings_audit` (append-only). Each entry captures:
-
-- `setting_table`, `setting_id` — which row changed
-- `source` — `http_setter` | `companion_setter` | `startup_default` | `schema_migration`
-- `actor` — caller IP (from `X-Forwarded-For` or `X-Real-IP`) or `"system"` / `"companion"`
-- `before_json`, `after_json` — full row state before and after
-
-Query: `GET /integrations/audit?table=<name>&settingId=<id>&since=<rfc3339>&limit=<n>`.
-
-Startup MUST be read-only against settings tables. The only allowed startup write is creating a singleton row if missing (with `source=startup_default`). A second startup on an unchanged DB produces zero new audit rows — enforced by the regression test in `crates/presenter-persistence/src/repository/tests.rs::second_startup_writes_no_audit_rows`.
-
-### Manual Import
-
-To re-import source data (ProPresenter libraries, Bibles):
-
-1. Go to Actions > "Import Data" > Run workflow
-2. Select environment (dev/production) and import type
-3. Default mode (`--keep`) preserves existing data
-4. `--purge` mode replaces all libraries (WARNING: destroys playlists via FK cascade)
-
-### Library Management
-
-ProPresenter libraries are stored in `data/libraries/` as the single source of truth.
-
-**To update songs:**
-
-1. Export from ProPresenter on Mac
-2. Copy `.pro` files to `data/libraries/<LIBRARY_NAME>/`
-3. Commit and push to dev
-4. Deploy syncs libraries to servers via `rsync`
-5. Run Import Data workflow if needed
-
-Deploy workflows automatically sync `data/libraries/` to `/opt/presenter*/libraries/` on target servers.
-
----
-
 ## Code Quality Standards
 
 ### Format & Lint (CI enforces)
 
-```bash
-cargo fmt --check                                              # Must pass
-cargo clippy --workspace --all-targets -- -D warnings -W clippy::all  # Must pass (zero warnings allowed)
-```
-
-### Naming Conventions
-
-- `snake_case` for module names
-- `PascalCase` for types
-- `mod.rs` for orchestration/re-exports only
-
----
-
-## Anti-Patterns (Never Do These)
-
-- **Don't delete production databases** - Use incremental migrations for schema changes
-- **Don't use arbitrary sleeps in tests** - Use retry-with-assert helpers
+Pre-push quality gate: `scripts/dev/quality-check.sh --strict --against origin/main` (what CI runs) — details in the ci skill.
 
 ---
 
 ## Documentation Standards
-
-### When to Update Docs
-
-- New features: Update relevant docs and CLAUDE.md
-- Architecture changes: Add/update ADR in `docs/adr/`
-- Configuration changes: Update `docs/configuration.md`
 
 ### ADR Process
 
@@ -392,16 +299,6 @@ cargo clippy --workspace --all-targets -- -D warnings -W clippy::all  # Must pas
 
 ### LAN IP (NOT localhost)
 
-The user accesses the server from another machine on the same network. **Always provide LAN IP URLs, never localhost.**
-
-**Production LAN IP:** `10.77.9.205`
-**Dev LAN IP:** `10.77.8.134`
-
-When providing URLs, use:
-
-- http://10.77.9.205/ui/operator (Production)
-- http://10.77.8.134:8080/ui/operator (Dev)
-- http://10.77.9.205/stage (Production stage)
-- http://10.77.8.134:8080/stage (Dev stage)
+The user accesses the server from another machine on the same network. **Always provide LAN IP URLs, never localhost.** (IPs are in the Deployed Instances table above.)
 
 **Never use localhost** — always use the LAN IP.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.208"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.208"
+version = "0.4.209"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -327,9 +327,18 @@ impl Repository {
         if let Some(id) = Self::find_library_id(txn, library_name).await? {
             return Ok(id);
         }
+        // Order by UpdatedAt DESC: repeated delete/recreate cycles of the
+        // same-named library leave MULTIPLE tombstoned rows behind (the
+        // partial unique index only guards LIVE rows — see
+        // idx_libraries_name_live_unique), and `.one()` with no explicit
+        // order picks an arbitrary one. Always deciding against the MOST
+        // RECENT tombstone is the one that's actually relevant to this
+        // race; an older, already-superseded tombstone would compare the
+        // presentation against the wrong timestamp entirely.
         if let Some(tombstoned) = library::Entity::find()
             .filter(library::Column::Name.eq(library_name.to_string()))
             .filter(library::Column::DeletedAt.is_not_null())
+            .order_by_desc(library::Column::UpdatedAt)
             .one(txn)
             .await?
         {

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -327,18 +327,29 @@ impl Repository {
         if let Some(id) = Self::find_library_id(txn, library_name).await? {
             return Ok(id);
         }
-        // Order by UpdatedAt DESC: repeated delete/recreate cycles of the
-        // same-named library leave MULTIPLE tombstoned rows behind (the
-        // partial unique index only guards LIVE rows — see
+        // Order by UpdatedAt DESC, SyncId DESC: repeated delete/recreate
+        // cycles of the same-named library leave MULTIPLE tombstoned rows
+        // behind (the partial unique index only guards LIVE rows — see
         // idx_libraries_name_live_unique), and `.one()` with no explicit
         // order picks an arbitrary one. Always deciding against the MOST
         // RECENT tombstone is the one that's actually relevant to this
         // race; an older, already-superseded tombstone would compare the
-        // presentation against the wrong timestamp entirely.
+        // presentation against the wrong timestamp entirely. `SyncId` is
+        // the tie-breaker for an EXACT `updated_at` collision (two rapid
+        // delete/recreate cycles can land on the same wall-clock
+        // millisecond) — it MUST be a peer-stable key, never a local-only
+        // one like the row `Id` (`find_live_by_name_candidate`'s own
+        // secondary sort), or two peers holding the same two tombstoned
+        // rows could break the tie in DIFFERENT directions and pick a
+        // DIFFERENT "most recent" tombstone each — reintroducing the exact
+        // divergence class this fix closes. `sync_id` converges identically
+        // on both sides once synced, so ordering by it is deterministic
+        // peer-to-peer.
         if let Some(tombstoned) = library::Entity::find()
             .filter(library::Column::Name.eq(library_name.to_string()))
             .filter(library::Column::DeletedAt.is_not_null())
             .order_by_desc(library::Column::UpdatedAt)
+            .order_by_desc(library::Column::SyncId)
             .one(txn)
             .await?
         {
@@ -354,6 +365,7 @@ impl Repository {
                         Expr::value(presentation_updated_at.to_rfc3339()),
                     )
                     .filter(library::Column::Id.eq(tombstoned.id.clone()))
+                    .filter(library::Column::DeletedAt.is_not_null())
                     .exec(txn)
                     .await?;
             }

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -130,7 +130,7 @@ impl Repository {
             let library_id = if incoming.deleted_at.is_some() {
                 existing.library_id.clone()
             } else {
-                Self::ensure_library(&txn, &incoming.library_name).await?
+                Self::ensure_library(&txn, &incoming.library_name, incoming.updated_at).await?
             };
             Self::write_synced_row(&txn, &existing.id, &library_id, incoming).await?;
             txn.commit().await?;
@@ -176,21 +176,21 @@ impl Repository {
         Ok(result)
     }
 
-    /// Look up an existing library by name — NEVER creates one (#558
+    /// Look up an existing LIVE library by name — NEVER creates one (#558
     /// round-4 U4). Used wherever "no library" can be treated as "nothing
     /// to do" without paying for a write. Generic over the connection
     /// (#558 W5/W8/W9) so the SAME implementation serves both the real
     /// apply (inside its transaction) and `resolve_sync_apply_target` (a
     /// plain pre-transaction probe, no transaction involved).
+    ///
+    /// #580: a same-named TOMBSTONED library is deliberately invisible here
+    /// — `ensure_library` (the only caller that may WRITE) decides that case
+    /// itself via LWW against the incoming presentation's `updated_at`,
+    /// rather than treating "no live match" as "nothing exists".
     async fn find_library_id<C: sea_orm::ConnectionTrait>(
         conn: &C,
         library_name: &str,
     ) -> anyhow::Result<Option<String>> {
-        // #578: only a LIVE (non-tombstoned) library is a valid attachment
-        // target for a synced presentation. If the local same-named library
-        // is soft-deleted, `ensure_library` creates a fresh live one rather
-        // than reviving a tombstone (the partial name-unique index allows a
-        // live row beside the tombstone).
         Ok(library::Entity::find()
             .filter(library::Column::Name.eq(library_name.to_string()))
             .filter(library::Column::DeletedAt.is_null())
@@ -290,17 +290,65 @@ impl Repository {
         )))
     }
 
-    /// Look up an existing library by name, creating it if missing (#558
-    /// round-4 U4). Call this ONLY once the caller is committed to
-    /// writing a presentation row into it — never speculatively, or a
-    /// skipped/never-write apply leaves behind a phantom, permanently-
-    /// empty library row.
+    /// Look up an existing LIVE library by name, or REVIVE-or-attach-to a
+    /// same-named TOMBSTONED one, or create a brand-new live library if
+    /// neither exists (#558 round-4 U4; #580). Call this ONLY once the
+    /// caller is committed to writing a presentation row into it — never
+    /// speculatively, or a skipped/never-write apply leaves behind a
+    /// phantom, permanently-empty library row.
+    ///
+    /// #580: previously, the moment no LIVE same-named library existed, this
+    /// ALWAYS minted a fresh one — even when a TOMBSTONED library of that
+    /// name already existed. That let a peer's concurrent
+    /// library-delete-vs-presentation-create race diverge the two instances
+    /// forever (one side ends up with a resurrected library holding the new
+    /// presentation, the other still shows the library hidden with the
+    /// presentation orphaned underneath it). Fix (decision on #580, option
+    /// b): decide live-vs-tombstoned from the TOMBSTONED library's own
+    /// `updated_at` against the incoming presentation's `updated_at` — the
+    /// SAME LWW mechanism `apply_sync_library` already uses for library
+    /// manifest sync (#578's `updated_at`/`sync_id`/`deleted_at` columns).
+    /// `presentation_updated_at > library_updated` (strictly, mirroring
+    /// `sync_should_apply`'s tie-break) revives the library in place —
+    /// clearing `deleted_at` and bumping `updated_at` to the presentation's
+    /// own timestamp so the peer's next pull sees a strictly newer live
+    /// library row and revives its own copy too. Otherwise the library
+    /// stays tombstoned and the presentation simply attaches to it (hidden,
+    /// matching what the peer that did the deleting already shows). Either
+    /// way the EXISTING library row is reused — its identity (`sync_id`)
+    /// never changes, and reviving it never revives any presentation
+    /// tombstoned under it (those carry their own tombstones with their own
+    /// `updated_at` and settle by their own LWW).
     async fn ensure_library(
         txn: &sea_orm::DatabaseTransaction,
         library_name: &str,
+        presentation_updated_at: DateTime<Utc>,
     ) -> anyhow::Result<String> {
         if let Some(id) = Self::find_library_id(txn, library_name).await? {
             return Ok(id);
+        }
+        if let Some(tombstoned) = library::Entity::find()
+            .filter(library::Column::Name.eq(library_name.to_string()))
+            .filter(library::Column::DeletedAt.is_not_null())
+            .one(txn)
+            .await?
+        {
+            let library_updated: DateTime<Utc> = tombstoned.updated_at.into();
+            if presentation_updated_at > library_updated {
+                library::Entity::update_many()
+                    .col_expr(
+                        library::Column::DeletedAt,
+                        Expr::value(Option::<String>::None),
+                    )
+                    .col_expr(
+                        library::Column::UpdatedAt,
+                        Expr::value(presentation_updated_at.to_rfc3339()),
+                    )
+                    .filter(library::Column::Id.eq(tombstoned.id.clone()))
+                    .exec(txn)
+                    .await?;
+            }
+            return Ok(tombstoned.id);
         }
         let id = uuid::Uuid::new_v4().to_string();
         library::Entity::insert(library::ActiveModel {
@@ -452,7 +500,7 @@ impl Repository {
         let library_id = if incoming.deleted_at.is_some() {
             Self::ensure_library_for_tombstone(txn, &incoming.library_name).await?
         } else {
-            Self::ensure_library(txn, &incoming.library_name).await?
+            Self::ensure_library(txn, &incoming.library_name, incoming.updated_at).await?
         };
         let new_id = uuid::Uuid::new_v4().to_string();
         presentation_entity::Entity::insert(presentation_entity::ActiveModel {

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -4,7 +4,7 @@
 //! crossed the 1000-line hard cap — the tests moved verbatim; shared helpers
 //! live in `sync_test_support`.
 use super::sync_test_support::{peer_song, repo, row, slide, updated_at_of};
-use crate::entities::{playlist_entry, presentation as presentation_entity};
+use crate::entities::{library, playlist_entry, presentation as presentation_entity};
 use sea_orm::EntityTrait;
 
 #[tokio::test]
@@ -496,5 +496,95 @@ async fn soft_delete_hides_the_song_but_keeps_the_row() {
     assert!(
         remaining.is_empty(),
         "playlist entries referencing the song are removed"
+    );
+}
+
+#[tokio::test]
+async fn ensure_library_picks_the_most_recent_tombstone_when_several_share_a_name() {
+    // #580 hardening: the partial unique index only guards LIVE rows
+    // (idx_libraries_name_live_unique), so repeated delete/recreate cycles
+    // of the same-named library leave MULTIPLE tombstoned rows behind.
+    // ensure_library's tombstone lookup must pick the MOST RECENT one (by
+    // updated_at) to compare against — picking an arbitrary/older one would
+    // LWW-compare the incoming presentation against the wrong tombstone
+    // entirely, e.g. wrongly reviving a long-superseded library.
+    let repo = repo().await;
+
+    let v1 = repo.create_library("Songs").await.unwrap();
+    repo.delete_library(v1.id).await.unwrap();
+    let v1_row_before = library::Entity::find_by_id(v1.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .expect("v1 row still exists, tombstoned");
+    let t1: chrono::DateTime<chrono::Utc> = v1_row_before.updated_at.into();
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let v2 = repo.create_library("Songs").await.unwrap();
+    repo.delete_library(v2.id).await.unwrap();
+    let v2_row_before = library::Entity::find_by_id(v2.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .expect("v2 row still exists, tombstoned");
+    let t2: chrono::DateTime<chrono::Utc> = v2_row_before.updated_at.into();
+    assert!(t2 > t1, "sanity: v2 was tombstoned strictly after v1");
+
+    // A live peer presentation whose updated_at sits STRICTLY BETWEEN the two
+    // tombstones: newer than v1's (would wrongly revive v1 if v1 were picked)
+    // but OLDER than v2's (correctly stays tombstoned when v2 -- the actually
+    // relevant, most recent tombstone -- is picked).
+    let between = t1 + (t2 - t1) / 2;
+    let peer = crate::SyncPresentation {
+        sync_id: "peer-p2-multi-tombstone".to_string(),
+        library_name: "Songs".to_string(),
+        name: "P2".to_string(),
+        updated_at: between,
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, id) = repo
+        .apply_sync_presentation(&peer, &std::collections::HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_row = row(&repo, id.expect("created presentation has an id")).await;
+
+    assert_eq!(
+        pres_row.library_id,
+        v2.id.to_string(),
+        "P2 must attach to v2 -- the MOST RECENT tombstone -- never v1 nor a \
+         freshly-minted third library"
+    );
+
+    let v1_row_after = library::Entity::find_by_id(v1.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        v1_row_after.deleted_at.is_some(),
+        "v1 is untouched -- still tombstoned"
+    );
+    let v2_row_after = library::Entity::find_by_id(v2.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        v2_row_after.deleted_at.is_some(),
+        "v2 stays tombstoned -- P2 is OLDER than v2's own tombstone, so no revival"
+    );
+
+    use sea_orm::{ColumnTrait, QueryFilter};
+    let all_songs = library::Entity::find()
+        .filter(library::Column::Name.eq("Songs".to_string()))
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert_eq!(
+        all_songs.len(),
+        2,
+        "exactly v1 and v2 -- no third library was minted"
     );
 }

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -45,6 +45,8 @@ mod sync_integration_breaker_tests;
 #[cfg(test)]
 mod sync_integration_tests;
 #[cfg(test)]
+mod sync_race_tests;
+#[cfg(test)]
 mod tests;
 mod timers;
 pub(crate) mod video_source_status;

--- a/crates/presenter-server/src/state/sync_race_tests.rs
+++ b/crates/presenter-server/src/state/sync_race_tests.rs
@@ -1,0 +1,217 @@
+//! #580 regression tests: the rare concurrent library-delete-vs-
+//! presentation-create race. Split into its own file rather than growing
+//! `sync_integration_tests.rs` (already near the file-size gate) — mirrors
+//! that file's two-peer `AppState` + `run_sync_cycle` harness with a small
+//! set of local helper duplicates.
+//!
+//! Scenario (from the issue): peer A deletes library `L`; peer B,
+//! concurrently, creates a NEW live presentation `P2` under the
+//! SAME-named `L` before ever seeing A's delete. #578 gave libraries their
+//! own LWW sync (`updated_at`/`sync_id`/`deleted_at`, `apply_sync_library`)
+//! but `ensure_library` (used when applying a LIVE presentation with no
+//! matching LIVE library) ignored a same-named TOMBSTONED library entirely
+//! and always minted a fresh live one — diverging the two peers. The fix
+//! (decision on #580: option (b)) decides live-vs-tombstoned from the
+//! tombstoned library's own `updated_at`, the SAME LWW mechanism already
+//! used everywhere else in this sync design.
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use presenter_core::{LibraryId, PresentationId};
+use tokio::time::sleep;
+
+use crate::router::build_router;
+use crate::state::sync::run_sync_cycle;
+use crate::state::AppState;
+
+async fn serve(state: AppState) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let router = build_router(state);
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder().build().unwrap()
+}
+
+fn find_song(libs: &[presenter_core::Library], name: &str) -> Option<presenter_core::Presentation> {
+    libs.iter()
+        .flat_map(|l| l.presentations.iter())
+        .find(|p| p.name == name)
+        .cloned()
+}
+
+async fn make_song(state: &AppState, lib: &str, name: &str) -> (LibraryId, PresentationId) {
+    let library = state.create_library(lib).await.unwrap();
+    let (lib_id, _, pres, _) = state
+        .create_presentation(library.id, name, None)
+        .await
+        .unwrap();
+    (lib_id, pres.id)
+}
+
+/// How many library rows (LIVE + tombstoned) currently carry this name — the
+/// #580 bug signature is a SECOND live row minted beside the existing
+/// (tombstoned) one instead of reusing/reviving it.
+async fn library_row_count_by_name(state: &AppState, name: &str) -> usize {
+    state
+        .repository()
+        .list_library_sync_manifest()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|l| l.name == name)
+        .count()
+}
+
+async fn library_is_deleted(state: &AppState, name: &str) -> Option<bool> {
+    state
+        .repository()
+        .list_library_sync_manifest()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.name == name)
+        .map(|l| l.deleted_at.is_some())
+}
+
+#[tokio::test]
+async fn concurrent_library_delete_and_presentation_create_keeps_tombstone_when_delete_is_newer() {
+    // Branch under test: the library DELETE is the newer event. Decision (b)
+    // says L must STAY tombstoned and P2 attach to it (hidden) — both sides
+    // converge on the SAME single library row, never a second freshly-minted
+    // live one.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+    let b_url = serve(b.clone()).await;
+
+    make_song(&a, "Songs", "Existing").await;
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert!(
+        find_song(&b.libraries().await.unwrap(), "Existing").is_some(),
+        "sanity: B holds the library + song before the race"
+    );
+    let lib_id_b = b
+        .libraries()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.name == "Songs")
+        .expect("B holds the live library after the first sync")
+        .id;
+
+    // B creates P2 under the SAME library — the older of the two racing
+    // events — never yet synced to A.
+    b.create_presentation(lib_id_b, "P2", None).await.unwrap();
+
+    // A deletes the whole library — strictly NEWER than B's create.
+    sleep(Duration::from_millis(5)).await;
+    let lib_id_a = a
+        .libraries()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.name == "Songs")
+        .unwrap()
+        .id;
+    a.delete_library(lib_id_a).await.unwrap();
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "Existing").is_none(),
+        "sanity: the library is gone on A right after the delete"
+    );
+
+    // Sync in both directions, per the issue: B pulls A's tombstone, then A
+    // pulls B's still-live P2.
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    run_sync_cycle(&a, &b_url, &client()).await.unwrap();
+
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "P2").is_none(),
+        "P2 must stay HIDDEN on A — attached to the still-tombstoned library, \
+         never surfaced through a resurrected live one"
+    );
+    assert_eq!(
+        library_is_deleted(&a, "Songs").await,
+        Some(true),
+        "the library delete is the newer event — it must stay tombstoned, never revived"
+    );
+    assert_eq!(
+        library_row_count_by_name(&a, "Songs").await,
+        1,
+        "#580 bug signature: a fresh live library must never be minted beside \
+         the existing tombstoned one for the same name"
+    );
+
+    // Converge B too — both sides end up in the SAME state (library hidden,
+    // P2 live-but-hidden underneath).
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert_eq!(
+        library_row_count_by_name(&b, "Songs").await,
+        1,
+        "B must not end up with a duplicate library row either"
+    );
+    assert_eq!(library_is_deleted(&b, "Songs").await, Some(true));
+}
+
+#[tokio::test]
+async fn concurrent_library_delete_and_presentation_create_revives_library_when_create_is_newer() {
+    // Same race, other tie-break — P2's create is the NEWER event. Decision
+    // (b): revive L (clear deleted_at, bump updated_at) and attach P2; a
+    // presentation tombstoned earlier UNDER L must stay tombstoned — reviving
+    // the LIBRARY must never revive presentations under it.
+    let a = AppState::in_memory().await.unwrap();
+    let b = AppState::in_memory().await.unwrap();
+    let a_url = serve(a.clone()).await;
+    let b_url = serve(b.clone()).await;
+
+    let (lib_id_a, trashed_id) = make_song(&a, "Songs", "AlreadyTrashed").await;
+    a.delete_presentation(trashed_id).await.unwrap();
+
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    let lib_id_b = b
+        .libraries()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|l| l.name == "Songs")
+        .expect("B holds the live (but song-empty) library after the first sync")
+        .id;
+
+    // A deletes the library — the older of the two racing events.
+    a.delete_library(lib_id_a).await.unwrap();
+
+    // B creates P2 under the SAME library name — strictly NEWER — never
+    // having synced A's delete yet.
+    sleep(Duration::from_millis(5)).await;
+    b.create_presentation(lib_id_b, "P2", None).await.unwrap();
+
+    // Sync both directions.
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    run_sync_cycle(&a, &b_url, &client()).await.unwrap();
+
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "P2").is_some(),
+        "P2's create is the newer event — the library must be REVIVED so P2 \
+         is visible again"
+    );
+    assert_eq!(
+        library_is_deleted(&a, "Songs").await,
+        Some(false),
+        "the library must be revived (deleted_at cleared), not left tombstoned"
+    );
+    assert_eq!(
+        library_row_count_by_name(&a, "Songs").await,
+        1,
+        "#580 bug signature: reviving must reuse the EXISTING library row, \
+         never mint a second fresh one"
+    );
+    assert!(
+        find_song(&a.libraries().await.unwrap(), "AlreadyTrashed").is_none(),
+        "reviving the LIBRARY must never revive a presentation tombstoned under it"
+    );
+}

--- a/crates/presenter-ui/.cargo/config.toml
+++ b/crates/presenter-ui/.cargo/config.toml
@@ -13,4 +13,7 @@ rustflags = ["-Ctarget-cpu=mvp", "-Ctarget-feature=+mutable-globals"]
 incremental = false
 
 [env]
-CARGO_INCREMENTAL = "0"
+# force = true: a plain KEY = "value" only applies when the process env does
+# NOT already define it — without force, an inherited shell CARGO_INCREMENTAL
+# would silently win over this config (see the root .cargo/config.toml note).
+CARGO_INCREMENTAL = { value = "0", force = true }

--- a/crates/presenter-ui/.cargo/config.toml
+++ b/crates/presenter-ui/.cargo/config.toml
@@ -3,3 +3,14 @@ build-std = ["std", "panic_abort"]
 
 [target.wasm32-unknown-unknown]
 rustflags = ["-Ctarget-cpu=mvp", "-Ctarget-feature=+mutable-globals"]
+
+# #585: incremental compilation disabled — this crate is OUTSIDE the
+# workspace (own Cargo.lock, own target/), so the repo-root .cargo/config.toml
+# never applies to it and it needs its own entry. Its incremental cache alone
+# accounted for ~9.3 GB (5.0 GB debug + 4.3 GB wasm32-unknown-unknown
+# debug+release) of the 55 GB that filled dev2's disk.
+[build]
+incremental = false
+
+[env]
+CARGO_INCREMENTAL = "0"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.207"
+version = "0.4.209"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary

Bundled batch: two independent, unrelated fixes on the same `dev` branch.

Closes #580
Closes #585

### #580 — rare concurrent library-delete-vs-presentation-create race can diverge

`ensure_library()` (used when applying a synced LIVE presentation) only ever looked at LIVE
libraries by name. The moment no live same-named library existed — even when a TOMBSTONED one
did — it unconditionally minted a fresh live library with a brand-new identity. In the race
described in the issue (peer A deletes library `L`; peer B concurrently creates presentation `P2`
under the same-named `L`, never yet synced to A), applying B's `P2` on A resurrected `L` under a
new identity instead of reusing the existing tombstoned row, diverging the two peers forever.

Fix (design decision recorded on the issue, option b): when no LIVE library matches, look for a
TOMBSTONED same-named one and decide live-vs-tombstoned from **its own `updated_at`** against the
incoming presentation's `updated_at` — the same LWW mechanism `apply_sync_library` already uses
for library manifest sync (#578's `updated_at`/`sync_id`/`deleted_at` columns). The precondition
(libraries carry a comparable `updated_at` through the sync path, same as presentations) was
verified before writing any code — it holds, so no new wire field was needed (the rejected,
larger option (a)).

Both tie-break branches:
- library delete newer than P2 → library stays tombstoned, P2 attaches to it (hidden) — matches
  what the deleting peer already shows.
- P2 newer than the delete → library is revived in place (`deleted_at` cleared, `updated_at`
  bumped to the presentation's own timestamp so the peer's next pull also revives).

Either way the EXISTING library row (and its `sync_id` identity) is reused — never a second fresh
one — and reviving the library never revives any presentation tombstoned under it (those settle by
their own LWW).

RED → GREEN:
- RED `11d4b5229a2ab87dce634284004e7db56108a176` — two-peer regression tests, both fail on current
  code (`crates/presenter-server/src/state/sync_race_tests.rs:82` and `:161`).
- GREEN `eb61430b638bfbc834a78fad39987ed89dbdfbdf` — the `ensure_library` fix; both tests pass, full
  workspace `cargo test` (853 tests) + `clippy --all-targets -- -D warnings` green.

### #585 — chore: disable incremental compilation (target/ grew to 55 GB on dev2)

`target/` grew to 55 GB (41 GB workspace + 14 GB `crates/presenter-ui/target`), 84% disk usage —
29 GB of it pure `incremental/` scratch cache that buys nothing on this Tier-1 (local-build)
machine, whose local runs are dominated by full `cargo test` / `cargo clippy --all-targets` sweeps
and `build-ui.sh` rather than repeated small edits to one crate.

- `.cargo/config.toml`: `[build] incremental = false` **and** `[profile.dev] incremental = false`
  (a per-profile setting overrides `[build]`'s) **and** `CARGO_INCREMENTAL = "0"` in `[env]` (an
  env var overrides both) — all three had to agree, or dev/test/clippy builds would have kept
  incremental compilation on regardless of the top-level setting.
- `crates/presenter-ui/.cargo/config.toml`: the identical `[build]`/`[env]` pair — that crate is
  OUTSIDE the workspace (own `Cargo.lock`, own `target/`), so the root config never reaches it.
- `.claude/skills/deploy/SKILL.md`: purge one-liner + disk-budget notes for next time.

Verified locally (commit `58595f048f2fa24a1860a91ce449b3e1fd981b91`): purged every `incremental/`
dir, then a fresh `cargo test --workspace` (853 tests) + `bash scripts/build-ui.sh` left
`incremental/` either absent or an EMPTY 4 KB placeholder (cargo/trunk still `mkdir`s the slot;
nothing gets cached into it) under every `target/` tree — no regrowth.

**CI duration (±10% acceptance criterion)** — baseline vs this PR's own run (see completion report
for the exact numbers once this run finishes): baseline `Pipeline` run `30162271015` (2026-07-25,
last dev push before this PR) — `Test` job 13m56s, `Build` job 8m17s, full pipeline ~41m20s.

## Test plan

- [x] RED regression test for #580 fails on pre-fix code (verified locally)
- [x] GREEN fix makes both #580 regression tests pass
- [x] Full workspace `cargo test` green (853 tests, all crates)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] #585 acceptance: no `incremental/` growth after a fresh `cargo test` + `build-ui.sh`
- [x] CI pipeline green (all jobs incl. deploy-dev)
