### PR TITLE
fix(router): typed 404 for resolume-test/playlist-entries + bible consistency (#608)

### DIFF
--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "crates/presenter-persistence/src/repository/**"
+  - "crates/presenter-server/src/router/**"
+  - "crates/presenter-server/src/state/**"
+---
+
+# Typed repository-refusal → HTTP-status pattern (#584, extended by #586/#587)
+
+When a repository/state method refuses because the URL's resource doesn't exist, it must return
+the router a **typed** error, never a bare `anyhow!("... not found")` string — a bare anyhow falls
+through the router's default `impl From<anyhow::Error> for AppError` to a 500, even though the
+correct response is 404 (or 422 for a body-referenced missing target).
+
+## The pattern
+
+1. **Producer** (repository or state method): `RepositoryError::NotFound(&'static str)` (URL
+   resource missing → 404) or `RepositoryError::TargetNotFound(&'static str)` (a resource named in
+   the request BODY is missing → 422) — both already defined in
+   `crates/presenter-persistence/src/repository/util.rs`. Use `.ok_or(RepositoryError::NotFound("..."))?`
+   or `return Err(RepositoryError::NotFound("...").into());` — see "clippy gotcha" below for why
+   `ok_or`, not `ok_or_else`.
+2. **Consumer** (router handler): add a small **private, per-file** helper —
+   ```rust
+   fn map_repository_not_found(err: anyhow::Error) -> AppError {
+       match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+           Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+           _ => err.into(),
+       }
+   }
+   ```
+   and wire it with `.map_err(map_repository_not_found)?` on the specific call that can fail this
+   way. **Never match on `err.to_string()`** — that silently stops matching the moment a
+   `.context(...)` gets added anywhere upstream (the #578→#584 regression).
+3. This is a **per-file private helper**, duplicated across `router/libraries.rs`,
+   `router/presentations.rs`, `router/playlists.rs`, `router/sync.rs`,
+   `router/bible/presentations.rs`, `router/integrations/{resolume,android_stage,video_source}.rs` —
+   NOT a shared/exported helper. Each PR that touches this pattern should keep it that way: a
+   shared helper is a bigger refactor than a scoped bug-fix batch needs, and increases review
+   surface for no behavior change.
+
+## Clippy gotcha: `ok_or`, not `ok_or_else`
+
+`.ok_or_else(|| RepositoryError::NotFound("..."))?` fails `cargo clippy` with
+`unnecessary_lazy_evaluations` — constructing a `NotFound(&'static str)` tuple variant from a
+string literal is cheap enough that clippy wants the eager form:
+`.ok_or(RepositoryError::NotFound("..."))?`. This bit #586/#587 (8 sites, caught by CI's Clippy job,
+fixed in a follow-up commit) — get it right the first time.
+
+## Trace every CALLER before assuming the repository layer is the only 500 source
+
+A "500 instead of 404" ticket's issue body often only lists `repository/*.rs` sites. But
+`state/*.rs` methods sometimes do their OWN existence check independent of (or in ADDITION to) the
+repository layer — e.g. `state/bible.rs`'s `delete_bible_slide`/`reorder_bible_slides` fetch the
+presentation themselves and raise their own `anyhow!("bible presentation not found")`, never
+touching the repository-layer refusal the issue body pointed at. Before fixing, grep every HTTP
+route's full call chain (router handler → state method → repository method) for `anyhow!(` — don't
+assume the issue body's site list is complete, especially after a file-split refactor (#590)
+changed line numbers.
+
+## Only convert sites with a real HTTP consumer
+
+Not every `anyhow!("... not found")` in these layers is reachable from HTTP traffic — some exist
+only for an internal background task (e.g. `resolume.rs`'s `update_resolume_host_active_port`,
+called only by the port-drift probe, which already `tracing::warn!`s and continues on error) or a
+CLI-only path (e.g. `bible/import.rs`'s `set_bible_source_digest`, reachable only via
+`ingest_bibles` / the `import-data.yml` workflow). Converting those adds scope with zero
+user-visible bug fixed — check every caller before including a site in the batch.

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -37,6 +37,14 @@ policy. Note: cargo-deny/cargo-audit can transiently FAIL then PASS on an immedi
 DB / lock timing) — re-run once before treating a deny/audit failure as real. A >120 fn added by a
 feature → split a helper out (e.g. #514 split `extract_inbound_video` out of `post_client_stats`).
 
+**`quality-check.sh --strict` is NOT Tier-0-safe** (#586/#587 lesson) — it internally shells out to
+`cargo clippy -p presenter-server --tests` and `cargo check` (advisory sections, but they still
+COMPILE). A worker under a "no local Rust build/check/clippy" constraint must NOT run this script's
+`--strict` mode; use the two underlying non-compiling checks directly instead:
+`bash scripts/dev/count_prod_lines.sh <one-file-per-call>` and
+`QC_TARGETS=<comma-separated-files> python3 scripts/dev/fn_length_check.py .` — both are pure
+bash/Python and cover the two hard-fail gates (file size, function length) without touching cargo.
+
 ## Runner Management
 
 Local runner host: `10.77.8.134` (same machine as dev server), label `self-hosted`/`local`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Local build/deploy workflow, CLIProxyAPI login | `.claude/skills/deploy/SKILL.md` |
 | Leptos/WASM frontend gotchas (view! macro, keyed `<For>`) | `.claude/skills/ui/SKILL.md` |
 | Database schema, migrations, settings audit, library import | `.claude/skills/database/SKILL.md` |
+| Repository refusal → HTTP 404/422 typed pattern (RepositoryError) | `.claude/rules/repository-error-pattern.md` (auto-loads on `repository/**`, `router/**`, `state/**`) |
 
 ## Always-Rules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.213"
+version = "0.4.214"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router/bible/broadcast.rs
+++ b/crates/presenter-server/src/router/bible/broadcast.rs
@@ -17,6 +17,21 @@ use presenter_core::{
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
+/// Maps a repository refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant returned by the persistence layer — never a
+/// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
+/// `map_repository_not_found`, #584). Any other error falls through to the
+/// default 500 mapping.
+///
+/// #608: extracted from an inline `map_err` closure to match the named-helper
+/// pattern the other six modules touched by #607 already use.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn get_active_bible_broadcast(
     State(state): State<AppState>,
@@ -95,14 +110,7 @@ pub(crate) async fn trigger_bible_broadcast(
         // #587: typed refusal (#584 pattern) — downcast to `RepositoryError`
         // instead of matching the `Display` string, which silently stops
         // matching the moment a `.context(...)` is added upstream.
-        .map_err(
-            |err| match err.downcast_ref::<presenter_persistence::RepositoryError>() {
-                Some(presenter_persistence::RepositoryError::NotFound(msg)) => {
-                    AppError::not_found(*msg)
-                }
-                _ => err.into(),
-            },
-        )
+        .map_err(map_repository_not_found)
 }
 
 /// Request body for the new single-source-of-truth trigger endpoint.

--- a/crates/presenter-server/src/router/bible/presentations.rs
+++ b/crates/presenter-server/src/router/bible/presentations.rs
@@ -231,7 +231,8 @@ pub(crate) async fn update_bible_slide(
             payload.bible_translation_reference,
             existing_metadata,
         )
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
 
     Ok(Json(bible_slide_to_dto(&updated)))
 }

--- a/crates/presenter-server/src/router/integrations/resolume.rs
+++ b/crates/presenter-server/src/router/integrations/resolume.rs
@@ -161,7 +161,8 @@ pub(crate) async fn test_resolume_host(
 ) -> Result<Json<TestConnectionResponse>, AppError> {
     let result = state
         .test_resolume_host_connection(ResolumeHostId::from_uuid(id))
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     Ok(Json(TestConnectionResponse {
         success: result.success,
         latency_ms: result.latency_ms,

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -197,7 +197,8 @@ pub(super) async fn replace_playlist_entries(
         .collect::<Result<Vec<_>, _>>()?;
     let playlist = state
         .replace_playlist_entries(PlaylistId::from_uuid(id), entries)
-        .await?;
+        .await
+        .map_err(map_repository_not_found)?;
     let enriched = state.enrich_playlist_with_names(playlist).await?;
     Ok(Json(enriched))
 }

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -3036,3 +3036,110 @@ async fn trigger_bible_broadcast_endpoint_missing_passage_returns_404() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn test_resolume_host_endpoint_missing_host_returns_404() {
+    // #608: `test_resolume_host_connection` (state/integrations.rs) still raised a bare
+    // `anyhow!("Resolume host not found")` after #586/#587 — the router file already had
+    // `map_repository_not_found` wired for other calls in the same file, but this site was
+    // simply missed during the #607 sweep.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/integrations/resolume/hosts/{random_id}/test"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn replace_playlist_entries_endpoint_missing_playlist_returns_404() {
+    // #608: `replace_playlist_entries` (state/presentations.rs) raises a bare
+    // `anyhow!("playlist not found after update")` on its tail `.find(...).ok_or_else` lookup —
+    // #586 named "playlist lookup / router/playlists.rs" generically and only the
+    // `showInDashboard` branch got mapped.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let random_id = uuid::Uuid::new_v4();
+    let body = json!({ "entries": [] }).to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/playlists/{random_id}/entries"))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn restore_presentation_endpoint_never_trashed_returns_404() {
+    // #608 item 4: `restore_presentation_endpoint_missing_trashed_presentation_returns_404`
+    // above claims to cover "an unknown id AND a never-trashed presentation" but only drives the
+    // unknown-id case. This drives the semantically distinct branch: the presentation EXISTS
+    // (`deleted_at IS NULL`), so `restore_presentation`'s `rows_affected == 0` check — not a
+    // plain existence check — is what must return 404. The underlying fix already landed in
+    // #586/#587; this closes the coverage gap the test comment overclaimed.
+    let app = build_router(AppState::in_memory().await.unwrap());
+    let create_library_body = serde_json::json!({ "name": "Restore Test Library" }).to_string();
+    let library_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/libraries")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_library_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let library_bytes = axum::body::to_bytes(library_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let library: Library = serde_json::from_slice(&library_bytes).unwrap();
+
+    let create_presentation_body = serde_json::json!({ "name": "Never Trashed" }).to_string();
+    let presentation_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/libraries/{}/presentations", library.id))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_presentation_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(presentation_response.status(), StatusCode::OK);
+    let presentation_bytes = axum::body::to_bytes(presentation_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let payload: CreateLibraryPresentationResponse =
+        serde_json::from_slice(&presentation_bytes).unwrap();
+
+    let restore_response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!(
+                    "/presentations/{}/restore",
+                    payload.presentation.id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(restore_response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/presenter-server/src/state/bible.rs
+++ b/crates/presenter-server/src/state/bible.rs
@@ -384,7 +384,12 @@ impl AppState {
             .repository
             .fetch_bible_presentation(presentation_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("bible presentation not found"))?;
+            // #608: typed refusal (#584/#586 pattern), for consistency with the other
+            // `update_bible_slide` refusal below and with `state/bible.rs`'s other converted
+            // sites — the router downcasts to `RepositoryError` and maps `NotFound` to 404
+            // instead of a bare 500 (TOCTOU-only in practice: masked by the router's own
+            // pre-checks under normal traffic, but a delete racing the pre-check would hit this).
+            .ok_or(RepositoryError::NotFound("bible presentation not found"))?;
 
         let main =
             SlideText::new(main_text).map_err(|err| anyhow::anyhow!("invalid main text: {err}"))?;
@@ -404,7 +409,7 @@ impl AppState {
             }
         }
         let updated_slide =
-            updated_slide.ok_or_else(|| anyhow::anyhow!("slide not found in presentation"))?;
+            updated_slide.ok_or(RepositoryError::NotFound("slide not found in presentation"))?;
 
         self.repository
             .replace_bible_presentation_slides(presentation_id, &presentation.slides)

--- a/crates/presenter-server/src/state/integrations.rs
+++ b/crates/presenter-server/src/state/integrations.rs
@@ -114,7 +114,11 @@ impl AppState {
             .await?
             .into_iter()
             .find(|h| h.id == id)
-            .ok_or_else(|| anyhow::anyhow!("Resolume host not found"))?;
+            // #608: typed refusal (#584/#586 pattern) — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
+            .ok_or(presenter_persistence::RepositoryError::NotFound(
+                "resolume host not found",
+            ))?;
         crate::resolume::test_connection(&host).await
     }
 

--- a/crates/presenter-server/src/state/presentations.rs
+++ b/crates/presenter-server/src/state/presentations.rs
@@ -237,7 +237,9 @@ impl AppState {
         playlists
             .into_iter()
             .find(|playlist| playlist.id == playlist_id)
-            .ok_or_else(|| anyhow::anyhow!("playlist not found after update"))
+            // #608: typed refusal (#584/#586 pattern) — the router downcasts to
+            // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
+            .ok_or(presenter_persistence::RepositoryError::NotFound("playlist not found").into())
     }
 
     // Presentation detail and cache

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -600,3 +600,35 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
 - **UNVERIFIED** (both issues): real stagebox TV / real phone confirmation — no physical device
   reachable from this dev box. Playwright-verified on the live prod DOM instead; flagged for the
   user's next in-person look.
+
+## 2026-07-27 — #586 + #587 typed 404 for remaining resolume/android-stage/video-source/playlist/bible/sync unknown-id refusals
+
+- **Design notes posted BEFORE any code** (predate the RED commit `28c311d1`):
+  https://github.com/zbynekdrlik/presenter/issues/586#issuecomment-5094251162 and
+  https://github.com/zbynekdrlik/presenter/issues/587#issuecomment-5094255429. Both re-verify the
+  site list against current `dev` (the #590 file split changed every line number the issue bodies
+  cited) — corrections: `update_resolume_host_active_port` has no HTTP consumer (dropped from
+  scope); `repository/bible/presentations.rs:169` (`replace_bible_presentation_slides`) is
+  TOCTOU-only, and the two ACTUALLY-reachable #587 500s (`delete_bible_slide`/`reorder_bible_slides`)
+  live in `state/bible.rs`, which the issue body omitted entirely.
+- Version bump `a4b97dde` (0.4.212 → 0.4.213).
+- RED `28c311d1`: 15 new `router/tests.rs` tests (unknown-id → 404 on a fresh in-memory DB). Pushed
+  alone and confirmed 14/15 FAIL with 500 on CI run 30287219099 (the 15th — bible-trigger
+  passage-not-found — already passed via the pre-existing string match, pinned before its
+  conversion).
+- GREEN `7f1b7ed8`: `RepositoryError::NotFound` conversions across `repository/{resolume,
+  android_stage, video_source, playlist, bible/presentations, sync}.rs` and `state/bible.rs`
+  (`delete_bible_slide`, `reorder_bible_slides`, `trigger_bible_passage`); a private
+  `map_repository_not_found` downcast helper added to each of the 7 touched router files
+  (`router/libraries.rs`/`presentations.rs` per-file convention from #584, not a shared helper);
+  `router/bible/broadcast.rs`'s string-match converted to the typed downcast. Follow-up
+  `8fe34e3e` fixed a clippy `unnecessary_lazy_evaluations` (8 sites: `ok_or_else(|| X)` →
+  `ok_or(X)` for the cheap `RepositoryError::NotFound` construction).
+- One bundled PR (dev→main #607, Closes #586 #587), merged `aae2d859`. Main Deploy green → prod
+  verified v0.4.213 live: DOM version label read via Playwright on `/ui/operator`, 0 console
+  errors/warnings, and all 7 previously-500ing endpoints spot-checked live now return 404
+  (resolume host PUT, android-stage DELETE, video-source activate, playlist favorite PATCH, bible
+  rename PATCH, presentation restore POST, bible trigger POST).
+- Left untouched (no HTTP consumer, so no user-visible bug): `update_resolume_host_active_port`
+  (internal port-drift background task only) and `repository/bible/import.rs`'s
+  `set_bible_source_digest` (CLI-only via `import-data.yml`).


### PR DESCRIPTION
Closes #608

Finishes the #586/#587 unknown-id 500→404 sweep that #607 started, catching the two sites it
missed plus 3 review nits found in a post-merge review of #607.

## 🟡 Fixed (500 → 404)

1. `POST /integrations/resolume/hosts/{id}/test` — `state/integrations.rs`
   `test_resolume_host_connection` raised a bare `anyhow!("Resolume host not found")`; the
   consumer already had `map_repository_not_found` defined but this call site was never wired to
   it.
2. `PUT /playlists/{id}/entries` — `state/presentations.rs` `replace_playlist_entries` raised a
   bare `anyhow!("playlist not found after update")` on its post-write lookup; #586 only converted
   the `showInDashboard` branch in `router/playlists.rs`.

## 🔵 Consistency nits

3. `router/bible/presentations.rs` `update_bible_slide` now maps through
   `map_repository_not_found`; `state/bible.rs`'s two bare `anyhow!` sites in the same method
   (presentation lookup, slide lookup) converted to `RepositoryError::NotFound` for consistency
   (TOCTOU-only in practice — masked by the router's own pre-checks under normal traffic).
4. `router/tests.rs` — added the missing never-trashed-presentation-restore test case; the old
   comment claimed to cover it but only drove the unknown-id case. The underlying behavior was
   already correct (fixed in #586/#587) — this closes a coverage gap only.
5. `router/bible/broadcast.rs` — extracted the inline `map_err` closure into the same named
   `map_repository_not_found` helper the other six modules use.

## Tests (RED before GREEN)

- `test_resolume_host_endpoint_missing_host_returns_404` (new, RED→GREEN)
- `replace_playlist_entries_endpoint_missing_playlist_returns_404` (new, RED→GREEN)
- `restore_presentation_endpoint_never_trashed_returns_404` (new, coverage-only — passed before
  and after the fix commit, since #586/#587 already fixed the underlying behavior)

RED commit `69a494f8` — CI run [30301772738](https://github.com/zbynekdrlik/presenter/actions/runs/30301772738)
failed with exactly the two expected assertion failures (500 vs 404) on `Test`; the coverage test
passed. GREEN commit `ad1919be` fixes both sites — CI run
[30302783323](https://github.com/zbynekdrlik/presenter/actions/runs/30302783323) is fully green
(all jobs incl. deploy-dev).

Design reasoning recorded on the issue: https://github.com/zbynekdrlik/presenter/issues/608#issuecomment-5096304872
