### PR TITLE
fix: typed error mapping #615 + WHEP test coverage #616

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.217"
+version = "0.4.218"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.217"
+version = "0.4.218"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ndi/src/manager/whep.rs
+++ b/crates/presenter-ndi/src/manager/whep.rs
@@ -6,9 +6,7 @@
 
 use anyhow::{anyhow, Result};
 
-use crate::pipeline::{
-    AddConsumerError, NdiPipeline, PipelineState, StreamProfile, MAX_CONSUMERS_PER_SOURCE,
-};
+use crate::pipeline::{AddConsumerError, NdiPipeline, PipelineState, StreamProfile};
 
 use super::{ActiveSource, NdiManager, NdiSessionError, WhepOp, WhepReply};
 
@@ -291,6 +289,7 @@ fn translate_add_consumer_error(err: AddConsumerError) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::MAX_CONSUMERS_PER_SOURCE;
 
     /// #616 Gap A: `translate_add_consumer_error` is the ONLY place
     /// `AddConsumerError::CapReached` becomes

--- a/crates/presenter-ndi/src/manager/whep.rs
+++ b/crates/presenter-ndi/src/manager/whep.rs
@@ -6,7 +6,9 @@
 
 use anyhow::{anyhow, Result};
 
-use crate::pipeline::{AddConsumerError, NdiPipeline, PipelineState, StreamProfile};
+use crate::pipeline::{
+    AddConsumerError, NdiPipeline, PipelineState, StreamProfile, MAX_CONSUMERS_PER_SOURCE,
+};
 
 use super::{ActiveSource, NdiManager, NdiSessionError, WhepOp, WhepReply};
 
@@ -161,12 +163,7 @@ impl NdiManager {
         let answer = pipeline
             .add_consumer(body, profile, turn_server)
             .await
-            .map_err(|err| match err {
-                AddConsumerError::CapReached { max } => {
-                    NdiSessionError::ConsumerCapReached { max }.into()
-                }
-                AddConsumerError::Other(err) => err,
-            })?;
+            .map_err(translate_add_consumer_error)?;
         let location = format!("/ndi/whep/{source_id}/{}", answer.session_id);
         tracing::info!(
             source_id = %source_id,
@@ -271,5 +268,73 @@ impl NdiManager {
             PipelineState::Stopped => Err(anyhow!("pipeline stopped")),
             PipelineState::Errored(e) => Err(anyhow!("pipeline errored: {e}")),
         }
+    }
+}
+
+/// Translate the pipeline's OWN typed `AddConsumerError` into the shared
+/// router-facing `NdiSessionError` at the ONE place it crosses into
+/// `anyhow::Result` (`whep_post`), so `ndi_whep.rs` has a single downcast
+/// target for every WHEP status decision (#589). `Other` passes through
+/// unchanged.
+///
+/// Pure + directly unit-tested (no `NdiManager` / libndi needed) so the
+/// `CapReached` → `NdiSessionError::ConsumerCapReached` translation seam —
+/// which is the ONLY place that mapping happens — is exercised on every
+/// host, including CI runners without libndi (#616 Gap A).
+fn translate_add_consumer_error(err: AddConsumerError) -> anyhow::Error {
+    match err {
+        AddConsumerError::CapReached { max } => NdiSessionError::ConsumerCapReached { max }.into(),
+        AddConsumerError::Other(err) => err,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #616 Gap A: `translate_add_consumer_error` is the ONLY place
+    /// `AddConsumerError::CapReached` becomes
+    /// `NdiSessionError::ConsumerCapReached`. Before this function was
+    /// extracted, no test exercised that translation seam — the pipeline
+    /// test asserted on `AddConsumerError::CapReached` (BEFORE), the router
+    /// test hand-built `NdiSessionError::ConsumerCapReached` (AFTER), and
+    /// nothing connected them. This test drives through the translation and
+    /// downcasts the result to assert the typed `NdiSessionError` variant
+    /// — not just `AddConsumerError`.
+    #[test]
+    fn cap_reached_translates_to_ndi_session_error() {
+        let err = translate_add_consumer_error(AddConsumerError::CapReached {
+            max: MAX_CONSUMERS_PER_SOURCE,
+        });
+        match err.downcast_ref::<NdiSessionError>() {
+            Some(NdiSessionError::ConsumerCapReached { max }) => {
+                assert_eq!(
+                    *max, MAX_CONSUMERS_PER_SOURCE,
+                    "cap value must survive the translation",
+                );
+            }
+            other => panic!(
+                "CapReached must translate to NdiSessionError::ConsumerCapReached, got: {other:?}"
+            ),
+        }
+    }
+
+    /// `Other(anyhow::Error)` must pass through UNCHANGED — the inner
+    /// error is extracted and returned as-is, not wrapped in an
+    /// `NdiSessionError` variant. The message text must survive verbatim.
+    #[test]
+    fn other_error_passes_through_unchanged() {
+        let err =
+            translate_add_consumer_error(AddConsumerError::Other(anyhow!("signaller emit failed")));
+        // Not an NdiSessionError at all — it's the raw inner anyhow.
+        assert!(
+            err.downcast_ref::<NdiSessionError>().is_none(),
+            "Other must NOT be wrapped in an NdiSessionError variant"
+        );
+        assert!(
+            err.to_string().contains("signaller emit failed"),
+            "inner error message must survive unchanged, got: {}",
+            err
+        );
     }
 }

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -83,6 +83,32 @@ fn map_post_whep_error(err: anyhow::Error) -> Result<WhepReply, AppError> {
     }
 }
 
+/// Idempotent DELETE: a session (or its whole source) that is already gone
+/// means the client's desired state holds — answer 204, not 404. The stage UI
+/// dispatches teardown DELETEs from both on_cleanup and pagehide, and after a
+/// server-side deactivate the session is gone before the DELETE arrives; a 404
+/// logged a browser console error ("Failed to load resource") on every
+/// deactivate/navigation cycle.
+///
+/// Pure + directly unit-tested (no live NdiManager needed) so the idempotency
+/// guard is exercised on every host — killing the cargo-mutants mutants that
+/// replace the match arms with `true`/`false` (which the handler-level test
+/// can't catch on a libndi-less CI runner, where the manager-missing 503
+/// short-circuits before the guard is reached). Same extraction shape as
+/// `map_post_whep_error` above (#431) and #616 Gap B.
+fn map_delete_whep_error(err: anyhow::Error) -> Result<WhepReply, AppError> {
+    match err.downcast_ref::<NdiSessionError>() {
+        Some(NdiSessionError::SourceNotActive) | Some(NdiSessionError::SessionNotFound { .. }) => {
+            Ok(WhepReply {
+                status: 204,
+                headers: Vec::new(),
+                body: None,
+            })
+        }
+        _ => Err(map_signaller_error(err)),
+    }
+}
+
 #[instrument(skip_all, fields(source_id = %source_id))]
 pub(crate) async fn post_whep_endpoint(
     Path(source_id): Path<String>,
@@ -188,24 +214,11 @@ pub(crate) async fn delete_whep_session(
         Ok(reply) => reply,
         // Idempotent DELETE: a session (or its whole source) that is already
         // gone means the client's desired state holds — answer 204, not 404.
-        // The stage UI dispatches teardown DELETEs from both on_cleanup and
-        // pagehide, and after a server-side deactivate the session is gone
-        // before the DELETE arrives; a 404 logged a browser console error
-        // ("Failed to load resource") on every deactivate/navigation cycle.
-        Err(err)
-            if matches!(
-                err.downcast_ref::<NdiSessionError>(),
-                Some(NdiSessionError::SourceNotActive)
-                    | Some(NdiSessionError::SessionNotFound { .. })
-            ) =>
-        {
-            WhepReply {
-                status: 204,
-                headers: Vec::new(),
-                body: None,
-            }
-        }
-        Err(err) => return Err(map_signaller_error(err)),
+        // Extracted into `map_delete_whep_error` (#616 Gap B) so the guard is
+        // directly unit-testable on CI runners without libndi (the handler
+        // short-circuits to 503 before reaching the guard when the manager is
+        // missing, mirroring #431's extraction of `map_post_whep_error`).
+        Err(err) => map_delete_whep_error(err)?,
     };
     Ok(into_response(reply))
 }
@@ -552,6 +565,7 @@ mod tests {
         let err: anyhow::Error = NdiSessionError::ConsumerCapReached { max: 8 }.into();
         let app_err = map_signaller_error(err);
         let resp = app_err.into_response();
+
         assert_eq!(
             resp.status(),
             StatusCode::SERVICE_UNAVAILABLE,
@@ -566,6 +580,83 @@ mod tests {
             Some("60"),
             "Retry-After header must be 60 seconds"
         );
+    }
+
+    /// #616 Gap B: `map_delete_whep_error` must return 204 for a
+    /// `SourceNotActive` — the DELETE is idempotent, a source that's already
+    /// gone means the client's desired state holds. The handler-level test
+    /// can't exercise this guard on a CI runner without libndi (the manager
+    /// is `None` → 503 short-circuit), so the extracted pure function is
+    /// tested directly. Kills the "guard with false" mutant.
+    #[test]
+    fn map_delete_whep_error_returns_204_for_source_not_active() {
+        match map_delete_whep_error(NdiSessionError::SourceNotActive.into()) {
+            Ok(reply) => {
+                assert_eq!(
+                    reply.status, 204,
+                    "DELETE of an inactive source must be 204 (idempotent)"
+                );
+                assert!(reply.body.is_none(), "204 reply carries no body");
+            }
+            Err(err) => panic!(
+                "not-active DELETE error must map to a 204 reply, got HTTP {}",
+                err.into_response().status()
+            ),
+        }
+    }
+
+    /// #616 Gap B: `SessionNotFound` is the other half of the idempotency
+    /// guard — a session that's already gone means the client's desired state
+    /// holds. Deliberately preserved even though production code rarely
+    /// reaches it (see the issue note about not "cleaning up" this branch).
+    #[test]
+    fn map_delete_whep_error_returns_204_for_session_not_found() {
+        match map_delete_whep_error(
+            NdiSessionError::SessionNotFound {
+                session_id: "test-session".to_string(),
+            }
+            .into(),
+        ) {
+            Ok(reply) => {
+                assert_eq!(
+                    reply.status, 204,
+                    "DELETE of a non-existent session must be 204 (idempotent)"
+                );
+            }
+            Err(err) => panic!(
+                "session-not-found DELETE error must map to a 204 reply, got HTTP {}",
+                err.into_response().status()
+            ),
+        }
+    }
+
+    /// #616 Gap B: a non-idempotent error must NOT become 204 — it maps to
+    /// `map_signaller_error` (503 for pipeline errors, 404 for unknown
+    /// sources via the generic path). Kills the "guard with true" mutant.
+    #[test]
+    fn map_delete_whep_error_passes_through_non_idempotent_errors() {
+        match map_delete_whep_error(anyhow::anyhow!("pipeline errored: ndisrc crash")) {
+            Ok(reply) => panic!(
+                "a non-idempotent error must NOT become a 204 reply, got status {}",
+                reply.status
+            ),
+            Err(err) => assert_eq!(
+                err.into_response().status(),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "a generic pipeline error maps to 503, not 204"
+            ),
+        }
+    }
+
+    #[test]
+    fn into_response_defaults_to_empty_body_when_none() {
+        let reply = WhepReply {
+            status: 204,
+            headers: Vec::new(),
+            body: None,
+        };
+        let resp = into_response(reply);
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     }
 
     /// #589: `map_signaller_error`'s SOURCE_NOT_ACTIVE_ERR → 404 branch had NO

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -681,17 +681,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn into_response_defaults_to_empty_body_when_none() {
-        let reply = WhepReply {
-            status: 204,
-            headers: Vec::new(),
-            body: None,
-        };
-        let resp = into_response(reply);
-        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-    }
-
     #[cfg(feature = "test-helpers")]
     #[tokio::test]
     async fn kill_pipeline_for_test_returns_404_or_503_for_unknown_source() {

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -66,6 +66,7 @@ pub(super) async fn list_slide_stage_layouts(
 mod tests {
     use super::*;
     use axum::extract::{Path, State};
+    use axum::response::IntoResponse;
 
     async fn seeded_state() -> (crate::state::AppState, presenter_core::Presentation) {
         let state = crate::state::AppState::in_memory().await.unwrap();
@@ -130,5 +131,64 @@ mod tests {
         )
         .await;
         assert!(result.is_err(), "unknown layout must be rejected");
+    }
+
+    /// #615: an unknown/invalid layout code must still answer 400 — the SAME
+    /// client-error status the route returns today. `StageLayoutRefusal` is
+    /// a client-side refusal (bad layout code), not an internal failure.
+    #[tokio::test]
+    async fn put_returns_400_for_unknown_layout_code() {
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let result = set_slide_stage_layout(
+            State(state),
+            Path((presentation.id.to_string(), slide_id.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("no-such-layout".to_string()),
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for an unknown layout code, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::BAD_REQUEST,
+            "an unknown layout code must be 400 (same client-error status as today, #615)"
+        );
+    }
+
+    /// #615: a genuine internal failure (here: a non-existent presentation
+    /// causes `assign_slide_stage_layout` to `bail!("presentation not
+    /// found")`, an untyped `anyhow::Error` that is NOT a
+    /// `StageLayoutRefusal`) must answer 500 — never 400. Before the fix,
+    /// the blanket `.map_err(AppError::bad_request)` masked this as a
+    /// client error.
+    #[tokio::test]
+    async fn put_returns_500_on_internal_failure_not_400() {
+        let (state, _presentation) = seeded_state().await;
+        // A valid-format UUID that doesn't correspond to any seeded
+        // presentation: `presentation_detail` returns `None`, the state
+        // method `bail!`s — a non-typed error that must fall through to 500.
+        let random_uuid = uuid::Uuid::new_v4();
+        let random_slide = presenter_core::SlideId::new();
+
+        let result = set_slide_stage_layout(
+            State(state),
+            Path((random_uuid.to_string(), random_slide.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("fulltext".to_string()),
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for a non-existent presentation, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "an internal failure must be 500, not 400 (#615)"
+        );
     }
 }

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use tracing::instrument;
 
 use super::AppError;
+use crate::state::stage_display::StageLayoutRefusal;
 use crate::state::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -46,8 +47,24 @@ pub(super) async fn set_slide_stage_layout(
             code,
         )
         .await
-        .map_err(AppError::bad_request)?;
+        .map_err(map_slide_stage_layout_error)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Maps a `assign_slide_stage_layout` error to its HTTP status via the TYPED
+/// `StageLayoutRefusal` — never a blanket `AppError::bad_request` (#615: that
+/// hid a genuine internal failure, e.g. a missing presentation or a DB error,
+/// as a benign client-side 400). Same shape as #588's
+/// `map_stage_layout_refusal` in `router/stage.rs`, but maps to
+/// `bad_request_message` (400) — the SAME client-error status this route has
+/// ALWAYS returned for bad layout codes — so only the fallthrough to 500
+/// changes, not the typed-refusal status. Any other error falls through to
+/// the router's default 500 mapping.
+fn map_slide_stage_layout_error(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<StageLayoutRefusal>() {
+        Some(refusal) => AppError::bad_request_message(refusal.to_string()),
+        None => err.into(),
+    }
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
## Summary

Closes #615, Closes #616 — two bundle-safe error-mapping + test-coverage fixes in one PR.

### #615 — `slide_stage_layout.rs` blanket-400 bug

**Root cause:** `.map_err(AppError::bad_request)` at `slide_stage_layout.rs:48` mapped EVERY error from `assign_slide_stage_layout` to HTTP 400, masking genuine internal failures (DB error, missing presentation, corrupted row) as client-side 400.

**Fix:** Extracted `map_slide_stage_layout_error` — downcasts the typed `StageLayoutRefusal` to the SAME 400 status (preserving existing client-visible behavior), lets everything else fall through to the router's default 500 mapping. Same shape as the `stage.rs` precedent.

### #616 — Two #589 test-coverage gaps

**Gap A:** The `AddConsumerError::CapReached` → `NdiSessionError::ConsumerCapReached` translation at `whep.rs:161-169` was the ONLY place that mapping happened, but no test exercised it — `NdiManager` requires libndi (not available on CI). Extracted into pure `fn translate_add_consumer_error` and unit-tested directly.

**Gap B:** The DELETE idempotency guard at `ndi_whep.rs:196-200` was unreachable on CI (manager is `None` → 503 short-circuit). Extracted into pure `fn map_delete_whep_error` (mirroring `map_post_whep_error`) and unit-tested `SourceNotActive`/`SessionNotFound` → 204, generic error → 503.

Both tests FAIL on mutation — vacuous test = the exact defect #616 exists to close.

## Test plan

- [ ] CI pipeline green (fmt, clippy, test, coverage, build, e2e, deploy-dev)
- [ ] #615 regression test `put_returns_500_on_internal_failure_not_400` passes (was failing on RED commit)
- [ ] #616 Gap A test `cap_reached_translates_to_ndi_session_error` passes
- [ ] #616 Gap B tests `map_delete_whep_error_*` pass
- [ ] Post-deploy: `curl http://10.77.8.134:8080/healthz` returns version `0.4.218`
