### PR TITLE
fix(sync/search): tombstone integrity batch — #634 data-loss, #636 restore/rename, #635 search leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.224"
+version = "0.4.225"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.224"
+version = "0.4.225"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/library_sync.rs
+++ b/crates/presenter-persistence/src/repository/library_sync.rs
@@ -69,7 +69,19 @@ impl Repository {
                 txn.commit().await?;
                 return Ok(SyncApplyOutcome::SkippedNotNewer);
             }
-            Self::write_library_row(&txn, &existing.id, incoming).await?;
+            // #636: a rename (this write leaves the row LIVE) can target a
+            // name a DIFFERENT live local library already owns —
+            // `idx_libraries_name_live_unique` would otherwise reject the
+            // UPDATE outright, and the caller (`reconcile_libraries`) only
+            // warn!ed and dropped it, forever, every cycle. A tombstone
+            // write is never at risk (the partial index only guards LIVE
+            // rows), so it always writes `incoming.name` verbatim.
+            let write_name = if incoming.deleted_at.is_none() {
+                Self::resolve_conflict_free_name(&txn, &incoming.name, &existing.id).await?
+            } else {
+                incoming.name.clone()
+            };
+            Self::write_library_row(&txn, &existing.id, incoming, &write_name).await?;
             txn.commit().await?;
             info!("sync library updated");
             return Ok(SyncApplyOutcome::Updated);
@@ -91,7 +103,9 @@ impl Repository {
                     txn.commit().await?;
                     return Ok(SyncApplyOutcome::SkippedNotNewer);
                 }
-                Self::write_library_row(&txn, &existing.id, incoming).await?;
+                // `existing` was found BY this exact name (`find_live_library_by_name`),
+                // so writing `incoming.name` verbatim can never newly collide.
+                Self::write_library_row(&txn, &existing.id, incoming, &incoming.name).await?;
                 txn.commit().await?;
                 info!("sync library adopted-by-name");
                 return Ok(SyncApplyOutcome::AdoptedByName);
@@ -142,10 +156,16 @@ impl Repository {
     /// (adopt), deleted_at, and the PEER's `updated_at` (never `now()` — an
     /// applied change is not a new local edit, which is what prevents an
     /// echo/ping-pong loop).
+    ///
+    /// `write_name` (#636) is the name actually WRITTEN to `Name`/`SearchName`
+    /// — usually `incoming.name` verbatim, but the rename call site passes an
+    /// already-disambiguated name (`resolve_conflict_free_name`) when
+    /// `incoming.name` collides with a DIFFERENT live library.
     async fn write_library_row(
         txn: &DatabaseTransaction,
         local_id: &str,
         incoming: &SyncLibraryManifestRow,
+        write_name: &str,
     ) -> anyhow::Result<()> {
         use library::Column;
         let deleted = incoming
@@ -153,8 +173,8 @@ impl Repository {
             .map(|d| Expr::value(d.to_rfc3339()))
             .unwrap_or_else(|| Expr::value(Option::<String>::None));
         library::Entity::update_many()
-            .col_expr(Column::Name, Expr::value(incoming.name.clone()))
-            .col_expr(Column::SearchName, Expr::value(fold_query(&incoming.name)))
+            .col_expr(Column::Name, Expr::value(write_name.to_string()))
+            .col_expr(Column::SearchName, Expr::value(fold_query(write_name)))
             .col_expr(Column::SyncId, Expr::value(incoming.sync_id.clone()))
             .col_expr(
                 Column::UpdatedAt,
@@ -165,6 +185,43 @@ impl Repository {
             .exec(txn)
             .await?;
         Ok(())
+    }
+
+    /// Resolve a name that is safe to write LIVE for `exclude_id` — i.e. one
+    /// no OTHER live library already owns (#636). Returns `desired` unchanged
+    /// when it's free; otherwise appends `" (2)"`, `" (3)"`, … until a free
+    /// name is found. This is what lets a peer rename that collides with a
+    /// DIFFERENT, already-known local identity always SUCCEED (both
+    /// libraries survive, live, under distinct names) instead of throwing a
+    /// `idx_libraries_name_live_unique` violation that used to be caught and
+    /// silently dropped forever by `reconcile_libraries`.
+    async fn resolve_conflict_free_name(
+        txn: &DatabaseTransaction,
+        desired: &str,
+        exclude_id: &str,
+    ) -> anyhow::Result<String> {
+        use sea_orm::QuerySelect;
+        let taken: std::collections::HashSet<String> = library::Entity::find()
+            .filter(library::Column::DeletedAt.is_null())
+            .filter(library::Column::Id.ne(exclude_id.to_string()))
+            .select_only()
+            .column(library::Column::Name)
+            .into_tuple()
+            .all(txn)
+            .await?
+            .into_iter()
+            .collect();
+        if !taken.contains(desired) {
+            return Ok(desired.to_string());
+        }
+        let mut suffix = 2u32;
+        loop {
+            let candidate = format!("{desired} ({suffix})");
+            if !taken.contains(&candidate) {
+                return Ok(candidate);
+            }
+            suffix += 1;
+        }
     }
 
     /// Hard-delete libraries tombstoned longer than `retain`. The FK

--- a/crates/presenter-persistence/src/repository/library_sync_tests.rs
+++ b/crates/presenter-persistence/src/repository/library_sync_tests.rs
@@ -117,7 +117,10 @@ async fn rename_by_sync_id_disambiguates_instead_of_colliding_with_a_different_l
         .await
         .unwrap()
         .unwrap();
-    assert!(foo_row.deleted_at.is_none(), "the renamed library stays live");
+    assert!(
+        foo_row.deleted_at.is_none(),
+        "the renamed library stays live"
+    );
     assert_ne!(
         foo_row.name, "Bar",
         "the colliding name must be disambiguated, never written verbatim \

--- a/crates/presenter-persistence/src/repository/library_sync_tests.rs
+++ b/crates/presenter-persistence/src/repository/library_sync_tests.rs
@@ -80,6 +80,57 @@ async fn rename_in_place_by_sync_id_preserves_id_and_presentations() {
 }
 
 #[tokio::test]
+async fn rename_by_sync_id_disambiguates_instead_of_colliding_with_a_different_live_library() {
+    // #636 regression: a peer rename applying via `write_library_row`'s
+    // `update_many` wrote `incoming.name` unconditionally. If a DIFFERENT
+    // live local library already owns that name, the UPDATE throws a
+    // unique-constraint violation on `idx_libraries_name_live_unique`; before
+    // the fix, `reconcile_libraries` (state/sync.rs) caught this and only
+    // `warn!`ed -- every future cycle repeated the identical failure forever,
+    // so the two peers never converged on this library's rename at all.
+    let repo = repo().await;
+
+    // A pre-existing, DIFFERENT live library already named "Bar".
+    repo.create_library("Bar").await.unwrap();
+
+    // A separate identity "Foo" the peer is renaming to "Bar" too.
+    let foo = repo.create_library("Foo").await.unwrap();
+    let foo_sid = library_row_by_name(&repo, "Foo").await.sync_id;
+
+    let outcome = repo
+        .apply_sync_library(&incoming(&foo_sid, "Bar", 1, false))
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome,
+        SyncApplyOutcome::Updated,
+        "the rename must apply -- never silently fail with a swallowed DB error"
+    );
+
+    // Both libraries survive, live, under DISTINCT names -- no data loss, no
+    // permanent silent-failure loop.
+    let libs = repo.fetch_libraries().await.unwrap();
+    assert_eq!(libs.len(), 2, "both libraries still exist, live");
+
+    let foo_row = library::Entity::find_by_id(foo.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(foo_row.deleted_at.is_none(), "the renamed library stays live");
+    assert_ne!(
+        foo_row.name, "Bar",
+        "the colliding name must be disambiguated, never written verbatim \
+         over an existing live library's name"
+    );
+    assert!(
+        foo_row.name.starts_with("Bar"),
+        "the disambiguated name is still recognizably based on 'Bar', got: {}",
+        foo_row.name
+    );
+}
+
+#[tokio::test]
 async fn tombstone_by_sync_id_hides_the_library() {
     let repo = repo().await;
     let lib = repo.create_library("Songs").await.unwrap();

--- a/crates/presenter-persistence/src/repository/search.rs
+++ b/crates/presenter-persistence/src/repository/search.rs
@@ -188,9 +188,14 @@ impl Repository {
             .await?;
 
         for (presentation_model, library_model_opt) in presentation_rows {
+            // #635: a tombstoned (soft-deleted) parent library must hide its
+            // presentations from search exactly like a trashed presentation
+            // hides itself — `library_model_opt` being `None` (library row
+            // gone entirely) was already excluded; a LIVE `Option` wrapping
+            // a TOMBSTONED row was not.
             let library_model = match library_model_opt {
-                Some(model) => model,
-                None => continue,
+                Some(model) if model.deleted_at.is_none() => model,
+                _ => continue,
             };
             if !ctx
                 .seen_presentation_ids
@@ -333,6 +338,33 @@ impl Repository {
             .all(&self.db)
             .await?;
 
+        let (pending, missing_library_ids) = Self::collect_pending_slides(ctx, slide_rows);
+        if !missing_library_ids.is_empty() {
+            self.backfill_live_library_names(ctx, missing_library_ids)
+                .await?;
+        }
+
+        for (slide_model, presentation_model) in pending {
+            if ctx.is_full() {
+                break;
+            }
+            Self::emit_slide_result(ctx, slide_model, presentation_model)?;
+        }
+
+        Ok(())
+    }
+
+    /// First pass over the raw slide-join rows: dedupe by slide id, drop rows
+    /// whose presentation vanished (`find_also_related` returned `None`), and
+    /// collect which library ids `ctx.library_names` doesn't know about yet
+    /// (extracted per the #558 round-3 function-length gate; #635 split).
+    fn collect_pending_slides(
+        ctx: &mut SearchContext,
+        slide_rows: Vec<(slide_entity::Model, Option<presentation_entity::Model>)>,
+    ) -> (
+        Vec<(slide_entity::Model, presentation_entity::Model)>,
+        HashSet<String>,
+    ) {
         let mut pending = Vec::new();
         let mut missing_library_ids: HashSet<String> = HashSet::new();
 
@@ -352,81 +384,104 @@ impl Repository {
             }
             pending.push((slide_model, presentation_model));
         }
+        (pending, missing_library_ids)
+    }
 
-        if !missing_library_ids.is_empty() {
-            let ids: Vec<String> = missing_library_ids.into_iter().collect();
-            let missing = library::Entity::find()
-                .filter(library::Column::Id.is_in(ids))
-                .all(&self.db)
-                .await?;
-            for model in missing {
+    /// Fetch and cache the names of libraries `ctx.library_names` doesn't
+    /// know about yet. #635: a TOMBSTONED library is deliberately NOT
+    /// inserted — `ctx.library_names` only ever holds LIVE libraries (every
+    /// phase enforces that invariant), and `emit_slide_result` skips any
+    /// presentation whose library has no entry here instead of falling back
+    /// to a blank name.
+    async fn backfill_live_library_names(
+        &self,
+        ctx: &mut SearchContext,
+        missing_library_ids: HashSet<String>,
+    ) -> anyhow::Result<()> {
+        let ids: Vec<String> = missing_library_ids.into_iter().collect();
+        let missing = library::Entity::find()
+            .filter(library::Column::Id.is_in(ids))
+            .all(&self.db)
+            .await?;
+        for model in missing {
+            if model.deleted_at.is_none() {
                 ctx.library_names
                     .insert(model.id.clone(), model.name.clone());
             }
         }
+        Ok(())
+    }
 
-        for (slide_model, presentation_model) in pending {
-            if ctx.is_full() {
-                break;
+    /// Classify + push ONE slide-text match into `ctx.results`, or skip it
+    /// silently (no library name known — tombstoned/missing library, #635;
+    /// token mismatch; or already emitted by `search_presentations`).
+    /// Extracted per the #558 round-3 function-length gate; #635 split.
+    fn emit_slide_result(
+        ctx: &mut SearchContext,
+        slide_model: slide_entity::Model,
+        presentation_model: presentation_entity::Model,
+    ) -> anyhow::Result<()> {
+        // #635: no entry means the library is tombstoned (or otherwise
+        // missing) — never fall back to a blank name, skip the slide
+        // entirely, exactly like a trashed presentation is skipped.
+        let Some(library_name) = ctx
+            .library_names
+            .get(&presentation_model.library_id)
+            .cloned()
+        else {
+            return Ok(());
+        };
+        let library_id = LibraryId::from_uuid(parse_uuid(&presentation_model.library_id)?);
+        let presentation_id = PresentationId::from_uuid(parse_uuid(&presentation_model.id)?);
+
+        // Worship slide text fields (bible slides live in a separate table).
+        let eff_main = slide_model.worship_main.as_str();
+        let eff_main_search = slide_model.worship_main_search.as_str();
+        let eff_translation = slide_model.worship_translate.as_str();
+        let eff_translation_search = slide_model.worship_translate_search.as_str();
+        let eff_stage = slide_model.worship_stage.as_str();
+        let eff_stage_search = slide_model.worship_stage_search.as_str();
+
+        if ctx.has_tokens {
+            let combined = fold_query(&format!(
+                "{} {} {} {} {}",
+                library_name, presentation_model.name, eff_main, eff_translation, eff_stage
+            ));
+            if !ctx.tokens.iter().all(|token| combined.contains(token)) {
+                return Ok(());
             }
-            let library_name = ctx
-                .library_names
-                .get(&presentation_model.library_id)
-                .cloned()
-                .unwrap_or_default();
-            let library_id = LibraryId::from_uuid(parse_uuid(&presentation_model.library_id)?);
-            let presentation_id = PresentationId::from_uuid(parse_uuid(&presentation_model.id)?);
-
-            // Worship slide text fields (bible slides live in a separate table).
-            let eff_main = slide_model.worship_main.as_str();
-            let eff_main_search = slide_model.worship_main_search.as_str();
-            let eff_translation = slide_model.worship_translate.as_str();
-            let eff_translation_search = slide_model.worship_translate_search.as_str();
-            let eff_stage = slide_model.worship_stage.as_str();
-            let eff_stage_search = slide_model.worship_stage_search.as_str();
-
-            if ctx.has_tokens {
-                let combined = fold_query(&format!(
-                    "{} {} {} {} {}",
-                    library_name, presentation_model.name, eff_main, eff_translation, eff_stage
-                ));
-                if !ctx.tokens.iter().all(|token| combined.contains(token)) {
-                    continue;
-                }
-            }
-
-            // Dedupe: a presentation already emitted by search_presentations
-            // (matched by name) must not be re-emitted from the slide-text
-            // phase. The insert returns false if the id was already present.
-            if !ctx
-                .seen_presentation_ids
-                .insert(presentation_model.id.clone())
-            {
-                continue;
-            }
-
-            let match_field = Self::classify_slide_match(
-                ctx,
-                eff_main,
-                eff_main_search,
-                eff_translation,
-                eff_translation_search,
-                eff_stage,
-                eff_stage_search,
-            );
-
-            ctx.results.push(SearchResult {
-                kind: SearchResultKind::Presentation,
-                library_id,
-                library_name: library_name.clone(),
-                presentation_id: Some(presentation_id),
-                presentation_name: Some(presentation_model.name.clone()),
-                slide_id: None,
-                match_field,
-                snippet: None,
-            });
         }
 
+        // Dedupe: a presentation already emitted by search_presentations
+        // (matched by name) must not be re-emitted from the slide-text
+        // phase. The insert returns false if the id was already present.
+        if !ctx
+            .seen_presentation_ids
+            .insert(presentation_model.id.clone())
+        {
+            return Ok(());
+        }
+
+        let match_field = Self::classify_slide_match(
+            ctx,
+            eff_main,
+            eff_main_search,
+            eff_translation,
+            eff_translation_search,
+            eff_stage,
+            eff_stage_search,
+        );
+
+        ctx.results.push(SearchResult {
+            kind: SearchResultKind::Presentation,
+            library_id,
+            library_name,
+            presentation_id: Some(presentation_id),
+            presentation_name: Some(presentation_model.name.clone()),
+            slide_id: None,
+            match_field,
+            snippet: None,
+        });
         Ok(())
     }
 }

--- a/crates/presenter-persistence/src/repository/search_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/search_trash_tests.rs
@@ -91,3 +91,89 @@ async fn trashed_library_is_not_searchable_by_name() {
         "a tombstoned library must never surface in search results, got: {after:?}"
     );
 }
+
+#[tokio::test]
+async fn presentation_under_a_tombstoned_library_is_not_searchable() {
+    // #635: `search_presentations` filtered the PRESENTATION's own
+    // `deleted_at` but never checked whether its PARENT LIBRARY was
+    // tombstoned; `search_slides` had the same gap on the slide-TEXT phase
+    // (and even fell back to a BLANK library name via `unwrap_or_default()`
+    // instead of skipping). A presentation can end up live under a
+    // tombstoned library through the sync-apply race #634 fixes (or any
+    // other bug) -- search must exclude it defensively regardless of how the
+    // inconsistent state arose, so this seeds it directly by tombstoning
+    // ONLY the library (never through `delete_library`, which would also
+    // tombstone the presentation and mask this exact gap).
+    let repo = repo().await;
+    let slide = Slide::new(
+        0,
+        SlideContent::new(
+            SlideText::new("A very distinctive lyric line two").unwrap(),
+            SlideText::new("").unwrap(),
+            SlideText::new("").unwrap(),
+            None,
+        ),
+    );
+    let presentation = Presentation::new("Orphaned Under Dead Library", vec![slide]).unwrap();
+    let library = Library::new("WillBeTombstonedOnly", vec![presentation]).unwrap();
+    let library_id = library.id;
+    repo.upsert_library(&library).await.unwrap();
+
+    // Sanity: searchable while the library is live, both by name and by
+    // slide text.
+    let before_name = repo
+        .search_presenter("Orphaned Under Dead Library", 10)
+        .await
+        .unwrap();
+    assert!(
+        before_name
+            .iter()
+            .any(|r| matches!(r.kind, SearchResultKind::Presentation)),
+        "sanity: the live presentation must be searchable by name"
+    );
+    let before_text = repo
+        .search_presenter("distinctive lyric line two", 10)
+        .await
+        .unwrap();
+    assert!(
+        before_text
+            .iter()
+            .any(|r| matches!(r.kind, SearchResultKind::Presentation)),
+        "sanity: the live presentation's lyrics must be searchable"
+    );
+
+    // Tombstone ONLY the library row directly -- the presentation underneath
+    // stays LIVE, reproducing the inconsistent state search must defend
+    // against regardless of its origin.
+    use crate::entities::library as library_entity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    library_entity::Entity::update_many()
+        .col_expr(
+            library_entity::Column::DeletedAt,
+            sea_orm::sea_query::Expr::value(chrono::Utc::now().to_rfc3339()),
+        )
+        .filter(library_entity::Column::Id.eq(library_id.to_string()))
+        .exec(&repo.db)
+        .await
+        .unwrap();
+
+    let after_name = repo
+        .search_presenter("Orphaned Under Dead Library", 10)
+        .await
+        .unwrap();
+    assert!(
+        after_name.is_empty(),
+        "a presentation under a tombstoned library must not surface by name, \
+         got: {after_name:?}"
+    );
+
+    let after_text = repo
+        .search_presenter("distinctive lyric line two", 10)
+        .await
+        .unwrap();
+    assert!(
+        after_text.is_empty(),
+        "a presentation under a tombstoned library must not surface by \
+         slide text, got: {after_text:?}"
+    );
+}

--- a/crates/presenter-persistence/src/repository/sync.rs
+++ b/crates/presenter-persistence/src/repository/sync.rs
@@ -146,6 +146,31 @@ impl Repository {
         presentation_id: presenter_core::PresentationId,
     ) -> anyhow::Result<()> {
         use presentation_entity::Column;
+        let existing = presentation_entity::Entity::find()
+            .filter(Column::Id.eq(presentation_id.to_string()))
+            .filter(Column::DeletedAt.is_not_null())
+            .one(&self.db)
+            .await?
+            .ok_or(RepositoryError::NotFound("no trashed presentation to restore"))?;
+
+        // #636: a restore that leaves the song under a STILL-tombstoned
+        // library accomplishes nothing durable -- the library's own
+        // deleted_at hides it from fetch_libraries, so the "restored" song
+        // stays unreachable, and it is now LIVE, so the next
+        // prune_deleted_libraries CASCADE hard-deletes it (worse than
+        // leaving it in the trash). Refuse cleanly instead of performing a
+        // mutation that helps nobody; no partial state change.
+        let library_tombstoned = library::Entity::find_by_id(existing.library_id.clone())
+            .one(&self.db)
+            .await?
+            .is_none_or(|lib| lib.deleted_at.is_some());
+        if library_tombstoned {
+            return Err(RepositoryError::Conflict(
+                "the presentation's library is still trashed — restore the library first",
+            )
+            .into());
+        }
+
         let now = Utc::now().to_rfc3339();
         let result = presentation_entity::Entity::update_many()
             .col_expr(Column::DeletedAt, Expr::value(Option::<String>::None))

--- a/crates/presenter-persistence/src/repository/sync.rs
+++ b/crates/presenter-persistence/src/repository/sync.rs
@@ -151,7 +151,9 @@ impl Repository {
             .filter(Column::DeletedAt.is_not_null())
             .one(&self.db)
             .await?
-            .ok_or(RepositoryError::NotFound("no trashed presentation to restore"))?;
+            .ok_or(RepositoryError::NotFound(
+                "no trashed presentation to restore",
+            ))?;
 
         // #636: a restore that leaves the song under a STILL-tombstoned
         // library accomplishes nothing durable -- the library's own

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -127,12 +127,19 @@ impl Repository {
             // runs first), so `ensure_library`'s live-only lookup would miss
             // it and create a fresh EMPTY LIVE library shell to hold the
             // tombstone. Only a LIVE apply (re)attaches to the peer's library.
-            let library_id = if incoming.deleted_at.is_some() {
-                existing.library_id.clone()
+            //
+            // #634: `ensure_library`'s second return value is `Some(ts)` when
+            // the target library stayed tombstoned (LWW decided NOT to
+            // revive it) — in that case THIS presentation must be written as
+            // tombstoned too, never left live under a dead parent (see
+            // `write_synced_row`'s `forced_delete` param).
+            let (library_id, forced_delete) = if incoming.deleted_at.is_some() {
+                (existing.library_id.clone(), None)
             } else {
                 Self::ensure_library(&txn, &incoming.library_name, incoming.updated_at).await?
             };
-            Self::write_synced_row(&txn, &existing.id, &library_id, incoming).await?;
+            Self::write_synced_row(&txn, &existing.id, &library_id, incoming, forced_delete)
+                .await?;
             txn.commit().await?;
             info!("sync updated");
             let id =
@@ -319,13 +326,28 @@ impl Repository {
     /// never changes, and reviving it never revives any presentation
     /// tombstoned under it (those carry their own tombstones with their own
     /// `updated_at` and settle by their own LWW).
+    ///
+    /// #634: returns `(library_id, forced_tombstone_at)`. `forced_tombstone_at`
+    /// is `Some(ts)` ONLY when the resolved library stayed tombstoned (the
+    /// LWW check above did NOT revive it) — the caller MUST then write the
+    /// presentation attaching here as tombstoned too, at `ts`, instead of
+    /// leaving it LIVE under a dead parent (a live row under a tombstoned
+    /// library was invisible — excluded from `fetch_libraries` — AND doomed
+    /// by the next `prune_deleted_libraries` CASCADE, with zero prior trace
+    /// it ever existed; real data loss, fixed here). `ts` is the LATER of
+    /// the two clocks (`presentation_updated_at.max(library_updated)`) so
+    /// the row's own clock only ever advances, letting a later sync cycle
+    /// still converge the peer onto the same tombstone once it too learns of
+    /// the deletion. `None` in every other case (live library found,
+    /// revived, or freshly created) — the caller's normal
+    /// `incoming.deleted_at`/`updated_at` apply unchanged.
     async fn ensure_library(
         txn: &sea_orm::DatabaseTransaction,
         library_name: &str,
         presentation_updated_at: DateTime<Utc>,
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<(String, Option<DateTime<Utc>>)> {
         if let Some(id) = Self::find_library_id(txn, library_name).await? {
-            return Ok(id);
+            return Ok((id, None));
         }
         // Order by UpdatedAt DESC, SyncId DESC: repeated delete/recreate
         // cycles of the same-named library leave MULTIPLE tombstoned rows
@@ -368,8 +390,13 @@ impl Repository {
                     .filter(library::Column::DeletedAt.is_not_null())
                     .exec(txn)
                     .await?;
+                return Ok((tombstoned.id, None));
             }
-            return Ok(tombstoned.id);
+            // #634: the tombstone wins (not revived) -- the presentation
+            // attaching here must be written as tombstoned too, never live
+            // under a dead parent.
+            let forced_at = presentation_updated_at.max(library_updated);
+            return Ok((tombstoned.id, Some(forced_at)));
         }
         let id = uuid::Uuid::new_v4().to_string();
         library::Entity::insert(library::ActiveModel {
@@ -386,7 +413,7 @@ impl Repository {
         })
         .exec(txn)
         .await?;
-        Ok(id)
+        Ok((id, None))
     }
 
     /// #578: resolve a library id for a brand-new TOMBSTONED presentation
@@ -493,7 +520,9 @@ impl Repository {
             info!("sync skip (adopt-by-name, local newer)");
             return Ok(Some((SyncApplyOutcome::SkippedNotNewer, None)));
         }
-        Self::write_synced_row(txn, &existing.id, library_id, incoming).await?;
+        // `library_id` here always came from `find_library_id` (LIVE-only
+        // lookup) — never a tombstoned library, so no `forced_delete` needed.
+        Self::write_synced_row(txn, &existing.id, library_id, incoming, None).await?;
         info!("sync adopted-by-name");
         let id = presenter_core::PresentationId::from_uuid(uuid::Uuid::parse_str(&existing.id)?);
         Ok(Some((SyncApplyOutcome::AdoptedByName, Some(id))))
@@ -525,11 +554,21 @@ impl Repository {
         // attach it to any existing same-named library (live or tombstoned),
         // or, if none exists, a TOMBSTONED library. A LIVE entry ensures a
         // live library as before.
-        let library_id = if incoming.deleted_at.is_some() {
-            Self::ensure_library_for_tombstone(txn, &incoming.library_name).await?
+        //
+        // #634: for a LIVE entry, `ensure_library`'s second return value is
+        // `Some(ts)` when the target library stayed tombstoned (not
+        // revived) — this new presentation must then be written as
+        // tombstoned too, never live under a dead parent.
+        let (library_id, forced_delete) = if incoming.deleted_at.is_some() {
+            (
+                Self::ensure_library_for_tombstone(txn, &incoming.library_name).await?,
+                None,
+            )
         } else {
             Self::ensure_library(txn, &incoming.library_name, incoming.updated_at).await?
         };
+        let effective_updated_at = forced_delete.unwrap_or(incoming.updated_at);
+        let effective_deleted_at = forced_delete.or(incoming.deleted_at);
         let new_id = uuid::Uuid::new_v4().to_string();
         presentation_entity::Entity::insert(presentation_entity::ActiveModel {
             id: Set(new_id.clone()),
@@ -537,9 +576,9 @@ impl Repository {
             name: Set(incoming.name.clone()),
             search_name: Set(fold_query(&incoming.name)),
             created_at: Set(Utc::now().into()),
-            updated_at: Set(incoming.updated_at.into()),
+            updated_at: Set(effective_updated_at.into()),
             sync_id: Set(incoming.sync_id.clone()),
-            deleted_at: Set(incoming.deleted_at.map(Into::into)),
+            deleted_at: Set(effective_deleted_at.map(Into::into)),
         })
         .exec(txn)
         .await?;
@@ -552,15 +591,25 @@ impl Repository {
     /// Update an existing local row IN PLACE (preserving its id + playlist refs):
     /// name, search_name, library, sync_id (adopt), deleted_at, and the PEER's
     /// updated_at (never now() — that is what prevents echo). Then replace slides.
+    ///
+    /// `forced_delete` (#634): `Some(ts)` when `library_id` resolved to a
+    /// library that stayed tombstoned (`ensure_library` declined to revive
+    /// it) — overrides BOTH `deleted_at` and `updated_at` so this row is
+    /// written as an explicit tombstone at `ts` instead of silently LIVE
+    /// under a dead parent (which the 30-day tombstone-prune cascade would
+    /// otherwise hard-delete with no prior trace). `None` for every other
+    /// caller — the incoming row's own `deleted_at`/`updated_at` apply as-is.
     async fn write_synced_row<C: sea_orm::ConnectionTrait>(
         conn: &C,
         local_id: &str,
         library_id: &str,
         incoming: &SyncPresentation,
+        forced_delete: Option<DateTime<Utc>>,
     ) -> anyhow::Result<()> {
         use presentation_entity::Column;
-        let deleted = incoming
-            .deleted_at
+        let effective_updated_at = forced_delete.unwrap_or(incoming.updated_at);
+        let effective_deleted_at = forced_delete.or(incoming.deleted_at);
+        let deleted = effective_deleted_at
             .map(|d| Expr::value(d.to_rfc3339()))
             .unwrap_or_else(|| Expr::value(Option::<String>::None));
         presentation_entity::Entity::update_many()
@@ -570,7 +619,7 @@ impl Repository {
             .col_expr(Column::SyncId, Expr::value(incoming.sync_id.clone()))
             .col_expr(
                 Column::UpdatedAt,
-                Expr::value(incoming.updated_at.to_rfc3339()),
+                Expr::value(effective_updated_at.to_rfc3339()),
             )
             .col_expr(Column::DeletedAt, deleted)
             .filter(Column::Id.eq(local_id))
@@ -965,11 +1014,16 @@ mod tests {
         // ensure_library: picks most recent tombstone by UpdatedAt DESC.
         // presentation_updated_at is OLDER than both → no revival, pure read.
         let txn2 = repo.db.begin().await.expect("begin txn");
-        let id_from_live_helper =
+        let (id_from_live_helper, forced_delete) =
             super::Repository::ensure_library(&txn2, "Songs", base - Duration::hours(3))
                 .await
                 .expect("resolve via live helper");
         txn2.rollback().await.expect("rollback");
+        assert!(
+            forced_delete.is_some(),
+            "presentation_updated_at is older than the tombstone -- it stays \
+             tombstoned, so the caller must be told to force-tombstone too (#634)"
+        );
 
         assert_eq!(
             id_from_tombstone_helper, id_from_live_helper,

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -331,6 +331,45 @@ async fn trash_lists_restores_and_prunes() {
 }
 
 #[tokio::test]
+async fn restore_presentation_refuses_when_the_parent_library_is_tombstoned() {
+    // #636 regression: restore_presentation used to clear the presentation's
+    // OWN deleted_at unconditionally, with no check on its parent library. A
+    // song "restored" under a still-tombstoned library becomes reachable by
+    // nothing (fetch_libraries excludes the library) AND is now LIVE, so the
+    // next tombstone-prune cascade hard-deletes it -- restoring it
+    // accomplished nothing durable and actively made things worse.
+    let repo = repo().await;
+    let lib = repo.create_library("Songs").await.unwrap();
+    let (_, _, song) = repo
+        .create_presentation(lib.id, "Trapped Song", Some(&[slide(0, "a")]))
+        .await
+        .unwrap();
+    // delete_library soft-deletes the library AND its live presentations in
+    // one transaction -- the realistic path that traps a song under a
+    // tombstoned library.
+    repo.delete_library(lib.id).await.unwrap();
+
+    let err = repo
+        .restore_presentation(song.id)
+        .await
+        .expect_err("restore must refuse while the parent library is tombstoned");
+    assert!(
+        matches!(
+            err.downcast_ref::<crate::RepositoryError>(),
+            Some(crate::RepositoryError::Conflict(_))
+        ),
+        "expected RepositoryError::Conflict, got: {err}"
+    );
+
+    let still_trashed = row(&repo, song.id).await;
+    assert!(
+        still_trashed.deleted_at.is_some(),
+        "a refused restore must leave the presentation exactly as tombstoned \
+         as before -- no partial mutation"
+    );
+}
+
+#[tokio::test]
 async fn reimport_preserves_a_trashed_songs_tombstone() {
     // S2 regression: upsert_library inserted EVERY incoming row with
     // deleted_at: None and updated_at: now() unconditionally — so

--- a/crates/presenter-persistence/src/repository/sync_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_trash_tests.rs
@@ -575,6 +575,16 @@ async fn ensure_library_picks_the_most_recent_tombstone_when_several_share_a_nam
         v2_row_after.deleted_at.is_some(),
         "v2 stays tombstoned -- P2 is OLDER than v2's own tombstone, so no revival"
     );
+    // #634 regression: P2 attaches to a library that stays tombstoned, so P2
+    // itself must ALSO be written as tombstoned -- a LIVE presentation
+    // parented to a dead library is invisible (excluded from
+    // fetch_libraries) and gets hard-deleted by the next tombstone-prune
+    // cascade with zero prior trace it ever existed.
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "P2 must be written as tombstoned -- it attaches to v2, which stays \
+         tombstoned; a live row under a dead library is silent data loss (#634)"
+    );
 
     use sea_orm::{ColumnTrait, QueryFilter};
     let all_songs = library::Entity::find()
@@ -639,6 +649,15 @@ async fn ensure_library_boundary_is_strict_greater_than_not_greater_or_equal() {
         lib_row_after.deleted_at.is_some(),
         "an EXACTLY EQUAL updated_at must not revive the library -- the LWW \
          boundary is strict `>`, not `>=`"
+    );
+    // #634 regression: same reasoning as the multi-tombstone test above --
+    // P2 stays attached to a library that stays tombstoned, so P2 must be
+    // written as tombstoned too, never silently live under a dead parent.
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "P2 must be written as tombstoned -- the library it attaches to \
+         stays tombstoned; a live row under a dead library is silent data \
+         loss (#634)"
     );
 }
 
@@ -722,5 +741,74 @@ async fn ensure_library_tie_breaks_identical_updated_at_tombstones_by_sync_id() 
     assert!(
         low_row_after.deleted_at.is_some(),
         "the losing tombstone (lower sync_id) is untouched -- still tombstoned"
+    );
+}
+
+#[tokio::test]
+async fn moving_an_existing_song_onto_a_tombstoned_library_tombstones_the_song_too() {
+    // #634 regression, step-1 path (existing local row matched by sync_id,
+    // UPDATED) -- the tombstone tests above exercise the SAME `ensure_library`
+    // bug via step-3 (brand-new sync_id, `apply_unknown_sync_id`). This proves
+    // the fix also covers an UPDATE: the peer moved an already-known
+    // presentation to a library that, locally, only exists tombstoned.
+    let repo = repo().await;
+    repo.create_library("Old").await.unwrap();
+
+    let initial = crate::SyncPresentation {
+        sync_id: "peer-move-test".to_string(),
+        library_name: "Old".to_string(),
+        name: "Moved Song".to_string(),
+        updated_at: chrono::Utc::now() - chrono::Duration::minutes(10),
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, id) = repo
+        .apply_sync_presentation(&initial, &std::collections::HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_id = id.expect("created presentation has an id");
+
+    let new_lib = repo.create_library("New").await.unwrap();
+    repo.delete_library(new_lib.id).await.unwrap();
+
+    // Peer moved the song to "New": newer than the song's own last-known
+    // updated_at (so LWW allows the update to apply) but OLDER than "New"'s
+    // own tombstone time (so the tombstone wins -- "New" stays dead).
+    let moved = crate::SyncPresentation {
+        sync_id: "peer-move-test".to_string(),
+        library_name: "New".to_string(),
+        name: "Moved Song".to_string(),
+        updated_at: chrono::Utc::now() - chrono::Duration::minutes(5),
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, _) = repo
+        .apply_sync_presentation(&moved, &std::collections::HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Updated);
+
+    let pres_row = row(&repo, pres_id).await;
+    assert_eq!(
+        pres_row.library_id,
+        new_lib.id.to_string(),
+        "the song reattaches to 'New' even though 'New' stays tombstoned"
+    );
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "the song must be written as tombstoned -- it now lives under a \
+         library that stays tombstoned; leaving it LIVE is silent data \
+         loss (#634)"
+    );
+
+    let new_lib_row = library::Entity::find_by_id(new_lib.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        new_lib_row.deleted_at.is_some(),
+        "'New' stays tombstoned -- the move is older than its own tombstone"
     );
 }

--- a/crates/presenter-persistence/src/repository/util.rs
+++ b/crates/presenter-persistence/src/repository/util.rs
@@ -57,6 +57,15 @@ pub enum RepositoryError {
     /// missing target), not 404 (#584).
     #[error("{0}")]
     TargetNotFound(&'static str),
+    /// A repository operation was refused because the resource is in a
+    /// state that makes it impossible right now — e.g. `restore_presentation`
+    /// refusing to restore a song whose PARENT LIBRARY is still tombstoned
+    /// (#636). The URL resource exists and is valid; the request just can't
+    /// be satisfied until other state changes. The router maps this to 409
+    /// via `downcast_ref` (`AppError::conflict`), mirroring the existing
+    /// `PasteSlidesError::AnchorVanished` -> 409 mapping.
+    #[error("{0}")]
+    Conflict(&'static str),
 }
 
 pub(super) fn parse_uuid(id: &str) -> Result<Uuid, RepositoryError> {

--- a/crates/presenter-server/src/router/sync.rs
+++ b/crates/presenter-server/src/router/sync.rs
@@ -20,9 +20,15 @@ use presenter_core::PresentationId;
 /// string match on the `Display` text (#587, mirrors `router/libraries.rs`'s
 /// `map_repository_not_found`, #584). Any other error falls through to the
 /// default 500 mapping.
+///
+/// #636: also maps `Conflict` — `restore_presentation` refusing a song whose
+/// parent library is still tombstoned — to 409, mirroring the existing
+/// `PasteSlidesError::AnchorVanished` -> `AppError::conflict` mapping
+/// (`router/presentations.rs`).
 fn map_repository_not_found(err: anyhow::Error) -> AppError {
     match err.downcast_ref::<presenter_persistence::RepositoryError>() {
         Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        Some(presenter_persistence::RepositoryError::Conflict(msg)) => AppError::conflict(*msg),
         _ => err.into(),
     }
 }

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -3192,3 +3192,78 @@ async fn restore_presentation_endpoint_never_trashed_returns_404() {
         .unwrap();
     assert_eq!(restore_response.status(), StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn restore_presentation_endpoint_returns_409_when_library_is_tombstoned() {
+    // #636: restore_presentation now refuses (typed Conflict -> 409) when the
+    // presentation's parent library is still tombstoned, instead of silently
+    // resurrecting a song that stays unreachable and doomed by the next
+    // tombstone-prune cascade.
+    let app = build_router(AppState::in_memory().await.unwrap());
+
+    let create_library_body = serde_json::json!({ "name": "Trapped Library" }).to_string();
+    let library_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri("/libraries")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_library_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let library_bytes = axum::body::to_bytes(library_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let library: Library = serde_json::from_slice(&library_bytes).unwrap();
+
+    let create_presentation_body = serde_json::json!({ "name": "Trapped Song" }).to_string();
+    let presentation_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!("/libraries/{}/presentations", library.id))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_presentation_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let presentation_bytes = axum::body::to_bytes(presentation_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let payload: CreateLibraryPresentationResponse =
+        serde_json::from_slice(&presentation_bytes).unwrap();
+
+    // Deleting the library soft-deletes it AND the live presentation under it.
+    let delete_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::DELETE)
+                .uri(format!("/libraries/{}", library.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+    let restore_response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(format!(
+                    "/presentations/{}/restore",
+                    payload.presentation.id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(restore_response.status(), StatusCode::CONFLICT);
+}


### PR DESCRIPTION
## Tombstone/sync batch — #634 + #636 + #635

Closes #634
Closes #636
Closes #635

### What

- **#634 (SYNC DATA LOSS):** `ensure_library` could attach a live presentation under a still-tombstoned library — the 30-day purge would then silently destroy it. Now a presentation syncing under a tombstoned library is itself written tombstoned (`sync_apply.rs`).
- **#636:** `restore_presentation` refuses (HTTP 409, new `RepositoryError::Conflict`) when the parent library is tombstoned; a peer rename that collides with a different live library's name disambiguates by `sync_id` instead of silently dropping forever.
- **#635:** `search_presentations` and `search_slides` exclude presentations under tombstoned libraries (`search_slides` split into helpers to stay under the fn-length cap).

### How verified

- RED→GREEN per ticket: `3dbd3651`→`0639eab3` (#634), `80ba277e`→`09a581a3` (#636), `dda8b946`→`9f5fa6e7` (#635).
- Version bump 0.4.225 first commit (`fe34cf46`).
- Pipeline run 31042967179 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Design comments with root cause + chosen approach on each ticket before code.

### Notes

- Follow-up filed by worker: #644 (library-restore capability — repo+API+UI, `needs-user-decision`).
- Diff 643 lines/12 files — slightly over the ~600 LoC bundling guideline, mostly RED test code; kept because #635 was already complete and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
