### PR TITLE
fix(repository): typed 404/422 mapping for library+presentation refusals (#584)

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -185,6 +185,13 @@ correctly (past `#[cfg(test)] mod tests;`). Two pre-existing-debt landmines:
   `build_driver` helpers + `stage_all`/`stage_main_meta` builders → all fns now ≤120). Check before
   editing: `bash scripts/dev/count_prod_lines.sh <file>` and
   `QC_TARGETS=<file> python3 scripts/dev/fn_length_check.py .`.
+  **#594 footgun: invoking `fn_length_check.py` with file PATHS as the argument (instead of `.` with
+  `QC_TARGETS` set) silently reports `{"violations": [], "warnings": []}` no matter what — the
+  script's only positional arg is `<repo_root>` to `os.walk`; a file path isn't a walkable directory,
+  so it silently walks nothing.** Appending finding-4's test onto an existing 88-line test function
+  once passed this false-negative local check, then failed CI's real `Quality Checks` job at 123
+  lines. ALWAYS invoke it exactly as shown above (repo root as arg 1, target file(s) via the
+  `QC_TARGETS` env var, newline-separated for multiple) — never pass a file path as argv[1].
   **Workaround when you must add code near an offender:** wire through a SMALL sibling file instead
   of the god-file (e.g. add the call in `state/integrations.rs`, not `state/mod.rs`), and put NEW
   tests in their OWN file (e.g. `resolume/latency_tests.rs`) so the bloated `tests.rs` stays out of

--- a/.claude/skills/database/SKILL.md
+++ b/.claude/skills/database/SKILL.md
@@ -43,6 +43,23 @@ To re-import source data (ProPresenter libraries, Bibles):
 3. Default mode (`--keep`) preserves existing data
 4. `--purge` mode replaces all libraries (WARNING: destroys playlists via FK cascade)
 
+## Testing a SQL secondary-sort tie-break — insert the LOSER first (#594 lesson)
+
+When testing that an `order_by_desc(SecondaryColumn)` tie-break actually matters (e.g.
+`ensure_library`'s `order_by_desc(UpdatedAt).order_by_desc(SyncId)` in
+`sync_apply.rs` — the `SyncId` tie-break decides which of several tombstoned rows sharing an
+identical `UpdatedAt` wins), **insert the row that must LOSE the tie-break FIRST and the row that
+must WIN it SECOND.** SQLite's `ORDER BY <primary> DESC` with NO secondary sort breaks a tie by
+returning matching rows in their natural/insertion order — so if you insert the expected WINNER
+first, the test still passes even with the real tie-break clause deleted from production code
+(insertion order coincidentally produces the same answer). This is a genuinely vacuous oracle: it
+looks like a real regression test but never fails when the thing it claims to test is removed.
+Caught by an independent `superpowers:requesting-code-review` pass on #594 (the reviewer
+empirically deleted the production tie-break line and reran the test to confirm). The fix costs
+nothing — just insert in loser-then-winner order — but you must think about it deliberately; it is
+not something `cargo test` or CI catches on its own, only a genuinely adversarial re-read (mutate
+the prod line, rerun the test, see if it fails) does.
+
 ## Library Management
 
 ProPresenter libraries are stored in `data/libraries/` as the single source of truth.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.210"
+version = "0.4.211"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.210"
+version = "0.4.211"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/lib.rs
+++ b/crates/presenter-persistence/src/lib.rs
@@ -28,6 +28,6 @@ mod repository;
 
 pub use audit::{ResolumePushAuditEntry, SettingsAuditEntry, SettingsAuditSource};
 pub use repository::{
-    sync_should_apply, DatabaseSettings, Repository, SyncApplyOutcome, SyncLibraryManifestRow,
-    SyncManifestRow, SyncPresentation, TrashedPresentation, PRUNE_HORIZON,
+    sync_should_apply, DatabaseSettings, Repository, RepositoryError, SyncApplyOutcome,
+    SyncLibraryManifestRow, SyncManifestRow, SyncPresentation, TrashedPresentation, PRUNE_HORIZON,
 };

--- a/crates/presenter-persistence/src/repository/library.rs
+++ b/crates/presenter-persistence/src/repository/library.rs
@@ -1,7 +1,6 @@
 use crate::entities::{
     library, library_favorite, presentation as presentation_entity, slide as slide_entity,
 };
-use anyhow::anyhow;
 use chrono::Utc;
 use presenter_core::{
     search::fold_query, Library, LibraryId, LibrarySummary, Presentation, PresentationId,
@@ -182,7 +181,9 @@ impl Repository {
             .exec(&self.db)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("library not found"));
+            // #584: typed refusal — the router downcasts to `RepositoryError`
+            // and maps `NotFound` to 404 instead of matching this string.
+            return Err(RepositoryError::NotFound("library not found").into());
         }
         Ok(())
     }
@@ -209,9 +210,10 @@ impl Repository {
             .exec(&txn)
             .await?;
         if lib_result.rows_affected == 0 {
-            // Missing (or already-deleted) library → NotFound; the router maps
-            // this exact message to 404 instead of a 500 (#578).
-            return Err(anyhow!("library not found"));
+            // Missing (or already-deleted) library → NotFound; the router
+            // downcasts to `RepositoryError::NotFound` and maps it to 404
+            // instead of a 500 (#578, typed via #584).
+            return Err(RepositoryError::NotFound("library not found").into());
         }
 
         // The ids of the LIVE presentations we're about to tombstone — needed

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -32,6 +32,9 @@ mod util;
 pub use library_sync::SyncLibraryManifestRow;
 pub use sync::{SyncManifestRow, SyncPresentation, TrashedPresentation};
 pub use sync_apply::{sync_should_apply, SyncApplyOutcome, PRUNE_HORIZON};
+// #584: exposed so the server crate can `downcast_ref` a repository refusal
+// to its typed variant instead of matching on the `Display` string.
+pub use util::RepositoryError;
 
 use util::{
     ableset_model_to_domain, android_stage_display_model_to_domain, osc_model_to_domain,

--- a/crates/presenter-persistence/src/repository/presentation.rs
+++ b/crates/presenter-persistence/src/repository/presentation.rs
@@ -162,7 +162,10 @@ impl Repository {
             .await?
             .is_none()
         {
-            return Err(anyhow!("target library not found"));
+            // #584: typed refusal — a body-referenced target that vanished,
+            // distinct from `NotFound` because the router maps it to 422
+            // (unprocessable request), not 404.
+            return Err(RepositoryError::TargetNotFound("target library not found").into());
         }
 
         let source = presentation_entity::Entity::find()
@@ -170,7 +173,7 @@ impl Repository {
             .filter(presentation_entity::Column::DeletedAt.is_null())
             .one(&txn)
             .await?
-            .ok_or_else(|| anyhow!("presentation not found"))?;
+            .ok_or(RepositoryError::NotFound("presentation not found"))?;
 
         let source_slides = slide_entity::Entity::find()
             .filter(slide_entity::Column::PresentationId.eq(source_id.clone()))
@@ -258,7 +261,9 @@ impl Repository {
             .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("presentation not found"));
+            // #584: typed refusal — the router downcasts to `RepositoryError`
+            // and maps `NotFound` to 404 (previously a bare 500).
+            return Err(RepositoryError::NotFound("presentation not found").into());
         }
         touch_presentation(&txn, &id).await?;
         txn.commit().await?;
@@ -287,7 +292,9 @@ impl Repository {
             .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("presentation not found"));
+            // #584: typed refusal — the router downcasts to `RepositoryError`
+            // and maps `NotFound` to 404 (previously a bare 500).
+            return Err(RepositoryError::NotFound("presentation not found").into());
         }
 
         // Preserve today's behavior: a deleted song leaves every playlist.

--- a/crates/presenter-persistence/src/repository/presentation_copy_tests.rs
+++ b/crates/presenter-persistence/src/repository/presentation_copy_tests.rs
@@ -1,6 +1,7 @@
 //! #570: deep-copy a presentation into another library. Kept in its own file
 //! (not `tests.rs`, which is already over the file-size cap) per the
 //! presenter-ci playbook.
+use super::util::RepositoryError;
 use crate::entities::presentation as presentation_entity;
 use crate::Repository;
 use presenter_core::{LibraryId, Slide, SlideContent, SlideText};
@@ -136,6 +137,16 @@ async fn copy_into_a_missing_library_errors_and_writes_nothing() {
         .copy_presentation_to_library(source.id, LibraryId::new())
         .await
         .expect_err("copy into a vanished library must fail");
+    // #584: assert the TYPED variant the router downcasts on, not just the
+    // Display text — a `.context(...)` added upstream could still change
+    // `to_string()` without this assertion catching a regression.
+    assert!(
+        matches!(
+            err.downcast_ref::<RepositoryError>(),
+            Some(RepositoryError::TargetNotFound(_))
+        ),
+        "expected RepositoryError::TargetNotFound, got: {err}"
+    );
     assert!(
         err.to_string().contains("target library not found"),
         "{err}"
@@ -158,6 +169,14 @@ async fn copying_a_trashed_presentation_errors() {
         .copy_presentation_to_library(source.id, lib_b.id)
         .await
         .expect_err("a soft-deleted song must not be copyable");
+    // #584: assert the TYPED variant, not just the Display text.
+    assert!(
+        matches!(
+            err.downcast_ref::<RepositoryError>(),
+            Some(RepositoryError::NotFound(_))
+        ),
+        "expected RepositoryError::NotFound, got: {err}"
+    );
     assert!(err.to_string().contains("presentation not found"), "{err}");
 
     let live = presentation_entity::Entity::find()

--- a/crates/presenter-persistence/src/repository/util.rs
+++ b/crates/presenter-persistence/src/repository/util.rs
@@ -44,6 +44,19 @@ pub enum RepositoryError {
     InvalidAbleSetPort(i32),
     #[error("ableset song prefix length {0} out of range")]
     InvalidAbleSetPrefix(i32),
+    /// A repository operation targeted a resource (identified by the URL /
+    /// the operation's own subject) that does not exist, or is already
+    /// soft-deleted. The router maps this to 404 via `downcast_ref` — never
+    /// an exact-string match on `Display` text (#584).
+    #[error("{0}")]
+    NotFound(&'static str),
+    /// A repository operation was refused because a resource named in the
+    /// REQUEST BODY (not the URL) does not exist — e.g. `copy_presentation`'s
+    /// `targetLibraryId`. Kept distinct from `NotFound` because the router
+    /// maps it to 422 (the URL resource is fine; the payload references a
+    /// missing target), not 404 (#584).
+    #[error("{0}")]
+    TargetNotFound(&'static str),
 }
 
 pub(super) fn parse_uuid(id: &str) -> Result<Uuid, RepositoryError> {

--- a/crates/presenter-server/src/router/libraries.rs
+++ b/crates/presenter-server/src/router/libraries.rs
@@ -79,6 +79,19 @@ pub(super) async fn create_library(
     Ok(Json(library))
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text, which silently stops matching the
+/// moment a `.context(...)` is added anywhere between here and the
+/// repository (#578 review gap, fixed by #584). Any other error falls
+/// through to the default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn rename_library(
     State(state): State<AppState>,
@@ -89,7 +102,10 @@ pub(super) async fn rename_library(
     if name.is_empty() {
         return Err(AppError::bad_request_message("name cannot be empty"));
     }
-    state.rename_library(LibraryId::from_uuid(id), name).await?;
+    state
+        .rename_library(LibraryId::from_uuid(id), name)
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -101,17 +117,7 @@ pub(super) async fn delete_library(
     state
         .delete_library(LibraryId::from_uuid(id))
         .await
-        .map_err(|err| {
-            // EXACT match on the repository's refusal message — a substring
-            // test would mis-map any internal error that happens to contain
-            // "not found" to a client error (mirrors copy_presentation's
-            // mapping in presentations.rs). #578 review gap: a missing or
-            // already-deleted library used to fall through to 500.
-            match err.to_string().as_str() {
-                "library not found" => AppError::not_found("library not found"),
-                _ => err.into(),
-            }
-        })?;
+        .map_err(map_repository_not_found)?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/presenter-server/src/router/presentations.rs
+++ b/crates/presenter-server/src/router/presentations.rs
@@ -95,6 +95,22 @@ pub(super) async fn get_presentation_detail(
     }
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#584; mirrors `libraries.rs`'s
+/// `map_repository_not_found`). `NotFound` (the URL resource itself is
+/// missing) maps to 404; `TargetNotFound` (a body-referenced resource is
+/// missing) maps to 422. Any other error falls through to the default 500.
+fn map_repository_error(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        Some(presenter_persistence::RepositoryError::TargetNotFound(msg)) => {
+            AppError::unprocessable(*msg)
+        }
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn update_presentation(
     State(state): State<AppState>,
@@ -108,7 +124,8 @@ pub(super) async fn update_presentation(
     let presentation_uuid = super::parse_uuid("presentationId", &id)?;
     state
         .rename_presentation(PresentationId::from_uuid(presentation_uuid), name)
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -120,7 +137,8 @@ pub(super) async fn delete_presentation(
     let presentation_uuid = super::parse_uuid("presentationId", &id)?;
     state
         .delete_presentation(PresentationId::from_uuid(presentation_uuid))
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -140,18 +158,7 @@ pub(super) async fn copy_presentation(
             LibraryId::from_uuid(library_uuid),
         )
         .await
-        .map_err(|err| {
-            // EXACT match on the repository's two refusal messages — a
-            // substring test would mis-map any internal error that happens
-            // to contain "not found" to a client error.
-            match err.to_string().as_str() {
-                // The body-referenced target vanished — the REQUEST is
-                // unprocessable (422), not a missing URL resource.
-                "target library not found" => AppError::unprocessable("target library not found"),
-                "presentation not found" => AppError::not_found("presentation not found"),
-                _ => err.into(),
-            }
-        })?;
+        .map_err(map_repository_error)?;
     Ok((
         StatusCode::CREATED,
         Json(PresentationDetailDto {

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -867,6 +867,71 @@ async fn delete_library_endpoint_missing_library_returns_404() {
 }
 
 #[tokio::test]
+async fn rename_library_endpoint_missing_library_returns_404() {
+    // #584: `rename_library`'s repository refusal ("library not found") had
+    // NO router-side mapping at all — unlike `delete_library` it fell
+    // through the default `AppError::from(anyhow::Error)` conversion to a
+    // bare 500, instead of the 404 a missing URL resource should return.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let rename_body = serde_json::json!({ "name": "Doesn't matter" }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PATCH)
+                .uri(format!("/libraries/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(rename_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn rename_presentation_endpoint_missing_presentation_returns_404() {
+    // #584: `rename_presentation`'s repository refusal ("presentation not
+    // found") had NO router-side mapping — it fell through to a bare 500
+    // instead of 404.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let rename_body = serde_json::json!({ "name": "Doesn't matter" }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PATCH)
+                .uri(format!("/presentations/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(rename_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_presentation_endpoint_missing_presentation_returns_404() {
+    // #584: `delete_presentation`'s repository refusal ("presentation not
+    // found") had NO router-side mapping — it fell through to a bare 500
+    // instead of 404.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/presentations/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn create_playlist_endpoint_supports_dashboard_flag() {
     let app = build_router(AppState::in_memory().await.unwrap());
     let create_body = serde_json::json!({

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4,6 +4,42 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 
 ---
 
+## 2026-07-26 — #594 post-merge review findings on PR #591 (PR #596, v0.4.210)
+
+- **Context:** adversarial review of already-merged PR #591 found 5 small findings (0 critical),
+  filed as #594. All fixed in one PR, no production `.rs` logic changed.
+- **Finding 1 (doc):** `[env] CARGO_INCREMENTAL = { force = true }` comment falsely claimed it
+  guards against a shell-exported var overriding the build. Corrected in both
+  `.cargo/config.toml` files + `.claude/skills/deploy/SKILL.md` — Cargo's `[env]` only affects
+  spawned processes, never Cargo's own config (verified empirically, cargo 1.97.0).
+- **Finding 2 (test)** `crates/presenter-server/src/state/sync_race_tests.rs:237` — added the
+  missing peer-B convergence assertion to the revive-branch race test (previously only checked A).
+- **Finding 3 (test)** `crates/presenter-persistence/src/repository/sync_trash_tests.rs:646` — new
+  test proving the `SyncId DESC` tie-break for two tombstones sharing an identical `updated_at`.
+  **Gotcha:** first version inserted the expected winner FIRST, which coincidentally still passed
+  with the tie-break line deleted (SQLite's no-secondary-sort tie fallback = insertion order) —
+  caught by `superpowers:requesting-code-review`'s independent reviewer, which empirically deleted
+  the production line and reran. Fixed by inserting the loser first (commit `88826f12`).
+- **Finding 4 (test)** `sync_trash_tests.rs:593` — new test proving the strict `>` LWW boundary
+  in `ensure_library` (exact `updated_at` equality must NOT revive). **Gotcha:** first push
+  appended this to the existing multi-tombstone test, pushing it to 123 lines and tripping the
+  `Quality Checks` >120-line function-length hard cap — fixed by extracting it into its own
+  self-contained test function (commit `bb65cb83`). Local `fn_length_check.py` must be invoked as
+  `QC_TARGETS=<file> python3 scripts/dev/fn_length_check.py .` (repo root as arg 1) — passing file
+  paths directly as argv silently walks nothing and false-negatives.
+- **Finding 5 (doc):** `crates/presenter-ui/.cargo/config.toml` wrongly claimed the root
+  `.cargo/config.toml` "never applies" because the crate is outside the workspace. Cargo discovers
+  config by directory ancestry, not workspace membership — `build-ui.sh` `cd`s into the crate
+  first, so the root config DOES merge in. Reworded as defensive duplication.
+- **Tier 0 (no local build) discipline:** all verification done via CI (2 Pipeline cycles — first
+  caught the function-length gate, second was clean) plus a deep `requesting-code-review` pass
+  that caught the vacuous-oracle gap in finding 3's test after CI was already green (CI cannot
+  catch a weak test oracle, only a genuinely independent adversarial re-read can).
+- **PR #596** (dev→main, `Closes #594`), merged `5ade6a81`. Main CI green → SNV deployed +
+  verified v0.4.210 (Playwright: operator loads, WASM ready, 24 libraries, 0 console errors).
+  GitHub Release v0.4.210 → `release.yml` deploy-pp succeeded (no #469 recurrence) → PP verified
+  v0.4.210 (Playwright + healthz). Post-release bump to 0.4.211 (`622b7157`).
+
 ## 2026-07-25 — #580 library-delete-vs-presentation-create race + #585 disable incremental compilation (PR #591, v0.4.209)
 
 - **#580 (bug):** `ensure_library()` in `sync_apply.rs` only ever looked at LIVE libraries by


### PR DESCRIPTION
## Summary

Adds typed `RepositoryError::NotFound` / `TargetNotFound` variants and converts the
library/presentation "refusal" call sites to match on the enum variant (`downcast_ref`)
instead of an exact-string `Display` match — per the ticket owner's 2026-07-25 scoping
comment (the mechanism-only slice; the full 21-site sweep is #586/#587/#588/#589).

- `RepositoryError` gains `NotFound(&'static str)` and `TargetNotFound(&'static str)`,
  exported from `presenter-persistence` for the server crate to `downcast_ref` on
  (mirrors the existing `TimerError` pattern in `router/timers.rs`).
- Producer sites converted: `library.rs::rename_library` / `delete_library`,
  `presentation.rs::copy_presentation_to_library` (both refusals) /
  `rename_presentation` / `delete_presentation`. Display text unchanged — the wire
  JSON error body does not change.
- Router sites converted: `router/libraries.rs`, `router/presentations.rs` — string
  matches replaced with variant matches via a small `map_repository_not_found` /
  `map_repository_error` helper per file.
- Fixes 3 live defects (500 where 404 is correct): `rename_library`,
  `rename_presentation`, `delete_presentation` had NO router-side mapping at all.

## Test plan

- [x] RED commit `6ed864e0`: new router tests (`rename_library_endpoint_missing_library_returns_404`,
  `rename_presentation_endpoint_missing_presentation_returns_404`,
  `delete_presentation_endpoint_missing_presentation_returns_404`) + updated
  `presentation_copy_tests.rs` assertions on the typed variant — fail against pre-fix code.
- [x] GREEN commit `96f24154`: producer + router conversion makes them pass.
- [x] CI green end-to-end (run 30262882927): fmt, clippy, quality checks, test, build,
  coverage, E2E (NDI + 3x Playwright), deploy-dev.

Closes #584
