### PR TITLE
fix: typed-refusal sweep edit_ops #611 + database skill prod-DB inspection #593

### DIFF
--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -121,3 +121,7 @@ axum. A test that calls the handler directly ONLY to seed state (drop the actual
 `set_stage_layout(State(state.clone()), Json(payload)).await.unwrap();` with no assignment — fails
 `cargo clippy -- -D warnings` on `unused_must_use`, because `.unwrap()`'s returned `Json<T>` is a
 bare statement. Bind it: `let _ = handler(...).await.unwrap();`.
+
+## Test-only imports must live inside `#[cfg(test)]`, not at module level (#616)
+
+When you extract a pure function for testability (the `map_post_whep_error` / `translate_add_consumer_error` / `map_delete_whep_error` pattern) and the test uses a CONSTANT from the parent module's imports (e.g. `MAX_CONSUMERS_PER_SOURCE` from `crate::pipeline`), that constant MUST be imported INSIDE the `#[cfg(test)] mod tests` block — NOT at the module level alongside the function's own imports. CI runs `cargo clippy -- -D warnings`, which rejects a module-level import used only in tests as `unused import` in the non-test build. The fix: move the offending item from the top-level `use crate::pipeline::{..., MAX_CONSUMERS_PER_SOURCE}` into the test module's own `use crate::pipeline::MAX_CONSUMERS_PER_SOURCE;` line.

--- a/.claude/skills/database/SKILL.md
+++ b/.claude/skills/database/SKILL.md
@@ -21,6 +21,57 @@ Schema is mutable during pre-release:
 - Imports happen only via the explicit Import Data workflow. Deploys never touch the database.
 - New server installations start with an empty libraries table. Run the Import Data workflow once after first deploy to populate it.
 
+## Inspecting a production database (read-only)
+
+Many data questions ("did this bug leave bad rows in production?", "how many
+favorites are dangling?") are answerable with a single read-only query. The
+live service holds the DB open in WAL mode, so a **read-only** handle cannot
+disturb it — inspect freely. Never re-derive the invocation from scratch; this
+is the standing procedure.
+
+The credential is **never** committed (skills are git-committed). Keep the
+value in local memory and reference it via the env-var form:
+
+```bash
+# SNV production (presenter.lan) — sqlite3 IS installed at /usr/bin/sqlite3
+sshpass -p "$PRESENTER_PROD_PW" ssh newlevel@presenter.lan \
+  "sqlite3 -readonly -header /opt/presenter/presenter.db 'SELECT ...'"
+
+# PP (companion-pp.lan) — same path; sqlite3 is installed there too
+sshpass -p "$PRESENTER_PROD_PW" ssh newlevel@companion-pp.lan \
+  "sqlite3 -readonly -header /opt/presenter/presenter.db 'SELECT ...'"
+```
+
+**Always `-readonly` for inspection.** It opens the handle in read-only mode,
+guaranteeing no statement can ever write — a safety net independent of the
+query text. The DB path is `/opt/presenter/presenter.db` on both hosts.
+
+**A prod-DB write / `DELETE` / `DROP` is a gated destructive action** and needs
+explicit user approval every time (per the global `no-destructive-remote-actions`
+rule). Inspection never does — but the moment a query mutates state, stop and
+ask first. Never run an ad-hoc `DELETE`/`UPDATE`/`DROP` against a production DB
+without approval, no matter how harmless it looks.
+
+The useful orientation query when investigating an integrity question — run it
+first to get a snapshot of the relevant counts:
+
+```sql
+SELECT (SELECT COUNT(*) FROM library_favorites),
+       (SELECT COUNT(*) FROM libraries),
+       (SELECT COUNT(*) FROM libraries WHERE deleted_at IS NOT NULL);
+```
+
+**Fallback when `sqlite3` is unavailable on a host** (a stripped-down image, a
+restricted shell): every Python install ships the `sqlite3` stdlib module, so
+the same read-only query works through it:
+
+```bash
+sshpass -p "$PRESENTER_PROD_PW" ssh newlevel@presenter.lan \
+  "python3 -c \"import sqlite3; c=sqlite3.connect('file:/opt/presenter/presenter.db?mode=ro', uri=True); print(list(c.execute('SELECT COUNT(*) FROM library_favorites')))\""
+```
+
+The `?mode=ro` URI enforces read-only the same way the CLI's `-readonly` does.
+
 ## Settings Audit Log
 
 All settings writes (ableset, osc, resolume hosts, android stage displays, video sources) are recorded in `settings_audit` (append-only). Each entry captures:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.218"
+version = "0.4.219"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.218"
+version = "0.4.219"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -632,6 +632,8 @@ mod presentations_copy_tests;
 #[cfg(test)]
 mod presentations_paste_tests;
 #[cfg(test)]
+mod presentations_slide_edit_tests;
+#[cfg(test)]
 mod sync_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/presenter-server/src/router/presentations.rs
+++ b/crates/presenter-server/src/router/presentations.rs
@@ -181,7 +181,8 @@ pub(super) async fn insert_slide(
             PresentationId::from_uuid(presentation_uuid),
             payload.position,
         )
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(Json(slides))
 }
 
@@ -197,7 +198,8 @@ pub(super) async fn duplicate_slide(
             PresentationId::from_uuid(presentation_uuid),
             SlideId::from_uuid(slide_uuid),
         )
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(Json(slides))
 }
 
@@ -213,7 +215,8 @@ pub(super) async fn delete_slide(
             PresentationId::from_uuid(presentation_uuid),
             SlideId::from_uuid(slide_uuid),
         )
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(Json(slides))
 }
 
@@ -231,7 +234,8 @@ pub(super) async fn reorder_slides(
         .collect();
     let slides = state
         .reorder_slides(PresentationId::from_uuid(presentation_uuid), order)
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(Json(slides))
 }
 
@@ -263,7 +267,9 @@ pub(super) async fn paste_slides(
         Err(crate::state::slides::PasteSlidesError::AnchorVanished) => Err(AppError::conflict(
             "the paste position no longer exists — refresh and try again",
         )),
-        Err(crate::state::slides::PasteSlidesError::Internal(err)) => Err(err.into()),
+        Err(crate::state::slides::PasteSlidesError::Internal(err)) => {
+            Err(map_repository_error(err))
+        }
     }
 }
 
@@ -285,7 +291,8 @@ pub(super) async fn update_slide_content(
             payload.group,
             payload.metadata,
         )
-        .await?;
+        .await
+        .map_err(map_repository_error)?;
     Ok(Json(updated))
 }
 

--- a/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
+++ b/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
@@ -73,7 +73,11 @@ async fn duplicate_on_a_vanished_presentation_is_a_404() {
     let resp = request(
         &app,
         "POST",
-        &format!("/presentations/{}/slides/{}/duplicate", fresh_uuid(), fresh_uuid()),
+        &format!(
+            "/presentations/{}/slides/{}/duplicate",
+            fresh_uuid(),
+            fresh_uuid()
+        ),
         None,
     )
     .await;
@@ -201,6 +205,27 @@ async fn reorder_naming_an_unknown_slide_in_the_body_is_a_422() {
     )
     .await;
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// --- insert_slide: POST /presentations/{pid}/slides ---
+// The 6th consumer of `lock_and_read_presentation_for_edit` (the shared
+// helper whose `:113` site this sweep converts). Same vanished-presentation
+// path as the other snapshot-replace ops — wiring it here keeps the sweep
+// complete so #608/#610-style misses don't recur.
+
+#[tokio::test]
+async fn insert_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let body = serde_json::json!({ "position": 0 });
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{}/slides", fresh_uuid()),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 // --- paste_slides: POST /presentations/{pid}/slides/paste ---

--- a/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
+++ b/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
@@ -1,0 +1,224 @@
+//! Router-level regression tests for the slide-edit typed-refusal sweep (#611).
+//!
+//! Before #611, `state/slides/edit_ops.rs` raised bare `anyhow::anyhow!("...
+//! not found")` at five sites — `lock_and_read_presentation_for_edit` (shared
+//! by every slide-edit op) and four slide-lookups. Those fell through the
+//! router's blanket `impl From<anyhow::Error> for AppError` (`router.rs:599`)
+//! as an opaque **500**, even though the correct response is 404 (URL
+//! resource missing) or 422 (a body-referenced slide missing). These tests
+//! drive the REAL registered routes through `build_router` + `tower::oneshot`
+//! — the non-vacuous pattern from `presentations_copy_tests.rs` — so a wrong
+//! URI cannot make axum itself return 404 and the assertion pass vacuously.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::router::build_router;
+use crate::state::AppState;
+
+async fn request(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<serde_json::Value>,
+) -> axum::http::Response<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(json) => {
+            builder = builder.header("content-type", "application/json");
+            builder.body(Body::from(json.to_string())).unwrap()
+        }
+        None => builder.body(Body::empty()).unwrap(),
+    };
+    app.clone().oneshot(request).await.unwrap()
+}
+
+/// Seeds a library + presentation with two slides; returns
+/// `(presentation_id, [slide_id, slide_id])` as UUID strings.
+async fn seed(state: &AppState) -> (String, [String; 2]) {
+    let library = state.create_library("Edit Refusal Lib").await.unwrap();
+    let mk = |main: &str| {
+        presenter_core::Slide::new(
+            0,
+            presenter_core::SlideContent::new(
+                presenter_core::SlideText::new(main).unwrap(),
+                presenter_core::SlideText::new("").unwrap(),
+                presenter_core::SlideText::new("").unwrap(),
+                None,
+            ),
+        )
+    };
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "Edit Refusal Song", Some(&[mk("A"), mk("B")]))
+        .await
+        .unwrap();
+    let ids: [String; 2] = [
+        presentation.slides[0].id.to_string(),
+        presentation.slides[1].id.to_string(),
+    ];
+    (presentation.id.to_string(), ids)
+}
+
+fn fresh_uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+// --- duplicate_slide: POST /presentations/{pid}/slides/{sid}/duplicate ---
+
+#[tokio::test]
+async fn duplicate_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{}/slides/{}/duplicate", fresh_uuid(), fresh_uuid()),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn duplicate_of_a_vanished_slide_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, _) = seed(&state).await;
+    let app = build_router(state);
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{pres_id}/slides/{}/duplicate", fresh_uuid()),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// --- delete_slide: DELETE /presentations/{pid}/slides/{sid} ---
+
+#[tokio::test]
+async fn delete_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let resp = request(
+        &app,
+        "DELETE",
+        &format!("/presentations/{}/slides/{}", fresh_uuid(), fresh_uuid()),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_of_a_vanished_slide_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, _) = seed(&state).await;
+    let app = build_router(state);
+    let resp = request(
+        &app,
+        "DELETE",
+        &format!("/presentations/{pres_id}/slides/{}", fresh_uuid()),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// --- update_slide_content: PATCH /presentations/{pid}/slides/{sid} ---
+
+#[tokio::test]
+async fn update_content_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let body = serde_json::json!({
+        "main": "x", "translation": "", "stage": ""
+    });
+    let resp = request(
+        &app,
+        "PATCH",
+        &format!("/presentations/{}/slides/{}", fresh_uuid(), fresh_uuid()),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn update_content_of_a_vanished_slide_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, _) = seed(&state).await;
+    let app = build_router(state);
+    let body = serde_json::json!({
+        "main": "x", "translation": "", "stage": ""
+    });
+    let resp = request(
+        &app,
+        "PATCH",
+        &format!("/presentations/{pres_id}/slides/{}", fresh_uuid()),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// --- reorder_slides: POST /presentations/{pid}/slides/reorder ---
+
+#[tokio::test]
+async fn reorder_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let body = serde_json::json!({ "slideIds": [fresh_uuid()] });
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{}/slides/reorder", fresh_uuid()),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn reorder_naming_an_unknown_slide_in_the_body_is_a_422() {
+    // The `slideIds` are BODY-referenced (not in the URL path), so a slide id
+    // that does not belong to the presentation is a body-referenced missing
+    // target → 422 (TargetNotFound), not 404 — matching the established
+    // `paste_slides` UnknownSlides→422 convention in the same module. The
+    // bogus id is sent ALONGSIDE a real one with matching length so the
+    // request reaches the per-slide lookup (`:452`), not the earlier
+    // length-mismatch guard (`:446`).
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, [real_a, _real_b]) = seed(&state).await;
+    let app = build_router(state);
+    let body = serde_json::json!({ "slideIds": [real_a, fresh_uuid()] });
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{pres_id}/slides/reorder"),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// --- paste_slides: POST /presentations/{pid}/slides/paste ---
+// (paste's own UnknownSlides/AnchorVanished semantics are covered by
+// `presentations_paste_tests.rs`; this only nails the shared
+// vanished-presentation path that used to be a 500.)
+
+#[tokio::test]
+async fn paste_on_a_vanished_presentation_is_a_404() {
+    let state = AppState::in_memory().await.unwrap();
+    let app = build_router(state);
+    let body = serde_json::json!({ "slideIds": [fresh_uuid()] });
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{}/slides/paste", fresh_uuid()),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -4,6 +4,7 @@
 
 use presenter_core::slide::SlideMetadata;
 use presenter_core::{Presentation, PresentationId, Slide, SlideContent, SlideId, SlideText};
+use presenter_persistence::RepositoryError;
 use std::collections::HashMap;
 
 use super::super::stage::blank_slide_content;
@@ -110,7 +111,7 @@ impl AppState {
             .repository
             .fetch_presentation_detail(presentation_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("presentation not found"))?;
+            .ok_or(RepositoryError::NotFound("presentation not found"))?;
         Ok((guard, presentation))
     }
 
@@ -244,7 +245,7 @@ impl AppState {
             .slides
             .iter()
             .find(|slide| slide.id == slide_id)
-            .ok_or_else(|| anyhow::anyhow!("slide not found"))?
+            .ok_or(RepositoryError::NotFound("slide not found"))?
             .clone();
 
         let main_text = SlideText::new(main).map_err(|err| anyhow::anyhow!(err))?;
@@ -347,7 +348,7 @@ impl AppState {
         let index = slides
             .iter()
             .position(|slide| slide.id == slide_id)
-            .ok_or_else(|| anyhow::anyhow!("slide not found"))?;
+            .ok_or(RepositoryError::NotFound("slide not found"))?;
         let source = slides[index].clone();
         let duplicate = Slide::new(0, source.content.clone());
         let duplicate_id = duplicate.id;
@@ -400,7 +401,7 @@ impl AppState {
         let index = slides
             .iter()
             .position(|slide| slide.id == slide_id)
-            .ok_or_else(|| anyhow::anyhow!("slide not found"))?;
+            .ok_or(RepositoryError::NotFound("slide not found"))?;
         slides.remove(index);
         if slides.is_empty() {
             slides.push(Slide::new(0, blank_slide_content()));
@@ -447,9 +448,9 @@ impl AppState {
         }
         let mut slides = Vec::with_capacity(order.len());
         for id in order {
-            let slide = map
-                .remove(&id)
-                .ok_or_else(|| anyhow::anyhow!("unknown slide in reorder request"))?;
+            let slide = map.remove(&id).ok_or(RepositoryError::TargetNotFound(
+                "unknown slide in reorder request",
+            ))?;
             slides.push(slide);
         }
         Self::reindex_slides(&mut slides);

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4,6 +4,26 @@ Terse per-issue record of autonomous cycles (issue #, commits, tests, decisions)
 
 ---
 
+## 2026-07-29 — #615 + #616 typed error mapping + WHEP test coverage (one PR)
+
+- **Version bump:** `0.4.217` → `0.4.218` (commit `57006330`).
+- **Design comments posted BEFORE first code commit:**
+  - #615: https://github.com/zbynekdrlik/presenter/issues/615#issuecomment-5100347639 — root cause
+    (`slide_stage_layout.rs:48` blanket `AppError::bad_request` masked internal failures as 400),
+    approach (downcast `StageLayoutRefusal` to SAME 400, fallthrough to 500), rejected alternative
+    (mapping to 404 like `stage.rs` — visible behavior change beyond scope).
+  - #616: https://github.com/zbynekdrlik/presenter/issues/616#issuecomment-5100347823 — Gap A root
+    cause (inline translation in `whep_post` untestable without libndi), Gap B root cause (inline
+    DELETE guard unreachable on CI). Approach: extract both into pure fns, unit-test directly.
+    Rejected: constructing full `NdiManager` in tests.
+- **#615 RED commit `d2123d08`:** `put_returns_400_for_unknown_layout_code` + `put_returns_500_on_internal_failure_not_400`.
+- **#615 + #616 GREEN commit `08cc9e77`:** `map_slide_stage_layout_error` (#615) +
+  `translate_add_consumer_error` (#616 Gap A) + `map_delete_whep_error` (#616 Gap B) +
+  7 new unit tests (2 for #615, 2 for Gap A, 3 for Gap B).
+- **PR #617:** `Closes #615`, `Closes #616`.
+
+---
+
 ## 2026-07-27 — #590 split repository/mod.rs + router/bible.rs before the 1000-line hard fail
 
 - **Design note posted BEFORE any code:**


### PR DESCRIPTION
## Summary

Closes #593, Closes #611 — bundle-safe typed-refusal sweep + docs addition.

### #611 — Slide-edit ops 500 instead of 404

Converted 5 bare `anyhow!("... not found")` sites in `edit_ops.rs` to `RepositoryError::NotFound(...)`, and wired `map_repository_error` onto the 5 slide-edit router handlers in `presentations.rs`. Same pattern as #584/#586/#587/#608.

### #593 — Database skill prod-DB inspection

Added "Inspecting a production database (read-only)" section to `.claude/skills/database/SKILL.md` with sshpass + sqlite3 -readonly procedure for SNV prod + PP.
