### PR TITLE
fix(ai): post-merge review fixes of #622 + fn-length refactor (v0.4.224)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -39,12 +39,15 @@ ignore = [
   # (>=5.4.2 patched). Same transitive-blocked pattern as the leptos entries above.
   "RUSTSEC-2026-0221", # event-listener StackSlot soundness (transitive via leptos)
   # rkyv 0.7.46 insufficient archive validation can cause out-of-bounds reads
-  # in archives containing Rc/Arc. Optional dependency of rust_decimal 1.41.0
-  # (transitive via sea-orm 1.1.20 → sqlx 0.8.6 → rust_decimal); the feature
+  # in archives containing Rc/Arc. Optional dependency of rust_decimal 1.41.0,
+  # which sea-orm 1.1.20 depends on DIRECTLY (#622 post-merge review finding
+  # 12 — this used to say "transitive via sea-orm → sqlx → rust_decimal",
+  # which is wrong: sqlx 0.8.6 also depends on rust_decimal directly and
+  # independently, there is no sea-orm→sqlx→rust_decimal chain); the feature
   # that pulls rkyv is never enabled in our dependency graph — `cargo tree -i
   # rkyv` prints nothing, so the vulnerable code is never compiled into any
   # binary. No upgrade path on our side: sea-orm/sqlx pin rust_decimal
   # 1.41.0, and the fix requires rkyv >=0.8.17, which is not reachable from
   # there.
-  "RUSTSEC-2026-0235", # rkyv OOB reads (transitive via sea-orm/sqlx, never compiled)
+  "RUSTSEC-2026-0235", # rkyv OOB reads (direct dep of sea-orm's rust_decimal, never compiled)
 ]

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -191,3 +191,15 @@ pre-existing, out-of-scope display quirk, left alone in #574). Do NOT reach for
 tab" — it would mismatch on every single load. Instead capture the baseline from the
 tab's OWN first `/healthz` response (`header.rs`'s `known_version` signal) and compare
 LATER polls against that captured value, never against a build-time constant.
+
+## E2E: NEVER mock a non-2xx response in a zero-console spec (#598)
+
+Chrome itself logs `Failed to load resource: the server responded with a status of <N>`
+for EVERY non-2xx fetch — `page.route` mocks included. A spec that fulfills a route with
+`status: 500` (or 401/404) and also asserts `expect(consoleMessages).toEqual([])` can
+NEVER pass; it fails identically on retry (not flake). To exercise a client fetch-failure
+branch with a clean console, fulfill with a MALFORMED 200 instead:
+`route.fulfill({ status: 200, contentType: "application/json", body: "not-json" })` —
+`get_json()` in `crates/presenter-ui/src/api/mod.rs` funnels non-2xx (`ApiError::Status`)
+and parse failure (`ApiError::Deserialize`) into the same `Err` path, and gloo-net's
+`json()` parses in pure Rust (zero browser console noise).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.223"
+version = "0.4.224"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/ai/client.rs
+++ b/crates/presenter-server/src/ai/client.rs
@@ -1,6 +1,25 @@
 use super::AiSettings;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+/// Shared HTTP client for `/ai/status` connectivity probes ONLY (#622
+/// post-merge review finding 3a). `check_connectivity` is polled every 5s by
+/// the operator-header status chip (`ai_status.rs`) — building a fresh
+/// `reqwest::Client` (own connection pool + TLS setup) on every single poll
+/// was needless per-call cost. `call_chat_completions` keeps its OWN client:
+/// a chat call is a one-off with a much longer 120s timeout, so reuse would
+/// not meaningfully help there.
+static CONNECTIVITY_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+fn connectivity_client() -> &'static reqwest::Client {
+    CONNECTIVITY_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
+}
 
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Serialize)]
@@ -98,11 +117,13 @@ pub async fn call_chat_completions(
         .context("failed to parse AI API response")
 }
 
-/// Ping the AI API to verify connectivity.
+/// Ping the AI API to verify connectivity. Uses the shared, lazily-built
+/// `connectivity_client()` (3s timeout) rather than a fresh client per call —
+/// this is polled every 5s by the status chip (#622 post-merge review
+/// finding 3a).
 pub async fn check_connectivity(settings: &AiSettings) -> anyhow::Result<()> {
     let url = format!("{}/models", settings.api_url.trim_end_matches('/'));
-    let client = reqwest::Client::new();
-    let mut req = client.get(&url);
+    let mut req = connectivity_client().get(&url);
 
     if let Some(key) = &settings.api_key {
         if !key.is_empty() {
@@ -110,11 +131,7 @@ pub async fn check_connectivity(settings: &AiSettings) -> anyhow::Result<()> {
         }
     }
 
-    let response = req
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-        .context("failed to reach AI API")?;
+    let response = req.send().await.context("failed to reach AI API")?;
 
     if !response.status().is_success() {
         anyhow::bail!("AI API returned status {}", response.status());

--- a/crates/presenter-server/src/ai/proxy.rs
+++ b/crates/presenter-server/src/ai/proxy.rs
@@ -6,11 +6,21 @@
 //! native `-claude-login` flow with callback URL forwarding.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
+
+/// Last-reported overall Claude auth state, process-wide (#622 post-merge
+/// review finding 3b): `None` = never reported yet, `Some(true)` = last
+/// scan was authenticated, `Some(false)` = last scan was NOT authenticated.
+/// Used so the "token is EXPIRED" log only WARNs on the TRANSITION into
+/// not-authenticated — a steady-state dead login, polled every 5s by the
+/// status chip, used to re-warn on every single scan (~12x/minute for the
+/// exact same already-known problem). One process runs one `ProxyManager`
+/// in practice, so a process-global is the right scope here.
+static LAST_REPORTED_AUTH: Mutex<Option<bool>> = Mutex::new(None);
 
 /// Holds a login child process and its stdout handle.
 /// The stdout must be kept alive to prevent SIGPIPE from killing the process.
@@ -180,6 +190,10 @@ impl ProxyManager {
         let mut authenticated = false;
         let mut fresh_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
         let mut expired_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
+        // Collected, not logged immediately — the WARN-vs-DEBUG decision
+        // (finding 3b) can only be made once the aggregate `authenticated`
+        // verdict is known, after the loop.
+        let mut expired_tokens: Vec<(String, String)> = Vec::new();
 
         while let Ok(Some(entry)) = entries.next_entry().await {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -214,14 +228,11 @@ impl ProxyManager {
                     authenticated = true;
                 }
                 TokenValidity::Expired { expired } => {
-                    // Every expired token is logged — AI auth is dead unless a
-                    // fresh (or unknown, fail-open) token is found elsewhere in
-                    // the scan.
-                    warn!(
-                        token = %name,
-                        expired = %expired,
-                        "Claude OAuth token is EXPIRED — reporting not authenticated; re-login required"
-                    );
+                    // AI auth is dead unless a fresh (or unknown, fail-open)
+                    // token is found elsewhere in the scan. Logged after the
+                    // loop, once, at WARN or DEBUG depending on whether this
+                    // is a new transition (finding 3b).
+                    expired_tokens.push((name.clone(), expired.clone()));
                     if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&expired) {
                         let is_newer = expired_max.as_ref().map_or(true, |(cur, _)| parsed > *cur);
                         if is_newer {
@@ -232,11 +243,57 @@ impl ProxyManager {
             }
         }
 
-        // The freshest FRESH token wins when one exists; otherwise the most
-        // recently expired one so the UI can say "expired at X".
-        let expires_at = fresh_max
-            .map(|(_, s)| s)
-            .or_else(|| expired_max.map(|(_, s)| s));
+        // #622 post-merge review finding 2: gate the fallback on the
+        // AGGREGATE `authenticated` verdict, not merely on whether a fresh
+        // token happens to exist. Before this, `fresh_max.or_else(expired_max)`
+        // let an EXPIRED token's past timestamp leak through as "validity"
+        // whenever `authenticated` was true ONLY via a fail-open `Unknown`
+        // token (no fresh token at all) — the UI would show "Prihlásenie
+        // platí do <a date in the past>". Authenticated must only ever
+        // surface a FRESH timestamp (`None` when no fresh token backs it);
+        // not-authenticated keeps showing the newest expired timestamp so
+        // the "vypršalo X" banner subtext still works.
+        let expires_at = if authenticated {
+            fresh_max.map(|(_, s)| s)
+        } else {
+            expired_max.map(|(_, s)| s)
+        };
+
+        // #622 post-merge review finding 3b: WARN only on the TRANSITION into
+        // not-authenticated (this scan found expired token(s) and last time
+        // we were authenticated, or this is the very first scan); repeat
+        // scans of an already-known-dead login log at DEBUG instead. A
+        // recovered login resets the tracked state so the NEXT time it dies
+        // we warn again rather than staying silent forever.
+        if authenticated {
+            if let Ok(mut last) = LAST_REPORTED_AUTH.lock() {
+                *last = Some(true);
+            }
+        } else if !expired_tokens.is_empty() {
+            let transitioned = match LAST_REPORTED_AUTH.lock() {
+                Ok(mut last) => {
+                    let changed = *last != Some(false);
+                    *last = Some(false);
+                    changed
+                }
+                Err(_) => true,
+            };
+            for (name, expired) in &expired_tokens {
+                if transitioned {
+                    warn!(
+                        token = %name,
+                        expired = %expired,
+                        "Claude OAuth token is EXPIRED — reporting not authenticated; re-login required"
+                    );
+                } else {
+                    debug!(
+                        token = %name,
+                        expired = %expired,
+                        "Claude OAuth token still expired — not authenticated (already reported)"
+                    );
+                }
+            }
+        }
 
         AuthScan {
             authenticated,

--- a/crates/presenter-server/src/ai/proxy.rs
+++ b/crates/presenter-server/src/ai/proxy.rs
@@ -63,6 +63,16 @@ struct AuthScan {
     expires_at: Option<String>,
 }
 
+/// Accumulated state from walking the auth directory's `claude-*` token
+/// files: whether any token is fresh, the latest-expiring fresh/expired
+/// timestamps seen so far, and every expired token (for the post-scan log).
+struct AuthDirScan {
+    authenticated: bool,
+    fresh_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)>,
+    expired_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)>,
+    expired_tokens: Vec<(String, String)>,
+}
+
 /// State of the managed CLIProxyAPI process.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -179,21 +189,53 @@ impl ProxyManager {
                 };
             }
         }
-        let auth_dir = self.auth_dir();
-        let Ok(mut entries) = tokio::fs::read_dir(&auth_dir).await else {
-            return AuthScan {
-                authenticated: false,
-                expires_at: None,
-            };
+
+        let scan = Self::scan_auth_dir(&self.auth_dir()).await;
+
+        // #622 post-merge review finding 2: gate the fallback on the
+        // AGGREGATE `authenticated` verdict, not merely on whether a fresh
+        // token happens to exist. Before this, `fresh_max.or_else(expired_max)`
+        // let an EXPIRED token's past timestamp leak through as "validity"
+        // whenever `authenticated` was true ONLY via a fail-open `Unknown`
+        // token (no fresh token at all) — the UI would show "Prihlásenie
+        // platí do <a date in the past>". Authenticated must only ever
+        // surface a FRESH timestamp (`None` when no fresh token backs it);
+        // not-authenticated keeps showing the newest expired timestamp so
+        // the "vypršalo X" banner subtext still works.
+        let expires_at = if scan.authenticated {
+            scan.fresh_max.map(|(_, s)| s)
+        } else {
+            scan.expired_max.map(|(_, s)| s)
         };
 
-        let mut authenticated = false;
-        let mut fresh_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
-        let mut expired_max: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
-        // Collected, not logged immediately — the WARN-vs-DEBUG decision
-        // (finding 3b) can only be made once the aggregate `authenticated`
-        // verdict is known, after the loop.
-        let mut expired_tokens: Vec<(String, String)> = Vec::new();
+        Self::report_auth_transition(scan.authenticated, &scan.expired_tokens);
+
+        AuthScan {
+            authenticated: scan.authenticated,
+            expires_at,
+        }
+    }
+
+    /// Walk `auth_dir`, classifying every `claude-*` token file, and
+    /// aggregate the authenticated verdict plus the fresh/expired timestamps
+    /// and expired-token list `scan_claude_auth` needs afterward. A
+    /// non-existent (or unreadable) `auth_dir` yields the same all-`None`,
+    /// not-authenticated result the caller previously got from its own early
+    /// return.
+    async fn scan_auth_dir(auth_dir: &Path) -> AuthDirScan {
+        let mut scan = AuthDirScan {
+            authenticated: false,
+            fresh_max: None,
+            expired_max: None,
+            // Collected, not logged immediately — the WARN-vs-DEBUG decision
+            // (finding 3b) can only be made once the aggregate `authenticated`
+            // verdict is known, after the loop.
+            expired_tokens: Vec::new(),
+        };
+
+        let Ok(mut entries) = tokio::fs::read_dir(auth_dir).await else {
+            return scan;
+        };
 
         while let Ok(Some(entry)) = entries.next_entry().await {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -214,57 +256,51 @@ impl ProxyManager {
             }
             match Self::token_validity(&entry.path()).await {
                 TokenValidity::Fresh { expired } => {
-                    authenticated = true;
+                    scan.authenticated = true;
                     if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&expired) {
-                        let is_newer = fresh_max.as_ref().map_or(true, |(cur, _)| parsed > *cur);
+                        let is_newer = scan
+                            .fresh_max
+                            .as_ref()
+                            .map_or(true, |(cur, _)| parsed > *cur);
                         if is_newer {
-                            fresh_max = Some((parsed, expired));
+                            scan.fresh_max = Some((parsed, expired));
                         }
                     }
                 }
                 TokenValidity::Unknown => {
                     // Unparseable expiry — fail-open, this token counts as valid.
                     warn!(token = %name, "Claude token has no parseable expiry; treating as valid");
-                    authenticated = true;
+                    scan.authenticated = true;
                 }
                 TokenValidity::Expired { expired } => {
                     // AI auth is dead unless a fresh (or unknown, fail-open)
                     // token is found elsewhere in the scan. Logged after the
                     // loop, once, at WARN or DEBUG depending on whether this
                     // is a new transition (finding 3b).
-                    expired_tokens.push((name.clone(), expired.clone()));
+                    scan.expired_tokens.push((name.clone(), expired.clone()));
                     if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(&expired) {
-                        let is_newer = expired_max.as_ref().map_or(true, |(cur, _)| parsed > *cur);
+                        let is_newer = scan
+                            .expired_max
+                            .as_ref()
+                            .map_or(true, |(cur, _)| parsed > *cur);
                         if is_newer {
-                            expired_max = Some((parsed, expired));
+                            scan.expired_max = Some((parsed, expired));
                         }
                     }
                 }
             }
         }
 
-        // #622 post-merge review finding 2: gate the fallback on the
-        // AGGREGATE `authenticated` verdict, not merely on whether a fresh
-        // token happens to exist. Before this, `fresh_max.or_else(expired_max)`
-        // let an EXPIRED token's past timestamp leak through as "validity"
-        // whenever `authenticated` was true ONLY via a fail-open `Unknown`
-        // token (no fresh token at all) — the UI would show "Prihlásenie
-        // platí do <a date in the past>". Authenticated must only ever
-        // surface a FRESH timestamp (`None` when no fresh token backs it);
-        // not-authenticated keeps showing the newest expired timestamp so
-        // the "vypršalo X" banner subtext still works.
-        let expires_at = if authenticated {
-            fresh_max.map(|(_, s)| s)
-        } else {
-            expired_max.map(|(_, s)| s)
-        };
+        scan
+    }
 
-        // #622 post-merge review finding 3b: WARN only on the TRANSITION into
-        // not-authenticated (this scan found expired token(s) and last time
-        // we were authenticated, or this is the very first scan); repeat
-        // scans of an already-known-dead login log at DEBUG instead. A
-        // recovered login resets the tracked state so the NEXT time it dies
-        // we warn again rather than staying silent forever.
+    /// #622 post-merge review finding 3b: WARN only on the TRANSITION into
+    /// not-authenticated (this scan found expired token(s) and last time we
+    /// were authenticated, or this is the very first scan); repeat scans of
+    /// an already-known-dead login log at DEBUG instead. A recovered login
+    /// resets the tracked state so the NEXT time it dies we warn again
+    /// rather than staying silent forever.
+    fn report_auth_transition(authenticated: bool, expired_tokens: &[(String, String)]) {
         if authenticated {
             if let Ok(mut last) = LAST_REPORTED_AUTH.lock() {
                 *last = Some(true);
@@ -278,7 +314,7 @@ impl ProxyManager {
                 }
                 Err(_) => true,
             };
-            for (name, expired) in &expired_tokens {
+            for (name, expired) in expired_tokens {
                 if transitioned {
                     warn!(
                         token = %name,
@@ -293,11 +329,6 @@ impl ProxyManager {
                     );
                 }
             }
-        }
-
-        AuthScan {
-            authenticated,
-            expires_at,
         }
     }
 

--- a/crates/presenter-server/src/ai/proxy.rs
+++ b/crates/presenter-server/src/ai/proxy.rs
@@ -786,4 +786,48 @@ mod tests {
         assert!(status.claude_authenticated);
         assert_eq!(status.token_expires_at, None);
     }
+
+    /// #622 post-merge review finding 2 (RED — expected-red by inspection;
+    /// Tier-0 forbids running `cargo test -p presenter-server` locally, so
+    /// this cannot be executed on this box, only reasoned through the code
+    /// path): `authenticated` becomes `true` here ONLY via the fail-open
+    /// `Unknown` token — there is no fresh token anywhere in the scan. A
+    /// SEPARATE, genuinely expired token also sits in the same auth dir.
+    ///
+    /// Before the fix, `expires_at = fresh_max.or_else(|| expired_max)` — with
+    /// `fresh_max` empty, the EXPIRED token's past timestamp leaks through as
+    /// if it were the validity backing `authenticated: true`, and the UI would
+    /// show "Prihlásenie ku Claude platí do <a date in the past>". The fix
+    /// gates the fallback on `authenticated` itself: authenticated must only
+    /// ever surface a FRESH timestamp, `None` when the only backing evidence
+    /// is an Unknown token.
+    #[tokio::test]
+    async fn status_hides_expired_timestamp_when_authenticated_via_unknown_token_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ProxyManager::new(tmp.path().to_path_buf());
+        let auth_dir = mgr.auth_dir();
+        tokio::fs::create_dir_all(&auth_dir).await.unwrap();
+        // Unparseable expiry — fail-open, makes `authenticated: true` with no
+        // fresh timestamp to back it.
+        tokio::fs::write(
+            auth_dir.join("claude-weird@example.com.json"),
+            r#"{"access_token":"a","type":"claude"}"#,
+        )
+        .await
+        .unwrap();
+        // A SEPARATE, genuinely expired token in the same auth dir.
+        let past = (Utc::now() - Duration::hours(2)).to_rfc3339();
+        write_token(&mgr, "expired@example.com", &past).await;
+
+        let status = mgr.status().await;
+        assert!(
+            status.claude_authenticated,
+            "the Unknown token fail-opens auth"
+        );
+        assert_eq!(
+            status.token_expires_at, None,
+            "authenticated via the Unknown token alone must never surface the OTHER \
+             (unrelated, expired) token's past timestamp as if it were validity"
+        );
+    }
 }

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.223"
+version = "0.4.224"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/ai_login_banner.rs
+++ b/crates/presenter-ui/src/components/ai_login_banner.rs
@@ -7,11 +7,21 @@
 //! an event and were fixed via SSH instead of through the GUI.
 //!
 //! This banner is keyed ONLY on the observable `proxy.claudeAuthenticated`
-//! (there is no `authentication_error` typed error anywhere in the code —
-//! see issue #599 comment recording that design decision). It is ALWAYS
-//! mounted (never conditionally rendered) so E2E tests assert on
-//! `data-visible`, never on element presence — the same discipline as the
-//! toast component.
+//! (no TYPED `authentication_error` exists in the router — `authentication_error`
+//! is only ever a free-text string an UPSTREAM call embeds in its failure
+//! message, named as such in `router/ai.rs`'s `compute_ai_connected` doc
+//! comment; there is nothing to pattern-match on client-side, so the UI keys
+//! on `claudeAuthenticated == false` instead). It is ALWAYS mounted (never
+//! conditionally rendered) so E2E tests assert on `data-visible`, never on
+//! element presence — the same discipline as the toast component.
+//!
+//! `authenticated` is tri-state (`Option<bool>`, #622 post-merge review
+//! finding 1): `None` means "no confirmed answer yet" (first status fetch
+//! still in flight, or the last fetch failed) and must NEVER be treated as
+//! "logged out" — before this, a failed fetch left the caller's plain `bool`
+//! at its initial `false` default forever, painting a false accusation. Only
+//! `Some(false)` — an actual, successful "not authenticated" response — shows
+//! the logged-out content.
 //!
 //! The CTA reuses the EXISTING `proxy_login`/`proxy_complete_login` flow
 //! already wired in `pages/ai.rs` (never duplicated here) — clicking it
@@ -21,30 +31,29 @@
 
 use leptos::prelude::*;
 
-/// Whether the primary logged-out banner should be shown at all.
-pub(crate) fn show_login_banner(authenticated: bool) -> bool {
-    !authenticated
+/// Whether the primary logged-out banner should be shown at all — ONLY on a
+/// CONFIRMED `Some(false)`. `None` (unknown: no answer yet, or the last fetch
+/// failed) must stay hidden — never accuse the operator of being logged out
+/// on a guess (#622 post-merge review finding 1).
+pub(crate) fn show_login_banner(authenticated: Option<bool>) -> bool {
+    authenticated == Some(false)
 }
 
 /// Whether the "still valid, renew soon" note should be shown — only while
-/// authenticated via a token whose expiry is actually known (never for
-/// API-key auth, which carries no expiry at all).
-pub(crate) fn show_validity_note(authenticated: bool, expires_at: Option<&str>) -> bool {
-    authenticated && expires_at.is_some()
+/// CONFIRMED authenticated (`Some(true)`) via a token whose expiry is
+/// actually known (never for API-key auth, which carries no expiry at all,
+/// and never while the auth state is merely unknown).
+pub(crate) fn show_validity_note(authenticated: Option<bool>, expires_at: Option<&str>) -> bool {
+    authenticated == Some(true) && expires_at.is_some()
 }
 
-/// Format an RFC3339 timestamp as `dd.mm.yyyy HH:MM` local time, mirroring
-/// `pages/settings::format_timestamp`. Falls back to the raw string when it
-/// cannot be parsed — never hide the operator-relevant timestamp.
+/// Format an RFC3339 timestamp as `dd.mm.yyyy HH:MM` local time. Thin
+/// wrapper over the shared `utils::timestamp::format_local_timestamp`
+/// (#622 post-merge review finding 10 — this used to duplicate
+/// `pages/settings::format_timestamp`'s parse/format/fallback body wholesale,
+/// differing only in the strftime pattern).
 pub(crate) fn format_expiry(value: &str) -> String {
-    use chrono::{DateTime, Local};
-    match value.parse::<DateTime<chrono::Utc>>() {
-        Ok(dt) => dt
-            .with_timezone(&Local)
-            .format("%d.%m.%Y %H:%M")
-            .to_string(),
-        Err(_) => value.to_string(),
-    }
+    crate::utils::timestamp::format_local_timestamp(value, "%d.%m.%Y %H:%M")
 }
 
 /// Subtext under the CTA — names WHEN the last login died (when known) so
@@ -67,7 +76,7 @@ pub(crate) fn validity_text(expires_at: &str) -> String {
 
 #[component]
 pub fn AiLoginBanner<F>(
-    authenticated: RwSignal<bool>,
+    authenticated: RwSignal<Option<bool>>,
     token_expires_at: RwSignal<Option<String>>,
     on_login: F,
 ) -> impl IntoView
@@ -79,11 +88,18 @@ where
     let validity_visible = move || {
         show_validity_note(authenticated.get(), token_expires_at.get().as_deref()).to_string()
     };
-    let validity = move || {
-        token_expires_at
-            .get()
-            .map(|ts| validity_text(&ts))
-            .unwrap_or_default()
+    // #622 post-merge review finding 8: gate the validity-note TEXT NODE's
+    // render on `show_validity_note` itself, not only on the wrapper's
+    // CSS-hidden `data-visible` attribute — the wrapper div stays always
+    // mounted (E2E asserts `data-visible`, same discipline as the login
+    // banner above), but its text content is never computed while hidden.
+    let validity_content = move || {
+        let expires = token_expires_at.get();
+        if show_validity_note(authenticated.get(), expires.as_deref()) {
+            expires.map(|ts| validity_text(&ts))
+        } else {
+            None
+        }
     };
 
     view! {
@@ -109,7 +125,7 @@ where
                 data-role="ai-token-validity"
                 data-visible=validity_visible
             >
-                {validity}
+                {validity_content}
             </div>
         </div>
     }
@@ -120,16 +136,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn banner_shown_only_when_not_authenticated() {
-        assert!(show_login_banner(false));
-        assert!(!show_login_banner(true));
+    fn banner_shown_only_on_confirmed_not_authenticated() {
+        assert!(show_login_banner(Some(false)));
+        assert!(!show_login_banner(Some(true)));
+    }
+
+    /// #622 post-merge review finding 1: `None` (no confirmed answer yet —
+    /// first fetch still in flight, or the last fetch failed) must NEVER be
+    /// treated as "logged out". Before the fix this state didn't exist —
+    /// callers collapsed it onto `false`, which is exactly the false
+    /// accusation this test guards against.
+    #[test]
+    fn banner_hidden_while_auth_state_is_unknown() {
+        assert!(!show_login_banner(None));
     }
 
     #[test]
-    fn validity_note_needs_both_authenticated_and_a_known_expiry() {
-        assert!(!show_validity_note(false, Some("2026-08-05T10:00:00Z")));
-        assert!(!show_validity_note(true, None));
-        assert!(show_validity_note(true, Some("2026-08-05T10:00:00Z")));
+    fn validity_note_needs_both_confirmed_authenticated_and_a_known_expiry() {
+        assert!(!show_validity_note(
+            Some(false),
+            Some("2026-08-05T10:00:00Z")
+        ));
+        assert!(!show_validity_note(Some(true), None));
+        assert!(show_validity_note(Some(true), Some("2026-08-05T10:00:00Z")));
+    }
+
+    #[test]
+    fn validity_note_hidden_while_auth_state_is_unknown_even_with_a_known_expiry() {
+        assert!(!show_validity_note(None, Some("2026-08-05T10:00:00Z")));
     }
 
     #[test]

--- a/crates/presenter-ui/src/components/ai_status.rs
+++ b/crates/presenter-ui/src/components/ai_status.rs
@@ -86,30 +86,54 @@ pub(crate) fn ai_chip_tooltip(state: &str) -> &'static str {
 pub fn AiStatusChip() -> impl IntoView {
     let status = RwSignal::new(None::<AiStatusResponse>);
     let poll_failures = RwSignal::new(0u32);
+    // #622 post-merge review finding 3(c): an in-flight guard (never start a
+    // new poll while one is still awaiting a response — no pile-up) plus a
+    // monotonic sequence counter (a response that is no longer the LATEST
+    // issued poll can never apply its data — defense in depth if a call ever
+    // races the guard, e.g. a future manual "check now" trigger).
+    let in_flight = RwSignal::new(false);
+    let poll_seq = RwSignal::new(0u64);
 
     let poll = move || {
+        if in_flight.get_untracked() {
+            return;
+        }
+        let seq = poll_seq.get_untracked() + 1;
+        poll_seq.set(seq);
+        in_flight.set(true);
         leptos::task::spawn_local(async move {
-            match check_status().await {
-                Ok(resp) => {
-                    poll_failures.set(0);
-                    status.set(Some(resp));
-                }
-                // One failure is a blip — never swallow the second, but
-                // never scream at the first either (see `STALE_AFTER_FAILURES`).
-                Err(err) => {
-                    let failures = poll_failures.get_untracked() + 1;
-                    poll_failures.set(failures);
-                    if is_stale(failures) {
-                        if !is_stale(failures - 1) {
-                            leptos::logging::warn!(
-                                "AI status poll failed {failures}x in a row — \
-                                 showing the chip as unknown rather than stale: {err}"
-                            );
+            let result = check_status().await;
+            if poll_seq.get_untracked() == seq {
+                match result {
+                    Ok(resp) => {
+                        poll_failures.set(0);
+                        status.set(Some(resp));
+                    }
+                    // One failure is a blip — never swallow the second, but
+                    // never scream at the first either (see `STALE_AFTER_FAILURES`).
+                    Err(err) => {
+                        let failures = poll_failures.get_untracked() + 1;
+                        poll_failures.set(failures);
+                        if is_stale(failures) {
+                            if !is_stale(failures - 1) {
+                                // #622 post-merge review finding 4: this used
+                                // to be `warn!`, which fires a console.warn on
+                                // every genuine 2nd-consecutive-failure — the
+                                // E2E zero-console assertion (rightly) treats
+                                // that as a bug. `log!` (console.log) is not
+                                // collected by the zero-console helper and
+                                // this is still fully visible in devtools.
+                                leptos::logging::log!(
+                                    "AI status poll failed {failures}x in a row — \
+                                     showing the chip as unknown rather than stale: {err}"
+                                );
+                            }
+                            status.set(None);
                         }
-                        status.set(None);
                     }
                 }
             }
+            in_flight.set(false);
         });
     };
     poll();

--- a/crates/presenter-ui/src/pages/ai.rs
+++ b/crates/presenter-ui/src/pages/ai.rs
@@ -50,7 +50,15 @@ pub fn AiPage() -> impl IntoView {
     // Proxy signals
     let proxy_running: RwSignal<bool> = RwSignal::new(false);
     let proxy_binary_found: RwSignal<bool> = RwSignal::new(false);
-    let proxy_authenticated: RwSignal<bool> = RwSignal::new(false);
+    // #622 post-merge review finding 1: tri-state — `None` means "no
+    // confirmed answer yet" (first status fetch still in flight, or the
+    // last fetch failed). Before the fix this was a plain `bool` defaulting
+    // to `false`, and a failed fetch never touched it — the login banner
+    // painted "Nie si prihlásený" before any real response arrived, and
+    // permanently after any single failed poll. Only a SUCCESSFUL fetch may
+    // ever set `Some(true)`/`Some(false)`; every fallible call site resets
+    // to `None` on `Err`.
+    let proxy_authenticated: RwSignal<Option<bool>> = RwSignal::new(None);
     // #599: expiry of the token backing `proxy_authenticated`, when known —
     // surfaced so the operator can renew BEFORE an event instead of only
     // discovering a dead login mid-service.
@@ -71,9 +79,11 @@ pub fn AiPage() -> impl IntoView {
                 connected.set(status.connected);
                 proxy_running.set(status.proxy.running);
                 proxy_binary_found.set(status.proxy.binary_found);
-                proxy_authenticated.set(status.proxy.claude_authenticated);
+                proxy_authenticated.set(Some(status.proxy.claude_authenticated));
                 token_expires_at.set(status.proxy.token_expires_at);
             }
+            // On `Err` `proxy_authenticated` stays at its initial `None` —
+            // unknown, never a guessed "logged out" (finding 1).
             // Restore conversation from server
             if let Ok(conv) = ai_api::get_conversation().await {
                 let restored: Vec<DisplayMessage> = conv
@@ -204,10 +214,15 @@ pub fn AiPage() -> impl IntoView {
                     connected.set(status.connected);
                     proxy_running.set(status.proxy.running);
                     proxy_binary_found.set(status.proxy.binary_found);
-                    proxy_authenticated.set(status.proxy.claude_authenticated);
+                    proxy_authenticated.set(Some(status.proxy.claude_authenticated));
                     token_expires_at.set(status.proxy.token_expires_at);
                 }
-                Err(_) => connected.set(false),
+                Err(_) => {
+                    connected.set(false);
+                    // Finding 1: a failed status fetch means UNKNOWN, never a
+                    // guessed "logged out" — reset, don't leave stale state.
+                    proxy_authenticated.set(None);
+                }
             }
         });
     };
@@ -371,7 +386,11 @@ pub fn AiPage() -> impl IntoView {
                                     {move || if proxy_running.get() { "Running" } else { "Stopped" }}
                                 </span>
                                 <span class="ai-chat__proxy-auth">
-                                    {move || if proxy_authenticated.get() { " | Claude: authenticated" } else { " | Claude: not authenticated" }}
+                                    {move || match proxy_authenticated.get() {
+                                        Some(true) => " | Claude: authenticated",
+                                        Some(false) => " | Claude: not authenticated",
+                                        None => " | Claude: unknown",
+                                    }}
                                 </span>
                                 <div class="ai-chat__proxy-buttons">
                                     <button
@@ -453,7 +472,7 @@ pub fn AiPage() -> impl IntoView {
                                                             match ai_api::proxy_complete_login(&url).await {
                                                                 Ok(status) => {
                                                                     proxy_running.set(status.running);
-                                                                    proxy_authenticated.set(status.claude_authenticated);
+                                                                    proxy_authenticated.set(Some(status.claude_authenticated));
                                                                     token_expires_at.set(status.token_expires_at);
                                                                     login_url.set(None);
                                                                     callback_input.set(String::new());
@@ -609,7 +628,7 @@ async fn send_message_sse(
     tool_progress: RwSignal<Vec<ToolProgress>>,
     error: RwSignal<Option<String>>,
     connected: RwSignal<bool>,
-    proxy_authenticated: RwSignal<bool>,
+    proxy_authenticated: RwSignal<Option<bool>>,
     token_expires_at: RwSignal<Option<String>>,
 ) -> Result<(), String> {
     let window = web_sys::window().ok_or("no window")?;
@@ -708,7 +727,7 @@ fn process_sse_event(
     tool_progress: &RwSignal<Vec<ToolProgress>>,
     error: &RwSignal<Option<String>>,
     connected: RwSignal<bool>,
-    proxy_authenticated: RwSignal<bool>,
+    proxy_authenticated: RwSignal<Option<bool>>,
     token_expires_at: RwSignal<Option<String>>,
 ) {
     let mut event_type = "";
@@ -776,11 +795,39 @@ fn process_sse_event(
             // re-check status so the primary login banner reacts immediately
             // instead of staying stale until the operator reloads or manually
             // checks the status dot.
+            //
+            // `error` is `&RwSignal<..>` (a borrowed reference, unlike the
+            // by-value `connected`/`proxy_authenticated`/`token_expires_at`
+            // params) — `RwSignal` is `Copy`, so dereference to an owned
+            // value the `'static` async block can hold (finding 6).
+            let error = *error;
             leptos::task::spawn_local(async move {
-                if let Ok(status) = ai_api::check_status().await {
-                    connected.set(status.connected);
-                    proxy_authenticated.set(status.proxy.claude_authenticated);
-                    token_expires_at.set(status.proxy.token_expires_at);
+                match ai_api::check_status().await {
+                    Ok(status) => {
+                        connected.set(status.connected);
+                        proxy_authenticated.set(Some(status.proxy.claude_authenticated));
+                        token_expires_at.set(status.proxy.token_expires_at);
+                        // #622 post-merge review finding 6: the recheck used
+                        // to be silent — the operator saw "AI error: ..." with
+                        // no hint that the fix is the already-visible login
+                        // banner above. Once the recheck CONFIRMS the auth is
+                        // dead, say so in the same error line.
+                        if !status.proxy.claude_authenticated {
+                            error.update(|current| {
+                                if let Some(text) = current {
+                                    text.push_str(
+                                        " — prihlásenie ku Claude vypršalo, použi \
+                                         Prihlásiť sa vyššie.",
+                                    );
+                                }
+                            });
+                        }
+                    }
+                    Err(_) => {
+                        // Finding 1: a failed recheck is UNKNOWN, never a
+                        // guessed state either way.
+                        proxy_authenticated.set(None);
+                    }
                 }
             });
         }

--- a/crates/presenter-ui/src/pages/settings/mod.rs
+++ b/crates/presenter-ui/src/pages/settings/mod.rs
@@ -53,16 +53,13 @@ pub(super) fn parse_port_in_range(raw: &str) -> Option<u16> {
 
 /// Format an RFC3339 timestamp string as `dd.mm.yyyy HH:MM:SS` in local time,
 /// matching the old `Intl.DateTimeFormat('sk-SK', …)` output. Returns the raw
-/// string unchanged when it cannot be parsed.
+/// string unchanged when it cannot be parsed. Thin wrapper over the shared
+/// `utils::timestamp::format_local_timestamp` (#622 post-merge review
+/// finding 10 — this used to duplicate
+/// `components::ai_login_banner::format_expiry`'s parse/format/fallback body
+/// wholesale, differing only in the strftime pattern).
 pub(super) fn format_timestamp(value: &str) -> String {
-    use chrono::{DateTime, Local};
-    match value.parse::<DateTime<chrono::Utc>>() {
-        Ok(dt) => dt
-            .with_timezone(&Local)
-            .format("%d.%m.%Y %H:%M:%S")
-            .to_string(),
-        Err(_) => value.to_string(),
-    }
+    crate::utils::timestamp::format_local_timestamp(value, "%d.%m.%Y %H:%M:%S")
 }
 
 pub(super) fn capitalize(s: &str) -> String {

--- a/crates/presenter-ui/src/utils/mod.rs
+++ b/crates/presenter-ui/src/utils/mod.rs
@@ -4,4 +4,5 @@ pub mod keyboard;
 pub mod song_parser;
 pub mod test_helpers;
 pub mod text;
+pub mod timestamp;
 pub mod window;

--- a/crates/presenter-ui/src/utils/timestamp.rs
+++ b/crates/presenter-ui/src/utils/timestamp.rs
@@ -1,0 +1,51 @@
+//! Shared RFC3339 -> local-time timestamp formatting.
+//!
+//! Extracted (#622 post-merge review finding 10) because
+//! `components::ai_login_banner::format_expiry` and
+//! `pages::settings::format_timestamp` had grown the exact same
+//! parse-then-format-then-fall-back-to-raw-string body, differing only in
+//! the `strftime` pattern each caller wants (banner: minutes only; settings:
+//! down to the second). One helper, two callers, two formats.
+
+use chrono::{DateTime, Local};
+
+/// Parse `value` as an RFC3339 timestamp and format it in LOCAL time using
+/// the given `chrono::format::strftime` pattern. Falls back to the raw input
+/// string, unchanged, when it cannot be parsed — callers must never hide an
+/// operator-relevant timestamp just because it came from a source using a
+/// slightly different (or malformed) timestamp convention.
+pub fn format_local_timestamp(value: &str, fmt: &str) -> String {
+    match value.parse::<DateTime<chrono::Utc>>() {
+        Ok(dt) => dt.with_timezone(&Local).format(fmt).to_string(),
+        Err(_) => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_a_valid_rfc3339_timestamp() {
+        let formatted = format_local_timestamp("2026-08-05T10:00:00Z", "%d.%m.%Y %H:%M");
+        assert!(formatted.contains("2026"), "got: {formatted}");
+    }
+
+    #[test]
+    fn different_patterns_produce_different_precision() {
+        let minutes = format_local_timestamp("2026-08-05T10:30:45Z", "%d.%m.%Y %H:%M");
+        let seconds = format_local_timestamp("2026-08-05T10:30:45Z", "%d.%m.%Y %H:%M:%S");
+        assert_ne!(
+            minutes, seconds,
+            "the two callers must keep their own precision"
+        );
+    }
+
+    #[test]
+    fn unparseable_timestamp_falls_back_to_the_raw_string() {
+        assert_eq!(
+            format_local_timestamp("not-a-date", "%d.%m.%Y %H:%M"),
+            "not-a-date"
+        );
+    }
+}

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2888,6 +2888,14 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   font-size: 0.8rem;
 }
 
+/* Wrapper around the login banner + validity note (#622 post-merge review
+   finding 9): THIS is the actual flex item inside `.ai-chat` (display:flex)
+   now that both children are nested one level deeper — flex-shrink on the
+   children themselves is a no-op once they're no longer direct flex items. */
+.ai-chat__login-status {
+  flex-shrink: 0;
+}
+
 /* Primary logged-out banner (#599) — always mounted, toggled via
    data-visible so E2E asserts the attribute rather than element presence. */
 .ai-chat__login-banner {
@@ -2896,7 +2904,6 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   border: 1px solid rgba(239, 68, 68, 0.4);
   border-radius: 8px;
   background: rgba(239, 68, 68, 0.1);
-  flex-shrink: 0;
 }
 
 .ai-chat__login-banner[data-visible="false"] {
@@ -2930,7 +2937,6 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   margin: 0.4rem 1rem 0;
   font-size: 0.75rem;
   color: var(--operator-muted);
-  flex-shrink: 0;
 }
 
 .ai-chat__token-validity[data-visible="false"] {

--- a/deny.toml
+++ b/deny.toml
@@ -44,11 +44,14 @@ ignore = [
     "RUSTSEC-2026-0221",
     # rkyv 0.7.46 insufficient archive validation can cause out-of-bounds
     # reads in archives containing Rc/Arc. Optional dependency of
-    # rust_decimal 1.41.0 (transitive via sea-orm 1.1.20 → sqlx 0.8.6); the
-    # feature that pulls rkyv is never enabled in our dependency graph —
-    # `cargo tree -i rkyv` prints nothing, so the code is never compiled. No
-    # upgrade path until sea-orm/sqlx move off rust_decimal 1.41.0 (fix
-    # requires rkyv >=0.8.17). Keep in sync with .cargo/audit.toml.
+    # rust_decimal 1.41.0, which sea-orm 1.1.20 depends on DIRECTLY (#622
+    # post-merge review finding 12 — this used to say "transitive via sea-orm
+    # → sqlx", which is wrong: sqlx 0.8.6 also depends on rust_decimal
+    # directly and independently, there is no sea-orm→sqlx→rust_decimal
+    # chain). The feature that pulls rkyv is never enabled in our dependency
+    # graph — `cargo tree -i rkyv` prints nothing, so the code is never
+    # compiled. No upgrade path until sea-orm/sqlx move off rust_decimal
+    # 1.41.0 (fix requires rkyv >=0.8.17). Keep in sync with .cargo/audit.toml.
     # https://rustsec.org/advisories/RUSTSEC-2026-0235
     "RUSTSEC-2026-0235",
 ]

--- a/tests/e2e/ai-login-visibility.spec.ts
+++ b/tests/e2e/ai-login-visibility.spec.ts
@@ -75,6 +75,33 @@ async function gotoAiPanel(page: Page) {
   );
 }
 
+test("an unresolved status check never shows the banner as a false accusation", async ({
+  page,
+}) => {
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  // Malformed 200 body — same technique `ai-status-chip.spec.ts` uses to
+  // exercise a failed status fetch without the browser's own non-2xx
+  // console noise. `check_status()` resolves `Err`, and never resolves
+  // `Ok`, for the lifetime of this test.
+  await page.route("**/ai/status", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "not-json" });
+  });
+
+  await gotoAiPanel(page);
+
+  // #622 post-merge review finding 1: before the fix, `proxy_authenticated`
+  // defaulted to `false` and a failed fetch never touched it, so the banner
+  // painted "Nie si prihlásený" before any real response ever arrived (and
+  // would stay that way forever). The real state here is UNKNOWN — the
+  // banner must stay hidden, not accuse the operator of being logged out.
+  const banner = page.locator('[data-role="ai-login-banner"]');
+  await page.waitForTimeout(2_000);
+  await expect(banner).toHaveAttribute("data-visible", "false");
+
+  expect(consoleMessages).toEqual([]);
+});
+
 test("logged out shows the primary login banner with a visible CTA", async ({
   page,
 }) => {
@@ -158,6 +185,73 @@ test("an expired token is named in the logged-out banner's subtext", async ({
   // logged out, even though we DO know an expiry.
   const validity = page.locator('[data-role="ai-token-validity"]');
   await expect(validity).toHaveAttribute("data-visible", "false");
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("clicking the CTA starts the existing Claude login flow", async ({
+  page,
+}) => {
+  // #622 post-merge review finding 7: the CTA reuses `pages/ai.rs`'s
+  // existing `proxy_login()` flow (never a duplicate) — prove the click
+  // actually fires POST /ai/proxy/login, the same request the settings-drawer
+  // "Claude Login" button uses.
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { claudeAuthenticated: false });
+
+  let loginRequested = false;
+  await page.route("**/ai/proxy/login", async (route) => {
+    loginRequested = true;
+    await route.fulfill({
+      json: { loginUrl: "https://claude.ai/oauth/authorize?fake=1" },
+    });
+  });
+
+  await gotoAiPanel(page);
+
+  const cta = page.locator('[data-role="ai-login-cta"]');
+  await expect(cta).toBeVisible();
+  await cta.click();
+
+  await expect.poll(() => loginRequested).toBe(true);
+
+  expect(consoleMessages).toEqual([]);
+});
+
+test("a chat auth error points the operator at the visible login banner", async ({
+  page,
+}) => {
+  // #622 post-merge review finding 6: before the fix, a chat-time auth
+  // failure only re-checked `/ai/status` silently — the displayed error text
+  // never told the operator WHERE to go. Mock an SSE "error" event from
+  // /ai/chat while /ai/status reports logged-out, and assert the error text
+  // carries the login hint (banner is already visible from the status mock).
+  const consoleMessages: string[] = [];
+  attachConsoleErrorCollector(page, consoleMessages);
+  await mockAiStatus(page, { claudeAuthenticated: false });
+
+  await page.route("**/ai/chat", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: 'event: error\ndata: {"message":"authentication_error"}\n\n',
+    });
+  });
+
+  await gotoAiPanel(page);
+
+  const banner = page.locator('[data-role="ai-login-banner"]');
+  await expect(banner).toHaveAttribute("data-visible", "true", { timeout: 30_000 });
+
+  const textarea = page.locator('[data-role="ai-input"]');
+  await textarea.fill("ahoj");
+  await page.locator('[data-role="ai-send"]').click();
+
+  const error = page.locator('[data-role="ai-error"]');
+  await expect(error).toBeVisible({ timeout: 15_000 });
+  await expect(error).toContainText("authentication_error");
+  await expect(error).toContainText(/prihlásenie ku Claude vypršalo/);
 
   expect(consoleMessages).toEqual([]);
 });

--- a/tests/e2e/ai-status-chip.spec.ts
+++ b/tests/e2e/ai-status-chip.spec.ts
@@ -170,6 +170,16 @@ test("a failed poll shows the neutral checking state, never a false failure clai
   const consoleMessages: string[] = [];
   attachConsoleErrorCollector(page, consoleMessages);
 
+  // #622 post-merge review finding 4: the ORIGINAL version of this test
+  // mocked a failure from the very first load and asserted "checking" — the
+  // chip's INITIAL state before any response ever arrives, so the assertion
+  // was trivially true even if the poll's `Err` arm were deleted entirely.
+  // This version proves an actual OK -> checking TRANSITION caused by real
+  // poll failures: start authenticated (chip reaches "ok"), then break the
+  // route and wait for >=2 poll ticks (5s interval, STALE_AFTER_FAILURES=2)
+  // so the chip is FORCED to fall back to "checking" — a regression that
+  // deletes the `Err` arm leaves the chip stuck on "ok" and fails this.
+  //
   // A non-2xx status here would be closer to a "real" failure, but Chrome
   // itself logs a "Failed to load resource: the server responded with a
   // status of 500" console error for ANY non-2xx fetch response — that is
@@ -181,15 +191,22 @@ test("a failed poll shows the neutral checking state, never a false failure clai
   // returns `Err(ApiError::Deserialize(..))`, handled identically to
   // `ApiError::Status` by `ai_status.rs`'s `poll` closure — via a pure
   // Rust-side `serde_json::from_str` parse error, with a clean console.
-  await page.route("**/ai/status", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: "not-json" });
-  });
+  await mockAiStatus(page, { running: true, binaryFound: true, claudeAuthenticated: true });
 
   await page.goto(new URL("/ui/operator", baseURL).toString());
   await page.waitForLoadState("networkidle");
 
   const chip = page.locator('[data-role="ai-status-chip"]');
-  await expect(chip).toHaveAttribute("data-state", "checking", { timeout: 30_000 });
+  await expect(chip).toHaveAttribute("data-state", "ok", { timeout: 30_000 });
+
+  await page.unroute("**/ai/status");
+  await page.route("**/ai/status", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "not-json" });
+  });
+
+  // AI_STATUS_REFRESH_MS = 5_000, STALE_AFTER_FAILURES = 2 — two consecutive
+  // failed ticks land at ~10s; wait well past that for the transition.
+  await expect(chip).toHaveAttribute("data-state", "checking", { timeout: 20_000 });
   await expect(chip).toHaveText("AI: kontrolujem…");
 
   expect(consoleMessages).toEqual([]);

--- a/tests/e2e/wasm-ai-chat.spec.ts
+++ b/tests/e2e/wasm-ai-chat.spec.ts
@@ -357,6 +357,15 @@ test.describe("AI Chat Connection Status", () => {
     expect(data).toHaveProperty("proxy");
     expect(data.proxy).toHaveProperty("running");
     expect(data.proxy).toHaveProperty("binaryFound");
+    // #622 post-merge review finding 5: #599 added `tokenExpiresAt` to
+    // `ProxyStatus` (no `skip_serializing_if`, so the key is always present,
+    // `null` when unknown) but no test ever proved it at the REAL HTTP
+    // boundary — only via mocked `/ai/status` responses in other specs. This
+    // is coverage-closing, not a regression guard: it already passes against
+    // current server code (the field has shipped since #622), and stays
+    // green as long as nobody adds a `skip_serializing_if` that would hide
+    // the key when the server has no known expiry.
+    expect(data.proxy).toHaveProperty("tokenExpiresAt");
   });
 });
 


### PR DESCRIPTION
Post-merge review of PR #622 (AI status chip + login banner, #598/#599) surfaced 1 🔴 + 6 🟡 + 5 🔵 findings. This PR ships all 12 fixes plus the version bump and a playbook lesson.

## Fixes (RED c8dae800 → GREEN 41549a4e)

- 🔴 Login banner no longer falsely accuses "logged out" before first status response or after a failed fetch — auth is a tri-state (`Option<bool>`), banner renders only on `Some(false)`
- 🟡 `token_expires_at` derived only from fresh tokens while authenticated; Unknown/Expired → `None` (no stale "valid until <past date>")
- 🟡 Shared `reqwest` client (OnceLock) with 3 s timeout instead of per-call construction
- 🟡 Status poll: in-flight guard + sequence counter (no out-of-order overwrites)
- 🟡 WARN only on auth-state transition (no per-tick log spam)
- 🟡 Poll-failure E2E rewritten to assert the real ok→checking transition after 2 failed ticks
- 🟡 Chat auth-error hint + CTA click covered by E2E
- 🔵 `wasm-ai-chat.spec.ts` asserts real endpoint `tokenExpiresAt` key; shared timestamp format helper (`utils/timestamp.rs`); `.ai-chat__login-status` CSS wrapper; deny/audit.toml wording fix; `warn!`→`log!` for expected states

## Also

- `b3cf1e38` — refactor: `scan_claude_auth` split below the 120-line fn cap (QC hard gate)
- `0476d6af` — version bump 0.4.223 → 0.4.224
- `ce905752` — playbook: never mock a non-2xx response in a zero-console spec (#598 lesson)

Pipeline green on head (run 31035392862) incl. E2E + deploy-dev; dev serves v0.4.224.
