### PR TITLE
fix: Tier-0 local-build policy + tombstone ordering alignment (#592, #595)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,11 +2,12 @@
 
 [build]
 # #585: incremental compilation disabled — the `incremental/` scratch cache
-# grew to 29 GB on dev2 for a Tier-1 (local-build) machine dominated by full
-# `cargo test` / `cargo clippy --all-targets` sweeps and build-ui.sh, where
-# incremental buys little wall-clock but costs real disk (also shared with
-# bakerion-ai's own target/ on the same disk). See .claude/skills/deploy for
-# the purge one-liner + disk-size expectations.
+# grew to 29 GB on dev2, dominated by full `cargo test` / `cargo clippy
+# --all-targets` sweeps and build-ui.sh, where incremental buys little
+# wall-clock but costs real disk (also shared with bakerion-ai's own
+# target/ on the same disk). Under Tier-0 (#592), builds run on CI runners
+# where incremental cache is irrelevant (fresh runner per job). See
+# .claude/skills/deploy for the purge one-liner + disk-size expectations.
 incremental = false
 
 # Use LLD linker for faster linking on Linux

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -14,10 +14,12 @@ triggers:
 
 # Presenter Deploy Skill
 
-## Local Build-Deploy-Iterate (Tier-1 Machine)
+## Local Build-Deploy-Iterate (Tier-0 Machine)
 
 CI takes ~38 min per push. Iterate locally; push only when the feature works end-to-end.
-This machine has `airuleset:local-builds=allowed` in CLAUDE.md => full builds are permitted.
+This project is Tier-0 (#592): heavy builds run on GitHub runners, not locally. The
+`block-tier0-local-build.sh` hook blocks local `cargo build`/`cargo test`. Use CI for
+compilation; this machine only runs the self-hosted E2E + deploy steps.
 
 Build order matters (WASM embedded into server at compile time via `include_dir!`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Local Build Policy
 
-<!-- airuleset:local-builds=allowed -->
-
-**Local Rust builds (cargo build, cargo clippy, cargo test) are ALLOWED on this machine.** This is the powerful dev2 build machine. Run fmt, clippy, test, and build locally before pushing. The global airuleset default (CI-only) does NOT apply here.
+**This project is Tier-0 (CI-only builds).** Heavy builds (`cargo build`, `cargo clippy`, `cargo test`) run on GitHub-hosted runners, not on this machine. The `block-tier0-local-build.sh` hook enforces this — do NOT add a `local-builds=allowed` marker to disarm it. Only lint and cheap compile checks may run locally, per the global `local-builds` skill. Dev2 is the self-hosted runner host for E2E + deploys, but compilation happens on GitHub's runners.
 
 <!-- Global rules applied via airuleset modules (~/devel/airuleset/):
      core/complete-planned-work, core/completion-report, core/autonomous-verification,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.219"
+version = "0.4.220"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.219"
+version = "0.4.220"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -906,6 +906,71 @@ mod tests {
     use super::{sync_should_apply, PRUNE_HORIZON};
     use chrono::{Duration, Utc};
 
+    #[tokio::test]
+    async fn tombstone_helpers_agree_on_same_named_tombstone() {
+        // #595 regression: ensure_library and ensure_library_for_tombstone
+        // must resolve to the SAME library row when multiple same-named
+        // tombstones exist. Before the fix, ensure_library_for_tombstone
+        // used only DeletedAt ASC — with equal deleted_at values, SQLite
+        // falls back to rowid (insertion) order and picks the OLDER row.
+        // ensure_library uses UpdatedAt DESC + SyncId DESC, picking the
+        // NEWER row → disagreement.
+        use crate::entities::library;
+        use sea_orm::{EntityTrait, Set, TransactionTrait};
+
+        let repo = super::Repository::connect_in_memory()
+            .await
+            .expect("in-memory db");
+        let base = Utc::now();
+        let delete_time = base - Duration::hours(1);
+
+        // Two tombstones: same name, same deleted_at, different updated_at/sync_id.
+        // Updated_at differs: older row = base-120min, newer row = base-0min.
+        // Both are older than the presentation time we'll pass to ensure_library,
+        // so no tombstone revival happens (pure resolution test).
+        for (id, updated_offset_min, sync_val) in
+            [("lib-older", 120_i64, "sync-aaa"), ("lib-newer", 0_i64, "sync-bbb")]
+        {
+            library::Entity::insert(library::ActiveModel {
+                id: Set(id.to_string()),
+                name: Set("Songs".to_string()),
+                search_name: Set("songs".to_string()),
+                created_at: Set((base - Duration::hours(2)).into()),
+                updated_at: Set((base - Duration::minutes(updated_offset_min)).into()),
+                sync_id: Set(sync_val.to_string()),
+                deleted_at: Set(Some(delete_time.into())),
+            })
+            .exec(&repo.db)
+            .await
+            .expect("insert tombstone");
+        }
+
+        // ensure_library_for_tombstone: among equal deleted_at, the secondary
+        // sort (after fix) must match ensure_library's UpdatedAt DESC.
+        let txn1 = repo.db.begin().await.expect("begin txn");
+        let id_from_tombstone_helper =
+            super::Repository::ensure_library_for_tombstone(&txn1, "Songs")
+                .await
+                .expect("resolve via tombstone helper");
+        txn1.rollback().await.expect("rollback");
+
+        // ensure_library: picks most recent tombstone by UpdatedAt DESC.
+        // presentation_updated_at is OLDER than both → no revival, pure read.
+        let txn2 = repo.db.begin().await.expect("begin txn");
+        let id_from_live_helper =
+            super::Repository::ensure_library(&txn2, "Songs", base - Duration::hours(3))
+                .await
+                .expect("resolve via live helper");
+        txn2.rollback().await.expect("rollback");
+
+        assert_eq!(
+            id_from_tombstone_helper, id_from_live_helper,
+            "both tombstone helpers must resolve to the same library row; \
+             tombstone helper picked {id_from_tombstone_helper}, \
+             live helper picked {id_from_live_helper}"
+        );
+    }
+
     #[test]
     fn lww_matrix() {
         let now = Utc::now();

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -935,9 +935,10 @@ mod tests {
         // Updated_at differs: older row = base-120min, newer row = base-0min.
         // Both are older than the presentation time we'll pass to ensure_library,
         // so no tombstone revival happens (pure resolution test).
-        for (id, updated_offset_min, sync_val) in
-            [("lib-older", 120_i64, "sync-aaa"), ("lib-newer", 0_i64, "sync-bbb")]
-        {
+        for (id, updated_offset_min, sync_val) in [
+            ("lib-older", 120_i64, "sync-aaa"),
+            ("lib-newer", 0_i64, "sync-bbb"),
+        ] {
             library::Entity::insert(library::ActiveModel {
                 id: Set(id.to_string()),
                 name: Set("Songs".to_string()),

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -400,10 +400,17 @@ impl Repository {
         library_name: &str,
     ) -> anyhow::Result<String> {
         // order_by DeletedAt ASC → live rows (NULL sorts first in SQLite) win
-        // over a tombstoned same-named row when both exist.
+        // over a tombstoned same-named row when both exist. Secondary sort
+        // (#595): UpdatedAt DESC + SyncId DESC — the SAME tiebreak
+        // `ensure_library` uses for tombstones, so both helpers resolve to
+        // the SAME row when multiple same-named tombstones exist. Without
+        // this, equal deleted_at values fall back to rowid order and the
+        // two helpers can pick DIFFERENT tombstones.
         if let Some(row) = library::Entity::find()
             .filter(library::Column::Name.eq(library_name.to_string()))
             .order_by_asc(library::Column::DeletedAt)
+            .order_by_desc(library::Column::UpdatedAt)
+            .order_by_desc(library::Column::SyncId)
             .one(txn)
             .await?
         {


### PR DESCRIPTION
## Summary

Two bundle-safe fixes in one PR:

- **#592** — Remove `<!-- airuleset:local-builds=allowed -->` marker from CLAUDE.md, re-arming the Tier-0 local-build hook. Rewrite the Local Build Policy section + correct stale Tier-1 references in `.cargo/config.toml` and `.claude/skills/deploy/SKILL.md`.
- **#595** — Fix `ensure_library_for_tombstone` tombstone ordering to match `ensure_library` (add `UpdatedAt DESC, SyncId DESC` secondary sort after the live-first `DeletedAt ASC`). Both helpers now resolve to the same library row when multiple same-named tombstones exist.

## Test plan

- [x] RED test: `tombstone_helpers_agree_on_same_named_tombstone` — two same-named tombstones (equal deleted_at, different updated_at), asserts both helpers return the same library ID
- [x] GREEN fix: Added secondary ordering, test now passes
- [x] cargo fmt --all passes
- [ ] CI full pipeline green

Closes #592, Closes #595
