### PR TITLE
fix: address 5 post-merge review findings on PR #591 (#594)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,13 +16,17 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 # Environment variables for build
 [env]
-# #585: an env var overrides [build]/[profile] settings, so this must stay
-# in lockstep with `incremental = false` above — never re-enable one without
-# the other. `force = true` is required: a plain `KEY = "value"` [env] entry
-# only applies when the process environment does NOT already define the
-# variable (Cargo config reference) — without force, a shell that happens to
-# export CARGO_INCREMENTAL would silently win over this config and defeat
-# the whole point of this fix.
+# #594: this [env] entry is INERT for Cargo's own incremental decision —
+# Cargo's [env] table sets variables for processes Cargo *spawns*, it does
+# NOT read [env] back for its own configuration (verified empirically on
+# cargo 1.97.0: a forced CARGO_TARGET_DIR was ignored by `cargo metadata`,
+# while a real process env var won — CARGO_INCREMENTAL goes through the same
+# accessor). The actual #585 disk fix is `[build] incremental = false` above
+# + `[profile.dev] incremental = false` below — those are what Cargo reads.
+# Kept here (with `force = true`) only because it DOES help a nested cargo
+# invocation spawned by a build script — real protection against a shell
+# that exports CARGO_INCREMENTAL for the top-level build would instead need
+# a guard in scripts/dev/quality-check.sh / scripts/build-ui.sh.
 CARGO_INCREMENTAL = { value = "0", force = true }
 
 # Alias definitions for common tasks

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -250,3 +250,28 @@ checks FROM THE CRATE DIR: `cd crates/presenter-ui && cargo fmt --check && cargo
 --all-targets -- -D warnings && cargo test --lib`. CI's Format job checks it explicitly
 (second step, `working-directory: crates/presenter-ui`) — an unformatted presenter-ui
 file now fails CI, so always `cargo fmt` inside the crate before pushing UI changes.
+
+## After a `--merge` (merge-commit) PR, ALWAYS merge main back into dev before continuing (#591)
+
+`gh pr merge <N> --merge` creates a NEW merge commit that lands ONLY on `main` — it is
+NOT automatically present on `dev`'s own history (dev's tip stays the pre-merge commit
+your PR was built on; only `main` gains the two-parent merge commit). Continuing
+straight to a post-release task on `dev` (e.g. the standard version-bump-after-release
+commit) WITHOUT first pulling that merge commit back in makes `dev` genuinely 1 commit
+behind `main` from the Branch Sync Check's point of view (`git rev-list --count
+HEAD..origin/main`) — even though every LINE of content already matches. The check
+fails with the exact fix in its own error message, but it costs a wasted CI cycle if
+you don't do it proactively:
+
+```bash
+git fetch origin
+git checkout dev
+git merge origin/main -m "Merge main (PR #N merge commit) back into dev"
+git push origin dev
+```
+
+This resolves as a clean, conflict-free merge (the content already matches — you're
+just re-uniting the two DAG branches at the merge commit), so it's always safe to run
+immediately after ANY `--merge`-style PR merge, before starting the next commit on dev
+(version bump or otherwise). `git rev-list --count origin/dev..origin/main` should read
+`0` before you push anything else.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -57,12 +57,21 @@ little wall-clock benefit (and this disk is shared with bakerion-ai's own
 
 **Fixed as of v0.4.209**: `incremental = false` in BOTH `[build]` and
 `[profile.dev]` of the repo-root `.cargo/config.toml` (a profile-level
-`incremental` setting overrides `[build]`'s, so both must agree — and
-`CARGO_INCREMENTAL` in `[env]` must match too, since an env var overrides
-config/profile settings), plus the identical `[build]`/`[env]` pair in
-`crates/presenter-ui/.cargo/config.toml` (that crate is OUTSIDE the
-workspace — own `Cargo.lock`, own `target/` — so the root config never
-reaches it). Verified locally: a full `cargo test --workspace` +
+`incremental` setting overrides `[build]`'s, so both must agree — Cargo's
+own incremental decision comes ONLY from `[build]`/`[profile.*]`), plus the
+identical `[build]` entry in `crates/presenter-ui/.cargo/config.toml`
+(duplicated defensively — Cargo discovers config by DIRECTORY ANCESTRY, not
+workspace membership, so the root config actually DOES merge into that
+crate's build when `build-ui.sh` `cd`s there first; the duplicate just keeps
+the setting attached to the crate if it's ever built from elsewhere).
+**#594 correction:** the `CARGO_INCREMENTAL` `[env]` entries in both files
+do NOT protect Cargo's own build — Cargo's `[env]` table only sets variables
+for processes Cargo *spawns*, it does not read `[env]` back for its own
+config (verified empirically on cargo 1.97.0). They're harmless to keep
+(they do affect a nested cargo invocation spawned by a build script) but
+real protection against a shell-exported `CARGO_INCREMENTAL` would need a
+guard in `scripts/dev/quality-check.sh` / `scripts/build-ui.sh` instead.
+Verified locally: a full `cargo test --workspace` +
 `bash scripts/build-ui.sh` after purging leaves `incremental/` either
 absent or an EMPTY 4 KB placeholder dir (cargo/trunk still `mkdir`s the
 slot; it just never writes cache content into it) under every `target/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.209"
+version = "0.4.210"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.209"
+version = "0.4.210"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -587,4 +587,114 @@ async fn ensure_library_picks_the_most_recent_tombstone_when_several_share_a_nam
         2,
         "exactly v1 and v2 -- no third library was minted"
     );
+
+    // #594 finding 4: the LWW boundary in `ensure_library` is a STRICT `>`
+    // (mirrors `sync_should_apply`'s own strict tie-break) — an incoming
+    // presentation whose `updated_at` is EXACTLY EQUAL to v2's must NOT
+    // revive it. Mutating the strict `>` to `>=` in production code would
+    // make this assertion fail.
+    let peer_tied = crate::SyncPresentation {
+        sync_id: "peer-p3-tied-with-v2".to_string(),
+        library_name: "Songs".to_string(),
+        name: "P3".to_string(),
+        updated_at: t2,
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome_tied, id_tied) = repo
+        .apply_sync_presentation(&peer_tied, &std::collections::HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome_tied, crate::SyncApplyOutcome::Created);
+    let pres_row_tied = row(&repo, id_tied.expect("created presentation has an id")).await;
+    assert_eq!(
+        pres_row_tied.library_id,
+        v2.id.to_string(),
+        "P3 (tied exactly with v2's own updated_at) still attaches to v2"
+    );
+    let v2_row_after_tie = library::Entity::find_by_id(v2.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        v2_row_after_tie.deleted_at.is_some(),
+        "an EXACTLY EQUAL updated_at must not revive the library -- the LWW \
+         boundary is strict `>`, not `>=`"
+    );
+}
+
+#[tokio::test]
+async fn ensure_library_tie_breaks_identical_updated_at_tombstones_by_sync_id() {
+    // #594 finding 3: the `order_by_desc(SyncId)` secondary key added
+    // alongside `order_by_desc(UpdatedAt)` in `ensure_library` (bd044c4e) is
+    // what makes two peers pick the SAME "most recent" tombstone when their
+    // `updated_at` values happen to be IDENTICAL (e.g. two rapid
+    // delete/recreate cycles landing on the same wall-clock millisecond).
+    // `ensure_library_picks_the_most_recent_tombstone_when_several_share_a_name`
+    // above never exercises this branch -- it deliberately sleeps 5ms so the
+    // two tombstones get DIFFERENT `updated_at` values. This test writes two
+    // tombstoned "Songs" rows with an IDENTICAL `updated_at` and distinct,
+    // known `sync_id`s directly (bypassing the sleep), so only the SyncId
+    // DESC tie-break decides the winner -- deterministic, independent of
+    // insertion order.
+    let repo = repo().await;
+    let tied_at: chrono::DateTime<chrono::Utc> = chrono::Utc::now();
+
+    let make_tombstoned_row = |id: String, sync_id: &str| library::ActiveModel {
+        id: sea_orm::Set(id),
+        name: sea_orm::Set("Songs".to_string()),
+        search_name: sea_orm::Set("songs".to_string()),
+        created_at: sea_orm::Set(tied_at.into()),
+        updated_at: sea_orm::Set(tied_at.into()),
+        sync_id: sea_orm::Set(sync_id.to_string()),
+        deleted_at: sea_orm::Set(Some(tied_at.into())),
+    };
+    let low_id = uuid::Uuid::new_v4().to_string();
+    let high_id = uuid::Uuid::new_v4().to_string();
+    // Inserted in an order that would pick the WRONG winner if the tie-break
+    // fell back to insertion order / row id instead of `sync_id` -- the
+    // lexicographically LOWER sync_id is inserted SECOND.
+    library::Entity::insert(make_tombstoned_row(high_id.clone(), "zzzzzzzz-tie-high"))
+        .exec(&repo.db)
+        .await
+        .unwrap();
+    library::Entity::insert(make_tombstoned_row(low_id.clone(), "aaaaaaaa-tie-low"))
+        .exec(&repo.db)
+        .await
+        .unwrap();
+
+    // A live peer presentation newer than the tied updated_at -- must attach
+    // to whichever tombstone wins the SyncId DESC tie-break: "zzzzzzzz...".
+    let peer = crate::SyncPresentation {
+        sync_id: "peer-p2-tied-tombstones".to_string(),
+        library_name: "Songs".to_string(),
+        name: "P2".to_string(),
+        updated_at: tied_at + chrono::Duration::seconds(5),
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, id) = repo
+        .apply_sync_presentation(&peer, &std::collections::HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_row = row(&repo, id.expect("created presentation has an id")).await;
+
+    assert_eq!(
+        pres_row.library_id, high_id,
+        "identical updated_at must tie-break on SyncId DESC -- the row with \
+         the lexicographically LATER sync_id ('zzzzzzzz...') wins, never an \
+         arbitrary/insertion-order pick"
+    );
+
+    let low_row_after = library::Entity::find_by_id(low_id)
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        low_row_after.deleted_at.is_some(),
+        "the losing tombstone (lower sync_id) is untouched -- still tombstoned"
+    );
 }

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -670,14 +670,22 @@ async fn ensure_library_tie_breaks_identical_updated_at_tombstones_by_sync_id() 
     };
     let low_id = uuid::Uuid::new_v4().to_string();
     let high_id = uuid::Uuid::new_v4().to_string();
-    // Inserted in an order that would pick the WRONG winner if the tie-break
-    // fell back to insertion order / row id instead of `sync_id` -- the
-    // lexicographically LOWER sync_id is inserted SECOND.
-    library::Entity::insert(make_tombstoned_row(high_id.clone(), "zzzzzzzz-tie-high"))
+    // Inserted with the row that must LOSE the tie-break FIRST and the row
+    // that must WIN it SECOND. SQLite's `ORDER BY UpdatedAt DESC` alone (no
+    // secondary sort) breaks a tie by returning matching rows in their
+    // natural/insertion order -- so if the `order_by_desc(SyncId)` line were
+    // ever deleted from `ensure_library`, an insertion-order fallback would
+    // pick whichever row was inserted FIRST. Inserting the loser (`low_id`)
+    // first means that fallback would wrongly return `low_id`, failing the
+    // assertion below -- proving the SyncId tie-break, not insertion order,
+    // is what selects `high_id`. (An earlier version of this test inserted
+    // the winner first, which coincidentally still passed with the tie-break
+    // line deleted -- a vacuous oracle caught by review.)
+    library::Entity::insert(make_tombstoned_row(low_id.clone(), "aaaaaaaa-tie-low"))
         .exec(&repo.db)
         .await
         .unwrap();
-    library::Entity::insert(make_tombstoned_row(low_id.clone(), "aaaaaaaa-tie-low"))
+    library::Entity::insert(make_tombstoned_row(high_id.clone(), "zzzzzzzz-tie-high"))
         .exec(&repo.db)
         .await
         .unwrap();

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -587,38 +587,56 @@ async fn ensure_library_picks_the_most_recent_tombstone_when_several_share_a_nam
         2,
         "exactly v1 and v2 -- no third library was minted"
     );
+}
 
-    // #594 finding 4: the LWW boundary in `ensure_library` is a STRICT `>`
-    // (mirrors `sync_should_apply`'s own strict tie-break) — an incoming
-    // presentation whose `updated_at` is EXACTLY EQUAL to v2's must NOT
-    // revive it. Mutating the strict `>` to `>=` in production code would
-    // make this assertion fail.
+#[tokio::test]
+async fn ensure_library_boundary_is_strict_greater_than_not_greater_or_equal() {
+    // #594 finding 4: the LWW boundary in `ensure_library` (sync_apply.rs:357)
+    // is a STRICT `>` (mirrors `sync_should_apply`'s own strict tie-break),
+    // documented as deliberate at :311 but previously untested -- mutating it
+    // to `>=` would pass every existing test (exact equality is near
+    // unreachable in practice, but the boundary itself was unproven). An
+    // incoming presentation whose `updated_at` is EXACTLY EQUAL to the
+    // tombstoned library's own must NOT revive it.
+    let repo = repo().await;
+
+    let lib = repo.create_library("Songs").await.unwrap();
+    repo.delete_library(lib.id).await.unwrap();
+    let lib_row = library::Entity::find_by_id(lib.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .expect("library row still exists, tombstoned");
+    let tombstoned_at: chrono::DateTime<chrono::Utc> = lib_row.updated_at.into();
+
     let peer_tied = crate::SyncPresentation {
-        sync_id: "peer-p3-tied-with-v2".to_string(),
+        sync_id: "peer-p2-tied-with-tombstone".to_string(),
         library_name: "Songs".to_string(),
-        name: "P3".to_string(),
-        updated_at: t2,
+        name: "P2".to_string(),
+        updated_at: tombstoned_at,
         deleted_at: None,
         slides: vec![slide(0, "x")],
     };
-    let (outcome_tied, id_tied) = repo
+    let (outcome, id) = repo
         .apply_sync_presentation(&peer_tied, &std::collections::HashSet::new())
         .await
         .unwrap();
-    assert_eq!(outcome_tied, crate::SyncApplyOutcome::Created);
-    let pres_row_tied = row(&repo, id_tied.expect("created presentation has an id")).await;
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_row = row(&repo, id.expect("created presentation has an id")).await;
     assert_eq!(
-        pres_row_tied.library_id,
-        v2.id.to_string(),
-        "P3 (tied exactly with v2's own updated_at) still attaches to v2"
+        pres_row.library_id,
+        lib.id.to_string(),
+        "P2 (tied exactly with the tombstone's own updated_at) still attaches \
+         to the existing tombstoned library"
     );
-    let v2_row_after_tie = library::Entity::find_by_id(v2.id.to_string())
+
+    let lib_row_after = library::Entity::find_by_id(lib.id.to_string())
         .one(&repo.db)
         .await
         .unwrap()
         .unwrap();
     assert!(
-        v2_row_after_tie.deleted_at.is_some(),
+        lib_row_after.deleted_at.is_some(),
         "an EXACTLY EQUAL updated_at must not revive the library -- the LWW \
          boundary is strict `>`, not `>=`"
     );

--- a/crates/presenter-server/src/state/sync_race_tests.rs
+++ b/crates/presenter-server/src/state/sync_race_tests.rs
@@ -214,4 +214,26 @@ async fn concurrent_library_delete_and_presentation_create_revives_library_when_
         find_song(&a.libraries().await.unwrap(), "AlreadyTrashed").is_none(),
         "reviving the LIBRARY must never revive a presentation tombstoned under it"
     );
+
+    // #594 finding 2: the test above only proves A's side of the race — at
+    // this point B is still DIVERGENT (its own library is still tombstoned,
+    // P2 is B's own live-but-orphaned row under it). Convergence is the
+    // PR's central claim, so it must be exercised on BOTH peers, mirroring
+    // the extra `run_sync_cycle` the stay-tombstoned test above already
+    // does for its own tie-break.
+    run_sync_cycle(&b, &a_url, &client()).await.unwrap();
+    assert_eq!(
+        library_is_deleted(&b, "Songs").await,
+        Some(false),
+        "B must also revive the library once it pulls A's newer, now-live copy"
+    );
+    assert_eq!(
+        library_row_count_by_name(&b, "Songs").await,
+        1,
+        "B must not end up with a duplicate library row either"
+    );
+    assert!(
+        find_song(&b.libraries().await.unwrap(), "P2").is_some(),
+        "P2 must be visible on B too, converged with A"
+    );
 }

--- a/crates/presenter-ui/.cargo/config.toml
+++ b/crates/presenter-ui/.cargo/config.toml
@@ -4,16 +4,24 @@ build-std = ["std", "panic_abort"]
 [target.wasm32-unknown-unknown]
 rustflags = ["-Ctarget-cpu=mvp", "-Ctarget-feature=+mutable-globals"]
 
-# #585: incremental compilation disabled — this crate is OUTSIDE the
-# workspace (own Cargo.lock, own target/), so the repo-root .cargo/config.toml
-# never applies to it and it needs its own entry. Its incremental cache alone
-# accounted for ~9.3 GB (5.0 GB debug + 4.3 GB wasm32-unknown-unknown
-# debug+release) of the 55 GB that filled dev2's disk.
+# #585/#594: incremental compilation disabled here too. Duplicated
+# DEFENSIVELY, not because it's strictly required today: Cargo discovers
+# config by DIRECTORY ANCESTRY, not workspace membership, so the repo-root
+# .cargo/config.toml DOES merge into this crate's build whenever
+# scripts/build-ui.sh `cd`s here first (verified empirically) — this crate
+# being OUTSIDE the workspace (own Cargo.lock, own target/) is unrelated to
+# that. This entry just keeps the setting attached to the crate in case it's
+# ever built from a different cwd. Its incremental cache alone accounted for
+# ~9.3 GB (5.0 GB debug + 4.3 GB wasm32-unknown-unknown debug+release) of the
+# 55 GB that filled dev2's disk.
 [build]
 incremental = false
 
 [env]
-# force = true: a plain KEY = "value" only applies when the process env does
-# NOT already define it — without force, an inherited shell CARGO_INCREMENTAL
-# would silently win over this config (see the root .cargo/config.toml note).
+# #594: like the root .cargo/config.toml, this [env] entry is INERT for
+# Cargo's own incremental decision — Cargo's [env] table only sets variables
+# for processes Cargo *spawns*, it does not read [env] back for its own
+# config. The actual fix is `[build] incremental = false` above. Kept here
+# (with `force = true`) only because it DOES help a nested cargo invocation
+# spawned by a build script.
 CARGO_INCREMENTAL = { value = "0", force = true }

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4,6 +4,47 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 
 ---
 
+## 2026-07-25 — #580 library-delete-vs-presentation-create race + #585 disable incremental compilation (PR #591, v0.4.209)
+
+- **#580 (bug):** `ensure_library()` in `sync_apply.rs` only ever looked at LIVE libraries by
+  name; when only a TOMBSTONED same-named one existed, it unconditionally minted a fresh live
+  library instead of considering it — diverging two peers forever in a rare concurrent
+  library-delete-vs-presentation-create race. Precondition verified first: libraries DO carry a
+  comparable `updated_at` through the sync path (#578's `apply_sync_library`), so the design
+  decision on the issue (option b: LWW against the tombstone) was implemented without inventing
+  a new wire field (the rejected, larger option a).
+- **RED** `11d4b522` — two-peer regression tests
+  (`crates/presenter-server/src/state/sync_race_tests.rs:82`, `:161`), both fail on pre-fix code.
+- **GREEN** `eb61430b` — `ensure_library` revives-or-attaches via LWW against the tombstoned
+  library's own `updated_at`; both tests pass.
+- **Self-review hardening** `d5321c6c` (+ regression test
+  `sync_trash_tests.rs:503`) — the tombstone lookup needs a most-recent pick when MULTIPLE
+  tombstones share a name (repeated delete/recreate cycles; the partial unique index only
+  guards LIVE rows). Confirmed failing without `order_by_desc(UpdatedAt)`, passing with it.
+- **Dispatched deep-review fixup** `bd044c4e` — reviewer found the multi-tombstone tie-break
+  wasn't peer-stable on an EXACT `updated_at` collision; added `SyncId DESC` as a peer-stable
+  secondary sort (never a local-only key like row `Id`). Also hardened `.cargo/config.toml`'s
+  `[env] CARGO_INCREMENTAL` to the `{ value = "0", force = true }` table form (a plain
+  `KEY = "value"` only wins when the shell doesn't already export it).
+- **#585 (chore)** `58595f04` — `target/` had grown to 55 GB on dev2 (29 GB pure
+  `incremental/` scratch cache). `incremental = false` in `[build]` AND `[profile.dev]` of both
+  `.cargo/config.toml` files (root + `crates/presenter-ui`, which is workspace-excluded and needs
+  its own entry) — a profile-level setting overrides `[build]`'s, so both had to agree. CI was
+  already running `CARGO_INCREMENTAL: 0` at the workflow-env level (`pipeline.yml`), so this is a
+  LOCAL-machine-only fix with zero CI-behavior change — verified: full `cargo test --workspace` +
+  `build-ui.sh` after purging left `incremental/` absent or an empty 4 KB placeholder everywhere.
+- **Gotcha hit + documented** `46c92ce2` — after `gh pr merge --merge`, the new merge commit
+  lands only on `main`; continuing straight to the version bump on `dev` tripped the Branch Sync
+  Check even though content matched. Fixed by merging `origin/main` back into `dev`
+  (`168d2a8b`) before the version bump; documented in `.claude/skills/ci/SKILL.md` so the next
+  session doesn't lose a CI cycle to it.
+- **Bundled PR #591** (dev→main, `Closes #580 #585`), merged `9431be31`. Main CI green → SNV
+  deployed + verified v0.4.209 (Playwright: operator loads, WASM ready, 24 libraries, 0 console
+  errors; `/integrations/sync/status` healthy, 0 errors). GitHub Release v0.4.209 →
+  `release.yml` deploy-pp succeeded (no #469 recurrence this time) → PP verified v0.4.209
+  (Playwright + healthz), both peers report each other at 0.4.209 with healthy sync. Post-release
+  bump to 0.4.210 (`fbbcc53e`).
+
 ## 2026-06-22 — #346 Decompose state/mod.rs AppState facade → subsystem managers (PR #456, v0.4.153)
 
 - **Validated still real:** `crates/presenter-server/src/state/mod.rs` = 1115 lines, `AppState` = 24 fields. NOT a 1000-line-cap fix — the CI fn-size gate miscounts this file (stops at the first `#[cfg(test)]` ~line 33; that undercount is open #407). So done as voluntary readability decomposition, not gate compliance.


### PR DESCRIPTION
## Summary

Post-merge adversarial review of the already-merged PR #591 (#580 sync race + #585 incremental
disk fix) surfaced 5 findings — 0 critical, all small. This PR closes all five, filed as #594.

- **Finding 1 (🟡):** `[env] CARGO_INCREMENTAL = { force = true }` was documented as guarding
  against a shell-exported `CARGO_INCREMENTAL` overriding the build config. Verified empirically
  (cargo 1.97.0) that Cargo's `[env]` table only sets variables for processes Cargo *spawns* — it
  is never read back for Cargo's own incremental decision, which comes solely from
  `[build]`/`[profile.*] incremental = false`. Corrected the comment in both `.cargo/config.toml`
  files and `.claude/skills/deploy/SKILL.md`. No behavior change — the #585 disk fix is unaffected.
- **Finding 2 (🟡):** the revive-branch race test
  (`concurrent_library_delete_and_presentation_create_revives_library_when_create_is_newer`)
  asserted only on peer A, leaving peer B's convergence — the PR's central claim — unproven. Added
  the mirroring `run_sync_cycle` + assertions on B.
- **Finding 3 (🟡):** the `order_by_desc(SyncId)` tie-break added in `bd044c4e` (for two tombstones
  sharing an identical `updated_at`) had no test. Added
  `ensure_library_tie_breaks_identical_updated_at_tombstones_by_sync_id`, which seeds two
  tombstones with an identical `updated_at` and known `sync_id`s directly.
- **Finding 4 (🔵):** the strict `>` LWW boundary in `ensure_library` was documented as deliberate
  but untested. Added `ensure_library_boundary_is_strict_greater_than_not_greater_or_equal`.
- **Finding 5 (🔵):** `presenter-ui`'s `.cargo/config.toml` claimed the repo-root config "never
  applies" because the crate is outside the workspace. Cargo discovers config by directory
  ancestry, not workspace membership — the root config DOES merge in when `build-ui.sh` `cd`s into
  the crate first. Reworded to state the duplicate entry is defensive, not required.

No production behavior changes for findings 2-4 — all new assertions already held against the
existing #591 code (confirmed green in CI, no code change needed to pass them).

Closes #594

## Test plan

- [x] `Test` job green in CI (all 3 new/extended tests pass against unmodified #591 production code)
- [x] `Quality Checks` job green (function-length gate — finding 4 split into its own test function
      after a first push tripped the >120-line hard cap)
- [x] `Deploy to Dev` green; `/healthz` on `10.77.8.134:8080` confirms `v0.4.210` live
