### PR TITLE
fix: AI status honesty #597 + AbleSet resolution observability #600

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,4 +31,11 @@ ignore = [
   # pair in deny.toml) once gst-plugin-ndi allows quick-xml >=0.41.
   "RUSTSEC-2026-0194", # quick-xml quadratic attr check (transitive, #522)
   "RUSTSEC-2026-0195", # quick-xml NsReader allocation DoS (transitive, #522)
+  # event-listener 5.4.1 soundness issue — StackSlot blindly implements Send/Sync
+  # for !Send tag types. Transitive dep via async-lock 3.4.2 → reactive_graph →
+  # leptos 0.7.8. INFO Unsound (not a vulnerability); we do not use the
+  # listener! macro or custom tags, so the unsafe code path is unreachable. No
+  # upgrade path until async-lock bumps its event-listener requirement
+  # (>=5.4.2 patched). Same transitive-blocked pattern as the leptos entries above.
+  "RUSTSEC-2026-0221", # event-listener StackSlot soundness (transitive via leptos)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.220"
+version = "0.4.222"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.221"
+version = "0.4.222"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/ableset.rs
+++ b/crates/presenter-core/src/ableset.rs
@@ -148,6 +148,39 @@ pub struct AbleSetStatusSnapshot {
     pub last_song: Option<AbleSetSongSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
+    /// Number of resolved entries in the library-name → presentation cache
+    /// (#600). `None` when the cache has not been enriched by the router-level
+    /// status handler (the bridge's own `status_snapshot` leaves it `None`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_size: Option<usize>,
+    /// When the library cache was last rebuilt (#600). Mirrors `last_updated`
+    /// from `AbleSetLibraryCache`. `None` when the cache has not been built.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_last_updated: Option<DateTime<Utc>>,
+    /// Last error from a library cache rebuild (#600). Separate from
+    /// `last_error` (which is the bridge-level error) because a cache rebuild
+    /// can fail (e.g. "library not found") even when the bridge is healthy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_last_error: Option<String>,
+    /// Ring buffer of recent resolution attempts (#600), newest last. Each
+    /// entry records the prefix, timestamp, and whether it resolved. Empty
+    /// until the first resolve call after startup.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub recent_attempts: Vec<AbleSetResolutionAttempt>,
+}
+
+/// A single AbleSet song-resolution attempt, surfaced read-only via
+/// `/integrations/ableset/status` (#600).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AbleSetResolutionAttempt {
+    /// ISO-8601 timestamp of the resolution attempt.
+    pub timestamp: DateTime<Utc>,
+    /// The incoming prefix that was looked up.
+    pub input: String,
+    /// Whether the prefix resolved to a known presentation (`true`) or was a
+    /// cache miss (`false`).
+    pub found: bool,
 }
 
 pub fn extract_song_prefix(name: &str, length: u8) -> Option<String> {

--- a/crates/presenter-core/src/ableset.rs
+++ b/crates/presenter-core/src/ableset.rs
@@ -165,7 +165,7 @@ pub struct AbleSetStatusSnapshot {
     /// Ring buffer of recent resolution attempts (#600), newest last. Each
     /// entry records the prefix, timestamp, and whether it resolved. Empty
     /// until the first resolve call after startup.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub recent_attempts: Vec<AbleSetResolutionAttempt>,
 }
 

--- a/crates/presenter-core/src/contract_tests.rs
+++ b/crates/presenter-core/src/contract_tests.rs
@@ -396,6 +396,10 @@ mod tests {
                 Some(Utc::now()),
             )),
             last_error: None,
+            cache_size: None,
+            cache_last_updated: None,
+            cache_last_error: None,
+            recent_attempts: Vec::new(),
         };
         let json = serde_json::to_string(&snapshot).expect("serialize");
         assert!(json.contains("followEnabled"), "expected camelCase: {json}");
@@ -438,6 +442,10 @@ mod tests {
             song_prefix_length: 3,
             last_song: None,
             last_error: Some("connection refused".to_string()),
+            cache_size: None,
+            cache_last_updated: None,
+            cache_last_error: None,
+            recent_attempts: Vec::new(),
         };
         let json = serde_json::to_string(&snapshot).expect("serialize");
         assert!(json.contains("lastError"), "expected camelCase: {json}");

--- a/crates/presenter-core/src/lib.rs
+++ b/crates/presenter-core/src/lib.rs
@@ -32,8 +32,8 @@ pub mod video_source;
 pub mod feature_flags;
 
 pub use ableset::{
-    extract_song_prefix, AbleSetSettings, AbleSetSettingsDraft, AbleSetSettingsValidationError,
-    AbleSetSongSnapshot, AbleSetStatusSnapshot,
+    extract_song_prefix, AbleSetResolutionAttempt, AbleSetSettings, AbleSetSettingsDraft,
+    AbleSetSettingsValidationError, AbleSetSongSnapshot, AbleSetStatusSnapshot,
 };
 pub use android_stage_display::{
     AndroidStageDisplay, AndroidStageDisplayDraft, AndroidStageDisplayValidationError,

--- a/crates/presenter-server/src/ableset.rs
+++ b/crates/presenter-server/src/ableset.rs
@@ -236,6 +236,13 @@ impl AbleSetBridge {
                 )
             }),
             last_error: status.last_error.clone(),
+            // Cache enrichment is the router-level status handler's job (#600).
+            // The bridge does not own the library cache, so it leaves these
+            // fields at their None/empty defaults.
+            cache_size: None,
+            cache_last_updated: None,
+            cache_last_error: None,
+            recent_attempts: Vec::new(),
         }
     }
 
@@ -340,6 +347,10 @@ fn mock_status_from_state(state: &MockAbleSetState) -> AbleSetStatusSnapshot {
             song_prefix_length: settings.song_prefix_length,
             last_song: state.last_song.clone(),
             last_error: None,
+            cache_size: None,
+            cache_last_updated: None,
+            cache_last_error: None,
+            recent_attempts: Vec::new(),
         }
     } else {
         AbleSetStatusSnapshot {
@@ -353,6 +364,10 @@ fn mock_status_from_state(state: &MockAbleSetState) -> AbleSetStatusSnapshot {
             song_prefix_length: 3,
             last_song: state.last_song.clone(),
             last_error: None,
+            cache_size: None,
+            cache_last_updated: None,
+            cache_last_error: None,
+            recent_attempts: Vec::new(),
         }
     }
 }

--- a/crates/presenter-server/src/osc/handler.rs
+++ b/crates/presenter-server/src/osc/handler.rs
@@ -237,7 +237,11 @@ async fn trigger_slide(
     };
 
     let Some(presentation_id) = app_state.resolve_ableset_presentation(&song.prefix).await? else {
-        debug!(prefix = %song.prefix, "AbleSet prefix missing in library");
+        warn!(
+            prefix = %song.prefix,
+            song = %song.name,
+            "AbleSet prefix missing in library — resolution miss"
+        );
         return Ok(());
     };
 

--- a/crates/presenter-server/src/router.rs
+++ b/crates/presenter-server/src/router.rs
@@ -628,6 +628,8 @@ fn parse_uuid(field: &str, value: &str) -> Result<Uuid, AppError> {
 }
 
 #[cfg(test)]
+mod ai_tests;
+#[cfg(test)]
 mod presentations_copy_tests;
 #[cfg(test)]
 mod presentations_paste_tests;

--- a/crates/presenter-server/src/router/ai.rs
+++ b/crates/presenter-server/src/router/ai.rs
@@ -257,6 +257,23 @@ pub(super) struct StatusResponse {
     pub proxy: ProxyStatus,
 }
 
+/// Compute AI `connected` status by ANDing TCP-level connectivity with Claude
+/// OAuth validity (#597).
+///
+/// The connectivity check (`check_connectivity`) pings the proxy's `/models`
+/// endpoint — it succeeds whenever the CLIProxyAPI process is running and
+/// answering on its port, regardless of whether the underlying Claude OAuth
+/// token is still valid. When the token expires, every real AI request fails
+/// with `authentication_error`, but `connected` used to report `true` because
+/// only the TCP ping was considered. This function ensures `connected` is
+/// `true` ONLY when both signals are healthy.
+///
+/// Extracted as a pure function so the truth-table is unit-testable without
+/// constructing a live ProxyManager + network connectivity.
+pub(super) fn compute_ai_connected(connectivity_ok: bool, claude_authenticated: bool) -> bool {
+    connectivity_ok && claude_authenticated
+}
+
 #[instrument(skip_all)]
 pub(super) async fn check_status(
     State(state): State<AppState>,
@@ -264,19 +281,25 @@ pub(super) async fn check_status(
     let settings = get_settings_internal(&state).await?;
     let proxy_status = state.ai_proxy().status().await;
 
-    let connection = crate::ai::client::check_connectivity(&settings).await;
-    match connection {
-        Ok(()) => Ok(Json(StatusResponse {
-            connected: true,
-            error: None,
-            proxy: proxy_status,
-        })),
-        Err(e) => Ok(Json(StatusResponse {
-            connected: false,
-            error: Some(e.to_string()),
-            proxy: proxy_status,
-        })),
-    }
+    let connectivity_ok = crate::ai::client::check_connectivity(&settings)
+        .await
+        .is_ok();
+
+    let connected = compute_ai_connected(connectivity_ok, proxy_status.claude_authenticated);
+
+    let error = if connected {
+        None
+    } else if !proxy_status.claude_authenticated {
+        Some("Claude not authenticated — run /ai/proxy/login to re-authorize".to_string())
+    } else {
+        Some("AI proxy unreachable".to_string())
+    };
+
+    Ok(Json(StatusResponse {
+        connected,
+        error,
+        proxy: proxy_status,
+    }))
 }
 
 // ── Proxy management ──

--- a/crates/presenter-server/src/router/ai_tests.rs
+++ b/crates/presenter-server/src/router/ai_tests.rs
@@ -12,9 +12,8 @@ fn connected_is_false_when_claude_not_authenticated_even_if_connectivity_ok() {
     // `claudeAuthenticated` is false. Every real AI request would fail with
     // `authentication_error`, so `connected` MUST be false — not the
     // misleading `true` it reported on prod SNV during the 2026-07 incident.
-    assert_eq!(
-        compute_ai_connected(true, false),
-        false,
+    assert!(
+        !compute_ai_connected(true, false),
         "connected must be false when claudeAuthenticated is false, even if \
          the proxy port answers the connectivity ping"
     );
@@ -22,9 +21,8 @@ fn connected_is_false_when_claude_not_authenticated_even_if_connectivity_ok() {
 
 #[test]
 fn connected_is_true_only_when_both_connectivity_and_auth_are_ok() {
-    assert_eq!(
+    assert!(
         compute_ai_connected(true, true),
-        true,
         "connected is true only when the proxy is reachable AND Claude is authenticated"
     );
 }
@@ -33,18 +31,16 @@ fn connected_is_true_only_when_both_connectivity_and_auth_are_ok() {
 fn connected_is_false_when_connectivity_fails_even_if_auth_appears_ok() {
     // Edge case: auth reports true (e.g. credential file exists) but the
     // proxy process is down/unreachable. `connected` must still be false.
-    assert_eq!(
-        compute_ai_connected(false, true),
-        false,
+    assert!(
+        !compute_ai_connected(false, true),
         "connected must be false when the proxy port is unreachable, regardless of auth state"
     );
 }
 
 #[test]
 fn connected_is_false_when_both_signals_fail() {
-    assert_eq!(
-        compute_ai_connected(false, false),
-        false,
+    assert!(
+        !compute_ai_connected(false, false),
         "connected must be false when neither connectivity nor auth is present"
     );
 }

--- a/crates/presenter-server/src/router/ai_tests.rs
+++ b/crates/presenter-server/src/router/ai_tests.rs
@@ -1,0 +1,50 @@
+//! Router-level tests for `/ai/status` (#597): the `connected` field MUST NOT
+//! report `true` when `proxy.claudeAuthenticated == false`. The TCP-only
+//! connectivity check is necessary but not sufficient — actual AI readiness
+//! requires a valid Claude OAuth session as well.
+
+use crate::router::ai::compute_ai_connected;
+
+#[test]
+fn connected_is_false_when_claude_not_authenticated_even_if_connectivity_ok() {
+    // #597: CLIProxyAPI process is running and answering /models (so the TCP
+    // connectivity ping succeeds), but the OAuth token has expired and
+    // `claudeAuthenticated` is false. Every real AI request would fail with
+    // `authentication_error`, so `connected` MUST be false — not the
+    // misleading `true` it reported on prod SNV during the 2026-07 incident.
+    assert_eq!(
+        compute_ai_connected(true, false),
+        false,
+        "connected must be false when claudeAuthenticated is false, even if \
+         the proxy port answers the connectivity ping"
+    );
+}
+
+#[test]
+fn connected_is_true_only_when_both_connectivity_and_auth_are_ok() {
+    assert_eq!(
+        compute_ai_connected(true, true),
+        true,
+        "connected is true only when the proxy is reachable AND Claude is authenticated"
+    );
+}
+
+#[test]
+fn connected_is_false_when_connectivity_fails_even_if_auth_appears_ok() {
+    // Edge case: auth reports true (e.g. credential file exists) but the
+    // proxy process is down/unreachable. `connected` must still be false.
+    assert_eq!(
+        compute_ai_connected(false, true),
+        false,
+        "connected must be false when the proxy port is unreachable, regardless of auth state"
+    );
+}
+
+#[test]
+fn connected_is_false_when_both_signals_fail() {
+    assert_eq!(
+        compute_ai_connected(false, false),
+        false,
+        "connected must be false when neither connectivity nor auth is present"
+    );
+}

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -2,10 +2,31 @@ use chrono::{DateTime, Utc};
 use presenter_core::{
     extract_song_prefix, AbleSetSettings, AbleSetSettingsDraft, AbleSetSongSnapshot, PresentationId,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use tracing::warn;
 
 use super::AppState;
 use crate::ableset::AbleSetStatusSnapshot;
+
+/// Maximum number of recent resolution attempts retained in the ring buffer
+/// (#600). Enough to cover a typical worship set (15-20 songs) while bounding
+/// memory on a long-running instance.
+const MAX_RECENT_ATTEMPTS: usize = 20;
+
+/// A single AbleSet song-resolution attempt, retained for diagnostic purposes
+/// (#600). Surfaced read-only via `/integrations/ableset/status` so operators
+/// can answer "it didn't work 30 min ago" from data instead of memory.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AbleSetResolutionAttempt {
+    /// ISO-8601 timestamp of the resolution attempt.
+    pub(crate) timestamp: DateTime<Utc>,
+    /// The incoming prefix (trimmed) that was looked up.
+    pub(crate) input: String,
+    /// Whether the prefix resolved to a known presentation (`true`) or was a
+    /// cache miss (`false`).
+    pub(crate) found: bool,
+}
 
 #[derive(Default)]
 pub(crate) struct AbleSetLibraryCache {
@@ -14,6 +35,7 @@ pub(crate) struct AbleSetLibraryCache {
     pub(crate) entries: HashMap<String, PresentationId>,
     pub(crate) last_updated: Option<DateTime<Utc>>,
     pub(crate) last_error: Option<String>,
+    pub(crate) recent_attempts: VecDeque<AbleSetResolutionAttempt>,
 }
 
 impl AbleSetLibraryCache {
@@ -31,6 +53,39 @@ impl AbleSetLibraryCache {
         } else {
             false
         }
+    }
+
+    /// Number of resolved entries in the cache (#600 status surface).
+    pub(crate) fn cache_size(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// When the cache was last rebuilt (#600 status surface).
+    pub(crate) fn last_updated(&self) -> Option<DateTime<Utc>> {
+        self.last_updated
+    }
+
+    /// Last error from a cache rebuild, if any (#600 status surface).
+    pub(crate) fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    /// Read-only view of the recent resolution-attempt ring buffer (#600).
+    pub(crate) fn recent_attempts(&self) -> &VecDeque<AbleSetResolutionAttempt> {
+        &self.recent_attempts
+    }
+
+    /// Record a resolution attempt in the ring buffer, evicting the oldest
+    /// entry when the cap is reached (FIFO).
+    fn record_attempt(&mut self, input: &str, found: bool) {
+        if self.recent_attempts.len() >= MAX_RECENT_ATTEMPTS {
+            self.recent_attempts.pop_front();
+        }
+        self.recent_attempts.push_back(AbleSetResolutionAttempt {
+            timestamp: Utc::now(),
+            input: input.to_string(),
+            found,
+        });
     }
 }
 
@@ -71,8 +126,27 @@ impl AppState {
         Ok(settings)
     }
 
+    /// Build the status snapshot, enriched with library-cache state (#600).
+    /// The bridge contributes the live AbleSet connection/tracking fields; the
+    /// cache layer contributes `cache_size`, `cache_last_updated`,
+    /// `cache_last_error`, and the recent resolution attempts. This merged
+    /// snapshot is what `GET /integrations/ableset/status` returns.
     pub async fn ableset_status_snapshot(&self) -> AbleSetStatusSnapshot {
-        self.ableset_bridge.status_snapshot().await
+        let mut snapshot = self.ableset_bridge.status_snapshot().await;
+        let cache = self.caches.ableset.read().await;
+        snapshot.cache_size = Some(cache.cache_size());
+        snapshot.cache_last_updated = cache.last_updated();
+        snapshot.cache_last_error = cache.last_error().map(str::to_owned);
+        snapshot.recent_attempts = cache
+            .recent_attempts()
+            .iter()
+            .map(|a| presenter_core::AbleSetResolutionAttempt {
+                timestamp: a.timestamp,
+                input: a.input.clone(),
+                found: a.found,
+            })
+            .collect();
+        snapshot
     }
 
     pub async fn set_ableset_follow(&self, enabled: bool) -> AbleSetStatusSnapshot {
@@ -97,8 +171,31 @@ impl AppState {
         }
         self.ensure_ableset_cache(&settings).await?;
         let lookup = key.to_ascii_lowercase();
-        let cache = self.caches.ableset.read().await;
-        Ok(cache.entries.get(&lookup).copied())
+
+        let result = {
+            let cache = self.caches.ableset.read().await;
+            cache.entries.get(&lookup).copied()
+        };
+
+        // Record the attempt in the ring buffer and log misses at WARN (#600).
+        // The buffer read-lock is released before acquiring the write-lock to
+        // avoid holding both halves of the RwLock simultaneously.
+        {
+            let mut cache = self.caches.ableset.write().await;
+            cache.record_attempt(key, result.is_some());
+            if result.is_none() {
+                warn!(
+                    prefix = key,
+                    cache_size = cache.cache_size(),
+                    library_name = cache.library_name.as_deref().unwrap_or("?"),
+                    last_updated = ?cache.last_updated(),
+                    last_error = cache.last_error(),
+                    "AbleSet prefix resolution miss — prefix not in cache"
+                );
+            }
+        }
+
+        Ok(result)
     }
 
     async fn ensure_ableset_cache(&self, settings: &AbleSetStatusSnapshot) -> anyhow::Result<()> {

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1535,3 +1535,179 @@ async fn video_source_status_route_is_not_shadowed_by_the_id_route() {
         "the status payload, not the by-id payload: {json}"
     );
 }
+
+// ── #600: AbleSet miss visibility + ring buffer ─────────────────────────────
+
+/// Helper: seed an in-memory state with a digit-prefixed library and enable
+/// AbleSet pointing at it, mirroring the existing AbleSet test setup.
+async fn seed_ableset_with_song(
+    library_name: &str,
+    song_name: &str,
+) -> (
+    crate::state::AppState,
+    presenter_core::PresentationId,
+) {
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library(library_name).await.unwrap();
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, song_name, None)
+        .await
+        .unwrap();
+
+    let draft = presenter_core::AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: library_name.to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(
+            draft,
+            presenter_persistence::SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+    (state, presentation.id)
+}
+
+/// #600: a resolution MISS must be recorded in the attempt ring buffer with
+/// `found=false`. On prod a miss leaves zero evidence — a WARN log (asserted
+/// separately) and the ring buffer are the diagnostic trail operators need.
+#[tokio::test]
+async fn ableset_miss_is_recorded_in_attempt_ring_buffer() {
+    let (state, _) = seed_ableset_with_song("Hymnal", "001 Amazing Grace").await;
+
+    // Resolve a prefix that does NOT exist in the seeded library.
+    let result = state.resolve_ableset_presentation("999").await.unwrap();
+    assert_eq!(result, None, "unknown prefix must resolve to None");
+
+    // The ring buffer must have recorded this miss.
+    let cache = state.caches.ableset.read().await;
+    let attempts = cache.recent_attempts();
+    let last = attempts.last().expect("at least one attempt recorded");
+    assert_eq!(last.input, "999", "input prefix must be recorded");
+    assert_eq!(last.found, false, "a miss must be recorded as found=false");
+}
+
+/// #600: a resolution HIT must be recorded in the attempt ring buffer with
+/// `found=true`. This proves the buffer tracks every attempt, not just misses.
+#[tokio::test]
+async fn ableset_hit_is_recorded_in_attempt_ring_buffer() {
+    let (state, expected_id) = seed_ableset_with_song("Hymnal", "001 Amazing Grace").await;
+
+    let result = state.resolve_ableset_presentation("001").await.unwrap();
+    assert_eq!(result, Some(expected_id));
+
+    let cache = state.caches.ableset.read().await;
+    let attempts = cache.recent_attempts();
+    let last = attempts.last().expect("at least one attempt recorded");
+    assert_eq!(last.input, "001");
+    assert_eq!(last.found, true, "a hit must be recorded as found=true");
+}
+
+/// #600: the ring buffer must cap at 20 entries (FIFO eviction). Without a
+/// cap, a long-running prod instance accumulates entries forever.
+#[tokio::test]
+async fn ableset_ring_buffer_caps_at_twenty_entries() {
+    let (state, _) = seed_ableset_with_song("Hymnal", "001 Amazing Grace").await;
+
+    // Resolve 25 different prefixes to overflow the 20-entry cap.
+    for i in 0..25 {
+        let prefix = format!("{i:03}");
+        let _ = state.resolve_ableset_presentation(&prefix).await.unwrap();
+    }
+
+    let cache = state.caches.ableset.read().await;
+    let attempts = cache.recent_attempts();
+    assert_eq!(
+        attempts.len(),
+        20,
+        "ring buffer must cap at 20 entries, got {}",
+        attempts.len()
+    );
+    // The FIRST 5 entries (000-004) must have been evicted; the buffer must
+    // contain entries 005-024.
+    assert_eq!(
+        attempts.first().map(|a| a.input.as_str()),
+        Some("005"),
+        "oldest entries must have been evicted (FIFO)"
+    );
+    assert_eq!(
+        attempts.last().map(|a| a.input.as_str()),
+        Some("024"),
+        "newest entry must be the last one pushed"
+    );
+}
+
+/// #600: `cache_size`, `cache_last_updated`, and `cache_last_error` must be
+/// readable from the AbleSet cache so the status endpoint can surface them.
+/// This test verifies the cache struct exposes these (already-existing) fields
+/// through accessor methods that the status handler will use.
+#[tokio::test]
+async fn ableset_cache_exposes_size_last_updated_and_last_error_for_status() {
+    let (state, _) = seed_ableset_with_song("Hymnal", "001 Amazing Grace").await;
+
+    // A successful resolve triggers a cache rebuild (library matched, one
+    // presentation with a valid prefix).
+    let _ = state.resolve_ableset_presentation("001").await.unwrap();
+
+    let cache = state.caches.ableset.read().await;
+    assert_eq!(
+        cache.cache_size(),
+        1,
+        "cache_size must report the one seeded presentation"
+    );
+    assert!(
+        cache.last_updated().is_some(),
+        "last_updated must be set after a cache rebuild"
+    );
+    assert_eq!(
+        cache.last_error(),
+        None,
+        "last_error must be None when the library was found and has valid prefixes"
+    );
+}
+
+/// #600: when the tracked library does not exist in the DB, `last_error` must
+/// be "library not found" — surfaced so operators can see WHY resolution is
+/// failing without SSH access.
+#[tokio::test]
+async fn ableset_cache_records_library_not_found_error_on_rebuild() {
+    let state = AppState::in_memory().await.unwrap();
+
+    // Enable AbleSet pointing at a library that does NOT exist.
+    let draft = presenter_core::AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Nonexistent Library".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(
+            draft,
+            presenter_persistence::SettingsAuditSource::HttpSetter,
+            "test",
+        )
+        .await
+        .unwrap();
+
+    let _ = state.resolve_ableset_presentation("001").await.unwrap();
+
+    let cache = state.caches.ableset.read().await;
+    assert_eq!(
+        cache.cache_size(),
+        0,
+        "no entries when the library does not exist"
+    );
+    assert_eq!(
+        cache.last_error().as_deref(),
+        Some("library not found"),
+        "last_error must explain the miss reason"
+    );
+}
+

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1586,7 +1586,7 @@ async fn ableset_miss_is_recorded_in_attempt_ring_buffer() {
     let attempts = cache.recent_attempts();
     let last = attempts.back().expect("at least one attempt recorded");
     assert_eq!(last.input, "999", "input prefix must be recorded");
-    assert_eq!(last.found, false, "a miss must be recorded as found=false");
+    assert!(!last.found, "a miss must be recorded as found=false");
 }
 
 /// #600: a resolution HIT must be recorded in the attempt ring buffer with
@@ -1602,7 +1602,7 @@ async fn ableset_hit_is_recorded_in_attempt_ring_buffer() {
     let attempts = cache.recent_attempts();
     let last = attempts.back().expect("at least one attempt recorded");
     assert_eq!(last.input, "001");
-    assert_eq!(last.found, true, "a hit must be recorded as found=true");
+    assert!(last.found, "a hit must be recorded as found=true");
 }
 
 /// #600: the ring buffer must cap at 20 entries (FIFO eviction). Without a
@@ -1702,7 +1702,7 @@ async fn ableset_cache_records_library_not_found_error_on_rebuild() {
         "no entries when the library does not exist"
     );
     assert_eq!(
-        cache.last_error().as_deref(),
+        cache.last_error(),
         Some("library not found"),
         "last_error must explain the miss reason"
     );

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1543,10 +1543,7 @@ async fn video_source_status_route_is_not_shadowed_by_the_id_route() {
 async fn seed_ableset_with_song(
     library_name: &str,
     song_name: &str,
-) -> (
-    crate::state::AppState,
-    presenter_core::PresentationId,
-) {
+) -> (crate::state::AppState, presenter_core::PresentationId) {
     let state = AppState::in_memory().await.unwrap();
     let library = state.create_library(library_name).await.unwrap();
     let (_, _, presentation, _) = state
@@ -1710,4 +1707,3 @@ async fn ableset_cache_records_library_not_found_error_on_rebuild() {
         "last_error must explain the miss reason"
     );
 }
-

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -1584,7 +1584,7 @@ async fn ableset_miss_is_recorded_in_attempt_ring_buffer() {
     // The ring buffer must have recorded this miss.
     let cache = state.caches.ableset.read().await;
     let attempts = cache.recent_attempts();
-    let last = attempts.last().expect("at least one attempt recorded");
+    let last = attempts.back().expect("at least one attempt recorded");
     assert_eq!(last.input, "999", "input prefix must be recorded");
     assert_eq!(last.found, false, "a miss must be recorded as found=false");
 }
@@ -1600,7 +1600,7 @@ async fn ableset_hit_is_recorded_in_attempt_ring_buffer() {
 
     let cache = state.caches.ableset.read().await;
     let attempts = cache.recent_attempts();
-    let last = attempts.last().expect("at least one attempt recorded");
+    let last = attempts.back().expect("at least one attempt recorded");
     assert_eq!(last.input, "001");
     assert_eq!(last.found, true, "a hit must be recorded as found=true");
 }
@@ -1628,12 +1628,12 @@ async fn ableset_ring_buffer_caps_at_twenty_entries() {
     // The FIRST 5 entries (000-004) must have been evicted; the buffer must
     // contain entries 005-024.
     assert_eq!(
-        attempts.first().map(|a| a.input.as_str()),
+        attempts.front().map(|a| a.input.as_str()),
         Some("005"),
         "oldest entries must have been evicted (FIFO)"
     );
     assert_eq!(
-        attempts.last().map(|a| a.input.as_str()),
+        attempts.back().map(|a| a.input.as_str()),
         Some("024"),
         "newest entry must be the last one pushed"
     );

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,14 @@ ignore = [
     "RUSTSEC-2026-0194",
     # https://rustsec.org/advisories/RUSTSEC-2026-0195
     "RUSTSEC-2026-0195",
+    # event-listener 5.4.1 StackSlot soundness issue — transitive via
+    # async-lock 3.4.2 → reactive_graph → leptos 0.7.8. INFO Unsound; we do
+    # not use the listener! macro or custom tags, so the unsafe path is
+    # unreachable. No upgrade path until async-lock bumps its event-listener
+    # requirement (>=5.4.2 patched). Same pattern as the leptos entries above.
+    # Keep in sync with .cargo/audit.toml.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0221
+    "RUSTSEC-2026-0221",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Closes #597, Closes #600 — AI status honesty + AbleSet resolution observability.

### #597 — /ai/status connected field lied

`StatusResponse.connected` was wired to a TCP-only connectivity check, so it reported `true` even when `claudeAuthenticated: false`. Now ANDs both — a logged-out proxy reports `connected: false`.

### #600 — AbleSet resolution failures left zero evidence

Cache misses were only logged at `debug!` (prod runs `info`). Now:
- Miss logging upgraded to `warn!`
- Status endpoint surfaces `cache_size`, `last_updated`, `last_error`
- Ring buffer of recent resolution attempts (max 20) exposed via status
