### PR TITLE
fix(router): typed 404 for remaining resolume/android-stage/video-source/playlist/bible/sync unknown-id refusals (#586, #587)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.212"
+version = "0.4.213"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/android_stage.rs
+++ b/crates/presenter-persistence/src/repository/android_stage.rs
@@ -83,7 +83,7 @@ impl Repository {
             .one(&txn)
             .await?
             // #586: typed refusal (#584 pattern).
-            .ok_or_else(|| RepositoryError::NotFound("android stage display not found"))?;
+            .ok_or(RepositoryError::NotFound("android stage display not found"))?;
         let before = android_stage_display_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
 

--- a/crates/presenter-persistence/src/repository/android_stage.rs
+++ b/crates/presenter-persistence/src/repository/android_stage.rs
@@ -4,7 +4,7 @@
 //! own file, calling the shared `Self::record_settings_audit_on` helper
 //! defined in `audit.rs`.
 
-use super::util::android_stage_display_model_to_domain;
+use super::util::{android_stage_display_model_to_domain, RepositoryError};
 use super::Repository;
 use crate::audit::SettingsAuditSource;
 use crate::entities::android_stage_display;
@@ -82,7 +82,8 @@ impl Repository {
         let existing = android_stage_display::Entity::find_by_id(id.to_string())
             .one(&txn)
             .await?
-            .ok_or_else(|| anyhow!("android stage display not found"))?;
+            // #586: typed refusal (#584 pattern).
+            .ok_or_else(|| RepositoryError::NotFound("android stage display not found"))?;
         let before = android_stage_display_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
 
@@ -132,7 +133,7 @@ impl Repository {
             .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("android stage display not found"));
+            return Err(RepositoryError::NotFound("android stage display not found").into());
         }
         Self::record_settings_audit_on(
             &txn,

--- a/crates/presenter-persistence/src/repository/bible/presentations.rs
+++ b/crates/presenter-persistence/src/repository/bible/presentations.rs
@@ -136,7 +136,7 @@ impl Repository {
             .exec(&self.db)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("bible presentation not found"));
+            return Err(RepositoryError::NotFound("bible presentation not found").into());
         }
         Ok(())
     }
@@ -147,7 +147,7 @@ impl Repository {
             .exec(&self.db)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("bible presentation not found"));
+            return Err(RepositoryError::NotFound("bible presentation not found").into());
         }
         Ok(())
     }
@@ -166,7 +166,7 @@ impl Repository {
             .await?
             .is_none()
         {
-            return Err(anyhow!("bible presentation not found"));
+            return Err(RepositoryError::NotFound("bible presentation not found").into());
         }
 
         bible_slide::Entity::delete_many()
@@ -199,7 +199,7 @@ impl Repository {
             .await?
             .is_none()
         {
-            return Err(anyhow!("bible presentation not found"));
+            return Err(RepositoryError::NotFound("bible presentation not found").into());
         }
 
         let existing_count = bible_slide::Entity::find()

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -1,7 +1,6 @@
 use crate::entities::{
     playlist, playlist_entry, playlist_favorite, presentation as presentation_entity,
 };
-use anyhow::anyhow;
 use chrono::Utc;
 use presenter_core::{playlist::PlaylistEntryKind, Playlist, PlaylistId, PresentationId};
 use sea_orm::{
@@ -131,7 +130,9 @@ impl Repository {
         if count > 0 {
             Ok(())
         } else {
-            Err(anyhow!("playlist not found"))
+            // #586: typed refusal (#584 pattern) — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
+            Err(RepositoryError::NotFound("playlist not found").into())
         }
     }
 

--- a/crates/presenter-persistence/src/repository/resolume.rs
+++ b/crates/presenter-persistence/src/repository/resolume.rs
@@ -3,7 +3,7 @@
 //! two-port model landed) — same pattern as `audit.rs`/`stage_state.rs`:
 //! a self-contained `impl Repository` block in its own file.
 
-use super::util::resolume_model_to_domain;
+use super::util::{resolume_model_to_domain, RepositoryError};
 use super::Repository;
 use crate::audit::SettingsAuditSource;
 use crate::entities::resolume_host;
@@ -79,7 +79,10 @@ impl Repository {
         let existing = resolume_host::Entity::find_by_id(id.to_string())
             .one(&txn)
             .await?
-            .ok_or_else(|| anyhow!("resolume host not found"))?;
+            // #586: typed refusal — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of
+            // matching a string (#584 pattern).
+            .ok_or_else(|| RepositoryError::NotFound("resolume host not found"))?;
         let before = resolume_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
         // #564: an explicit host/port edit invalidates any previously
@@ -181,7 +184,8 @@ impl Repository {
             .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("resolume host not found"));
+            // #586: typed refusal (#584 pattern) — see update_resolume_host above.
+            return Err(RepositoryError::NotFound("resolume host not found").into());
         }
         Self::record_settings_audit_on(
             &txn,

--- a/crates/presenter-persistence/src/repository/resolume.rs
+++ b/crates/presenter-persistence/src/repository/resolume.rs
@@ -82,7 +82,7 @@ impl Repository {
             // #586: typed refusal — the router downcasts to
             // `RepositoryError` and maps `NotFound` to 404 instead of
             // matching a string (#584 pattern).
-            .ok_or_else(|| RepositoryError::NotFound("resolume host not found"))?;
+            .ok_or(RepositoryError::NotFound("resolume host not found"))?;
         let before = resolume_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
         // #564: an explicit host/port edit invalidates any previously

--- a/crates/presenter-persistence/src/repository/sync.rs
+++ b/crates/presenter-persistence/src/repository/sync.rs
@@ -155,7 +155,9 @@ impl Repository {
             .exec(&self.db)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow::anyhow!("no trashed presentation to restore"));
+            // #587: typed refusal (#584 pattern) — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
+            return Err(RepositoryError::NotFound("no trashed presentation to restore").into());
         }
         Ok(())
     }

--- a/crates/presenter-persistence/src/repository/video_source.rs
+++ b/crates/presenter-persistence/src/repository/video_source.rs
@@ -4,7 +4,7 @@
 //! own file, calling the shared `Self::record_settings_audit_on` helper
 //! defined in `audit.rs`.
 
-use super::util::video_source_model_to_domain;
+use super::util::{video_source_model_to_domain, RepositoryError};
 use super::Repository;
 use crate::audit::SettingsAuditSource;
 use crate::entities::video_source;
@@ -92,7 +92,8 @@ impl Repository {
         let existing = video_source::Entity::find_by_id(id.to_string())
             .one(&txn)
             .await?
-            .ok_or_else(|| anyhow!("video source not found"))?;
+            // #586: typed refusal (#584 pattern).
+            .ok_or_else(|| RepositoryError::NotFound("video source not found"))?;
         let before = video_source_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
 
@@ -140,7 +141,7 @@ impl Repository {
             .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
-            return Err(anyhow!("video source not found"));
+            return Err(RepositoryError::NotFound("video source not found").into());
         }
         Self::record_settings_audit_on(
             &txn,
@@ -175,7 +176,8 @@ impl Repository {
         let existing = video_source::Entity::find_by_id(id.to_string())
             .one(&txn)
             .await?
-            .ok_or_else(|| anyhow!("video source not found"))?;
+            // #586: typed refusal (#584 pattern).
+            .ok_or_else(|| RepositoryError::NotFound("video source not found"))?;
         let target_before = video_source_model_to_domain(existing.clone())?;
         let target_before_json = serde_json::to_value(&target_before)?;
 

--- a/crates/presenter-persistence/src/repository/video_source.rs
+++ b/crates/presenter-persistence/src/repository/video_source.rs
@@ -93,7 +93,7 @@ impl Repository {
             .one(&txn)
             .await?
             // #586: typed refusal (#584 pattern).
-            .ok_or_else(|| RepositoryError::NotFound("video source not found"))?;
+            .ok_or(RepositoryError::NotFound("video source not found"))?;
         let before = video_source_model_to_domain(existing.clone())?;
         let before_json = serde_json::to_value(&before)?;
 
@@ -177,7 +177,7 @@ impl Repository {
             .one(&txn)
             .await?
             // #586: typed refusal (#584 pattern).
-            .ok_or_else(|| RepositoryError::NotFound("video source not found"))?;
+            .ok_or(RepositoryError::NotFound("video source not found"))?;
         let target_before = video_source_model_to_domain(existing.clone())?;
         let target_before_json = serde_json::to_value(&target_before)?;
 

--- a/crates/presenter-server/src/router/bible/broadcast.rs
+++ b/crates/presenter-server/src/router/bible/broadcast.rs
@@ -88,18 +88,21 @@ pub(crate) async fn trigger_bible_broadcast(
         main_reference_label: payload.main_reference_label,
         translation_reference_label: payload.translation_reference_label,
     };
-    match state
+    state
         .trigger_bible_passage(&payload.translation, &reference, text_overrides)
         .await
-    {
-        Ok(broadcast) => Ok(Json(broadcast)),
-        Err(err) => {
-            if err.to_string().contains("passage not found") {
-                return Err(AppError::not_found("passage not found"));
-            }
-            Err(err.into())
-        }
-    }
+        .map(Json)
+        // #587: typed refusal (#584 pattern) — downcast to `RepositoryError`
+        // instead of matching the `Display` string, which silently stops
+        // matching the moment a `.context(...)` is added upstream.
+        .map_err(
+            |err| match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+                Some(presenter_persistence::RepositoryError::NotFound(msg)) => {
+                    AppError::not_found(*msg)
+                }
+                _ => err.into(),
+            },
+        )
 }
 
 /// Request body for the new single-source-of-truth trigger endpoint.

--- a/crates/presenter-server/src/router/bible/presentations.rs
+++ b/crates/presenter-server/src/router/bible/presentations.rs
@@ -95,6 +95,18 @@ fn bible_presentation_to_detail(presentation: &BiblePresentation) -> BiblePresen
     }
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#587, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn list_bible_presentations(
     State(state): State<AppState>,
@@ -148,7 +160,8 @@ pub(crate) async fn rename_bible_presentation_handler(
     }
     state
         .rename_bible_presentation(BiblePresentationId::from_uuid(id), name)
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
@@ -159,7 +172,8 @@ pub(crate) async fn delete_bible_presentation_handler(
 ) -> Result<axum::http::StatusCode, AppError> {
     state
         .delete_bible_presentation(BiblePresentationId::from_uuid(id))
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
@@ -237,7 +251,8 @@ pub(crate) async fn append_bible_presentation_handler(
     }
     let presentation = state
         .append_bible_presentation_slides(BiblePresentationId::from_uuid(id), slides)
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(bible_presentation_to_detail(&presentation)))
 }
 
@@ -262,7 +277,8 @@ pub(crate) async fn delete_bible_presentation_slide(
             BiblePresentationId::from_uuid(pres_uuid),
             BibleSlideId::from_uuid(slide_uuid),
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(bible_presentation_to_detail(&presentation)))
 }
 
@@ -292,6 +308,7 @@ pub(crate) async fn reorder_bible_presentation_slides(
 
     let presentation = state
         .reorder_bible_slides(BiblePresentationId::from_uuid(id), slide_ids)
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(bible_presentation_to_detail(&presentation)))
 }

--- a/crates/presenter-server/src/router/integrations/android_stage.rs
+++ b/crates/presenter-server/src/router/integrations/android_stage.rs
@@ -79,6 +79,18 @@ fn normalize_launch_component(component: &str) -> String {
     }
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn list_android_stage_displays(
     State(state): State<AppState>,
@@ -135,7 +147,8 @@ pub(crate) async fn update_android_stage_display(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     let status = state.android_stage_status_for(display.id).await;
     Ok(Json(AndroidStageDisplayDto::from_display(display, status)))
 }
@@ -153,7 +166,8 @@ pub(crate) async fn delete_android_stage_display(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 

--- a/crates/presenter-server/src/router/integrations/resolume.rs
+++ b/crates/presenter-server/src/router/integrations/resolume.rs
@@ -58,6 +58,18 @@ const fn default_resolume_port() -> u16 {
     8090
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn list_resolume_hosts(
     State(state): State<AppState>,
@@ -110,7 +122,8 @@ pub(crate) async fn update_resolume_host(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     let status = state.resolume_status_for(host.id).await;
     Ok(Json(ResolumeHostDto::from_host(host, status)))
 }
@@ -128,7 +141,8 @@ pub(crate) async fn delete_resolume_host(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 

--- a/crates/presenter-server/src/router/integrations/video_source.rs
+++ b/crates/presenter-server/src/router/integrations/video_source.rs
@@ -44,6 +44,18 @@ pub(crate) struct VideoSourceRequest {
     ndi_name: String,
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn list_video_sources(
     State(state): State<AppState>,
@@ -132,7 +144,8 @@ pub(crate) async fn update_video_source(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(VideoSourceDto::from_source(source)))
 }
 
@@ -149,7 +162,8 @@ pub(crate) async fn delete_video_source(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
@@ -166,7 +180,8 @@ pub(crate) async fn activate_video_source(
             SettingsAuditSource::HttpSetter,
             &actor,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(VideoSourceDto::from_source(source)))
 }
 

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -53,6 +53,18 @@ pub(super) enum PlaylistEntryPayload {
     },
 }
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn list_playlists(
     State(state): State<AppState>,
@@ -108,7 +120,10 @@ pub(super) async fn update_playlist(
     }
 
     if let Some(favorite) = payload.show_in_dashboard {
-        state.set_playlist_favorite(playlist_id, favorite).await?;
+        state
+            .set_playlist_favorite(playlist_id, favorite)
+            .await
+            .map_err(map_repository_not_found)?;
     }
 
     let updated = state

--- a/crates/presenter-server/src/router/sync.rs
+++ b/crates/presenter-server/src/router/sync.rs
@@ -15,6 +15,18 @@ use crate::state::sync::{
 use crate::state::AppState;
 use presenter_core::PresentationId;
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#587, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn get_sync_manifest(
     State(state): State<AppState>,
@@ -93,6 +105,7 @@ pub(super) async fn restore_presentation(
     let uuid = super::parse_uuid("presentationId", &id)?;
     state
         .restore_presentation(PresentationId::from_uuid(uuid))
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -2708,3 +2708,331 @@ async fn live_ws_preview_client_is_excluded_from_stage_count() {
     preview_ws.close(None).await.unwrap();
     server.abort();
 }
+
+// #586/#587: bare `anyhow!("... not found")` refusals from the repository/
+// state layer fall through the router's default `From<anyhow::Error> for
+// AppError` mapping to a 500, instead of the 404 a missing URL resource
+// should return. Same root cause + fix pattern as #584 (see
+// `rename_library_endpoint_missing_library_returns_404` above) — extended
+// here to the resolume/android-stage/video-source/playlist endpoints (#586)
+// and the bible/sync endpoints (#587). Every test below drives a FRESH
+// in-memory DB, so any UUID is guaranteed to be "not found".
+
+#[tokio::test]
+async fn update_resolume_host_endpoint_missing_host_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "label": "Test Host",
+        "host": "10.0.0.1",
+        "port": 8090,
+        "isEnabled": true
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/integrations/resolume/hosts/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_resolume_host_endpoint_missing_host_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/integrations/resolume/hosts/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_android_stage_display_endpoint_missing_display_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "label": "Test Display",
+        "host": "10.0.0.1",
+        "port": 8080,
+        "launchComponent": "com.tcl.browser",
+        "isEnabled": true
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/integrations/android-stage/displays/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_android_stage_display_endpoint_missing_display_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/integrations/android-stage/displays/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_video_source_endpoint_missing_source_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "label": "Test Camera",
+        "ndiName": "CAM1"
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/integrations/video-sources/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_video_source_endpoint_missing_source_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/integrations/video-sources/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn activate_video_source_endpoint_missing_source_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/integrations/video-sources/{random_id}/activate"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_playlist_favorite_endpoint_missing_playlist_returns_404() {
+    // #586: `update_playlist`'s `showInDashboard` branch calls
+    // `set_playlist_favorite`, which repository-side calls
+    // `ensure_playlist_exists` — a bare `anyhow!("playlist not found")` with
+    // no router-side mapping, falling through to a bare 500.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({ "showInDashboard": true }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PATCH)
+                .uri(format!("/playlists/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn rename_bible_presentation_endpoint_missing_presentation_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({ "name": "Doesn't matter" }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PATCH)
+                .uri(format!("/bible/presentations/{random_id}"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_bible_presentation_endpoint_missing_presentation_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/bible/presentations/{random_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn append_bible_presentation_slides_endpoint_missing_presentation_returns_404() {
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "slides": [
+            { "bibleMain": "Test main", "bibleTranslation": "Test translation" }
+        ]
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/bible/presentations/{random_id}/append"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_bible_presentation_slide_endpoint_missing_presentation_returns_404() {
+    // #587: `delete_bible_presentation_slide` → `state::bible::delete_bible_slide`
+    // fetches the presentation via a bare `anyhow!("bible presentation not
+    // found")` with no router-side mapping — falls through to a bare 500.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_presentation_id = uuid::Uuid::new_v4();
+    let random_slide_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!(
+                    "/bible/presentations/{random_presentation_id}/slides/{random_slide_id}"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn reorder_bible_presentation_slides_endpoint_missing_presentation_returns_404() {
+    // #587: `reorder_bible_presentation_slides` → `state::bible::reorder_bible_slides`
+    // fetches the presentation via a bare `anyhow!("bible presentation not
+    // found")` with no router-side mapping — falls through to a bare 500.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({ "slideIds": [] }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/bible/presentations/{random_id}/slides/reorder"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn restore_presentation_endpoint_missing_trashed_presentation_returns_404() {
+    // #587: `restore_presentation`'s repository refusal ("no trashed
+    // presentation to restore") had no router-side mapping — falls through
+    // to a bare 500 instead of 404, on both an unknown id AND a
+    // never-trashed presentation.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/presentations/{random_id}/restore"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn trigger_bible_broadcast_endpoint_missing_passage_returns_404() {
+    // #587: this 404 already worked, but via a fragile
+    // `err.to_string().contains("passage not found")` string match on the
+    // `Display` text rather than a typed `downcast_ref` — pin it with a
+    // regression test now that it's converted to the typed pattern.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let body = json!({
+        "translation": "kjv",
+        "book": "Genesis",
+        "chapter": 1,
+        "verseStart": 1
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/bible/trigger")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -11,6 +11,7 @@ use presenter_core::{
     BibleSlideId, BibleSlideOutput, BibleTranslation, Slide, SlideText,
 };
 use presenter_importer::bible::BibleIngestionService;
+use presenter_persistence::RepositoryError;
 use std::collections::HashMap;
 
 /// Optional text overrides for triggered Bible slides (when the user edits text in the UI).
@@ -291,12 +292,14 @@ impl AppState {
             .repository
             .fetch_bible_presentation(presentation_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+            // #587: typed refusal (#584 pattern) — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
+            .ok_or_else(|| RepositoryError::NotFound("bible presentation not found"))?;
 
         let before = presentation.slides.len();
         presentation.slides.retain(|s| s.id != slide_id);
         if presentation.slides.len() == before {
-            return Err(anyhow::anyhow!("slide not found in presentation"));
+            return Err(RepositoryError::NotFound("slide not found in presentation").into());
         }
 
         self.repository
@@ -325,7 +328,8 @@ impl AppState {
             .repository
             .fetch_bible_presentation(presentation_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+            // #587: typed refusal (#584 pattern), see delete_bible_slide above.
+            .ok_or_else(|| RepositoryError::NotFound("bible presentation not found"))?;
 
         // Build a lookup of existing slides by ID.
         let mut by_id: HashMap<BibleSlideId, BiblePresentationSlide> = presentation
@@ -463,7 +467,7 @@ impl AppState {
                     .find_bible_passage(translation_code, reference)
                     .await?
                     .map(|p| p.translation)
-                    .ok_or_else(|| anyhow::anyhow!("passage not found"))?
+                    .ok_or_else(|| RepositoryError::NotFound("passage not found"))?
             } else {
                 range[0].translation.clone()
             };
@@ -473,7 +477,7 @@ impl AppState {
             self.repository
                 .find_bible_passage(translation_code, reference)
                 .await?
-                .ok_or_else(|| anyhow::anyhow!("passage not found"))?
+                .ok_or_else(|| RepositoryError::NotFound("passage not found"))?
         } else {
             // Combine multiple verses into a single passage
             let mut combined_text = String::new();

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -294,7 +294,7 @@ impl AppState {
             .await?
             // #587: typed refusal (#584 pattern) — the router downcasts to
             // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
-            .ok_or_else(|| RepositoryError::NotFound("bible presentation not found"))?;
+            .ok_or(RepositoryError::NotFound("bible presentation not found"))?;
 
         let before = presentation.slides.len();
         presentation.slides.retain(|s| s.id != slide_id);
@@ -329,7 +329,7 @@ impl AppState {
             .fetch_bible_presentation(presentation_id)
             .await?
             // #587: typed refusal (#584 pattern), see delete_bible_slide above.
-            .ok_or_else(|| RepositoryError::NotFound("bible presentation not found"))?;
+            .ok_or(RepositoryError::NotFound("bible presentation not found"))?;
 
         // Build a lookup of existing slides by ID.
         let mut by_id: HashMap<BibleSlideId, BiblePresentationSlide> = presentation
@@ -467,7 +467,7 @@ impl AppState {
                     .find_bible_passage(translation_code, reference)
                     .await?
                     .map(|p| p.translation)
-                    .ok_or_else(|| RepositoryError::NotFound("passage not found"))?
+                    .ok_or(RepositoryError::NotFound("passage not found"))?
             } else {
                 range[0].translation.clone()
             };
@@ -477,7 +477,7 @@ impl AppState {
             self.repository
                 .find_bible_passage(translation_code, reference)
                 .await?
-                .ok_or_else(|| RepositoryError::NotFound("passage not found"))?
+                .ok_or(RepositoryError::NotFound("passage not found"))?
         } else {
             // Combine multiple verses into a single passage
             let mut combined_text = String::new();


### PR DESCRIPTION
## Summary

Extends the #584 typed-refusal pattern (`RepositoryError::NotFound` + `downcast_ref`, never a `Display` string match) to the sites left over after that PR, across two related tickets:

- **#586** — resolume host update/delete, android stage display update/delete, video source update/delete/activate, playlist favorite toggle all returned 500 instead of 404 for an unknown id.
- **#587** — bible presentation rename/delete/append, delete-slide, reorder-slide, and presentation restore returned 500 instead of 404; the bible-trigger passage-not-found 404 already worked but via a fragile `Display`-string match with no regression test.

Both issue bodies were stale (line numbers predate the #590 file split); the actual site list was re-verified against current `dev` and is recorded in the design-approach comments on each issue, posted before the first code commit.

## Changes

- Repository/state layer: swap bare `anyhow!("... not found")` for typed `RepositoryError::NotFound("...")` at 11 sites across `repository/resolume.rs`, `repository/android_stage.rs`, `repository/video_source.rs`, `repository/playlist.rs`, `repository/bible/presentations.rs`, `repository/sync.rs`, and `state/bible.rs` (two of the #587 sites — `delete_bible_slide`/`reorder_bible_slides` — live in `state/bible.rs`, not the repository layer the issue body pointed at).
- Router layer: each affected handler wires `.map_err(map_repository_not_found)` through a small private per-file helper, matching the existing `router/libraries.rs`/`router/presentations.rs` convention — not a new shared/exported helper (kept the blast radius small for a bug-fix batch).
- `router/bible/broadcast.rs`: converts the `err.to_string().contains("passage not found")` string match to the same typed `downcast_ref` pattern.
- Left untouched (no HTTP consumer, so no user-visible 500): `update_resolume_host_active_port` (internal background task only) and `repository/bible/import.rs`'s `set_bible_source_digest` (CLI-only via `import-data.yml`).

## Tests

15 new router-level tests in `router/tests.rs` (RED-committed before the fix, `[red]`/`[green]` commit pair), each driving a fresh in-memory DB where any UUID is guaranteed "not found": 8 for #586's endpoints, 6 for #587's presentation/slide/restore endpoints, plus 1 pinning the bible-trigger passage-not-found 404 through the new typed path.

Closes #586
Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvGUZLpEBDEH8JaJ1nX3UB
