### PR TITLE
fix: discriminate internal failures from not-found refusals (#588, #589)

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -88,6 +88,32 @@ CI has TWO runs per push: "PR Automation" (fast, Label/Validate) and "Pipeline" 
 Test→Build→E2E→deploy). `gh run list --limit 1` often returns PR Automation — filter:
 `gh run list --branch dev --limit 5 | grep Pipeline`.
 
+## Dead `deb.nodesource.com` apt source breaks `--with-deps` browser install (#610)
+
+The `NDI WebRTC E2E` job's "Install Playwright (branded Chrome for H.264)" step runs
+`npx playwright install --with-deps chromium chrome`, which internally does `apt-get update` across
+EVERY configured apt source — if ANY one source 403s, the whole `apt-get` call fails and Playwright
+reports "Failed to install browsers" / exit code 100, even though every OTHER OS dependency would
+have resolved fine.
+
+**Symptom:** job fails at that exact step with `E: Failed to fetch https://deb.nodesource.com/...
+403 Forbidden` / `The repository '...' is no longer signed.` Confirm it's a real dead endpoint (not
+a transient blip) with `curl -sI https://deb.nodesource.com/node_22.x/dists/nodistro/InRelease` —
+a Cloudflare/S3 `AccessDenied` on retry means the endpoint is genuinely gone, not flaky.
+
+**Why it's safe to just delete the source:** this runner's actual node/npm come from **nvm**
+(`NVM_BIN` is set in the runner's `~/actions-runner/.env`, e.g. `v24.12.0`), not the dpkg
+`nodejs` package `deb.nodesource.com` provides. The nodesource apt source is leftover
+provisioning cruft with no live consumer — check `which -a node npm` (nvm path first) and
+`cat ~/actions-runner/.env` before assuming otherwise.
+
+**Fix:**
+```bash
+sudo rm -f /etc/apt/sources.list.d/nodesource.list /usr/share/keyrings/nodesource.gpg
+sudo apt-get update   # should now complete cleanly, no 403s
+gh run rerun <run-id> --failed   # reruns only the failed job, others stay untouched
+```
+
 ## GPU Wedge Recovery (#445)
 
 **dev2's single RTX 5050 is SHARED** between Presenter CI runner (`presenter-local`) and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.213"
+version = "0.4.216"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.215"
+version = "0.4.216"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -37,12 +37,31 @@ pub use lifecycle::PipelineStartError;
 /// `NdiConnectionStatus` events.
 pub type StatusCallback = Arc<dyn Fn(String) + Send + Sync>;
 
-/// Sentinel error message returned by `whep_signaller_call` when the requested
-/// source has no active pipeline. The WHEP HTTP shim string-matches on this
-/// to translate the error into a 404. Exposed as a `pub const` so the shim
-/// imports the same literal — preventing silent 503-instead-of-404 drift if
-/// the message is ever rewritten.
-pub const SOURCE_NOT_ACTIVE_ERR: &str = "source not active";
+/// Typed WHEP-session refusal returned across the `presenter-ndi` →
+/// `presenter-server` HTTP-shim boundary. The router
+/// (`router/integrations/ndi_whep.rs`) `downcast_ref`s on this enum to pick
+/// an HTTP status — never a string match on `Display` text, which used to
+/// silently break the moment a `.context(...)` was added anywhere upstream
+/// (#589, mirrors the persistence-layer `RepositoryError` fix in
+/// #584/#586/#587 across a different crate boundary).
+///
+/// `Display` text is kept byte-identical to the pre-#589 raw strings
+/// (`SOURCE_NOT_ACTIVE_ERR` was `"source not active"`) so log output and the
+/// JSON error body are unchanged.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum NdiSessionError {
+    /// The requested source has no active pipeline.
+    #[error("source not active")]
+    SourceNotActive,
+    /// The per-source soft consumer cap (`MAX_CONSUMERS_PER_SOURCE`) was hit.
+    #[error("WHEP consumer cap reached ({max} per source) — try again later")]
+    ConsumerCapReached { max: usize },
+    /// A trickle-ICE PATCH referenced a `session_id` no longer in the
+    /// sessions map (the deployed flow is non-trickle, so this is a late/
+    /// stale candidate — see `NdiPipeline::add_ice_candidate`'s doc comment).
+    #[error("session not found: {session_id}")]
+    SessionNotFound { session_id: String },
+}
 
 /// One operation in the WHEP signaller protocol.
 pub enum WhepOp {

--- a/crates/presenter-ndi/src/manager.rs
+++ b/crates/presenter-ndi/src/manager.rs
@@ -48,7 +48,7 @@ pub type StatusCallback = Arc<dyn Fn(String) + Send + Sync>;
 /// `Display` text is kept byte-identical to the pre-#589 raw strings
 /// (`SOURCE_NOT_ACTIVE_ERR` was `"source not active"`) so log output and the
 /// JSON error body are unchanged.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum NdiSessionError {
     /// The requested source has no active pipeline.
     #[error("source not active")]

--- a/crates/presenter-ndi/src/manager/whep.rs
+++ b/crates/presenter-ndi/src/manager/whep.rs
@@ -6,9 +6,9 @@
 
 use anyhow::{anyhow, Result};
 
-use crate::pipeline::{NdiPipeline, PipelineState, StreamProfile};
+use crate::pipeline::{AddConsumerError, NdiPipeline, PipelineState, StreamProfile};
 
-use super::{ActiveSource, NdiManager, WhepOp, WhepReply, SOURCE_NOT_ACTIVE_ERR};
+use super::{ActiveSource, NdiManager, NdiSessionError, WhepOp, WhepReply};
 
 impl NdiManager {
     /// Snapshot of every active pipeline's current state.
@@ -136,7 +136,7 @@ impl NdiManager {
         let active = self.active.lock().await;
         let src = active
             .get(source_id)
-            .ok_or_else(|| anyhow!(SOURCE_NOT_ACTIVE_ERR))?;
+            .ok_or(NdiSessionError::SourceNotActive)?;
         Self::ensure_streaming(src)?;
         Ok(std::sync::Arc::clone(&src.pipeline))
     }
@@ -152,7 +152,21 @@ impl NdiManager {
         turn_server: Option<String>,
     ) -> Result<WhepReply> {
         let pipeline = self.streaming_pipeline(source_id).await?;
-        let answer = pipeline.add_consumer(body, profile, turn_server).await?;
+        // `add_consumer` returns the pipeline's OWN typed `AddConsumerError`
+        // (its `CapReached` variant + a catch-all `Other(anyhow::Error)`) —
+        // translate `CapReached` into the shared `NdiSessionError` HERE, at
+        // the one place it crosses into the router-facing `anyhow::Result`,
+        // so `ndi_whep.rs` has a single downcast target for every WHEP
+        // status decision (#589). `Other` passes through unchanged.
+        let answer = pipeline
+            .add_consumer(body, profile, turn_server)
+            .await
+            .map_err(|err| match err {
+                AddConsumerError::CapReached { max } => {
+                    NdiSessionError::ConsumerCapReached { max }.into()
+                }
+                AddConsumerError::Other(err) => err,
+            })?;
         let location = format!("/ndi/whep/{source_id}/{}", answer.session_id);
         tracing::info!(
             source_id = %source_id,
@@ -232,7 +246,7 @@ impl NdiManager {
             let active = self.active.lock().await;
             let src = active
                 .get(source_id)
-                .ok_or_else(|| anyhow!(SOURCE_NOT_ACTIVE_ERR))?;
+                .ok_or(NdiSessionError::SourceNotActive)?;
             std::sync::Arc::clone(&src.pipeline)
             // active lock dropped here
         };

--- a/crates/presenter-ndi/src/pipeline/consumers.rs
+++ b/crates/presenter-ndi/src/pipeline/consumers.rs
@@ -47,6 +47,7 @@ use super::{
     build::consumer_h264_caps, AddConsumerError, NdiPipeline, PipelineSnapshot, SessionSnapshot,
     StreamProfile, WhepAnswer,
 };
+use crate::manager::NdiSessionError;
 use crate::whep_session::{IceCandidate, LivenessState, WhepConnectionState, WhepSession};
 
 /// RAII owner of a consumer pipeline from the moment it is assembled until it
@@ -269,7 +270,9 @@ impl NdiPipeline {
         let sessions = self.sessions.lock().await;
         let session = sessions
             .get(session_id)
-            .ok_or_else(|| anyhow!("session not found: {session_id}"))?;
+            .ok_or_else(|| NdiSessionError::SessionNotFound {
+                session_id: session_id.to_string(),
+            })?;
         let webrtcbin = session.webrtcbin.clone();
         let candidate = candidate.to_string();
         drop(sessions);

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -563,6 +563,28 @@ mod tests {
         );
     }
 
+    /// #589: `map_signaller_error`'s SOURCE_NOT_ACTIVE_ERR → 404 branch had NO
+    /// unit test at all — only the consumer-cap branch was covered. Worse,
+    /// the branch decides status by `err.to_string().contains(...)`, which
+    /// breaks the moment upstream code wraps the error with `.context(...)`
+    /// (a `.context()` call replaces the anyhow `Display` text with the
+    /// context message — the original "source not active" text is no longer
+    /// visible to a string match, only to a downcast that walks the chain).
+    /// This test simulates exactly that: a genuinely "source not active"
+    /// error that picked up an unrelated context wrapper somewhere upstream.
+    /// It must still map to 404.
+    #[test]
+    fn map_signaller_error_source_not_active_survives_context_wrapping() {
+        let err = anyhow::anyhow!(SOURCE_NOT_ACTIVE_ERR)
+            .context("signaller call failed while forwarding to the pipeline");
+        let app_err = map_signaller_error(err);
+        assert_eq!(
+            app_err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "a source-not-active error must map to 404 even wrapped in extra context (#589)"
+        );
+    }
+
     #[test]
     fn into_response_defaults_to_empty_body_when_none() {
         let reply = WhepReply {

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -9,7 +9,7 @@ use axum::{
     http::HeaderMap,
     response::Response,
 };
-use presenter_ndi::manager::{WhepOp, WhepReply, SOURCE_NOT_ACTIVE_ERR};
+use presenter_ndi::manager::{NdiSessionError, WhepOp, WhepReply};
 use presenter_ndi::StreamProfile;
 use tracing::instrument;
 
@@ -34,26 +34,30 @@ fn into_response(reply: WhepReply) -> Response {
         .expect("valid response")
 }
 
-/// Map a `whep_signaller_call` error string to the right HTTP status.
+/// Map a `whep_signaller_call` error to the right HTTP status via the TYPED
+/// `NdiSessionError` — never a string match on `Display` text (#589: that
+/// silently broke the moment `.context(...)` was added anywhere upstream in
+/// `presenter-ndi`, mirroring the persistence-layer `RepositoryError` fix in
+/// #584/#586/#587 across a different crate boundary).
 ///
-/// "source not active" → 404 (the WHEP spec calls for 404 when the resource
-/// doesn't exist). "consumer cap reached" → 503 + Retry-After: 60 (browser
+/// `SourceNotActive` → 404 (the WHEP spec calls for 404 when the resource
+/// doesn't exist). `ConsumerCapReached` → 503 + Retry-After: 60 (browser
 /// should back off, not hammer). Anything else (pipeline starting / stopped /
-/// errored, signaller emit failures) → 503 so WHEP clients back off and retry.
+/// errored, signaller emit failures, `SessionNotFound`) → 503 so WHEP clients
+/// back off and retry.
 fn map_signaller_error(err: anyhow::Error) -> AppError {
-    let msg = err.to_string();
-    if msg.contains(SOURCE_NOT_ACTIVE_ERR) {
-        AppError::not_found("NDI source not active")
-    } else if msg.contains("consumer cap reached") {
-        AppError::service_unavailable_with_retry(format!("WHEP: {msg}"), 60)
-    } else {
-        AppError::service_unavailable(format!("WHEP: {msg}"))
+    match err.downcast_ref::<NdiSessionError>() {
+        Some(NdiSessionError::SourceNotActive) => AppError::not_found("NDI source not active"),
+        Some(NdiSessionError::ConsumerCapReached { .. }) => {
+            AppError::service_unavailable_with_retry(format!("WHEP: {err}"), 60)
+        }
+        _ => AppError::service_unavailable(format!("WHEP: {err}")),
     }
 }
 
 /// #431: map a `whep_signaller_call` POST error to its WHEP response.
 ///
-/// A configured-but-not-currently-producing source (`SOURCE_NOT_ACTIVE_ERR`)
+/// A configured-but-not-currently-producing source (`NdiSessionError::SourceNotActive`)
 /// is a transient, EXPECTED state — answer 204 No Content, NOT 404. The stage
 /// only POSTs WHEP for a source the operator has activated (it never renders an
 /// `<NdiVideo>` for an unknown source), so "source not active" here means
@@ -65,18 +69,17 @@ fn map_signaller_error(err: anyhow::Error) -> AppError {
 /// (404 for unknown on the session-scoped paths, 503 otherwise).
 ///
 /// Pure + directly unit-tested (no live NdiManager needed) so the
-/// `SOURCE_NOT_ACTIVE_ERR` → 204 vs the fall-through → error distinction is
+/// `SourceNotActive` → 204 vs the fall-through → error distinction is
 /// exercised even on a host without libndi — which is required to KILL the
 /// mutation-testing mutants on this match guard.
 fn map_post_whep_error(err: anyhow::Error) -> Result<WhepReply, AppError> {
-    if err.to_string().contains(SOURCE_NOT_ACTIVE_ERR) {
-        Ok(WhepReply {
+    match err.downcast_ref::<NdiSessionError>() {
+        Some(NdiSessionError::SourceNotActive) => Ok(WhepReply {
             status: 204,
             headers: Vec::new(),
             body: None,
-        })
-    } else {
-        Err(map_signaller_error(err))
+        }),
+        _ => Err(map_signaller_error(err)),
     }
 }
 
@@ -190,8 +193,11 @@ pub(crate) async fn delete_whep_session(
         // before the DELETE arrives; a 404 logged a browser console error
         // ("Failed to load resource") on every deactivate/navigation cycle.
         Err(err)
-            if err.to_string().contains(SOURCE_NOT_ACTIVE_ERR)
-                || err.to_string().contains("session not found") =>
+            if matches!(
+                err.downcast_ref::<NdiSessionError>(),
+                Some(NdiSessionError::SourceNotActive)
+                    | Some(NdiSessionError::SessionNotFound { .. })
+            ) =>
         {
             WhepReply {
                 status: 204,
@@ -486,18 +492,17 @@ mod tests {
     }
 
     /// #431 + mutation-kill: `map_post_whep_error` must return a 204 reply for a
-    /// `SOURCE_NOT_ACTIVE_ERR` (configured-but-not-producing) and an Err for
-    /// anything else. Tested directly (no NdiManager) so the match-guard
-    /// `err.to_string().contains(SOURCE_NOT_ACTIVE_ERR)` is exercised on every
-    /// host — killing the cargo-mutants mutants that replace it with
-    /// `true`/`false` (which the handler-level tests couldn't catch on a
-    /// libndi-less CI runner, where the manager-missing 503 short-circuits
-    /// before the guard).
+    /// `NdiSessionError::SourceNotActive` (configured-but-not-producing) and an
+    /// Err for anything else. Tested directly (no NdiManager) so the
+    /// downcast-match guard is exercised on every host — killing the
+    /// cargo-mutants mutants that replace it with `true`/`false` (which the
+    /// handler-level tests couldn't catch on a libndi-less CI runner, where
+    /// the manager-missing 503 short-circuits before the guard).
     #[test]
     fn map_post_whep_error_returns_204_for_source_not_active() {
         // Guard MUST be true for a not-active error → 204 reply, NOT an Err.
         // Kills the "guard with false" mutant.
-        match map_post_whep_error(anyhow::anyhow!(SOURCE_NOT_ACTIVE_ERR)) {
+        match map_post_whep_error(NdiSessionError::SourceNotActive.into()) {
             Ok(reply) => {
                 assert_eq!(
                     reply.status, 204,
@@ -529,7 +534,7 @@ mod tests {
         }
 
         // A consumer-cap error also passes through (503 + Retry-After), never 204.
-        match map_post_whep_error(anyhow::anyhow!("WHEP consumer cap reached (8 per source)")) {
+        match map_post_whep_error(NdiSessionError::ConsumerCapReached { max: 8 }.into()) {
             Ok(reply) => panic!(
                 "consumer-cap must not become a 204 reply, got status {}",
                 reply.status
@@ -544,7 +549,7 @@ mod tests {
 
     #[test]
     fn map_signaller_error_consumer_cap_emits_503_with_retry_after() {
-        let err = anyhow::anyhow!("WHEP consumer cap reached (8 per source) — try again later");
+        let err: anyhow::Error = NdiSessionError::ConsumerCapReached { max: 8 }.into();
         let app_err = map_signaller_error(err);
         let resp = app_err.into_response();
         assert_eq!(
@@ -575,7 +580,7 @@ mod tests {
     /// It must still map to 404.
     #[test]
     fn map_signaller_error_source_not_active_survives_context_wrapping() {
-        let err = anyhow::anyhow!(SOURCE_NOT_ACTIVE_ERR)
+        let err = anyhow::Error::from(NdiSessionError::SourceNotActive)
             .context("signaller call failed while forwarding to the pipeline");
         let app_err = map_signaller_error(err);
         assert_eq!(

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -266,7 +266,7 @@ mod set_stage_layout_error_mapping_tests {
         let state = crate::state::AppState::in_memory().await.unwrap();
         // Seed the timers row (created lazily by the first stage-context
         // rebuild) via an initial, unrelated valid layout switch.
-        set_stage_layout(
+        let _ = set_stage_layout(
             State(state.clone()),
             Json(StageLayoutUpdateRequest {
                 code: "timer".to_string(),

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -233,3 +233,90 @@ mod broadcast_live_handler_tests {
         assert!(!state.broadcast_live());
     }
 }
+
+/// #588: `set_stage_layout` must discriminate a genuine internal failure from
+/// an unknown/invalid layout code — not blanket-map every error to 404.
+#[cfg(test)]
+mod set_stage_layout_error_mapping_tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+
+    /// An internal failure unrelated to the layout code itself (here: a
+    /// corrupted `timers` row surfaced while `broadcast_stage_snapshots`
+    /// rebuilds the stage context after a VALID layout switch) must answer
+    /// 500 — never 404. Before the #588 fix, `set_stage_layout` mapped every
+    /// error from `set_stage_layout_code` to `AppError::not_found`, so this
+    /// genuine server fault was reported to the client as "layout not
+    /// found".
+    #[tokio::test]
+    async fn set_stage_layout_returns_500_on_internal_failure_not_404() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        // Seed the timers row (created lazily by the first stage-context
+        // rebuild) via an initial, unrelated valid layout switch.
+        set_stage_layout(
+            State(state.clone()),
+            Json(StageLayoutUpdateRequest {
+                code: "timer".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Corrupt the persisted timer state directly via raw SQL so the next
+        // stage-context rebuild hits `RepositoryError::UnknownTimerState` —
+        // a real internal fault, unrelated to the requested layout code.
+        let conn = state.repository().connection();
+        sea_orm::ConnectionTrait::execute(
+            conn,
+            sea_orm::Statement::from_string(
+                sea_orm::ConnectionTrait::get_database_backend(conn),
+                "UPDATE timers SET countdown_state = 'corrupted-state'".to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+
+        // Switch to a DIFFERENT valid, operator-selectable code so the
+        // early-return-on-unchanged-code guard doesn't short-circuit before
+        // `broadcast_stage_snapshots` runs.
+        let result = set_stage_layout(
+            State(state),
+            Json(StageLayoutUpdateRequest {
+                code: "preach".to_string(),
+            }),
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("expected an error from the corrupted timers row, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "an internal failure on the layout-switch path must be 500, not 404 (#588)"
+        );
+    }
+
+    /// An unknown/invalid layout code must still answer 404 — the acceptance
+    /// criterion #588 must NOT regress.
+    #[tokio::test]
+    async fn set_stage_layout_returns_404_for_unknown_code() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        let result = set_stage_layout(
+            State(state),
+            Json(StageLayoutUpdateRequest {
+                code: "no-such-layout".to_string(),
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for an unknown layout code, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "an unknown layout code must be 404"
+        );
+    }
+}

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use super::{parse_uuid, AppError};
+use crate::state::stage_display::StageLayoutRefusal;
 use crate::state::AppState;
 use axum::http::StatusCode;
 use presenter_core::{
@@ -70,7 +71,7 @@ pub(super) async fn get_stage_layout(
 /// surfaced by `broadcast_stage_snapshots`, as a benign "layout not found").
 /// Any other error falls through to the default 500 mapping.
 fn map_stage_layout_refusal(err: anyhow::Error) -> AppError {
-    match err.downcast_ref::<crate::state::stage_display::StageLayoutRefusal>() {
+    match err.downcast_ref::<StageLayoutRefusal>() {
         Some(refusal) => AppError::not_found(refusal.to_string()),
         None => err.into(),
     }

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -64,6 +64,18 @@ pub(super) async fn get_stage_layout(
     }))
 }
 
+/// Maps a `set_stage_layout_code` refusal to its HTTP status via the TYPED
+/// `StageLayoutRefusal` error — never a blanket `.to_string()`-based 404
+/// (#588: that hid a genuine internal failure, e.g. a corrupted `timers` row
+/// surfaced by `broadcast_stage_snapshots`, as a benign "layout not found").
+/// Any other error falls through to the default 500 mapping.
+fn map_stage_layout_refusal(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<crate::state::stage_display::StageLayoutRefusal>() {
+        Some(refusal) => AppError::not_found(refusal.to_string()),
+        None => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn set_stage_layout(
     State(state): State<AppState>,
@@ -76,7 +88,7 @@ pub(super) async fn set_stage_layout(
     let layout = state
         .set_stage_layout_code(code)
         .await
-        .map_err(|err| AppError::not_found(err.to_string()))?;
+        .map_err(map_stage_layout_refusal)?;
     Ok(Json(StageLayoutResponse {
         code: layout.code.clone(),
         layout,

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -37,7 +37,7 @@ mod seed;
 mod slide_stage_layout;
 pub(crate) mod slides;
 pub(crate) mod stage;
-mod stage_display;
+pub(crate) mod stage_display;
 mod stage_state;
 pub(crate) mod sync;
 #[cfg(test)]

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -6,6 +6,26 @@ use crate::live::LiveEvent;
 use presenter_core::{
     StageDisplayLayout, StageDisplaySnapshot, API_STAGE_LAYOUT_CODE, DEFAULT_STAGE_LAYOUT_CODE,
 };
+use thiserror::Error;
+
+/// A `POST /stage/layout` request refused a `code` that is not a valid,
+/// operator-selectable layout. The router (`router/stage.rs`) downcasts on
+/// this TYPED error to answer 404 — never a blanket `.to_string()`-based
+/// mapping, which used to hide a genuine internal failure (e.g. a corrupted
+/// `timers` row surfaced while rebuilding the stage context) as a benign
+/// "layout not found" (#588). Any OTHER error from `set_stage_layout_code`
+/// falls through to the router's default 500 mapping.
+///
+/// `Display` text is kept byte-identical to the pre-#588 messages —
+/// `set_stage_layout_code_rejects_camera_crew` (`state/tests.rs`) asserts on
+/// the exact `CameraCrew` wording.
+#[derive(Debug, Error)]
+pub(crate) enum StageLayoutRefusal {
+    #[error("'{0}' is not an operator-selectable layout; it is served only at /ui/camera")]
+    CameraCrew(String),
+    #[error("unknown stage layout: {0}")]
+    UnknownCode(String),
+}
 
 /// `app_settings` key under which the operator-selected stage layout code is
 /// persisted so it survives a server restart/deploy (issue #384). Stored via
@@ -105,12 +125,10 @@ impl AppState {
     /// two paths can never drift apart).
     pub(super) fn validate_operator_selectable(code: &str) -> anyhow::Result<StageDisplayLayout> {
         if code == "camera-crew" {
-            return Err(anyhow::anyhow!(
-                "'camera-crew' is not an operator-selectable layout; it is served only at /ui/camera"
-            ));
+            return Err(StageLayoutRefusal::CameraCrew(code.to_string()).into());
         }
         StageDisplayLayout::find_operator_selectable(code)
-            .ok_or_else(|| anyhow::anyhow!("unknown stage layout: {code}"))
+            .ok_or_else(|| StageLayoutRefusal::UnknownCode(code.to_string()).into())
     }
 
     pub async fn set_stage_layout_code(&self, code: &str) -> anyhow::Result<StageDisplayLayout> {

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -659,3 +659,30 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
   errors/warnings), plus curl-verified both fixed endpoints now return 404 on an unknown id
   (`POST /integrations/resolume/hosts/{id}/test`, `PUT /playlists/{id}/entries`) and the restore
   endpoint's sanity check still 404s.
+
+## #610: `PUT /playlists/{id}/entries` still 500s for a non-empty body — #609's own regression test dodged it
+
+- Design comment posted before any code: https://github.com/zbynekdrlik/presenter/issues/610#issuecomment-5097450786
+- Version bump `f19540e4` (0.4.214 → 0.4.215).
+- RED `27cff18e`: rewrote `replace_playlist_entries_endpoint_missing_playlist_returns_404` to seed
+  a real presentation over HTTP and PUT a non-empty `entries` array (previously `{"entries": []}`,
+  the one shape that skips the repository's insert loop). Pushed alone, CI run 30310638017 —
+  `Test` job failed exactly on this test, `left: 500, right: 404`, all other jobs green.
+- GREEN `90819e36`: `PlaylistRepository::replace_playlist_entries` (`repository/playlist.rs`) now
+  calls the existing `ensure_playlist_exists` helper as its first line, matching the typed-refusal
+  pattern already used elsewhere in the file. Traced all 4 callers (router HTTP path,
+  `ensure_demo_playlist`, 2 test seeders) — all create the playlist first, so no behavior change.
+  Plus 2 doc fixes: `.claude/skills/ci/SKILL.md`'s Tier-0 warning corrected to "NOT Tier-0-safe in
+  ANY mode" (fmt/clippy/check run unconditionally, `--strict` only controls fatality);
+  `.claude/rules/repository-error-pattern.md`'s module list gained the missing
+  `router/bible/broadcast.rs` (9 modules, not 8) + noted `router/presentations.rs`'s
+  `map_repository_error` naming exception. CI run 30311605427: first attempt's `NDI WebRTC E2E`
+  job failed on an UNRELATED dead `deb.nodesource.com` apt source on the self-hosted runner
+  (403 Forbidden, confirmed reproducible via direct `curl`/`apt-get update`) — fixed by removing
+  the stale `/etc/apt/sources.list.d/nodesource.list` + keyring on dev2 (unused: the runner's
+  actual node/npm come from nvm per `NVM_BIN` in the runner's `.env`); reran just the failed job,
+  fully green afterward (22/22 jobs incl. Deploy to Dev).
+- PR #612 (Closes #610), merged `8c650c81`. Main Deploy CI run 30314489187 green. Dev fast-forward
+  push (merge-back per #591) CI run 30315091607 also fully green. Prod + dev both verified v0.4.215
+  live via `/healthz`; functional check on both: `PUT /playlists/{unknown}/entries` with a real
+  seeded presentation id now returns 404 `{"message":"playlist not found"}` (was 500).


### PR DESCRIPTION
## Summary

Two bug fixes that discriminate a genuine internal failure from a resource-not-found refusal, replacing string-matching with typed errors on both crate boundaries the codebase already established this pattern for.

- **#588** — `POST /stage/layout` (`router/stage.rs::set_stage_layout`) mapped EVERY error from `set_stage_layout_code` to 404, hiding real internal faults (e.g. a corrupted `timers` row surfaced while rebuilding the stage context) as "layout not found". Introduces `StageLayoutRefusal` (state layer), matched via `downcast_ref` in the router — only a genuine unknown/invalid code answers 404; anything else falls through to 500.
- **#589** — `ndi_whep.rs` decided WHEP HTTP status by substring-matching `err.to_string()` against text raised by the `presenter-ndi` crate — a de-facto, unenforced cross-crate contract that silently breaks the moment `.context(...)` is added upstream. Exports a typed `NdiSessionError` (`SourceNotActive`, `ConsumerCapReached`, `SessionNotFound`) from `presenter-ndi`, matched via `downcast_ref` in the router. All four behaviors (503+Retry-After, 404, 204 reinterpret, idempotent-delete 204) are preserved exactly. Adds the missing unit test for the `SourceNotActive` → 404 branch, proven robust to context-wrapping.

Closes #588
Closes #589

## Test plan

- [x] RED commit per issue, failing before the fix, passing after
- [x] `cargo fmt --all -- --check` clean
- [x] CI dev pipeline green (all jobs incl. Clippy, Test, Coverage, Build, E2E, Deploy to Dev)
- [ ] Post-merge: verify main CI + prod deploy, functional probe of both endpoints
