### PR TITLE
chore: playbook capture + version bump for #588/#589

### DIFF
--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -3,9 +3,11 @@ paths:
   - "crates/presenter-persistence/src/repository/**"
   - "crates/presenter-server/src/router/**"
   - "crates/presenter-server/src/state/**"
+  - "crates/presenter-ndi/src/manager/**"
+  - "crates/presenter-ndi/src/pipeline/**"
 ---
 
-# Typed repository-refusal → HTTP-status pattern (#584, extended by #586/#587)
+# Typed repository-refusal → HTTP-status pattern (#584, extended by #586/#587, #588, #589)
 
 When a repository/state method refuses because the URL's resource doesn't exist, it must return
 the router a **typed** error, never a bare `anyhow!("... not found")` string — a bare anyhow falls
@@ -82,3 +84,40 @@ everywhere it could be. Both #608 misses (`router/integrations/resolume.rs`'s `t
 defined and used elsewhere in the SAME file. Before adding a new helper to a router file, `grep -n
 "map_repository_not_found" <file>` first — if it exists, the fix is a one-line `.map_err(...)` wire,
 not a new helper.
+
+## Not every refusal is a `RepositoryError` — a DOMAIN error gets its OWN small enum (#588, #589)
+
+`RepositoryError::NotFound`/`TargetNotFound` is for refusals that actually originate in the
+PERSISTENCE layer. A refusal decided entirely in the STATE layer (no DB touched at all — e.g.
+`stage_display.rs::validate_operator_selectable` rejecting an unknown layout `code`) or across a
+DIFFERENT crate boundary (e.g. `presenter-ndi`'s WHEP session refusals) must NOT be forced through
+`RepositoryError` — that's a wrong-layer dependency and `NotFound(&'static str)` can't cheaply carry
+a dynamic message anyway. Define a small locally-scoped `thiserror::Error` enum next to where the
+refusal is decided instead, and downcast on THAT type in the router — exactly the same shape,
+just a different concrete type. Precedent for this ALREADY existed before #588/#589:
+`router/timers.rs` downcasts `presenter_core::timer::TimerError`, a domain error from a THIRD crate
+boundary. Two more examples now: `StageLayoutRefusal` (`state/stage_display.rs`, same-crate,
+`pub(crate)`) and `NdiSessionError` (`presenter_ndi::manager`, `pub`, crosses the ndi↔server crate
+boundary). When a single router-facing decision point needs to translate a DIFFERENT existing typed
+error (e.g. the pipeline's own `AddConsumerError::CapReached`) into the shared vocabulary, do it at
+the ONE call site where it crosses into the shared `anyhow::Result` (see `NdiManager::whep_post`) —
+don't make the router downcast on two parallel taxonomies for the same decision.
+
+## `anyhow::Error::downcast_ref` walks the WHOLE context chain — verified in anyhow's own source
+
+The reason string-matching breaks under `.context(...)` while `downcast_ref` doesn't is NOT
+incidental — it's the documented mechanism. `Error::context()` builds a `ContextError<C, E>` whose
+vtable's `object_downcast` (`context_chain_downcast` in `anyhow`'s `error.rs`) checks the context
+type `C` first and, if it doesn't match, RECURSES into the wrapped error's OWN vtable — so
+`err.downcast_ref::<E>()` finds `E` no matter how many `.context(...)` layers were added on top,
+while `err.to_string()` only ever shows the OUTERMOST context message. This is what makes the
+typed-error pattern robust and string-matching fragile — cite it when justifying the pattern instead
+of re-deriving it from scratch (confirmed against `anyhow-1.0.103/src/error.rs` on this box).
+
+## clippy `unused_must_use` on a discarded handler-call in a test (#588)
+
+A router handler that returns `Result<Json<T>, AppError>` makes `Json<T>` `#[must_use]` through
+axum. A test that calls the handler directly ONLY to seed state (drop the actual response) —
+`set_stage_layout(State(state.clone()), Json(payload)).await.unwrap();` with no assignment — fails
+`cargo clippy -- -D warnings` on `unused_must_use`, because `.unwrap()`'s returned `Json<T>` is a
+bare statement. Bind it: `let _ = handler(...).await.unwrap();`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.216"
+version = "0.4.217"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.216"
+version = "0.4.217"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -686,3 +686,49 @@ _RED-before-GREEN verified: RED 40b3147c (#437), 61564d81 (#438) precede their G
   push (merge-back per #591) CI run 30315091607 also fully green. Prod + dev both verified v0.4.215
   live via `/healthz`; functional check on both: `PUT /playlists/{unknown}/entries` with a real
   seeded presentation id now returns 404 `{"message":"playlist not found"}` (was 500).
+
+## 2026-07-28 — #588 + #589: stop hiding internal failures behind string-matched 404s (bundled batch)
+
+- Design notes posted BEFORE any code:
+  https://github.com/zbynekdrlik/presenter/issues/588#issuecomment-5099102993 (#588) and
+  https://github.com/zbynekdrlik/presenter/issues/589#issuecomment-5099104053 (#589) — both predate
+  their first RED commits (`73592290`, `7fa6dcd7`).
+- Version bump `b8b1a743` (0.4.215 → 0.4.216).
+- **#588** RED `73592290`: `router/stage.rs`'s `set_stage_layout_returns_500_on_internal_failure_not_404`
+  seeds the `timers` singleton row via a real layout switch, corrupts `countdown_state` with raw SQL
+  so the NEXT switch hits `RepositoryError::UnknownTimerState` deep in `broadcast_stage_snapshots` —
+  unrelated to the requested code — and asserts 500; failed on unfixed code (observed 404, the
+  blanket `.map_err(AppError::not_found)`). GREEN `398e53f7`: new `StageLayoutRefusal` enum
+  (`state/stage_display.rs`, `CameraCrew`/`UnknownCode`, `Display` byte-identical to the old
+  messages) + `map_stage_layout_refusal` in the router downcasting on it — everything else falls to
+  the default 500.
+- **#589** RED `7fa6dcd7`: `ndi_whep.rs`'s `map_signaller_error_source_not_active_survives_context_wrapping`
+  wraps `anyhow!(SOURCE_NOT_ACTIVE_ERR)` in `.context(...)` and asserts 404; failed on unfixed code
+  (the `.to_string().contains(...)` match only sees the outer context message, falls to 503). GREEN
+  `a133893b`: new `NdiSessionError` enum (`presenter_ndi::manager` — `SourceNotActive`,
+  `ConsumerCapReached{max}`, `SessionNotFound{session_id}`, `Display` byte-identical to the old raw
+  strings) replaces every `anyhow!(...)` raise site in `manager/whep.rs` + `pipeline/consumers.rs`;
+  the pipeline's own `AddConsumerError::CapReached` is translated into it at the single
+  `whep_post` boundary. Router's 3 status-deciding sites now `downcast_ref::<NdiSessionError>()`
+  instead of `.contains(...)`.
+- Fixup `5142ab32`: `cargo clippy -D warnings` failed on `unused_must_use` — the #588 RED test's
+  seed call discarded the handler's `#[must_use]` `Json<...>` with a bare `.unwrap();` statement;
+  fixed with `let _ = ...`.
+- Dispatched `superpowers:requesting-code-review` against `origin/main..HEAD` before merging (built
+  + ran the crates locally on dev2, per project policy) — 0 Critical/Important, 2 Minor (unused
+  `Clone` derive on `NdiSessionError`, an inline fully-qualified path instead of a `use` import);
+  both fixed in `6d5040d0`, which also caught a stale Cargo.lock (workspace versions still read
+  0.4.213 from before #590's version churn) and refreshed it to 0.4.216.
+- PR #613 (Closes #588, Closes #589), merged `3e86654a`. Main Deploy CI run 30328062127 green.
+  Prod + dev both verified v0.4.216 live via `/healthz`. Functional checks: `POST /stage/layout`
+  with an unknown code → 404 `{"message":"unknown stage layout: ..."}` on both; WHEP POST/DELETE
+  against an unknown/inactive NDI source → 204 on both (the #431-established not-active contract,
+  now typed instead of string-matched).
+- Playbook: `.claude/rules/repository-error-pattern.md` gained presenter-ndi to its `paths:`, plus
+  3 new sections — (1) not every refusal is a `RepositoryError`, a domain error decided outside the
+  persistence layer gets its OWN small `thiserror` enum (precedent: `router/timers.rs`'s
+  `TimerError` downcast already existed pre-#588); (2) `anyhow::Error::downcast_ref` provably walks
+  the WHOLE `.context(...)` chain (traced through `anyhow-1.0.103/src/error.rs`'s
+  `context_chain_downcast`) — that's WHY the pattern is robust and string-matching isn't; (3) the
+  `unused_must_use` clippy gotcha above. Landed after #613 merged, so it rides its own version bump
+  (0.4.216 → 0.4.217) and its own tiny PR to keep dev strictly ahead of main.


### PR DESCRIPTION
## Summary

Doc-only follow-up after #613 (fix: discriminate internal failures from not-found refusals, #588 + #589) merged: captures the playbook findings from that batch's post-merge review, per `project-playbook-maintenance.md`.

- `.claude/rules/repository-error-pattern.md`: added `presenter-ndi` to its `paths:`, and 3 new sections (domain refusals outside the persistence layer get their own typed enum; `anyhow::downcast_ref` walks the whole `.context()` chain, traced through anyhow's own source; the `unused_must_use` clippy gotcha on a discarded handler `Json<T>` in a test).
- `docs/autopilot-log.md`: recorded the #588/#589 cycle.
- Version bump 0.4.216 → 0.4.217 (dev must stay ahead of main after #613's merge).

No functional/behavior change — CI is green because nothing in `crates/` changed except the version bump.

## Test plan

- [x] CI dev pipeline green (all jobs)
- [x] No functional change — nothing beyond docs + version bump touched
