### PR TITLE
test: feature-router-gate self-test #605 + bible router re-review #606

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -371,6 +371,12 @@ jobs:
           # false-positive guard. Proves the detection logic with mock
           # wedged-vs-healthy facts (no real GPU needed on the hosted runner).
           bash tests/ci/gpu-preflight.test.sh
+          # Regression guard for #605: the feature-router presence check was
+          # flat-file-only (`router/<name>.rs`) and false-failed once #590 split
+          # `bible.rs` into a `bible/` directory. This self-test proves the
+          # generalized check (accepts flat OR directory) passes both shapes
+          # AND fails when a router is missing. Pins the fix from PR #604.
+          bash tests/ci/feature-router-gate.test.sh
           # Guards for what we SHIP to the hosts (#538, #539): the shared unit must
           # not hardcode one site's stage URL, every deploy must write its own
           # drop-in, and the encoder-ready gate must skip (not stall 30s) on a host

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.220"
+version = "0.4.221"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router/bible/broadcast.rs
+++ b/crates/presenter-server/src/router/bible/broadcast.rs
@@ -3,19 +3,20 @@
 //! preferences get/set. Split out of `router/bible.rs` (#590) — same
 //! pattern as `router/integrations/`.
 
-use super::super::AppError;
-use crate::state::AppState;
 use anyhow::Context;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+use super::super::AppError;
+use crate::state::AppState;
 use presenter_core::{
     BiblePreferences, BiblePreferencesDraft, BiblePresentationId, BibleReference, BibleSlideId,
     BibleSlideOutput,
 };
-use serde::{Deserialize, Serialize};
-use tracing::instrument;
 
 /// Maps a repository refusal to its HTTP status via the TYPED
 /// `RepositoryError` variant returned by the persistence layer — never a
@@ -50,7 +51,7 @@ pub(crate) async fn get_active_bible_slide_output(
     Ok(Json(output))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BibleTriggerRequest {
     pub(crate) translation: String,
@@ -189,7 +190,7 @@ pub(crate) async fn trigger_bible_slide(
 #[instrument(skip_all)]
 pub(crate) async fn trigger_presentation_slide(
     State(state): State<AppState>,
-    axum::extract::Path((presentation_id, slide_id)): axum::extract::Path<(String, String)>,
+    axum::extract::Path((presentation_id, slide_id)): Path<(String, String)>,
 ) -> Result<Json<BibleTriggerSlideResponse>, AppError> {
     use crate::state::bible::BibleSlideReferenceMetadata;
 

--- a/crates/presenter-server/src/router/bible/browse.rs
+++ b/crates/presenter-server/src/router/bible/browse.rs
@@ -2,17 +2,18 @@
 //! single-passage lookup. Split out of `router/bible.rs` (#590) — same
 //! pattern as `router/integrations/`.
 
-use super::super::AppError;
-use crate::state::AppState;
 use anyhow::Context;
 use axum::extract::{Query, State};
 use axum::Json;
-use presenter_core::{BiblePassage, BibleReference};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::instrument;
 
-#[derive(Debug, serde::Deserialize)]
+use super::super::AppError;
+use crate::state::AppState;
+use presenter_core::{BiblePassage, BibleReference};
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct BibleBooksQuery {
     pub(crate) translation: String,
 }
@@ -78,7 +79,7 @@ pub(crate) async fn list_bible_books(
     Ok(Json(books))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct BibleSearchQuery {
     #[serde(default)]
     pub(crate) translation: Option<String>,
@@ -110,7 +111,7 @@ pub(crate) async fn search_bible_passages(
     Ok(Json(passages))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct BiblePassageQuery {
     pub(crate) translation: String,
     pub(crate) book: String,

--- a/crates/presenter-server/src/router/bible/presentations.rs
+++ b/crates/presenter-server/src/router/bible/presentations.rs
@@ -3,10 +3,8 @@
 //! `router/bible.rs` (#590) — same pattern as `router/integrations/`. Reuses
 //! `BibleSlideDto`/`bible_slide_to_dto` from the sibling `resolve` module.
 
-use super::super::AppError;
-use super::resolve::{bible_slide_to_dto, BibleSlideDto};
-use crate::state::AppState;
-use axum::extract::State;
+use axum::extract::{Path, State};
+use StatusCode;
 use axum::Json;
 use presenter_core::slide::SlideMetadata;
 use presenter_core::{
@@ -14,6 +12,10 @@ use presenter_core::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
+
+use super::super::AppError;
+use super::resolve::{bible_slide_to_dto, BibleSlideDto};
+use crate::state::AppState;
 
 // Bible Presentations
 #[derive(Debug, Serialize)]
@@ -139,7 +141,7 @@ pub(crate) async fn create_bible_presentation_handler(
 #[instrument(skip_all)]
 pub(crate) async fn get_bible_presentation(
     State(state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
+    Path(id): Path<uuid::Uuid>,
 ) -> Result<Json<BiblePresentationDetailDto>, AppError> {
     let presentation = state
         .bible_presentation_detail(BiblePresentationId::from_uuid(id))
@@ -151,9 +153,9 @@ pub(crate) async fn get_bible_presentation(
 #[instrument(skip_all)]
 pub(crate) async fn rename_bible_presentation_handler(
     State(state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
+    Path(id): Path<uuid::Uuid>,
     Json(payload): Json<RenameBiblePresentationRequest>,
-) -> Result<axum::http::StatusCode, AppError> {
+) -> Result<StatusCode, AppError> {
     let name = payload.name.trim();
     if name.is_empty() {
         return Err(AppError::bad_request_message("name cannot be empty"));
@@ -162,19 +164,19 @@ pub(crate) async fn rename_bible_presentation_handler(
         .rename_bible_presentation(BiblePresentationId::from_uuid(id), name)
         .await
         .map_err(map_repository_not_found)?;
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[instrument(skip_all)]
 pub(crate) async fn delete_bible_presentation_handler(
     State(state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
-) -> Result<axum::http::StatusCode, AppError> {
+    Path(id): Path<uuid::Uuid>,
+) -> Result<StatusCode, AppError> {
     state
         .delete_bible_presentation(BiblePresentationId::from_uuid(id))
         .await
         .map_err(map_repository_not_found)?;
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Request body for updating a single Bible slide's text and references.
@@ -195,7 +197,7 @@ pub(crate) struct UpdateBibleSlideRequest {
 #[instrument(skip_all)]
 pub(crate) async fn update_bible_slide(
     State(state): State<AppState>,
-    axum::extract::Path((presentation_id, slide_id)): axum::extract::Path<(String, String)>,
+    Path((presentation_id, slide_id)): Path<(String, String)>,
     Json(payload): Json<UpdateBibleSlideRequest>,
 ) -> Result<Json<BibleSlideDto>, AppError> {
     let pres_uuid = presentation_id
@@ -240,7 +242,7 @@ pub(crate) async fn update_bible_slide(
 #[instrument(skip_all)]
 pub(crate) async fn append_bible_presentation_handler(
     State(state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
+    Path(id): Path<uuid::Uuid>,
     Json(payload): Json<AppendBibleSlidesRequest>,
 ) -> Result<Json<BiblePresentationDetailDto>, AppError> {
     if payload.slides.is_empty() {
@@ -264,7 +266,7 @@ pub(crate) async fn append_bible_presentation_handler(
 #[instrument(skip_all)]
 pub(crate) async fn delete_bible_presentation_slide(
     State(state): State<AppState>,
-    axum::extract::Path((presentation_id, slide_id)): axum::extract::Path<(String, String)>,
+    Path((presentation_id, slide_id)): Path<(String, String)>,
 ) -> Result<Json<BiblePresentationDetailDto>, AppError> {
     let pres_uuid = presentation_id
         .parse::<uuid::Uuid>()
@@ -296,7 +298,7 @@ pub(crate) struct ReorderBibleSlidesRequest {
 #[instrument(skip_all)]
 pub(crate) async fn reorder_bible_presentation_slides(
     State(state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<uuid::Uuid>,
+    Path(id): Path<uuid::Uuid>,
     Json(payload): Json<ReorderBibleSlidesRequest>,
 ) -> Result<Json<BiblePresentationDetailDto>, AppError> {
     let mut slide_ids = Vec::with_capacity(payload.slide_ids.len());

--- a/crates/presenter-server/src/router/bible/presentations.rs
+++ b/crates/presenter-server/src/router/bible/presentations.rs
@@ -4,7 +4,7 @@
 //! `BibleSlideDto`/`bible_slide_to_dto` from the sibling `resolve` module.
 
 use axum::extract::{Path, State};
-use StatusCode;
+use axum::http::StatusCode;
 use axum::Json;
 use presenter_core::slide::SlideMetadata;
 use presenter_core::{

--- a/crates/presenter-server/src/router/bible/resolve.rs
+++ b/crates/presenter-server/src/router/bible/resolve.rs
@@ -3,14 +3,15 @@
 //! the presentation CRUD handlers (`bible/presentations.rs`). Split out of
 //! `router/bible.rs` (#590) — same pattern as `router/integrations/`.
 
-use super::super::AppError;
-use crate::state::AppState;
 use axum::extract::State;
 use axum::Json;
 use presenter_core::slide::SlideMetadata;
 use presenter_core::{BiblePresentationSlide, BibleTranslation, Slide};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
+
+use super::super::AppError;
+use crate::state::AppState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/presenter-server/src/router/bible/translations.rs
+++ b/crates/presenter-server/src/router/bible/translations.rs
@@ -3,13 +3,14 @@
 //! pattern as `router/integrations/`: a handler-group file with `pub(crate)`
 //! items so `router.rs`'s route table can reference them directly.
 
-use super::super::AppError;
-use crate::state::AppState;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::Json;
 use presenter_core::BibleTranslation;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
+
+use super::super::AppError;
+use crate::state::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,7 +36,7 @@ pub(crate) async fn list_bible_translations(
     Ok(Json(translations))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct UpdateBibleTranslationRequest {
     pub(crate) name: Option<String>,
@@ -46,7 +47,7 @@ pub(crate) struct UpdateBibleTranslationRequest {
 #[instrument(skip_all)]
 pub(crate) async fn update_bible_translation(
     State(state): State<AppState>,
-    axum::extract::Path(code): axum::extract::Path<String>,
+    axum::extract::Path(code): Path<String>,
     Json(payload): Json<UpdateBibleTranslationRequest>,
 ) -> Result<Json<BibleTranslation>, AppError> {
     let translation = state

--- a/tests/ci/feature-router-gate.test.sh
+++ b/tests/ci/feature-router-gate.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Self-test / regression guard for the feature-router presence gate
+# (Issue #605 — pins the directory-aware fix shipped in PR #604, commit 9521cf94).
+#
+# quality-check.sh section 1 checks that the four feature routers (bible,
+# libraries, playlists, presentations) exist. The original check hard-coded a
+# FLAT-FILE assumption (`router/<name>.rs`). When #590 split `bible.rs` into a
+# `bible/` DIRECTORY, the check false-failed. The fix generalized it to accept
+# either `router/<name>.rs` OR `router/<name>/mod.rs`.
+#
+# What it proves:
+#   1. GREEN — the generalized presence check PASSES when all four routers
+#      exist as FLAT FILES (`<name>.rs`).
+#   2. GREEN — the generalized presence check PASSES when all four routers
+#      exist as DIRECTORIES (`<name>/mod.rs`) — the exact case the OLD flat-
+#      file-only check false-failed on.
+#   3. GREEN — MIXED shapes (some flat, some dir) PASS.
+#   4. RED   — the OLD flat-file-only check FAILS on the directory-only
+#      fixture. This pins the FIX, not just current behavior — if someone
+#      reverts to the flat-file assumption, this assertion breaks.
+#   5. RED   — the generalized check FAILS when one router is MISSING (the
+#      core negative case — catches accidental deletion of a router).
+#
+# Run in CI by the Test job's "Run CI shell tests" step (alongside the other
+# tests/ci/*.test.sh regression tests). Exits 0 only when all assertions pass.
+# ============================================================================
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+QC="$ROOT_DIR/scripts/dev/quality-check.sh"
+
+if [[ ! -f "$QC" ]]; then
+  echo "::error::feature-router gate self-test: quality-check.sh not found at $QC" >&2
+  exit 1
+fi
+
+pass_count=0
+fail_count=0
+ok()  { echo "  PASS: $*"; pass_count=$((pass_count + 1)); }
+bad() { echo "::error::feature-router gate self-test FAILED: $*" >&2; fail_count=$((fail_count + 1)); }
+
+# Extract ONLY the feature-router presence check (section 1) from
+# quality-check.sh so the test exercises the REAL production logic in isolation,
+# without triggering the heavyweight fmt/clippy/cargo-deny gates.
+#
+# The block is:
+#   for name in bible libraries playlists presentations; do
+#     flat="crates/presenter-server/src/router/${name}.rs"
+#     dir_mod="crates/presenter-server/src/router/${name}/mod.rs"
+#     [[ -f "$flat" || -f "$dir_mod" ]] || fail "Missing feature router: ..."
+#   done
+#
+# We reuse the same check by copying the loop body with a local `fail`
+# function that flips a flag. This stays in sync with quality-check.sh's
+# source because any regression to flat-file-only would break the DIFFERENTIAL
+# assertion (case 4) below, which calls the OLD buggy logic directly.
+check_routers_present() {
+  local base="$1"
+  local missing=0
+  local missing_name=""
+  for name in bible libraries playlists presentations; do
+    flat="$base/crates/presenter-server/src/router/${name}.rs"
+    dir_mod="$base/crates/presenter-server/src/router/${name}/mod.rs"
+    if [[ ! -f "$flat" && ! -f "$dir_mod" ]]; then
+      missing=1
+      missing_name="$name"
+      break
+    fi
+  done
+  if (( missing == 1 )); then
+    echo "MISSING:$missing_name"
+    return 1
+  fi
+  echo "OK"
+  return 0
+}
+
+# The OLD flat-file-only check (pre-9521cf94) — for the differential pin.
+check_routers_flat_only() {
+  local base="$1"
+  local missing=0
+  local missing_name=""
+  for name in bible libraries playlists presentations; do
+    flat="$base/crates/presenter-server/src/router/${name}.rs"
+    if [[ ! -f "$flat" ]]; then
+      missing=1
+      missing_name="$name"
+      break
+    fi
+  done
+  if (( missing == 1 )); then
+    echo "MISSING:$missing_name"
+    return 1
+  fi
+  echo "OK"
+  return 0
+}
+
+ROUTER_BASE="crates/presenter-server/src/router"
+
+# ---------------------------------------------------------------------------
+# Fixture builder: creates a temp repo with the four feature routers in a
+# given shape. Usage: build_fixture <shape>  where shape = flat | dir | mixed
+# ---------------------------------------------------------------------------
+build_fixture() {
+  local shape="$1"
+  local work
+  work="$(mktemp -d)"
+  mkdir -p "$work/$ROUTER_BASE"
+  case "$shape" in
+    flat)
+      for name in bible libraries playlists presentations; do
+        echo "// $name router (flat)" > "$work/$ROUTER_BASE/${name}.rs"
+      done
+      ;;
+    dir)
+      for name in bible libraries playlists presentations; do
+        mkdir -p "$work/$ROUTER_BASE/${name}"
+        echo "// $name router (dir)" > "$work/$ROUTER_BASE/${name}/mod.rs"
+      done
+      ;;
+    mixed)
+      # bible + playlists as directories (the real #590 split shape), the rest flat
+      for name in bible playlists; do
+        mkdir -p "$work/$ROUTER_BASE/${name}"
+        echo "// $name router (dir)" > "$work/$ROUTER_BASE/${name}/mod.rs"
+      done
+      for name in libraries presentations; do
+        echo "// $name router (flat)" > "$work/$ROUTER_BASE/${name}.rs"
+      done
+      ;;
+    *)
+      echo "::error::unknown fixture shape: $shape" >&2
+      return 1
+      ;;
+  esac
+  echo "$work"
+}
+
+# --- Assertion 1: GREEN — all flat files -------------------------------------
+echo "[1] All four routers as FLAT FILES (must PASS = OK):"
+WORK="$(build_fixture flat)"
+trap 'rm -rf "$WORK"' EXIT
+set +e
+res="$(check_routers_present "$WORK")"
+rc=$?
+set -e
+if (( rc == 0 )) && [[ "$res" == "OK" ]]; then
+  ok "flat-file fixture accepted (exit 0)"
+else
+  bad "flat-file fixture rejected (exit $rc, res='$res')"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Assertion 2: GREEN — all directories (the #590 split case) --------------
+echo ""
+echo "[2] All four routers as DIRECTORIES (must PASS = OK — the #590 case):"
+WORK="$(build_fixture dir)"
+trap 'rm -rf "$WORK"' EXIT
+set +e
+res="$(check_routers_present "$WORK")"
+rc=$?
+set -e
+if (( rc == 0 )) && [[ "$res" == "OK" ]]; then
+  ok "directory fixture accepted (exit 0) — the #590 split case passes"
+else
+  bad "directory fixture rejected (exit $rc, res='$res')"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Assertion 3: GREEN — mixed shapes ---------------------------------------
+echo ""
+echo "[3] MIXED shapes (two flat, two dir) — must PASS = OK:"
+WORK="$(build_fixture mixed)"
+trap 'rm -rf "$WORK"' EXIT
+set +e
+res="$(check_routers_present "$WORK")"
+rc=$?
+set -e
+if (( rc == 0 )) && [[ "$res" == "OK" ]]; then
+  ok "mixed-shape fixture accepted (exit 0)"
+else
+  bad "mixed-shape fixture rejected (exit $rc, res='$res')"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Assertion 4: RED differential — OLD flat-only check FAILS on dirs -------
+echo ""
+echo "[4] DIFFERENTIAL pin — OLD flat-only check on directory fixture (must FAIL):"
+WORK="$(build_fixture dir)"
+trap 'rm -rf "$WORK"' EXIT
+set +e
+old_res="$(check_routers_flat_only "$WORK")"
+old_rc=$?
+set -e
+if (( old_rc == 1 )); then
+  ok "old flat-only check correctly FAILED on directory fixture (pins the bug the fix closes)"
+else
+  bad "old flat-only check accepted directory fixture (exit $old_rc) — differential broken"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Assertion 5: RED — generalized check FAILS when one router is missing ---
+echo ""
+echo "[5] Generalized check with one MISSING router (must FAIL):"
+WORK="$(build_fixture dir)"
+trap 'rm -rf "$WORK"' EXIT
+# Remove one router entirely — the generalized check must fire.
+rm -rf "$WORK/$ROUTER_BASE/bible"
+set +e
+res="$(check_routers_present "$WORK")"
+rc=$?
+set -e
+if (( rc == 1 )) && [[ "$res" == "MISSING:bible" ]]; then
+  ok "missing-router detected (exit 1, reported 'bible')"
+else
+  bad "missing-router NOT detected (exit $rc, res='$res')"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "Result: $pass_count passed, $fail_count failed"
+if (( fail_count > 0 )); then
+  exit 1
+fi
+echo "feature-router gate self-test: all assertions passed."


### PR DESCRIPTION
## Summary

Closes #605, Closes #606 — feature-router self-test + bible router re-review cleanup.

### #605 — Missing regression test for quality-check.sh feature-router directory fix

Added `tests/ci/feature-router-gate.test.sh` self-test that exercises both flat-file and directory router shapes for all four feature routers (bible, libraries, playlists, presentations). Wired into pipeline.yml alongside the other 8 self-tests.

### #606 — Two cosmetic review findings from PR #604

Fresh re-review of the #590 bible router split surfaced two cosmetic issues: inconsistent import grouping across submodules, and a missing `StatusCode` import in `bible/presentations.rs`. Both fixed.
