### PR TITLE
fix(playlist): [green] check playlist exists before replacing entries (#610)

### DIFF
--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -66,3 +66,14 @@ called only by the port-drift probe, which already `tracing::warn!`s and continu
 CLI-only path (e.g. `bible/import.rs`'s `set_bible_source_digest`, reachable only via
 `ingest_bibles` / the `import-data.yml` workflow). Converting those adds scope with zero
 user-visible bug fixed — check every caller before including a site in the batch.
+
+## Grep the router file for an ALREADY-EXISTING unwired helper before assuming one is missing (#608)
+
+A "sweep" batch (#586/#587) converts several sites across many files in one pass, and it is easy to
+add the `map_repository_not_found` helper to a file for site A while a DIFFERENT call in that same
+file (site B) still has a bare `?` — the helper exists and compiles fine, it's just not wired
+everywhere it could be. Both #608 misses (`router/integrations/resolume.rs`'s `test_resolume_host`,
+`router/playlists.rs`'s `replace_playlist_entries`) were exactly this: the helper was already
+defined and used elsewhere in the SAME file. Before adding a new helper to a router file, `grep -n
+"map_repository_not_found" <file>` first — if it exists, the fix is a one-line `.map_err(...)` wire,
+not a new helper.

--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -34,10 +34,15 @@ correct response is 404 (or 422 for a body-referenced missing target).
    `.context(...)` gets added anywhere upstream (the #578→#584 regression).
 3. This is a **per-file private helper**, duplicated across `router/libraries.rs`,
    `router/presentations.rs`, `router/playlists.rs`, `router/sync.rs`,
-   `router/bible/presentations.rs`, `router/integrations/{resolume,android_stage,video_source}.rs` —
-   NOT a shared/exported helper. Each PR that touches this pattern should keep it that way: a
-   shared helper is a bigger refactor than a scoped bug-fix batch needs, and increases review
-   surface for no behavior change.
+   `router/bible/presentations.rs`, `router/bible/broadcast.rs`,
+   `router/integrations/{resolume,android_stage,video_source}.rs` — 9 modules total (verify with
+   `grep -rln "fn map_repository_not_found\|fn map_repository_error" crates/presenter-server/src/router/`
+   if this list drifts again). NOT a shared/exported helper. Each PR that touches this pattern
+   should keep it that way: a shared helper is a bigger refactor than a scoped bug-fix batch needs,
+   and increases review surface for no behavior change.
+   **Naming exception:** every module above names the helper `map_repository_not_found` EXCEPT
+   `router/presentations.rs`, which names it `map_repository_error` — don't assume the name is
+   uniform when grepping for it.
 
 ## Clippy gotcha: `ok_or`, not `ok_or_else`
 

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -37,10 +37,11 @@ policy. Note: cargo-deny/cargo-audit can transiently FAIL then PASS on an immedi
 DB / lock timing) — re-run once before treating a deny/audit failure as real. A >120 fn added by a
 feature → split a helper out (e.g. #514 split `extract_inbound_video` out of `post_client_stats`).
 
-**`quality-check.sh --strict` is NOT Tier-0-safe** (#586/#587 lesson) — it internally shells out to
-`cargo clippy -p presenter-server --tests` and `cargo check` (advisory sections, but they still
-COMPILE). A worker under a "no local Rust build/check/clippy" constraint must NOT run this script's
-`--strict` mode; use the two underlying non-compiling checks directly instead:
+**`quality-check.sh` is NOT Tier-0-safe in ANY mode** (#586/#587 lesson, corrected #610) — it
+unconditionally shells out to `cargo fmt --all --check`, `cargo clippy -p presenter-server --tests`,
+and `cargo check` regardless of `--strict`; that flag only decides whether a failing check is fatal,
+not whether these run. A worker under a "no local Rust build/check/clippy" constraint must NOT run
+this script at all, in any mode; use the two underlying non-compiling checks directly instead:
 `bash scripts/dev/count_prod_lines.sh <one-file-per-call>` and
 `QC_TARGETS=<comma-separated-files> python3 scripts/dev/fn_length_check.py .` — both are pure
 bash/Python and cover the two hard-fail gates (file size, function length) without touching cargo.

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -45,6 +45,23 @@ COMPILE). A worker under a "no local Rust build/check/clippy" constraint must NO
 `QC_TARGETS=<comma-separated-files> python3 scripts/dev/fn_length_check.py .` — both are pure
 bash/Python and cover the two hard-fail gates (file size, function length) without touching cargo.
 
+## RED-before-GREEN verification under Tier-0 — push RED alone, read `--log-failed` (#608)
+
+A Tier-0 worker (no local `cargo test`) cannot run the new regression test locally to watch it
+fail. The only way to satisfy "verify it fails for the right reason" is via CI itself: commit the
+RED test(s), push ALONE (before the fix commit exists), poll the run, and once the `Test` job
+reaches a terminal `failure`, read `gh run view <id> --log-failed | grep -iE "FAILED|assertion"` to
+confirm the SPECIFIC new test names are the ones that failed (not some unrelated flake) and that
+the failure is the expected assertion (e.g. status-code mismatch), not a compile error or panic
+from something else. Only then commit + push the GREEN fix and poll again for a fully green run.
+This costs 2 pipeline runs instead of 1, but is the only way this project's Tier-0 constraint and
+`regression-test-first.md`'s RED-before-GREEN mandate can both be satisfied — do not skip the RED
+push to save a CI cycle (#607, #608 both did exactly this: RED push failed on cue, GREEN push went
+green). If the RED batch includes a coverage-only test alongside real bug-fix tests (a test that
+should already pass because the underlying behavior isn't actually broken), confirm from the SAME
+`--log-failed` output that it's absent from the failed-test list — that's your proof it wasn't
+accidentally testing the wrong thing.
+
 ## Runner Management
 
 Local runner host: `10.77.8.134` (same machine as dev server), label `self-hosted`/`local`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.214"
+version = "0.4.215"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -150,6 +150,11 @@ impl Repository {
         playlist_id: PlaylistId,
         entries: &[presenter_core::PlaylistEntry],
     ) -> anyhow::Result<()> {
+        // #610: without this check, an unknown `playlist_id` with a NON-EMPTY `entries` slice
+        // trips `fk_playlist_entries_playlist` on the INSERT below (PRAGMA foreign_keys = ON) ->
+        // raw DbErr -> 500. An empty slice skipped the insert loop and never exercised that path.
+        self.ensure_playlist_exists(playlist_id).await?;
+
         let txn = self.db.begin().await?;
 
         playlist_entry::Entity::delete_many()

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -3060,18 +3060,67 @@ async fn test_resolume_host_endpoint_missing_host_returns_404() {
 
 #[tokio::test]
 async fn replace_playlist_entries_endpoint_missing_playlist_returns_404() {
-    // #608: `replace_playlist_entries` (state/presentations.rs) raises a bare
-    // `anyhow!("playlist not found after update")` on its tail `.find(...).ok_or_else` lookup —
-    // #586 named "playlist lookup / router/playlists.rs" generically and only the
-    // `showInDashboard` branch got mapped.
+    // #610: #608/#609 fixed the state-layer post-check, but
+    // `PlaylistRepository::replace_playlist_entries` (repository/playlist.rs) still has NO
+    // existence check of its own — it deletes (no-op for an unknown playlist), then INSERTs.
+    // With `PRAGMA foreign_keys = ON` + `fk_playlist_entries_playlist`, a NON-EMPTY `entries`
+    // array trips an FK violation on insert -> raw DbErr -> 500. An EMPTY array (#609's
+    // regression test) skips the insert loop entirely and never exercises that path, so it
+    // stayed green while every real client payload still 500s. This test seeds a real
+    // presentation and drives the actual insert path with a non-empty body.
     let app = build_router(AppState::in_memory().await.unwrap());
-    let random_id = uuid::Uuid::new_v4();
-    let body = json!({ "entries": [] }).to_string();
+
+    let create_library_body = json!({ "name": "Playlist Entries Test Library" }).to_string();
+    let library_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/libraries")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_library_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(library_response.status(), StatusCode::OK);
+    let library_bytes = axum::body::to_bytes(library_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let library: Library = serde_json::from_slice(&library_bytes).unwrap();
+
+    let create_presentation_body = json!({ "name": "Seed Presentation" }).to_string();
+    let presentation_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/libraries/{}/presentations", library.id))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_presentation_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(presentation_response.status(), StatusCode::OK);
+    let presentation_bytes = axum::body::to_bytes(presentation_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let payload: CreateLibraryPresentationResponse =
+        serde_json::from_slice(&presentation_bytes).unwrap();
+
+    let random_playlist_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "entries": [
+            { "type": "presentation", "presentationId": payload.presentation.id }
+        ]
+    })
+    .to_string();
     let response = app
         .oneshot(
             Request::builder()
                 .method(axum::http::Method::PUT)
-                .uri(format!("/playlists/{random_id}/entries"))
+                .uri(format!("/playlists/{random_playlist_id}/entries"))
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
                 .body(Body::from(body))
                 .unwrap(),

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -632,3 +632,30 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
 - Left untouched (no HTTP consumer, so no user-visible bug): `update_resolume_host_active_port`
   (internal port-drift background task only) and `repository/bible/import.rs`'s
   `set_bible_source_digest` (CLI-only via `import-data.yml`).
+
+## 2026-07-27 — #608 finish-the-job: 2 missed 500→404 sites + 3 review nits from #607
+
+- **Design notes posted BEFORE any code** (predates RED commit `69a494f8`):
+  https://github.com/zbynekdrlik/presenter/issues/608#issuecomment-5096304872. Root cause: #607's
+  manual per-site sweep missed `state/integrations.rs`'s `test_resolume_host_connection` and
+  `state/presentations.rs`'s `replace_playlist_entries` (both still bare `anyhow!`, both had the
+  consumer's `map_repository_not_found` helper already sitting unused in the same router file).
+- Version bump `426b7644` (0.4.213 → 0.4.214).
+- RED `69a494f8`: 3 new `router/tests.rs` tests. Pushed alone, confirmed on CI run 30301772738 —
+  exactly the 2 expected assertion failures (500 vs 404) on `test_resolume_host_endpoint_
+  missing_host_returns_404` and `replace_playlist_entries_endpoint_missing_playlist_returns_404`;
+  the 3rd (`restore_presentation_endpoint_never_trashed_returns_404`, a coverage-only addition —
+  the underlying behavior was already correct since #586/#587) passed as expected.
+- GREEN `ad1919be`: `RepositoryError::NotFound` at `state/integrations.rs:117` +
+  `state/presentations.rs:240`, wired to the ALREADY-PRESENT `map_repository_not_found` helpers in
+  `router/integrations/resolume.rs` and `router/playlists.rs`. Plus 3 nits: `state/bible.rs`'s
+  `update_bible_slide` (2 bare `anyhow!` sites) converted for consistency + wired at
+  `router/bible/presentations.rs:234`; `router/bible/broadcast.rs`'s inline `map_err` closure
+  extracted into the same named helper pattern; the never-trashed test closes the #608 item-4
+  comment overclaim. CI run 30302783323 fully green (Test, Build, all 3 E2E shards, NDI E2E,
+  Deploy to Dev).
+- PR #609 (Closes #608), merged `090f7efe`. Main Deploy CI run 30305963268 green. Prod verified
+  v0.4.214 live: DOM version label read via Playwright on `/ui/operator` (0 console
+  errors/warnings), plus curl-verified both fixed endpoints now return 404 on an unknown id
+  (`POST /integrations/resolume/hosts/{id}/test`, `PUT /playlists/{id}/entries`) and the restore
+  endpoint's sanity check still 404s.


### PR DESCRIPTION
## Summary

Post-merge adversarial review of #609 found #609's own regression test dodged the bug it claimed to fix, plus two doc defects in files #609 touched. Fixes all three.

- **`PUT /playlists/{unknown}/entries` still 500s for any non-empty body.** `PlaylistRepository::replace_playlist_entries` never checked the playlist existed before inserting entries; a non-empty `entries` array tripped `fk_playlist_entries_playlist` (`PRAGMA foreign_keys = ON`) → raw `DbErr` → 500. #609's test sent `{"entries": []}`, the one shape that skips the insert loop entirely. Fixed by calling the existing `ensure_playlist_exists` helper as the first line of the method (same typed-refusal pattern already used elsewhere in the file). Traced all 4 callers — all create the playlist before calling this method, so no behavior change for any of them.
- **`.claude/skills/ci/SKILL.md`** — corrected the Tier-0 warning: `quality-check.sh` shells out to `cargo fmt/clippy/check` unconditionally, not only under `--strict`.
- **`.claude/rules/repository-error-pattern.md`** — added the missing `router/bible/broadcast.rs` module (9 modules total, not 8) and noted `router/presentations.rs`'s naming exception (`map_repository_error`).

## Test plan

- [x] RED commit (`27cff18e`): rewritten regression test seeds a real presentation and PUTs a non-empty `entries` array against an unknown playlist — failed `left: 500, right: 404` on CI (run 30310638017, `Test` job only).
- [x] GREEN commit (`90819e36`): repository fix + doc fixes — full pipeline green (run 30311605427; NDI E2E job's first attempt failed on an unrelated dead `deb.nodesource.com` apt source on the self-hosted runner — fixed the runner (removed the stale nodesource.list, `apt-get update` now clean) and reran; all 22 jobs green including Deploy to Dev).
- [x] Functional verification pending on this deployed dev build and on prod after merge.

Closes #610
