### PR TITLE
feat: operator AI status chip (#598) + visible AI login + token validity (#599)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -38,4 +38,13 @@ ignore = [
   # upgrade path until async-lock bumps its event-listener requirement
   # (>=5.4.2 patched). Same transitive-blocked pattern as the leptos entries above.
   "RUSTSEC-2026-0221", # event-listener StackSlot soundness (transitive via leptos)
+  # rkyv 0.7.46 insufficient archive validation can cause out-of-bounds reads
+  # in archives containing Rc/Arc. Optional dependency of rust_decimal 1.41.0
+  # (transitive via sea-orm 1.1.20 → sqlx 0.8.6 → rust_decimal); the feature
+  # that pulls rkyv is never enabled in our dependency graph — `cargo tree -i
+  # rkyv` prints nothing, so the vulnerable code is never compiled into any
+  # binary. No upgrade path on our side: sea-orm/sqlx pin rust_decimal
+  # 1.41.0, and the fix requires rkyv >=0.8.17, which is not reachable from
+  # there.
+  "RUSTSEC-2026-0235", # rkyv OOB reads (transitive via sea-orm/sqlx, never compiled)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.222"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.222"
+version = "0.4.223"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/ai/proxy.rs
+++ b/crates/presenter-server/src/ai/proxy.rs
@@ -30,12 +30,27 @@ const PROXY_BINARY_NAME: &str = "cli-proxy-api";
 
 /// Freshness classification of an on-disk Claude OAuth token (#438).
 enum TokenValidity {
-    /// Token's `expired` timestamp is in the future — usable.
-    Fresh,
+    /// Token's `expired` timestamp is in the future — usable. Carries the raw
+    /// RFC3339 string so #599 can surface it to the UI.
+    Fresh { expired: String },
     /// Token's `expired` timestamp is in the past — dead, re-login required.
     Expired { expired: String },
     /// File unreadable or has no parseable `expired` field — fail-open as valid.
     Unknown,
+}
+
+/// Result of scanning on-disk Claude auth state (#599): whether Presenter
+/// treats the account as authenticated, and — when derivable — the RFC3339
+/// expiry of the token that "wins" the scan. Surfaced in the UI so an
+/// operator can renew a login BEFORE it dies mid-event instead of only
+/// discovering it dead when an AI request silently fails (2026-07-26).
+struct AuthScan {
+    authenticated: bool,
+    /// The latest-expiring FRESH token's expiry when any token is fresh;
+    /// otherwise the most-recently-expired token's expiry (so the UI can say
+    /// "expired at X"); `None` for API-key auth, no tokens on disk, or tokens
+    /// with no parseable expiry at all.
+    expires_at: Option<String>,
 }
 
 /// State of the managed CLIProxyAPI process.
@@ -47,6 +62,10 @@ pub struct ProxyStatus {
     pub api_url: String,
     pub binary_found: bool,
     pub claude_authenticated: bool,
+    /// RFC3339 expiry of the token backing `claude_authenticated`, when
+    /// derivable from on-disk state (#599). `None` for API-key auth, no
+    /// tokens on disk, or tokens with no parseable expiry.
+    pub token_expires_at: Option<String>,
 }
 
 /// Configuration for the embedded proxy.
@@ -127,7 +146,8 @@ impl ProxyManager {
         self.deploy_dir.join("cli-proxy-api-config.yaml")
     }
 
-    /// Check if Claude credentials exist AND are still valid.
+    /// Check if Claude credentials exist AND are still valid, and — when
+    /// derivable (#599) — the expiry of the token backing that verdict.
     ///
     /// An explicit `claude-api-key` in the config counts as authenticated.
     /// Otherwise, OAuth token files (`claude-*.json`) are validated: a token
@@ -138,16 +158,29 @@ impl ProxyManager {
     /// #438 MVP scope). A token file with no parseable `expired` field is
     /// treated as valid (fail-open) so we never regress a working install on a
     /// format we don't recognise — only a *provably* expired token is rejected.
-    pub async fn is_claude_authenticated(&self) -> bool {
+    ///
+    /// Single pass so `status()` never has to read the same token files twice.
+    async fn scan_claude_auth(&self) -> AuthScan {
         if let Ok(content) = tokio::fs::read_to_string(self.config_path()).await {
             if content.contains("claude-api-key:") {
-                return true;
+                return AuthScan {
+                    authenticated: true,
+                    expires_at: None,
+                };
             }
         }
         let auth_dir = self.auth_dir();
         let Ok(mut entries) = tokio::fs::read_dir(&auth_dir).await else {
-            return false;
+            return AuthScan {
+                authenticated: false,
+                expires_at: None,
+            };
         };
+
+        let mut authenticated = false;
+        let mut fresh_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
+        let mut expired_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
+
         while let Ok(Some(entry)) = entries.next_entry().await {
             let name = entry.file_name().to_string_lossy().into_owned();
             if !name.contains("claude") {
@@ -166,26 +199,49 @@ impl ProxyManager {
                 }
             }
             match Self::token_validity(&entry.path()).await {
-                TokenValidity::Fresh => return true,
+                TokenValidity::Fresh { expired } => {
+                    authenticated = true;
+                    if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&expired) {
+                        let is_newer = fresh_max.as_ref().map_or(true, |(cur, _)| parsed > *cur);
+                        if is_newer {
+                            fresh_max = Some((parsed, expired));
+                        }
+                    }
+                }
                 TokenValidity::Unknown => {
                     // Unparseable expiry — fail-open, this token counts as valid.
                     warn!(token = %name, "Claude token has no parseable expiry; treating as valid");
-                    return true;
+                    authenticated = true;
                 }
                 TokenValidity::Expired { expired } => {
-                    // Each expired token is logged individually; reaching the end
-                    // of the loop without an early `return true` means every token
-                    // we inspected was present-but-expired → AI auth is dead and a
-                    // re-login is required.
+                    // Every expired token is logged — AI auth is dead unless a
+                    // fresh (or unknown, fail-open) token is found elsewhere in
+                    // the scan.
                     warn!(
                         token = %name,
                         expired = %expired,
                         "Claude OAuth token is EXPIRED — reporting not authenticated; re-login required"
                     );
+                    if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&expired) {
+                        let is_newer = expired_max.as_ref().map_or(true, |(cur, _)| parsed > *cur);
+                        if is_newer {
+                            expired_max = Some((parsed, expired));
+                        }
+                    }
                 }
             }
         }
-        false
+
+        // The freshest FRESH token wins when one exists; otherwise the most
+        // recently expired one so the UI can say "expired at X".
+        let expires_at = fresh_max
+            .map(|(_, s)| s)
+            .or_else(|| expired_max.map(|(_, s)| s));
+
+        AuthScan {
+            authenticated,
+            expires_at,
+        }
     }
 
     /// Inspect a `claude-*.json` OAuth token file and classify its freshness
@@ -207,7 +263,9 @@ impl ProxyManager {
                         expired: expired_str.to_string(),
                     }
                 } else {
-                    TokenValidity::Fresh
+                    TokenValidity::Fresh {
+                        expired: expired_str.to_string(),
+                    }
                 }
             }
             Err(_) => TokenValidity::Unknown,
@@ -322,12 +380,15 @@ request-retry: 2
         let port = config.port;
         drop(config);
 
+        let auth_scan = self.scan_claude_auth().await;
+
         ProxyStatus {
             running: self.is_running().await,
             port,
             api_url: format!("http://127.0.0.1:{port}/v1"),
             binary_found: self.binary_path().await.is_some(),
-            claude_authenticated: self.is_claude_authenticated().await,
+            claude_authenticated: auth_scan.authenticated,
+            token_expires_at: auth_scan.expires_at,
         }
     }
 
@@ -555,7 +616,7 @@ mod tests {
     }
 
     /// Regression for #438: an EXPIRED OAuth token must report NOT authenticated.
-    /// Before the fix, `is_claude_authenticated()` only checked file existence,
+    /// Before the fix, `scan_claude_auth()` only checked file existence,
     /// so a dead/expired token reported `claudeAuthenticated:true` (masked the
     /// 2026-06-20 PP outage). No network — pure file + timestamp check.
     #[tokio::test]
@@ -565,7 +626,7 @@ mod tests {
         let past = (Utc::now() - Duration::hours(2)).to_rfc3339();
         write_token(&mgr, "expired@example.com", &past).await;
         assert!(
-            !mgr.is_claude_authenticated().await,
+            !mgr.scan_claude_auth().await.authenticated,
             "an expired token must not count as authenticated"
         );
     }
@@ -578,7 +639,7 @@ mod tests {
         let future = (Utc::now() + Duration::hours(8)).to_rfc3339();
         write_token(&mgr, "fresh@example.com", &future).await;
         assert!(
-            mgr.is_claude_authenticated().await,
+            mgr.scan_claude_auth().await.authenticated,
             "a fresh token must count as authenticated"
         );
     }
@@ -593,7 +654,7 @@ mod tests {
         write_token(&mgr, "dead@example.com", &past).await;
         write_token(&mgr, "live@example.com", &future).await;
         assert!(
-            mgr.is_claude_authenticated().await,
+            mgr.scan_claude_auth().await.authenticated,
             "a fresh token alongside an expired one must count as authenticated"
         );
     }
@@ -604,7 +665,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mgr = ProxyManager::new(tmp.path().to_path_buf());
         assert!(
-            !mgr.is_claude_authenticated().await,
+            !mgr.scan_claude_auth().await.authenticated,
             "no token files means not authenticated"
         );
     }
@@ -626,7 +687,7 @@ mod tests {
         .await
         .unwrap();
         assert!(
-            mgr.is_claude_authenticated().await,
+            mgr.scan_claude_auth().await.authenticated,
             "a token with no parseable expiry must fail open as authenticated"
         );
     }
@@ -645,8 +706,84 @@ mod tests {
         let past = (Utc::now() - Duration::hours(2)).to_rfc3339();
         write_token(&mgr, "expired@example.com", &past).await;
         assert!(
-            !mgr.is_claude_authenticated().await,
+            !mgr.scan_claude_auth().await.authenticated,
             "a claude-named subdir must not grant authentication while the only token is expired"
         );
+    }
+
+    /// #599: `status().token_expires_at` surfaces a fresh token's expiry so
+    /// the UI can show the operator how long the login stays valid.
+    #[tokio::test]
+    async fn status_reports_fresh_token_expiry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let future = (Utc::now() + Duration::hours(8)).to_rfc3339();
+        write_token(&mgr, "fresh@example.com", &future).await;
+        let status = mgr.status().await;
+        assert!(status.claude_authenticated);
+        assert_eq!(status.token_expires_at, Some(future));
+    }
+
+    /// #599: when every token is expired, `token_expires_at` still surfaces
+    /// the newest expiry — "expired at X" — even though `claude_authenticated`
+    /// is false, so the login banner can name when the last login died.
+    #[tokio::test]
+    async fn status_reports_newest_expiry_when_all_tokens_expired() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let older = (Utc::now() - Duration::hours(5)).to_rfc3339();
+        let newer = (Utc::now() - Duration::hours(1)).to_rfc3339();
+        write_token(&mgr, "older@example.com", &older).await;
+        write_token(&mgr, "newer@example.com", &newer).await;
+        let status = mgr.status().await;
+        assert!(!status.claude_authenticated);
+        assert_eq!(status.token_expires_at, Some(newer));
+    }
+
+    /// #599: among several FRESH tokens, the one expiring LATEST wins —
+    /// the UI should report the longest remaining validity, not an
+    /// arbitrary one.
+    #[tokio::test]
+    async fn status_reports_latest_expiry_among_multiple_fresh_tokens() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let sooner = (Utc::now() + Duration::hours(2)).to_rfc3339();
+        let later = (Utc::now() + Duration::hours(9)).to_rfc3339();
+        write_token(&mgr, "sooner@example.com", &sooner).await;
+        write_token(&mgr, "later@example.com", &later).await;
+        let status = mgr.status().await;
+        assert!(status.claude_authenticated);
+        assert_eq!(status.token_expires_at, Some(later));
+    }
+
+    /// #599: no tokens on disk at all → `token_expires_at` is `None`, never a
+    /// guessed/placeholder timestamp.
+    #[tokio::test]
+    async fn status_reports_no_expiry_when_no_tokens_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let status = mgr.status().await;
+        assert!(!status.claude_authenticated);
+        assert_eq!(status.token_expires_at, None);
+    }
+
+    /// #599: a token with no parseable `expired` field carries no timestamp
+    /// to surface — `token_expires_at` stays `None` even though the fail-open
+    /// behavior still reports authenticated.
+    #[tokio::test]
+    async fn status_reports_no_expiry_for_unparseable_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let auth_dir = mgr.auth_dir();
+        tokio::fs::create_dir_all(&auth_dir).await.unwrap();
+        tokio::fs::write(
+            auth_dir.join("claude-weird@example.com.json"),
+            r#"{"access_token":"a","type":"claude"}"#,
+        )
+        .await
+        .unwrap();
+        let status = mgr.status().await;
+        assert!(status.claude_authenticated);
+        assert_eq!(status.token_expires_at, None);
     }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.209"
+version = "0.4.223"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/api/ai.rs
+++ b/crates/presenter-ui/src/api/ai.rs
@@ -51,6 +51,11 @@ pub struct ProxyStatus {
     pub api_url: String,
     pub binary_found: bool,
     pub claude_authenticated: bool,
+    /// RFC3339 expiry of the token backing `claude_authenticated` (#599).
+    /// `#[serde(default)]` so an OLDER server payload (before this field
+    /// existed) still deserializes cleanly — the #600 lesson.
+    #[serde(default)]
+    pub token_expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/presenter-ui/src/components/ai_login_banner.rs
+++ b/crates/presenter-ui/src/components/ai_login_banner.rs
@@ -1,0 +1,166 @@
+//! Primary logged-out state for the AI panel (#599).
+//!
+//! Before this, a dead Claude login only showed up as a small "Claude: not
+//! authenticated" line buried inside the AI panel's COLLAPSED settings
+//! drawer — nothing pointed the operator at the existing login flow at
+//! `/ui/operator/ai`. Real incident 2026-07-26: AI verses died right before
+//! an event and were fixed via SSH instead of through the GUI.
+//!
+//! This banner is keyed ONLY on the observable `proxy.claudeAuthenticated`
+//! (there is no `authentication_error` typed error anywhere in the code —
+//! see issue #599 comment recording that design decision). It is ALWAYS
+//! mounted (never conditionally rendered) so E2E tests assert on
+//! `data-visible`, never on element presence — the same discipline as the
+//! toast component.
+//!
+//! The CTA reuses the EXISTING `proxy_login`/`proxy_complete_login` flow
+//! already wired in `pages/ai.rs` (never duplicated here) — clicking it
+//! calls back into `pages/ai.rs` via the `on_login` prop, which both starts
+//! that flow and opens the settings drawer so the link/paste steps become
+//! visible.
+
+use leptos::prelude::*;
+
+/// Whether the primary logged-out banner should be shown at all.
+pub(crate) fn show_login_banner(authenticated: bool) -> bool {
+    !authenticated
+}
+
+/// Whether the "still valid, renew soon" note should be shown — only while
+/// authenticated via a token whose expiry is actually known (never for
+/// API-key auth, which carries no expiry at all).
+pub(crate) fn show_validity_note(authenticated: bool, expires_at: Option<&str>) -> bool {
+    authenticated && expires_at.is_some()
+}
+
+/// Format an RFC3339 timestamp as `dd.mm.yyyy HH:MM` local time, mirroring
+/// `pages/settings::format_timestamp`. Falls back to the raw string when it
+/// cannot be parsed — never hide the operator-relevant timestamp.
+pub(crate) fn format_expiry(value: &str) -> String {
+    use chrono::{DateTime, Local};
+    match value.parse::<DateTime<chrono::Utc>>() {
+        Ok(dt) => dt
+            .with_timezone(&Local)
+            .format("%d.%m.%Y %H:%M")
+            .to_string(),
+        Err(_) => value.to_string(),
+    }
+}
+
+/// Subtext under the CTA — names WHEN the last login died (when known) so
+/// the operator isn't guessing whether this is a fresh install or a lapsed
+/// renewal.
+pub(crate) fn banner_subtext(expires_at: Option<&str>) -> String {
+    match expires_at {
+        Some(ts) => format!("Predchádzajúce prihlásenie vypršalo {}.", format_expiry(ts)),
+        None => "Zatiaľ nie je prihlásený k Claude AI na tomto serveri.".to_string(),
+    }
+}
+
+/// The "still valid, renew soon" note text.
+pub(crate) fn validity_text(expires_at: &str) -> String {
+    format!(
+        "Prihlásenie ku Claude platí do {}.",
+        format_expiry(expires_at)
+    )
+}
+
+#[component]
+pub fn AiLoginBanner<F>(
+    authenticated: RwSignal<bool>,
+    token_expires_at: RwSignal<Option<String>>,
+    on_login: F,
+) -> impl IntoView
+where
+    F: Fn() + 'static,
+{
+    let visible = move || show_login_banner(authenticated.get()).to_string();
+    let subtext = move || banner_subtext(token_expires_at.get().as_deref());
+    let validity_visible = move || {
+        show_validity_note(authenticated.get(), token_expires_at.get().as_deref()).to_string()
+    };
+    let validity = move || {
+        token_expires_at
+            .get()
+            .map(|ts| validity_text(&ts))
+            .unwrap_or_default()
+    };
+
+    view! {
+        <div class="ai-chat__login-status">
+            <div
+                class="ai-chat__login-banner"
+                data-role="ai-login-banner"
+                data-visible=visible
+            >
+                <p class="ai-chat__login-banner-title">"Nie si prihlásený ku Claude AI"</p>
+                <p class="ai-chat__login-banner-subtext">{subtext}</p>
+                <button
+                    type="button"
+                    class="ai-chat__btn ai-chat__btn--primary"
+                    data-role="ai-login-cta"
+                    on:click=move |_| on_login()
+                >
+                    "Prihlásiť sa"
+                </button>
+            </div>
+            <div
+                class="ai-chat__token-validity"
+                data-role="ai-token-validity"
+                data-visible=validity_visible
+            >
+                {validity}
+            </div>
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn banner_shown_only_when_not_authenticated() {
+        assert!(show_login_banner(false));
+        assert!(!show_login_banner(true));
+    }
+
+    #[test]
+    fn validity_note_needs_both_authenticated_and_a_known_expiry() {
+        assert!(!show_validity_note(false, Some("2026-08-05T10:00:00Z")));
+        assert!(!show_validity_note(true, None));
+        assert!(show_validity_note(true, Some("2026-08-05T10:00:00Z")));
+    }
+
+    #[test]
+    fn expiry_is_formatted_as_local_date_time() {
+        // A UTC timestamp with a known offset — assert only that it parses
+        // into the expected calendar date, since the exact hour depends on
+        // the CI runner's local timezone.
+        let formatted = format_expiry("2026-08-05T10:00:00Z");
+        assert!(formatted.contains("2026"), "got: {formatted}");
+    }
+
+    #[test]
+    fn unparseable_timestamp_falls_back_to_the_raw_string() {
+        assert_eq!(format_expiry("not-a-date"), "not-a-date");
+    }
+
+    #[test]
+    fn subtext_names_the_expiry_when_known() {
+        let text = banner_subtext(Some("2026-08-05T10:00:00Z"));
+        assert!(text.contains("vypršalo"), "got: {text}");
+    }
+
+    #[test]
+    fn subtext_is_generic_when_expiry_unknown() {
+        let text = banner_subtext(None);
+        assert!(!text.contains("vypršalo"), "got: {text}");
+    }
+
+    #[test]
+    fn validity_text_names_the_expiry() {
+        let text = validity_text("2026-08-05T10:00:00Z");
+        assert!(text.contains("platí do"), "got: {text}");
+    }
+}

--- a/crates/presenter-ui/src/components/ai_status.rs
+++ b/crates/presenter-ui/src/components/ai_status.rs
@@ -1,0 +1,230 @@
+//! Operator-header AI connection indicator (#598): mirrors the Resolume
+//! connection chip (`components/resolume_status.rs`, #564) so a logged-out
+//! or otherwise broken AI proxy is visible up front instead of only being
+//! discovered when a live verse request silently fails to arrive mid-event
+//! (2026-07-26).
+//!
+//! Unlike the Resolume chips (one per host, identity in the label, severity
+//! in the dot), there is exactly one AI proxy — so the label itself carries
+//! the state, computed from the three NESTED `proxy.*` booleans
+//! (`AiStatusResponse::proxy`), never the flat top-level `connected` field.
+//! #597 already ANDs those three into `connected`, but a single bool still
+//! can't say WHICH check failed, which is the whole point of this chip.
+//!
+//! Placement (#573): mounted in the operator header's TOP brand row, inside
+//! `.operator__brand-nav`, immediately after `<ResolumeStatusChips />` —
+//! connection/status indicators belong next to the surface-nav pills, never
+//! next to the Stage Output select in `operator__header-right`.
+
+use leptos::prelude::*;
+
+use crate::api::ai::{check_status, AiStatusResponse};
+
+const AI_STATUS_REFRESH_MS: u32 = 5_000;
+
+/// How many CONSECUTIVE poll failures before the chip admits it does not
+/// know, rather than clinging to a possibly long-stale last-known state.
+/// Same threshold and reasoning as `pages/settings/video_sources.rs`'s
+/// `STALE_AFTER_FAILURES` — a single failed poll is a blip (a page
+/// navigation aborting an in-flight fetch is not an outage) and must not
+/// flip the chip to a failure state or log anything.
+pub(crate) const STALE_AFTER_FAILURES: u32 = 2;
+
+pub(crate) fn is_stale(consecutive_failures: u32) -> bool {
+    consecutive_failures >= STALE_AFTER_FAILURES
+}
+
+/// Which of the four states the chip is in right now. `None` covers both
+/// "the first poll hasn't answered yet" and "polling has failed twice in a
+/// row" — both are genuinely unknown, never a guessed failure state.
+pub(crate) fn ai_chip_state(status: Option<&AiStatusResponse>) -> &'static str {
+    match status {
+        None => "checking",
+        Some(s) if !s.proxy.binary_found => "missing-binary",
+        Some(s) if !s.proxy.running => "proxy-down",
+        Some(s) if !s.proxy.claude_authenticated => "logged-out",
+        Some(_) => "ok",
+    }
+}
+
+/// The chip's visible text — Slovak, matching the existing operator copy.
+pub(crate) fn ai_chip_label(state: &str) -> &'static str {
+    match state {
+        "ok" => "AI: pripojené",
+        "logged-out" => "AI: odhlásené",
+        "proxy-down" => "AI: proxy nebeží",
+        "missing-binary" => "AI: chýba binárka",
+        _ => "AI: kontrolujem…",
+    }
+}
+
+/// Dot color: green only when everything checks out, yellow while genuinely
+/// unknown, red for any of the three confirmed problems.
+pub(crate) fn ai_chip_dot(state: &str) -> &'static str {
+    match state {
+        "ok" => "green",
+        "checking" => "yellow",
+        _ => "red",
+    }
+}
+
+/// Tooltip text — names the exact problem and tells the operator the chip
+/// is clickable straight through to the AI panel where it's fixed.
+pub(crate) fn ai_chip_tooltip(state: &str) -> &'static str {
+    match state {
+        "ok" => "AI je pripojená a prihlásená. Kliknutím otvoríš AI panel.",
+        "logged-out" => {
+            "AI proxy beží, ale nie je prihlásená ku Claude. Kliknutím otvoríš AI panel a prihlásiš sa."
+        }
+        "proxy-down" => "AI proxy nebeží. Kliknutím otvoríš AI panel.",
+        "missing-binary" => "Na serveri chýba binárka AI proxy. Kliknutím otvoríš AI panel.",
+        _ => "Zisťujem stav AI…",
+    }
+}
+
+#[component]
+pub fn AiStatusChip() -> impl IntoView {
+    let status = RwSignal::new(None::<AiStatusResponse>);
+    let poll_failures = RwSignal::new(0u32);
+
+    let poll = move || {
+        leptos::task::spawn_local(async move {
+            match check_status().await {
+                Ok(resp) => {
+                    poll_failures.set(0);
+                    status.set(Some(resp));
+                }
+                // One failure is a blip — never swallow the second, but
+                // never scream at the first either (see `STALE_AFTER_FAILURES`).
+                Err(err) => {
+                    let failures = poll_failures.get_untracked() + 1;
+                    poll_failures.set(failures);
+                    if is_stale(failures) {
+                        if !is_stale(failures - 1) {
+                            leptos::logging::warn!(
+                                "AI status poll failed {failures}x in a row — \
+                                 showing the chip as unknown rather than stale: {err}"
+                            );
+                        }
+                        status.set(None);
+                    }
+                }
+            }
+        });
+    };
+    poll();
+
+    // `forget()` — the timer dies with page navigation (no client-side
+    // router), same as every other operator-header/settings poller. Not
+    // `on_cleanup`: `gloo_timers::Interval` is not `Send`, which the host
+    // (non-wasm) `cargo test --lib` build of this crate requires.
+    let interval = gloo_timers::callback::Interval::new(AI_STATUS_REFRESH_MS, move || {
+        poll();
+    });
+    interval.forget();
+
+    let state = move || status.with(|s| ai_chip_state(s.as_ref()));
+    let dot_class = move || format!("operator__ai-dot operator__ai-dot--{}", ai_chip_dot(state()));
+    let label = move || ai_chip_label(state());
+    let tooltip = move || ai_chip_tooltip(state());
+
+    view! {
+        <a
+            class="operator__ai-chip"
+            data-role="ai-status-chip"
+            data-state=state
+            title=tooltip
+            href="/ui/operator/ai"
+        >
+            <span class=dot_class aria-hidden="true"></span>
+            <span class="operator__ai-chip-label">{label}</span>
+        </a>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::ai::ProxyStatus;
+
+    fn status(binary_found: bool, running: bool, claude_authenticated: bool) -> AiStatusResponse {
+        AiStatusResponse {
+            connected: binary_found && running && claude_authenticated,
+            error: None,
+            proxy: ProxyStatus {
+                running,
+                port: 18787,
+                api_url: "http://127.0.0.1:18787/v1".to_string(),
+                binary_found,
+                claude_authenticated,
+            },
+        }
+    }
+
+    #[test]
+    fn no_status_yet_is_checking() {
+        assert_eq!(ai_chip_state(None), "checking");
+    }
+
+    #[test]
+    fn all_three_signals_true_is_ok() {
+        let s = status(true, true, true);
+        assert_eq!(ai_chip_state(Some(&s)), "ok");
+    }
+
+    #[test]
+    fn not_authenticated_is_the_most_common_real_state() {
+        let s = status(true, true, false);
+        assert_eq!(ai_chip_state(Some(&s)), "logged-out");
+    }
+
+    #[test]
+    fn proxy_not_running_is_reported_even_when_binary_found() {
+        let s = status(true, false, true);
+        assert_eq!(ai_chip_state(Some(&s)), "proxy-down");
+    }
+
+    #[test]
+    fn missing_binary_wins_over_the_other_two_flags() {
+        // running/claude_authenticated can't be meaningfully true if the
+        // binary itself is missing, but prove the precedence anyway.
+        let s = status(false, true, true);
+        assert_eq!(ai_chip_state(Some(&s)), "missing-binary");
+    }
+
+    #[test]
+    fn labels_are_slovak_and_state_specific() {
+        assert_eq!(ai_chip_label("ok"), "AI: pripojené");
+        assert_eq!(ai_chip_label("logged-out"), "AI: odhlásené");
+        assert_eq!(ai_chip_label("proxy-down"), "AI: proxy nebeží");
+        assert_eq!(ai_chip_label("missing-binary"), "AI: chýba binárka");
+        assert_eq!(ai_chip_label("checking"), "AI: kontrolujem…");
+    }
+
+    #[test]
+    fn only_ok_is_green_only_checking_is_yellow_the_rest_are_red() {
+        assert_eq!(ai_chip_dot("ok"), "green");
+        assert_eq!(ai_chip_dot("checking"), "yellow");
+        assert_eq!(ai_chip_dot("logged-out"), "red");
+        assert_eq!(ai_chip_dot("proxy-down"), "red");
+        assert_eq!(ai_chip_dot("missing-binary"), "red");
+    }
+
+    #[test]
+    fn tooltip_names_the_exact_problem_and_the_click_target() {
+        assert!(ai_chip_tooltip("logged-out").contains("nie je prihlásená"));
+        assert!(ai_chip_tooltip("proxy-down").contains("nebeží"));
+        assert!(ai_chip_tooltip("missing-binary").contains("chýba"));
+        for state in ["ok", "logged-out", "proxy-down", "missing-binary"] {
+            assert!(ai_chip_tooltip(state).contains("AI panel"));
+        }
+    }
+
+    #[test]
+    fn one_failed_poll_is_a_blip_two_in_a_row_is_stale() {
+        assert!(!is_stale(0));
+        assert!(!is_stale(1));
+        assert!(is_stale(2));
+        assert!(is_stale(7));
+    }
+}

--- a/crates/presenter-ui/src/components/ai_status.rs
+++ b/crates/presenter-ui/src/components/ai_status.rs
@@ -124,7 +124,12 @@ pub fn AiStatusChip() -> impl IntoView {
     interval.forget();
 
     let state = move || status.with(|s| ai_chip_state(s.as_ref()));
-    let dot_class = move || format!("operator__ai-dot operator__ai-dot--{}", ai_chip_dot(state()));
+    let dot_class = move || {
+        format!(
+            "operator__ai-dot operator__ai-dot--{}",
+            ai_chip_dot(state())
+        )
+    };
     let label = move || ai_chip_label(state());
     let tooltip = move || ai_chip_tooltip(state());
 

--- a/crates/presenter-ui/src/components/ai_status.rs
+++ b/crates/presenter-ui/src/components/ai_status.rs
@@ -162,6 +162,7 @@ mod tests {
                 api_url: "http://127.0.0.1:18787/v1".to_string(),
                 binary_found,
                 claude_authenticated,
+                token_expires_at: None,
             },
         }
     }

--- a/crates/presenter-ui/src/components/header.rs
+++ b/crates/presenter-ui/src/components/header.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::api::bible as bible_api;
+use crate::components::ai_status::AiStatusChip;
 use crate::components::resolume_status::ResolumeStatusChips;
 use crate::components::stage_preview::StagePreview;
 use crate::components::surface_nav::SurfaceNav;
@@ -212,6 +213,7 @@ pub fn Header() -> impl IntoView {
                     <div class="operator__brand-nav">
                         <SurfaceNav />
                         <ResolumeStatusChips />
+                        <AiStatusChip />
                     </div>
                 </div>
                 <form class="operator__search" data-role="global-search-form" role="search" autocomplete="off"

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_status;
 pub mod header;
 pub mod info_popover;
 pub mod library_list;

--- a/crates/presenter-ui/src/components/mod.rs
+++ b/crates/presenter-ui/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_login_banner;
 pub mod ai_status;
 pub mod header;
 pub mod info_popover;

--- a/crates/presenter-ui/src/pages/ai.rs
+++ b/crates/presenter-ui/src/pages/ai.rs
@@ -5,6 +5,7 @@ use wasm_bindgen_futures::JsFuture;
 use web_sys::js_sys;
 
 use crate::api::ai as ai_api;
+use crate::components::ai_login_banner::AiLoginBanner;
 use crate::state::AppContext;
 
 /// A single displayed chat message.
@@ -50,6 +51,10 @@ pub fn AiPage() -> impl IntoView {
     let proxy_running: RwSignal<bool> = RwSignal::new(false);
     let proxy_binary_found: RwSignal<bool> = RwSignal::new(false);
     let proxy_authenticated: RwSignal<bool> = RwSignal::new(false);
+    // #599: expiry of the token backing `proxy_authenticated`, when known —
+    // surfaced so the operator can renew BEFORE an event instead of only
+    // discovering a dead login mid-service.
+    let token_expires_at: RwSignal<Option<String>> = RwSignal::new(None);
     let proxy_loading: RwSignal<bool> = RwSignal::new(false);
     let login_url: RwSignal<Option<String>> = RwSignal::new(None);
     let callback_input: RwSignal<String> = RwSignal::new(String::new());
@@ -67,6 +72,7 @@ pub fn AiPage() -> impl IntoView {
                 proxy_running.set(status.proxy.running);
                 proxy_binary_found.set(status.proxy.binary_found);
                 proxy_authenticated.set(status.proxy.claude_authenticated);
+                token_expires_at.set(status.proxy.token_expires_at);
             }
             // Restore conversation from server
             if let Ok(conv) = ai_api::get_conversation().await {
@@ -109,7 +115,17 @@ pub fn AiPage() -> impl IntoView {
         });
 
         leptos::task::spawn_local(async move {
-            match send_message_sse(&text, messages, tool_progress, error).await {
+            match send_message_sse(
+                &text,
+                messages,
+                tool_progress,
+                error,
+                connected,
+                proxy_authenticated,
+                token_expires_at,
+            )
+            .await
+            {
                 Ok(()) => {}
                 Err(e) => {
                     error.set(Some(format!("Failed to get AI response: {e}")));
@@ -189,6 +205,7 @@ pub fn AiPage() -> impl IntoView {
                     proxy_running.set(status.proxy.running);
                     proxy_binary_found.set(status.proxy.binary_found);
                     proxy_authenticated.set(status.proxy.claude_authenticated);
+                    token_expires_at.set(status.proxy.token_expires_at);
                 }
                 Err(_) => connected.set(false),
             }
@@ -229,6 +246,30 @@ pub fn AiPage() -> impl IntoView {
         settings_open.update(|v| *v = !*v);
     };
 
+    // #599: the ONE Claude-login trigger, shared by the settings-drawer
+    // "Claude Login" button AND the primary logged-out banner's CTA — the
+    // banner never duplicates this flow, it only also opens the drawer so
+    // the link/paste steps below become visible.
+    let start_login = move || {
+        proxy_loading.set(true);
+        login_url.set(None);
+        leptos::task::spawn_local(async move {
+            match ai_api::proxy_login().await {
+                Ok(resp) => {
+                    login_url.set(Some(resp.login_url));
+                }
+                Err(e) => {
+                    error.set(Some(format!("Login failed: {e}")));
+                }
+            }
+            proxy_loading.set(false);
+        });
+    };
+    let on_banner_login = move || {
+        settings_open.set(true);
+        start_login();
+    };
+
     view! {
         <div class="ai-chat" data-role="ai-chat">
             <div class="ai-chat__header">
@@ -262,6 +303,14 @@ pub fn AiPage() -> impl IntoView {
                     </button>
                 </div>
             </div>
+
+            // #599: primary logged-out state — never buried, always the
+            // first thing shown when Claude auth is dead.
+            <AiLoginBanner
+                authenticated=proxy_authenticated
+                token_expires_at=token_expires_at
+                on_login=on_banner_login
+            />
 
             // Settings panel (collapsible)
             <div
@@ -364,21 +413,7 @@ pub fn AiPage() -> impl IntoView {
                                         class="ai-chat__btn"
                                         data-role="ai-proxy-login"
                                         prop:disabled=move || proxy_loading.get()
-                                        on:click=move |_| {
-                                            proxy_loading.set(true);
-                                            login_url.set(None);
-                                            leptos::task::spawn_local(async move {
-                                                match ai_api::proxy_login().await {
-                                                    Ok(resp) => {
-                                                        login_url.set(Some(resp.login_url));
-                                                    }
-                                                    Err(e) => {
-                                                        error.set(Some(format!("Login failed: {e}")));
-                                                    }
-                                                }
-                                                proxy_loading.set(false);
-                                            });
-                                        }
+                                        on:click=move |_| start_login()
                                     >
                                         "Claude Login"
                                     </button>
@@ -419,6 +454,7 @@ pub fn AiPage() -> impl IntoView {
                                                                 Ok(status) => {
                                                                     proxy_running.set(status.running);
                                                                     proxy_authenticated.set(status.claude_authenticated);
+                                                                    token_expires_at.set(status.token_expires_at);
                                                                     login_url.set(None);
                                                                     callback_input.set(String::new());
                                                                     toast_variant.set("success".to_string());
@@ -572,6 +608,9 @@ async fn send_message_sse(
     messages: RwSignal<Vec<DisplayMessage>>,
     tool_progress: RwSignal<Vec<ToolProgress>>,
     error: RwSignal<Option<String>>,
+    connected: RwSignal<bool>,
+    proxy_authenticated: RwSignal<bool>,
+    token_expires_at: RwSignal<Option<String>>,
 ) -> Result<(), String> {
     let window = web_sys::window().ok_or("no window")?;
 
@@ -629,7 +668,15 @@ async fn send_message_sse(
                 while let Some(event_end) = buffer.find("\n\n") {
                     let event_text = buffer[..event_end].to_string();
                     buffer = buffer[event_end + 2..].to_string();
-                    process_sse_event(&event_text, &messages, &tool_progress, &error);
+                    process_sse_event(
+                        &event_text,
+                        &messages,
+                        &tool_progress,
+                        &error,
+                        connected,
+                        proxy_authenticated,
+                        token_expires_at,
+                    );
                 }
             }
         }
@@ -637,7 +684,15 @@ async fn send_message_sse(
         if done {
             // Process any remaining data in buffer
             if !buffer.trim().is_empty() {
-                process_sse_event(&buffer, &messages, &tool_progress, &error);
+                process_sse_event(
+                    &buffer,
+                    &messages,
+                    &tool_progress,
+                    &error,
+                    connected,
+                    proxy_authenticated,
+                    token_expires_at,
+                );
             }
             break;
         }
@@ -652,6 +707,9 @@ fn process_sse_event(
     messages: &RwSignal<Vec<DisplayMessage>>,
     tool_progress: &RwSignal<Vec<ToolProgress>>,
     error: &RwSignal<Option<String>>,
+    connected: RwSignal<bool>,
+    proxy_authenticated: RwSignal<bool>,
+    token_expires_at: RwSignal<Option<String>>,
 ) {
     let mut event_type = "";
     let mut data = String::new();
@@ -714,6 +772,17 @@ fn process_sse_event(
                 let msg = val["message"].as_str().unwrap_or("Unknown error");
                 error.set(Some(format!("AI error: {msg}")));
             }
+            // #599: a chat error might mean the Claude auth died mid-session —
+            // re-check status so the primary login banner reacts immediately
+            // instead of staying stale until the operator reloads or manually
+            // checks the status dot.
+            leptos::task::spawn_local(async move {
+                if let Ok(status) = ai_api::check_status().await {
+                    connected.set(status.connected);
+                    proxy_authenticated.set(status.proxy.claude_authenticated);
+                    token_expires_at.set(status.proxy.token_expires_at);
+                }
+            });
         }
         _ => {}
     }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2888,6 +2888,55 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   font-size: 0.8rem;
 }
 
+/* Primary logged-out banner (#599) — always mounted, toggled via
+   data-visible so E2E asserts the attribute rather than element presence. */
+.ai-chat__login-banner {
+  margin: 0.75rem 1rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.1);
+  flex-shrink: 0;
+}
+
+.ai-chat__login-banner[data-visible="false"] {
+  display: none;
+}
+
+.ai-chat__login-banner-title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+  color: var(--operator-text);
+}
+
+.ai-chat__login-banner-subtext {
+  margin: 0 0 0.6rem;
+  font-size: 0.8rem;
+  color: var(--operator-muted);
+}
+
+.ai-chat__btn--primary {
+  background: var(--operator-accent);
+  color: #fff;
+  border-color: var(--operator-accent);
+  font-weight: 600;
+}
+
+.ai-chat__btn--primary:hover {
+  background: var(--operator-accent-dark);
+}
+
+.ai-chat__token-validity {
+  margin: 0.4rem 1rem 0;
+  font-size: 0.75rem;
+  color: var(--operator-muted);
+  flex-shrink: 0;
+}
+
+.ai-chat__token-validity[data-visible="false"] {
+  display: none;
+}
+
 /* Network mode indicator (LAN/WAN pill) */
 .network-indicator {
   font-size: 0.75rem;

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -361,6 +361,55 @@ body.operator {
   background: #ef4444;
 }
 
+/* #598: AI connection indicator — a single chip mirroring the Resolume
+   chips' visual language (same `.operator__brand-nav` group, same dot +
+   pill shape), but rendered as a link straight to the AI panel
+   (`/ui/operator/ai`) since there's exactly one AI proxy to check, not one
+   chip per host. */
+.operator__ai-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  background: var(--operator-panel);
+  border: 1px solid var(--operator-border);
+  font-size: 0.7rem;
+  line-height: 1.2;
+  color: rgba(255, 255, 255, 0.75);
+  white-space: nowrap;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.operator__ai-chip:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.operator__ai-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: #475569;
+}
+
+/* Green = fully connected + authenticated. Yellow = genuinely unknown (first
+   poll, or 2+ consecutive poll failures). Red = a confirmed real problem —
+   logged out, proxy down, or the binary is missing (the label text says
+   which). */
+.operator__ai-dot--green {
+  background: #22c55e;
+}
+
+.operator__ai-dot--yellow {
+  background: #f59e0b;
+}
+
+.operator__ai-dot--red {
+  background: #ef4444;
+}
+
 .operator__stage-layout {
   display: flex;
   flex-direction: column;

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,15 @@ ignore = [
     # Keep in sync with .cargo/audit.toml.
     # https://rustsec.org/advisories/RUSTSEC-2026-0221
     "RUSTSEC-2026-0221",
+    # rkyv 0.7.46 insufficient archive validation can cause out-of-bounds
+    # reads in archives containing Rc/Arc. Optional dependency of
+    # rust_decimal 1.41.0 (transitive via sea-orm 1.1.20 → sqlx 0.8.6); the
+    # feature that pulls rkyv is never enabled in our dependency graph —
+    # `cargo tree -i rkyv` prints nothing, so the code is never compiled. No
+    # upgrade path until sea-orm/sqlx move off rust_decimal 1.41.0 (fix
+    # requires rkyv >=0.8.17). Keep in sync with .cargo/audit.toml.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0235
+    "RUSTSEC-2026-0235",
 ]
 
 [licenses]

--- a/tests/e2e/ai-login-visibility.spec.ts
+++ b/tests/e2e/ai-login-visibility.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E for #599: the AI panel's PRIMARY logged-out state.
+ *
+ * Before this, a dead Claude login only surfaced as a small line buried
+ * inside the AI panel's collapsed settings drawer — nothing told the
+ * operator to use the existing login flow at `/ui/operator/ai` (real
+ * incident 2026-07-26: AI verses died right before an event, fixed via SSH
+ * instead of the GUI).
+ *
+ * Mirrors `ai-status-chip.spec.ts`'s technique: the real login state depends
+ * on this box's CLIProxyAPI session, so every scenario is driven by
+ * intercepting `/ai/status` via `page.route`, never the live proxy.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  attachConsoleErrorCollector,
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+async function mockAiStatus(
+  page: Page,
+  proxy: {
+    claudeAuthenticated: boolean;
+    tokenExpiresAt?: string | null;
+  },
+) {
+  await page.route("**/ai/status", async (route) => {
+    await route.fulfill({
+      json: {
+        connected: proxy.claudeAuthenticated,
+        error: proxy.claudeAuthenticated
+          ? null
+          : "Claude not authenticated — run /ai/proxy/login to re-authorize",
+        proxy: {
+          running: true,
+          port: 18787,
+          apiUrl: "http://127.0.0.1:18787/v1",
+          binaryFound: true,
+          claudeAuthenticated: proxy.claudeAuthenticated,
+          tokenExpiresAt: proxy.tokenExpiresAt ?? null,
+        },
+      },
+    });
+  });
+}
+
+async function gotoAiPanel(page: Page) {
+  await page.goto(new URL("/ui/operator/ai", baseURL).toString());
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+  await page.waitForFunction(
+    () => document.body.getAttribute("data-view") === "ai",
+    { timeout: 5_000 },
+  );
+}
+
+test("logged out shows the primary login banner with a visible CTA", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { claudeAuthenticated: false });
+
+  await gotoAiPanel(page);
+
+  const banner = page.locator('[data-role="ai-login-banner"]');
+  await expect(banner).toHaveAttribute("data-visible", "true", { timeout: 30_000 });
+  await expect(banner).toBeVisible();
+
+  const cta = page.locator('[data-role="ai-login-cta"]');
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveText("Prihlásiť sa");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("logged in shows no login banner", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, {
+    claudeAuthenticated: true,
+    tokenExpiresAt: "2099-01-01T00:00:00Z",
+  });
+
+  await gotoAiPanel(page);
+
+  const banner = page.locator('[data-role="ai-login-banner"]');
+  // Always mounted (never conditionally rendered) — assert the attribute,
+  // never element count/visibility, per the toast-component discipline.
+  await expect(banner).toHaveAttribute("data-visible", "false", { timeout: 30_000 });
+  await expect(banner).toBeHidden();
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("a known token expiry shows how long the login stays valid while authenticated", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, {
+    claudeAuthenticated: true,
+    tokenExpiresAt: "2099-06-15T12:00:00Z",
+  });
+
+  await gotoAiPanel(page);
+
+  const validity = page.locator('[data-role="ai-token-validity"]');
+  await expect(validity).toHaveAttribute("data-visible", "true", { timeout: 30_000 });
+  await expect(validity).toBeVisible();
+  await expect(validity).toHaveText(/plat[íi] do/);
+  await expect(validity).toHaveText(/2099/);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("an expired token is named in the logged-out banner's subtext", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, {
+    claudeAuthenticated: false,
+    tokenExpiresAt: "2020-03-10T08:00:00Z",
+  });
+
+  await gotoAiPanel(page);
+
+  const banner = page.locator('[data-role="ai-login-banner"]');
+  await expect(banner).toHaveAttribute("data-visible", "true", { timeout: 30_000 });
+
+  const subtext = banner.locator(".ai-chat__login-banner-subtext");
+  await expect(subtext).toHaveText(/vypr[šs]alo/);
+  await expect(subtext).toHaveText(/2020/);
+
+  // The validity note is the "still valid" state — must stay hidden while
+  // logged out, even though we DO know an expiry.
+  const validity = page.locator('[data-role="ai-token-validity"]');
+  await expect(validity).toHaveAttribute("data-visible", "false");
+
+  expect(consoleMessages).toEqual([]);
+});

--- a/tests/e2e/ai-status-chip.spec.ts
+++ b/tests/e2e/ai-status-chip.spec.ts
@@ -170,8 +170,19 @@ test("a failed poll shows the neutral checking state, never a false failure clai
   const consoleMessages: string[] = [];
   attachConsoleErrorCollector(page, consoleMessages);
 
+  // A non-2xx status here would be closer to a "real" failure, but Chrome
+  // itself logs a "Failed to load resource: the server responded with a
+  // status of 500" console error for ANY non-2xx fetch response — that is
+  // browser-generated, unrelated to app code, and unavoidable, so the
+  // combination of "mock a 500" + "assert zero console" can never pass
+  // (`crates/presenter-ui/src/api/mod.rs`'s `get_json` returns
+  // `Err(ApiError::Status(..))` before ever touching the body). A malformed
+  // 200 body exercises the exact same client failure branch — `check_status()`
+  // returns `Err(ApiError::Deserialize(..))`, handled identically to
+  // `ApiError::Status` by `ai_status.rs`'s `poll` closure — via a pure
+  // Rust-side `serde_json::from_str` parse error, with a clean console.
   await page.route("**/ai/status", async (route) => {
-    await route.fulfill({ status: 500, body: "boom" });
+    await route.fulfill({ status: 200, contentType: "application/json", body: "not-json" });
   });
 
   await page.goto(new URL("/ui/operator", baseURL).toString());

--- a/tests/e2e/ai-status-chip.spec.ts
+++ b/tests/e2e/ai-status-chip.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * E2E for #598: the operator-header AI connection indicator, mirroring the
+ * Resolume chip (#564, `resolume-status-chip.spec.ts`).
+ *
+ * Unlike Resolume (many hosts, each proven by a real mock TCP server), there
+ * is exactly one AI proxy on this server, and its real login state depends
+ * on this box's CLIProxyAPI session — not something a test should depend
+ * on. So the four required states are driven by intercepting `/ai/status`
+ * itself via `page.route`, the same technique `operator-version-recovery.spec.ts`
+ * already uses for `/healthz`.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  attachConsoleErrorCollector,
+  deriveTestConfig,
+  refreshDevData,
+  startTestServer,
+  stopServer,
+  type ServerHandle,
+} from "./support";
+
+let serverHandle: ServerHandle | undefined;
+let baseURL: string;
+
+test.describe.configure({ timeout: 180_000 });
+
+test.beforeAll(async ({}, testInfo) => {
+  const config = deriveTestConfig(testInfo);
+  baseURL = config.baseURL;
+  await refreshDevData(config.dbUrl);
+  serverHandle = await startTestServer(config.port, config.dbUrl);
+});
+
+test.afterAll(async () => {
+  await stopServer(serverHandle);
+  serverHandle = undefined;
+});
+
+async function mockAiStatus(
+  page: Page,
+  proxy: { running: boolean; binaryFound: boolean; claudeAuthenticated: boolean },
+) {
+  await page.route("**/ai/status", async (route) => {
+    await route.fulfill({
+      json: {
+        connected: proxy.running && proxy.binaryFound && proxy.claudeAuthenticated,
+        error: null,
+        proxy: {
+          running: proxy.running,
+          port: 18787,
+          apiUrl: "http://127.0.0.1:18787/v1",
+          binaryFound: proxy.binaryFound,
+          claudeAuthenticated: proxy.claudeAuthenticated,
+        },
+      },
+    });
+  });
+}
+
+test("mounted in the top brand row, never next to Stage Output", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: true, binaryFound: true, claudeAuthenticated: true });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator('[data-role="ai-status-chip"]')).toHaveCount(1);
+  await expect(
+    page.locator('.operator__header-brand [data-role="ai-status-chip"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('.operator__header-right [data-role="ai-status-chip"]'),
+  ).toHaveCount(0);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("all three signals healthy shows the connected state and links to the AI panel", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: true, binaryFound: true, claudeAuthenticated: true });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "ok", { timeout: 30_000 });
+  await expect(chip).toHaveText("AI: pripojené");
+  await expect(chip).toHaveAttribute("href", "/ui/operator/ai");
+  await expect(chip).toHaveAttribute("title", /prihlásená/);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("not authenticated is reported distinctly from a down proxy or a missing binary", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: true, binaryFound: true, claudeAuthenticated: false });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "logged-out", { timeout: 30_000 });
+  await expect(chip).toHaveText("AI: odhlásené");
+  await expect(chip).toHaveAttribute("title", /nie je prihlásená/);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("proxy not running is reported distinctly", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: false, binaryFound: true, claudeAuthenticated: false });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "proxy-down", { timeout: 30_000 });
+  await expect(chip).toHaveText("AI: proxy nebeží");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("missing binary is reported distinctly", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: false, binaryFound: false, claudeAuthenticated: false });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "missing-binary", { timeout: 30_000 });
+  await expect(chip).toHaveText("AI: chýba binárka");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("clicking the chip navigates straight to the AI panel", async ({ page }) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { running: true, binaryFound: true, claudeAuthenticated: false });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "logged-out", { timeout: 30_000 });
+  await chip.click();
+  await page.waitForSelector('body[data-wasm-ready="true"]', { timeout: 30_000 });
+
+  await expect(page).toHaveURL(/\/ui\/operator\/ai$/);
+  const aiButton = page.locator('[data-role="view-toggle"][data-view="ai"]');
+  await expect(aiButton).toHaveAttribute("data-active", "true");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("a failed poll shows the neutral checking state, never a false failure claim, with a clean console", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+
+  await page.route("**/ai/status", async (route) => {
+    await route.fulfill({ status: 500, body: "boom" });
+  });
+
+  await page.goto(new URL("/ui/operator", baseURL).toString());
+  await page.waitForLoadState("networkidle");
+
+  const chip = page.locator('[data-role="ai-status-chip"]');
+  await expect(chip).toHaveAttribute("data-state", "checking", { timeout: 30_000 });
+  await expect(chip).toHaveText("AI: kontrolujem…");
+
+  expect(consoleMessages).toEqual([]);
+});


### PR DESCRIPTION
## Batch: operator AI status chip (#598) + visible AI login flow (#599)

Closes #598
Closes #599

### #598 — Operator AI connection status chip
- New `AiStatusChip` component in the top surface-nav row (after Resolume chips): polls `/ai/status`, shows ok / logged-out / proxy-down / missing-binary states, click-through to `/ui/operator/ai`.
- Neutral "checking" state on poll failure (never accuses a healthy server).
- E2E: `tests/e2e/ai-status-chip.spec.ts` — four mocked states + mount location + click-through + poll-failure neutrality, zero-console asserted.

### #599 — AI login no longer hidden
- AI panel shows a primary logged-out banner with a "Prihlás sa" CTA when `claudeAuthenticated:false`; chat auth error triggers a status recheck.
- Server `ProxyStatus` gains `tokenExpiresAt` (expiry of the freshest auth token) surfaced through router → client DTO (`#[serde(default)]`) → validity note in the panel, so token renewal can happen before an event.
- `scan_claude_auth()` replaces `is_claude_authenticated()` in `ai/proxy.rs` (+5 unit tests); new `ai_login_banner.rs` component (+7 unit tests).
- RED spec `tests/e2e/ai-login-visibility.spec.ts` committed before the GREEN implementation.

### CI fixes picked up in this batch
- `a16a326c` — ignore RUSTSEC-2026-0235 (rkyv OOB reads): transitive optional dep of rust_decimal via sea-orm/sqlx, feature never enabled, `cargo tree -i rkyv` empty — never compiled.
- `d81910c1` — #598 poll-failure spec: mock a malformed 200 body instead of HTTP 500 (Chrome logs `Failed to load resource` for any non-2xx, which made the zero-console assertion impossible; client handles both via the same `Err` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
