### PR TITLE
fix(sync/search): #646 review-fix batch — LWW-neutral forced tombstone, rename convergence, SQL-side search exclusion

### DIFF
--- a/.claude/rules/repository-error-pattern.md
+++ b/.claude/rules/repository-error-pattern.md
@@ -17,8 +17,10 @@ correct response is 404 (or 422 for a body-referenced missing target).
 ## The pattern
 
 1. **Producer** (repository or state method): `RepositoryError::NotFound(&'static str)` (URL
-   resource missing → 404) or `RepositoryError::TargetNotFound(&'static str)` (a resource named in
-   the request BODY is missing → 422) — both already defined in
+   resource missing → 404), `RepositoryError::TargetNotFound(&'static str)` (a resource named in
+   the request BODY is missing → 422), or `RepositoryError::Conflict(&'static str)` (the resource
+   exists but its current state forbids the operation — e.g. #636's restore_presentation under a
+   still-tombstoned library → 409) — all defined in
    `crates/presenter-persistence/src/repository/util.rs`. Use `.ok_or(RepositoryError::NotFound("..."))?`
    or `return Err(RepositoryError::NotFound("...").into());` — see "clippy gotcha" below for why
    `ok_or`, not `ok_or_else`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Local build/deploy workflow, CLIProxyAPI login | `.claude/skills/deploy/SKILL.md` |
 | Leptos/WASM frontend gotchas (view! macro, keyed `<For>`) | `.claude/skills/ui/SKILL.md` |
 | Database schema, migrations, settings audit, library import | `.claude/skills/database/SKILL.md` |
-| Repository refusal → HTTP 404/422 typed pattern (RepositoryError) | `.claude/rules/repository-error-pattern.md` (auto-loads on `repository/**`, `router/**`, `state/**`) |
+| Repository refusal → HTTP 404/409/422 typed pattern (RepositoryError) | `.claude/rules/repository-error-pattern.md` (auto-loads on `repository/**`, `router/**`, `state/**`) |
 
 ## Always-Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.225"
+version = "0.4.226"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.225"
+version = "0.4.226"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/library_sync.rs
+++ b/crates/presenter-persistence/src/repository/library_sync.rs
@@ -76,12 +76,28 @@ impl Repository {
             // warn!ed and dropped it, forever, every cycle. A tombstone
             // write is never at risk (the partial index only guards LIVE
             // rows), so it always writes `incoming.name` verbatim.
-            let write_name = if incoming.deleted_at.is_none() {
-                Self::resolve_conflict_free_name(&txn, &incoming.name, &existing.id).await?
+            //
+            // #646: when disambiguation actually changed the name, the
+            // write is stamped with LOCAL `Utc::now()` instead of
+            // `incoming.updated_at` — otherwise both sites hold the SAME
+            // clock for this sync_id (the peer's own rename time) and the
+            // strict `>` LWW gate skips our disambiguated name FOREVER on
+            // the peer's next pull, so the two sites never converge. A
+            // non-colliding rename (the common case) is unaffected.
+            let (write_name, write_updated_at) = if incoming.deleted_at.is_none() {
+                let resolved =
+                    Self::resolve_conflict_free_name(&txn, &incoming.name, &existing.id).await?;
+                let stamp = if resolved == incoming.name {
+                    incoming.updated_at
+                } else {
+                    Utc::now()
+                };
+                (resolved, stamp)
             } else {
-                incoming.name.clone()
+                (incoming.name.clone(), incoming.updated_at)
             };
-            Self::write_library_row(&txn, &existing.id, incoming, &write_name).await?;
+            Self::write_library_row(&txn, &existing.id, incoming, &write_name, write_updated_at)
+                .await?;
             txn.commit().await?;
             info!("sync library updated");
             return Ok(SyncApplyOutcome::Updated);
@@ -105,7 +121,14 @@ impl Repository {
                 }
                 // `existing` was found BY this exact name (`find_live_library_by_name`),
                 // so writing `incoming.name` verbatim can never newly collide.
-                Self::write_library_row(&txn, &existing.id, incoming, &incoming.name).await?;
+                Self::write_library_row(
+                    &txn,
+                    &existing.id,
+                    incoming,
+                    &incoming.name,
+                    incoming.updated_at,
+                )
+                .await?;
                 txn.commit().await?;
                 info!("sync library adopted-by-name");
                 return Ok(SyncApplyOutcome::AdoptedByName);
@@ -161,11 +184,18 @@ impl Repository {
     /// — usually `incoming.name` verbatim, but the rename call site passes an
     /// already-disambiguated name (`resolve_conflict_free_name`) when
     /// `incoming.name` collides with a DIFFERENT live library.
+    ///
+    /// `write_updated_at` (#646) is the `UpdatedAt` actually WRITTEN —
+    /// usually `incoming.updated_at` verbatim, but the rename call site
+    /// passes LOCAL `Utc::now()` when `write_name` was disambiguated, so
+    /// this instance's rename outranks what the peer just pushed on its
+    /// next pull (see the call site's doc comment).
     async fn write_library_row(
         txn: &DatabaseTransaction,
         local_id: &str,
         incoming: &SyncLibraryManifestRow,
         write_name: &str,
+        write_updated_at: DateTime<Utc>,
     ) -> anyhow::Result<()> {
         use library::Column;
         let deleted = incoming
@@ -178,7 +208,7 @@ impl Repository {
             .col_expr(Column::SyncId, Expr::value(incoming.sync_id.clone()))
             .col_expr(
                 Column::UpdatedAt,
-                Expr::value(incoming.updated_at.to_rfc3339()),
+                Expr::value(write_updated_at.to_rfc3339()),
             )
             .col_expr(Column::DeletedAt, deleted)
             .filter(Column::Id.eq(local_id))

--- a/crates/presenter-persistence/src/repository/library_sync_tests.rs
+++ b/crates/presenter-persistence/src/repository/library_sync_tests.rs
@@ -4,7 +4,7 @@
 use super::Repository;
 use crate::entities::library;
 use crate::{SyncApplyOutcome, SyncLibraryManifestRow};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
 async fn repo() -> Repository {
@@ -125,6 +125,105 @@ async fn rename_by_sync_id_disambiguates_instead_of_colliding_with_a_different_l
         foo_row.name, "Bar (2)",
         "#646 test hardening: the disambiguated name is deterministic, not \
          just 'recognizably based on Bar'"
+    );
+}
+
+#[tokio::test]
+async fn rename_disambiguation_bumps_updated_at_so_the_rename_converges() {
+    // #646 settled design: after writing the disambiguated name,
+    // `write_library_row` must bump ITS `updated_at` to LOCAL now() --
+    // never the incoming rename's own clock -- so this instance's rename
+    // wins the NEXT round and the peer converges onto the disambiguated
+    // name. Before this fix, the disambiguated write reused the peer's OWN
+    // `updated_at`: equal clocks on both sites + the strict `>` LWW
+    // tie-break meant the peer's next pull skipped the disambiguated name
+    // FOREVER -- the two sites permanently held different names for the
+    // same sync_id.
+    let repo = repo().await;
+    repo.create_library("Bar").await.unwrap();
+
+    // Insert "Foo" directly with a deliberately OLD updated_at -- the peer
+    // rename below is unambiguously newer under LWW, with a huge margin
+    // under "real now" for the bump assertion, with no reliance on
+    // sub-millisecond wall-clock ordering.
+    let foo_id = uuid::Uuid::new_v4().to_string();
+    let foo_sid = "peer-foo-sid".to_string();
+    let old = Utc::now() - Duration::hours(1);
+    library::Entity::insert(library::ActiveModel {
+        id: sea_orm::Set(foo_id.clone()),
+        name: sea_orm::Set("Foo".to_string()),
+        search_name: sea_orm::Set("foo".to_string()),
+        created_at: sea_orm::Set(old.into()),
+        updated_at: sea_orm::Set(old.into()),
+        sync_id: sea_orm::Set(foo_sid.clone()),
+        deleted_at: sea_orm::Set(None),
+    })
+    .exec(&repo.db)
+    .await
+    .unwrap();
+
+    let peer_rename_at = Utc::now() - Duration::minutes(30);
+    let peer_rename = SyncLibraryManifestRow {
+        sync_id: foo_sid.clone(),
+        name: "Bar".to_string(),
+        updated_at: peer_rename_at,
+        deleted_at: None,
+    };
+    let outcome = repo.apply_sync_library(&peer_rename).await.unwrap();
+    assert_eq!(outcome, SyncApplyOutcome::Updated);
+
+    let row = library::Entity::find_by_id(foo_id.clone())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.name, "Bar (2)", "deterministic disambiguated name");
+    let stored_updated_at: DateTime<Utc> = row.updated_at.into();
+    assert!(
+        stored_updated_at > peer_rename_at,
+        "the disambiguated write must be stamped strictly newer than the \
+         incoming rename it disambiguated -- otherwise a peer pull sees \
+         equal clocks and the strict `>` LWW gate skips it forever"
+    );
+
+    // Second round: a PEER still holding the pre-disambiguation state
+    // (name "Bar", at its own rename's clock) receives OUR disambiguated
+    // write as an incoming manifest entry -- it must adopt "Bar (2)".
+    // (Calling the helper via `self::` since `repo` is already shadowed by
+    // the local variable above.)
+    let peer_repo = self::repo().await;
+    library::Entity::insert(library::ActiveModel {
+        id: sea_orm::Set(uuid::Uuid::new_v4().to_string()),
+        name: sea_orm::Set("Bar".to_string()),
+        search_name: sea_orm::Set("bar".to_string()),
+        created_at: sea_orm::Set(old.into()),
+        updated_at: sea_orm::Set(peer_rename_at.into()),
+        sync_id: sea_orm::Set(foo_sid.clone()),
+        deleted_at: sea_orm::Set(None),
+    })
+    .exec(&peer_repo.db)
+    .await
+    .unwrap();
+
+    let our_disambiguated = SyncLibraryManifestRow {
+        sync_id: foo_sid.clone(),
+        name: row.name.clone(),
+        updated_at: stored_updated_at,
+        deleted_at: None,
+    };
+    let second_round = peer_repo
+        .apply_sync_library(&our_disambiguated)
+        .await
+        .unwrap();
+    assert_eq!(
+        second_round,
+        SyncApplyOutcome::Updated,
+        "the peer must accept our disambiguated name on the next round"
+    );
+    let peer_row = library_row_by_name(&peer_repo, "Bar (2)").await;
+    assert_eq!(
+        peer_row.sync_id, foo_sid,
+        "converged onto the same identity"
     );
 }
 

--- a/crates/presenter-persistence/src/repository/library_sync_tests.rs
+++ b/crates/presenter-persistence/src/repository/library_sync_tests.rs
@@ -121,15 +121,10 @@ async fn rename_by_sync_id_disambiguates_instead_of_colliding_with_a_different_l
         foo_row.deleted_at.is_none(),
         "the renamed library stays live"
     );
-    assert_ne!(
-        foo_row.name, "Bar",
-        "the colliding name must be disambiguated, never written verbatim \
-         over an existing live library's name"
-    );
-    assert!(
-        foo_row.name.starts_with("Bar"),
-        "the disambiguated name is still recognizably based on 'Bar', got: {}",
-        foo_row.name
+    assert_eq!(
+        foo_row.name, "Bar (2)",
+        "#646 test hardening: the disambiguated name is deterministic, not \
+         just 'recognizably based on Bar'"
     );
 }
 

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -21,6 +21,8 @@ mod stage_state;
 mod sync;
 mod sync_apply;
 #[cfg(test)]
+mod sync_apply_review_tests;
+#[cfg(test)]
 mod sync_test_support;
 #[cfg(test)]
 mod sync_tests;

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -23,6 +23,8 @@ mod sync_apply;
 #[cfg(test)]
 mod sync_apply_review_tests;
 #[cfg(test)]
+mod sync_restore_review_tests;
+#[cfg(test)]
 mod sync_test_support;
 #[cfg(test)]
 mod sync_tests;

--- a/crates/presenter-persistence/src/repository/search.rs
+++ b/crates/presenter-persistence/src/repository/search.rs
@@ -3,12 +3,29 @@ use presenter_core::{
     search::{fold_query, query_tokens},
     LibraryId, PresentationId, SearchMatchField, SearchResult, SearchResultKind,
 };
-use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::{
+    sea_query::{Query, SelectStatement},
+    ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+};
 use std::collections::{HashMap, HashSet};
 use tracing::instrument;
 
 use super::util::parse_uuid;
 use super::Repository;
+
+/// SQL subquery selecting the ids of LIVE (non-tombstoned) libraries (#646).
+/// Filtering `LibraryId.in_subquery(...)` with this BEFORE `.limit()` keeps
+/// an excluded (live-under-tombstoned-library) row from ever consuming a
+/// result slot — the OLD code applied this exclusion AFTER the SQL `LIMIT`,
+/// in Rust, so a page full of excluded rows sorting early could starve a
+/// genuine match sorting later in the same page.
+fn live_library_ids_subquery() -> SelectStatement {
+    Query::select()
+        .column(library::Column::Id)
+        .from(library::Entity)
+        .and_where(library::Column::DeletedAt.is_null())
+        .to_owned()
+}
 
 struct SearchContext {
     tokens: Vec<String>,
@@ -181,6 +198,10 @@ impl Repository {
         let presentation_rows = presentation_entity::Entity::find()
             .filter(presentation_condition)
             .filter(presentation_entity::Column::DeletedAt.is_null())
+            // #646: exclude a tombstoned-library row's presentations IN
+            // SQL, before `.limit()` — see `live_library_ids_subquery`'s
+            // doc comment. The Rust-side check below stays as a cheap belt.
+            .filter(presentation_entity::Column::LibraryId.in_subquery(live_library_ids_subquery()))
             .order_by_asc(presentation_entity::Column::Name)
             .limit(remaining as u64)
             .find_also_related(library::Entity)
@@ -332,6 +353,9 @@ impl Repository {
         let slide_rows = slide_entity::Entity::find()
             .filter(slide_condition)
             .filter(presentation_entity::Column::DeletedAt.is_null())
+            // #646: same SQL-side exclusion as `search_presentations` —
+            // see `live_library_ids_subquery`'s doc comment.
+            .filter(presentation_entity::Column::LibraryId.in_subquery(live_library_ids_subquery()))
             .order_by_asc(slide_entity::Column::Position)
             .limit(remaining as u64)
             .find_also_related(presentation_entity::Entity)

--- a/crates/presenter-persistence/src/repository/search_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/search_trash_tests.rs
@@ -212,6 +212,111 @@ async fn presentation_under_a_tombstoned_library_is_not_searchable() {
     );
 }
 
+/// Tombstone ONLY the given library row directly, leaving its live
+/// presentations underneath untouched — mirrors
+/// `presentation_under_a_tombstoned_library_is_not_searchable` above.
+async fn tombstone_library_row_only(repo: &Repository, library_id: presenter_core::LibraryId) {
+    use crate::entities::library as library_entity;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    library_entity::Entity::update_many()
+        .col_expr(
+            library_entity::Column::DeletedAt,
+            sea_orm::sea_query::Expr::value(chrono::Utc::now().to_rfc3339()),
+        )
+        .filter(library_entity::Column::Id.eq(library_id.to_string()))
+        .exec(&repo.db)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn search_limit_is_not_consumed_by_presentations_under_a_tombstoned_library() {
+    // #646: `search_presentations`'s `.limit(remaining)` was applied BEFORE
+    // the Rust-side tombstoned-library exclusion, so anomalous
+    // live-under-tombstoned rows sorting alphabetically EARLY consumed the
+    // LIMIT budget, starving a genuine live match sorting later in the same
+    // page. Seed 2 such anomalies (named to sort first) plus ONE genuine
+    // live match (sorts last) and search with limit=2 -- the genuine match
+    // must still come back.
+    let repo = repo().await;
+
+    let anomaly_lib = Library::new(
+        "AnomalyLib",
+        vec![
+            Presentation::new("Aardvark Anomaly Match", Vec::new()).unwrap(),
+            Presentation::new("Bumblebee Anomaly Match", Vec::new()).unwrap(),
+        ],
+    )
+    .unwrap();
+    let anomaly_lib_id = anomaly_lib.id;
+    repo.upsert_library(&anomaly_lib).await.unwrap();
+
+    let genuine_lib = Library::new(
+        "GenuineLib",
+        vec![Presentation::new("Zebra Anomaly Match", Vec::new()).unwrap()],
+    )
+    .unwrap();
+    repo.upsert_library(&genuine_lib).await.unwrap();
+
+    tombstone_library_row_only(&repo, anomaly_lib_id).await;
+
+    let results = repo.search_presenter("Anomaly Match", 2).await.unwrap();
+    assert!(
+        results
+            .iter()
+            .any(|r| r.presentation_name.as_deref() == Some("Zebra Anomaly Match")),
+        "the genuine live match must not be starved by anomalies consuming \
+         the LIMIT budget ahead of it, got: {results:?}"
+    );
+    assert!(
+        results.iter().all(|r| {
+            r.presentation_name.as_deref() != Some("Aardvark Anomaly Match")
+                && r.presentation_name.as_deref() != Some("Bumblebee Anomaly Match")
+        }),
+        "the anomalies themselves must never surface, got: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_limit_is_not_consumed_by_slides_under_a_tombstoned_library() {
+    // #646: same LIMIT-starvation shape as the presentations test above,
+    // one level down in `search_slides` (the join is via
+    // `presentation_entity`, not `library` directly). Insert the anomalies
+    // FIRST -- tied Position=0, no secondary sort in the slide-text query,
+    // so SQLite's tie-break falls back to insertion/rowid order, exactly
+    // what an unfiltered LIMIT would return first.
+    let repo = repo().await;
+
+    let anomaly_lib = Library::new(
+        "AnomalyLib2",
+        vec![
+            Presentation::new("A1", vec![slide_with_text("Starving Lyric One")]).unwrap(),
+            Presentation::new("A2", vec![slide_with_text("Starving Lyric Two")]).unwrap(),
+        ],
+    )
+    .unwrap();
+    let anomaly_lib_id = anomaly_lib.id;
+    repo.upsert_library(&anomaly_lib).await.unwrap();
+
+    let genuine_lib = Library::new(
+        "GenuineLib2",
+        vec![Presentation::new("G1", vec![slide_with_text("Starving Lyric Three")]).unwrap()],
+    )
+    .unwrap();
+    repo.upsert_library(&genuine_lib).await.unwrap();
+
+    tombstone_library_row_only(&repo, anomaly_lib_id).await;
+
+    let results = repo.search_presenter("Starving Lyric", 2).await.unwrap();
+    assert!(
+        results
+            .iter()
+            .any(|r| r.presentation_name.as_deref() == Some("G1")),
+        "the genuine live slide match must not be starved by anomalies \
+         consuming the LIMIT budget ahead of it, got: {results:?}"
+    );
+}
+
 #[tokio::test]
 async fn slide_under_a_library_row_that_no_longer_exists_at_all_is_dropped_silently() {
     // #646 test hardening: `backfill_live_library_names` already skips a

--- a/crates/presenter-persistence/src/repository/search_trash_tests.rs
+++ b/crates/presenter-persistence/src/repository/search_trash_tests.rs
@@ -10,6 +10,40 @@ async fn repo() -> Repository {
         .expect("in-memory repo")
 }
 
+fn slide_with_text(main: &str) -> Slide {
+    Slide::new(
+        0,
+        SlideContent::new(
+            SlideText::new(main).unwrap(),
+            SlideText::new("").unwrap(),
+            SlideText::new("").unwrap(),
+            None,
+        ),
+    )
+}
+
+/// Build a Repository on a DEDICATED single-connection in-memory database
+/// (own schema copy, not the shared-cache pool `repo()` uses) so a raw
+/// `PRAGMA foreign_keys = OFF` reliably applies to the SAME connection that
+/// then hard-deletes a library row — letting a test construct a presentation
+/// whose `library_id` points at NO row at all, a state the FK-enforced
+/// schema makes unreachable through any normal write path (#646 test
+/// hardening for `backfill_live_library_names`'s silent drop).
+async fn repo_allowing_fk_bypass() -> Repository {
+    use presenter_migration::MigratorTrait;
+    use sea_orm::{ConnectOptions, Database};
+    let mut opts = ConnectOptions::new("sqlite::memory:");
+    opts.max_connections(1).min_connections(1);
+    let db = Database::connect(opts).await.expect("connect");
+    Repository::apply_sqlite_pragmas(&db)
+        .await
+        .expect("pragmas");
+    presenter_migration::Migrator::up(&db, None)
+        .await
+        .expect("migrate");
+    Repository { db }
+}
+
 #[tokio::test]
 async fn trashed_song_lyrics_are_not_searchable() {
     // S10 regression: search_presenter's two NAME-search phases
@@ -175,5 +209,64 @@ async fn presentation_under_a_tombstoned_library_is_not_searchable() {
         after_text.is_empty(),
         "a presentation under a tombstoned library must not surface by \
          slide text, got: {after_text:?}"
+    );
+}
+
+#[tokio::test]
+async fn slide_under_a_library_row_that_no_longer_exists_at_all_is_dropped_silently() {
+    // #646 test hardening: `backfill_live_library_names` already skips a
+    // TOMBSTONED library (see the test above); this pins the OTHER branch
+    // of the SAME `None` check -- a library row that is ENTIRELY MISSING
+    // (not merely tombstoned) must be dropped the same way, never falling
+    // back to a blank name.
+    let repo = repo_allowing_fk_bypass().await;
+    let presentation = Presentation::new(
+        "Orphaned By Deletion",
+        vec![slide_with_text("A vanished library lyric")],
+    )
+    .unwrap();
+    let library = Library::new("WillBeHardDeleted", vec![presentation]).unwrap();
+    let library_id = library.id;
+    repo.upsert_library(&library).await.unwrap();
+
+    // Sanity: searchable while the library row still exists.
+    let before = repo
+        .search_presenter("vanished library lyric", 10)
+        .await
+        .unwrap();
+    assert!(
+        before
+            .iter()
+            .any(|r| matches!(r.kind, SearchResultKind::Presentation)),
+        "sanity: searchable while the library row still exists"
+    );
+
+    // Hard-delete ONLY the library row, bypassing the FK's own ON DELETE
+    // CASCADE (which would otherwise remove the presentation + slide right
+    // along with it) -- the presentation row is left dangling, exactly the
+    // state `backfill_live_library_names` must defend against.
+    use crate::entities::library as library_entity;
+    use sea_orm::{ConnectionTrait, EntityTrait};
+    repo.db
+        .execute_unprepared("PRAGMA foreign_keys = OFF")
+        .await
+        .unwrap();
+    library_entity::Entity::delete_by_id(library_id.to_string())
+        .exec(&repo.db)
+        .await
+        .unwrap();
+    repo.db
+        .execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .unwrap();
+
+    let after = repo
+        .search_presenter("vanished library lyric", 10)
+        .await
+        .unwrap();
+    assert!(
+        after.is_empty(),
+        "a slide whose library row no longer exists at all must never \
+         surface in search results, got: {after:?}"
     );
 }

--- a/crates/presenter-persistence/src/repository/sync.rs
+++ b/crates/presenter-persistence/src/repository/sync.rs
@@ -6,7 +6,9 @@ use super::Repository;
 use crate::entities::{library, presentation as presentation_entity, slide as slide_entity};
 use chrono::{DateTime, Utc};
 use presenter_core::Slide;
-use sea_orm::{sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{
+    sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, TransactionTrait,
+};
 use tracing::instrument;
 
 /// One manifest row — identity + timestamps, ALL songs including trashed.
@@ -146,32 +148,31 @@ impl Repository {
         presentation_id: presenter_core::PresentationId,
     ) -> anyhow::Result<()> {
         use presentation_entity::Column;
+        // #646: the library probe + the update now share ONE transaction
+        // (previously two independent, unlocked reads + a write) so a
+        // concurrent library prune/tombstone can never land between the
+        // check and the write.
+        let txn = self.db.begin().await?;
         let existing = presentation_entity::Entity::find()
             .filter(Column::Id.eq(presentation_id.to_string()))
             .filter(Column::DeletedAt.is_not_null())
-            .one(&self.db)
+            .one(&txn)
             .await?
             .ok_or(RepositoryError::NotFound(
                 "no trashed presentation to restore",
             ))?;
 
-        // #636: a restore that leaves the song under a STILL-tombstoned
+        // #636/#646: a restore that leaves the song under a STILL-tombstoned
         // library accomplishes nothing durable -- the library's own
         // deleted_at hides it from fetch_libraries, so the "restored" song
         // stays unreachable, and it is now LIVE, so the next
-        // prune_deleted_libraries CASCADE hard-deletes it (worse than
-        // leaving it in the trash). Refuse cleanly instead of performing a
-        // mutation that helps nobody; no partial state change.
-        let library_tombstoned = library::Entity::find_by_id(existing.library_id.clone())
-            .one(&self.db)
-            .await?
-            .is_none_or(|lib| lib.deleted_at.is_some());
-        if library_tombstoned {
-            return Err(RepositoryError::Conflict(
-                "the presentation's library is still trashed — restore the library first",
-            )
-            .into());
-        }
+        // prune_deleted_libraries CASCADE hard-deletes it. A library row
+        // that is MISSING ENTIRELY is a DIFFERENT situation (404, not 409)
+        // -- see `classify_restore_library`.
+        let library = library::Entity::find_by_id(existing.library_id.clone())
+            .one(&txn)
+            .await?;
+        classify_restore_library(library.as_ref())?;
 
         let now = Utc::now().to_rfc3339();
         let result = presentation_entity::Entity::update_many()
@@ -179,13 +180,14 @@ impl Repository {
             .col_expr(Column::UpdatedAt, Expr::value(now))
             .filter(Column::Id.eq(presentation_id.to_string()))
             .filter(Column::DeletedAt.is_not_null())
-            .exec(&self.db)
+            .exec(&txn)
             .await?;
         if result.rows_affected == 0 {
             // #587: typed refusal (#584 pattern) — the router downcasts to
             // `RepositoryError` and maps `NotFound` to 404 instead of a bare 500.
             return Err(RepositoryError::NotFound("no trashed presentation to restore").into());
         }
+        txn.commit().await?;
         Ok(())
     }
 
@@ -203,5 +205,69 @@ impl Repository {
             .exec(&self.db)
             .await?;
         Ok(res.rows_affected)
+    }
+}
+
+/// #646: classify what `restore_presentation` must do based on the parent
+/// library's state. `None` (the row is entirely missing) is `NotFound`
+/// (404) — a DIFFERENT situation from `Some(tombstoned)` (still trashed,
+/// 409) that the old `is_none_or` folded into the same `Conflict`. A pure
+/// function so both branches are directly unit-testable without needing to
+/// defeat the schema's own FK constraint (which makes a genuinely dangling
+/// `library_id` unreachable through any normal write path) just to exercise
+/// the "missing" branch.
+fn classify_restore_library(library: Option<&library::Model>) -> Result<(), RepositoryError> {
+    match library {
+        None => Err(RepositoryError::NotFound(
+            "the presentation's library no longer exists",
+        )),
+        Some(lib) if lib.deleted_at.is_some() => Err(RepositoryError::Conflict(
+            "the presentation's library is still trashed — restore the library first",
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_restore_library;
+    use crate::entities::library;
+    use crate::RepositoryError;
+    use chrono::Utc;
+
+    fn library_model(deleted: bool) -> library::Model {
+        let now = Utc::now();
+        library::Model {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: "Songs".to_string(),
+            search_name: "songs".to_string(),
+            created_at: now.into(),
+            updated_at: now.into(),
+            sync_id: uuid::Uuid::new_v4().to_string(),
+            deleted_at: deleted.then_some(now.into()),
+        }
+    }
+
+    #[test]
+    fn missing_library_row_is_not_found() {
+        assert!(matches!(
+            classify_restore_library(None),
+            Err(RepositoryError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn tombstoned_library_row_is_conflict() {
+        let tombstoned = library_model(true);
+        assert!(matches!(
+            classify_restore_library(Some(&tombstoned)),
+            Err(RepositoryError::Conflict(_))
+        ));
+    }
+
+    #[test]
+    fn live_library_row_is_ok() {
+        let live = library_model(false);
+        assert!(classify_restore_library(Some(&live)).is_ok());
     }
 }

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -327,20 +327,30 @@ impl Repository {
     /// tombstoned under it (those carry their own tombstones with their own
     /// `updated_at` and settle by their own LWW).
     ///
-    /// #634: returns `(library_id, forced_tombstone_at)`. `forced_tombstone_at`
-    /// is `Some(ts)` ONLY when the resolved library stayed tombstoned (the
-    /// LWW check above did NOT revive it) — the caller MUST then write the
-    /// presentation attaching here as tombstoned too, at `ts`, instead of
-    /// leaving it LIVE under a dead parent (a live row under a tombstoned
-    /// library was invisible — excluded from `fetch_libraries` — AND doomed
-    /// by the next `prune_deleted_libraries` CASCADE, with zero prior trace
-    /// it ever existed; real data loss, fixed here). `ts` is the LATER of
-    /// the two clocks (`presentation_updated_at.max(library_updated)`) so
-    /// the row's own clock only ever advances, letting a later sync cycle
-    /// still converge the peer onto the same tombstone once it too learns of
-    /// the deletion. `None` in every other case (live library found,
-    /// revived, or freshly created) — the caller's normal
-    /// `incoming.deleted_at`/`updated_at` apply unchanged.
+    /// #634/#646: returns `(library_id, forced_tombstone_at)`.
+    /// `forced_tombstone_at` is `Some(library_updated)` — the LIBRARY's OWN
+    /// tombstone time, ONLY — when the resolved library stayed tombstoned
+    /// (the LWW check above did NOT revive it). The caller writes the
+    /// presentation attaching here as tombstoned too (`deleted_at` only —
+    /// `updated_at` stays the incoming row's own clock, untouched), instead
+    /// of leaving it LIVE under a dead parent (invisible to
+    /// `fetch_libraries`, doomed by the next `prune_deleted_libraries`
+    /// CASCADE with zero prior trace; real data loss, fixed here).
+    ///
+    /// #646: this used to be `presentation_updated_at.max(library_updated)`,
+    /// applied to BOTH `updated_at` and `deleted_at` — that let the forced
+    /// row's clock jump past its true incoming value, LWW-beating the
+    /// peer's own live copy of the same song and, past `PRUNE_HORIZON`,
+    /// risking a zero-trash-window hard-delete. Returning only the
+    /// library's own clock (paired with the incoming row's UNCHANGED
+    /// `updated_at` at the call site) keeps the forced tombstone
+    /// LWW-neutral: equal clocks + the strict `>` gate mean it never
+    /// propagates to the peer and never beats a live copy — deletion only
+    /// ever reaches the peer through the library-level channel.
+    ///
+    /// `None` in every other case (live library found, revived, or freshly
+    /// created) — the caller's normal `incoming.deleted_at`/`updated_at`
+    /// apply unchanged.
     async fn ensure_library(
         txn: &sea_orm::DatabaseTransaction,
         library_name: &str,
@@ -392,11 +402,12 @@ impl Repository {
                     .await?;
                 return Ok((tombstoned.id, None));
             }
-            // #634: the tombstone wins (not revived) -- the presentation
-            // attaching here must be written as tombstoned too, never live
-            // under a dead parent.
-            let forced_at = presentation_updated_at.max(library_updated);
-            return Ok((tombstoned.id, Some(forced_at)));
+            // #634/#646: the tombstone wins (not revived) -- the
+            // presentation attaching here must be written as tombstoned
+            // too, never live under a dead parent. `library_updated` alone
+            // (never max'd against `presentation_updated_at`) -- see the
+            // doc comment above for why maxing was the #646 data-loss bug.
+            return Ok((tombstoned.id, Some(library_updated)));
         }
         let id = uuid::Uuid::new_v4().to_string();
         library::Entity::insert(library::ActiveModel {
@@ -567,7 +578,9 @@ impl Repository {
         } else {
             Self::ensure_library(txn, &incoming.library_name, incoming.updated_at).await?
         };
-        let effective_updated_at = forced_delete.unwrap_or(incoming.updated_at);
+        // #646: `updated_at` is ALWAYS the incoming row's own clock, never
+        // overridden -- only `deleted_at` is forced. See `ensure_library`'s
+        // doc comment.
         let effective_deleted_at = forced_delete.or(incoming.deleted_at);
         let new_id = uuid::Uuid::new_v4().to_string();
         presentation_entity::Entity::insert(presentation_entity::ActiveModel {
@@ -576,13 +589,13 @@ impl Repository {
             name: Set(incoming.name.clone()),
             search_name: Set(fold_query(&incoming.name)),
             created_at: Set(Utc::now().into()),
-            updated_at: Set(effective_updated_at.into()),
+            updated_at: Set(incoming.updated_at.into()),
             sync_id: Set(incoming.sync_id.clone()),
             deleted_at: Set(effective_deleted_at.map(Into::into)),
         })
         .exec(txn)
         .await?;
-        Self::replace_slides(txn, &new_id, incoming).await?;
+        Self::replace_slides(txn, &new_id, incoming, effective_deleted_at.is_some()).await?;
         info!("sync created");
         let id = presenter_core::PresentationId::from_uuid(uuid::Uuid::parse_str(&new_id)?);
         Ok((SyncApplyOutcome::Created, Some(id)))
@@ -592,13 +605,12 @@ impl Repository {
     /// name, search_name, library, sync_id (adopt), deleted_at, and the PEER's
     /// updated_at (never now() — that is what prevents echo). Then replace slides.
     ///
-    /// `forced_delete` (#634): `Some(ts)` when `library_id` resolved to a
-    /// library that stayed tombstoned (`ensure_library` declined to revive
-    /// it) — overrides BOTH `deleted_at` and `updated_at` so this row is
-    /// written as an explicit tombstone at `ts` instead of silently LIVE
-    /// under a dead parent (which the 30-day tombstone-prune cascade would
-    /// otherwise hard-delete with no prior trace). `None` for every other
-    /// caller — the incoming row's own `deleted_at`/`updated_at` apply as-is.
+    /// `forced_delete` (#634, restated by #646): `Some(library_tombstone_at)`
+    /// when `library_id` resolved to a library that stayed tombstoned —
+    /// overrides ONLY `deleted_at` (to the library's own honest tombstone
+    /// time); `updated_at` is NEVER overridden (see `ensure_library`'s doc
+    /// comment for why). `None` for every other caller — the incoming row's
+    /// own `deleted_at` applies as-is.
     async fn write_synced_row<C: sea_orm::ConnectionTrait>(
         conn: &C,
         local_id: &str,
@@ -607,7 +619,6 @@ impl Repository {
         forced_delete: Option<DateTime<Utc>>,
     ) -> anyhow::Result<()> {
         use presentation_entity::Column;
-        let effective_updated_at = forced_delete.unwrap_or(incoming.updated_at);
         let effective_deleted_at = forced_delete.or(incoming.deleted_at);
         let deleted = effective_deleted_at
             .map(|d| Expr::value(d.to_rfc3339()))
@@ -619,21 +630,44 @@ impl Repository {
             .col_expr(Column::SyncId, Expr::value(incoming.sync_id.clone()))
             .col_expr(
                 Column::UpdatedAt,
-                Expr::value(effective_updated_at.to_rfc3339()),
+                // #646: NEVER forced -- always the incoming row's own clock.
+                Expr::value(incoming.updated_at.to_rfc3339()),
             )
             .col_expr(Column::DeletedAt, deleted)
             .filter(Column::Id.eq(local_id))
             .exec(conn)
             .await?;
-        Self::replace_slides(conn, local_id, incoming).await
+
+        if forced_delete.is_some() {
+            // #646 finding 3: clean playlist references the SAME way
+            // `delete_library`/`delete_presentation` do on a real local
+            // delete. Markers are handled below via `replace_slides`.
+            // Scoped to the FORCED case per the settled design -- a
+            // GENUINE incoming tombstone's own gap is filed as #649.
+            use crate::entities::playlist_entry;
+            playlist_entry::Entity::delete_many()
+                .filter(playlist_entry::Column::PresentationId.eq(local_id.to_string()))
+                .exec(conn)
+                .await?;
+        }
+
+        Self::replace_slides(conn, local_id, incoming, effective_deleted_at.is_some()).await
     }
 
     /// Wholesale slide replacement carrying the peer's slide ids (global v4 uniqueness
     /// makes id collisions a non-issue).
+    ///
+    /// `effective_deleted` (#646): whether this write's row ends up
+    /// tombstoned — the CALLER's decision, which can differ from
+    /// `incoming.deleted_at` for a force-tombstone (incoming is live, the
+    /// local write is forced dead). The old code read `incoming.deleted_at`
+    /// directly here, so a forced tombstone wrongly REMAPPED its old
+    /// markers instead of clearing them (#646 finding 3).
     async fn replace_slides<C: sea_orm::ConnectionTrait>(
         conn: &C,
         presentation_id: &str,
         incoming: &SyncPresentation,
+        effective_deleted: bool,
     ) -> anyhow::Result<()> {
         // #558 S9 + R4: capture the OLD stage-layout markers BEFORE the
         // wholesale slide replacement, together with the OLD slide's own
@@ -649,8 +683,10 @@ impl Repository {
         // `delete_presentation`'s local-delete behavior and CLEAR the
         // song's markers instead of carrying them across the trash
         // boundary — else a later restore flips the stage to a stale
-        // layout the operator never re-applied.
-        let (old_markers, old_content) = if incoming.deleted_at.is_some() {
+        // layout the operator never re-applied. #646: gated on the
+        // EFFECTIVE deleted status (see doc comment above), not
+        // `incoming.deleted_at` directly.
+        let (old_markers, old_content) = if effective_deleted {
             (Vec::new(), Vec::new())
         } else {
             Self::markers_with_content(conn, presentation_id).await?

--- a/crates/presenter-persistence/src/repository/sync_apply_review_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_review_tests.rs
@@ -1,0 +1,264 @@
+//! #646 adversarial-review regression tests for the #634 forced-tombstone
+//! path in `sync_apply.rs`. Kept in its OWN sibling file rather than growing
+//! `sync_apply.rs` (959 prod lines) or `sync_trash_tests.rs` (853) toward the
+//! 1000-line hard cap — mirrors the `sync_trash_tests`/`search_trash_tests`
+//! split precedent. Shared helpers live in `sync_test_support`.
+use super::sync_test_support::{peer_song, repo, row, slide};
+use crate::entities::{library, playlist_entry, slide_stage_layout};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use std::collections::HashSet;
+
+#[tokio::test]
+async fn forced_tombstone_pins_deleted_at_to_the_library_clock_and_updated_at_to_the_incoming_clock(
+) {
+    // #646 critical finding: the OLD code stamped BOTH `deleted_at` and
+    // `updated_at` of a force-tombstoned row with
+    // `presentation_updated_at.max(library_updated)` — a single, maxed
+    // timestamp. That let `updated_at` jump PAST its true incoming value,
+    // which could then LWW-beat the peer's own live copy of the same song.
+    // Pin the fix: the two stamps are DISTINCT, each from its own honest
+    // source.
+    let repo = repo().await;
+    repo.create_library("Old").await.unwrap();
+
+    let initial = peer_song("peer-pin-stamps", "Pinned Song", "x", 30);
+    let (outcome, id) = repo
+        .apply_sync_presentation(&initial, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_id = id.expect("created presentation has an id");
+
+    let new_lib = repo.create_library("New").await.unwrap();
+    repo.delete_library(new_lib.id).await.unwrap();
+    let new_lib_row = library::Entity::find_by_id(new_lib.id.to_string())
+        .one(&repo.db)
+        .await
+        .unwrap()
+        .expect("library row still exists, tombstoned");
+    let library_tombstone_at: chrono::DateTime<chrono::Utc> = new_lib_row.updated_at.into();
+
+    // Newer than the song's own clock (so the update applies) but OLDER
+    // than "New"'s tombstone (so the tombstone wins) -- and DISTINCT from
+    // the library's tombstone time, so a maxed stamp is provably wrong.
+    let moved_updated_at = library_tombstone_at - chrono::Duration::minutes(10);
+    let moved = crate::SyncPresentation {
+        sync_id: "peer-pin-stamps".to_string(),
+        library_name: "New".to_string(),
+        name: "Pinned Song".to_string(),
+        updated_at: moved_updated_at,
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, _) = repo
+        .apply_sync_presentation(&moved, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Updated);
+
+    let pres_row = row(&repo, pres_id).await;
+    let stored_deleted_at: chrono::DateTime<chrono::Utc> =
+        pres_row.deleted_at.expect("forced tombstone").into();
+    let stored_updated_at: chrono::DateTime<chrono::Utc> = pres_row.updated_at.into();
+
+    assert_eq!(
+        stored_deleted_at, library_tombstone_at,
+        "deleted_at must be the LIBRARY's own tombstone time, never max'd \
+         against the presentation's clock"
+    );
+    assert_eq!(
+        stored_updated_at, moved_updated_at,
+        "updated_at must stay the INCOMING presentation's own clock, \
+         unchanged -- never bumped to the (later) library tombstone time"
+    );
+    assert_ne!(
+        stored_deleted_at, stored_updated_at,
+        "sanity: the two stamps are genuinely distinct here -- a maxed \
+         single stamp would make them equal"
+    );
+}
+
+#[tokio::test]
+async fn forced_tombstone_is_lww_neutral_and_never_beats_a_peers_live_copy() {
+    // #646 critical finding, the actual data-loss mechanism: a forced
+    // tombstone carrying the SAME clock a peer already holds LIVE must
+    // never apply onto that peer's copy -- the strict `>` LWW gate treats
+    // equal clocks as "not newer". Deletion reaches the peer only through
+    // the library-level channel, never by this forced row directly beating
+    // a live copy.
+    let repo = repo().await;
+    repo.create_library("Old").await.unwrap();
+    repo.apply_sync_presentation(
+        &peer_song("peer-lww-neutral", "Neutral Song", "x", 30),
+        &HashSet::new(),
+    )
+    .await
+    .unwrap();
+
+    let new_lib = repo.create_library("New").await.unwrap();
+    repo.delete_library(new_lib.id).await.unwrap();
+
+    let moved_updated_at = chrono::Utc::now() - chrono::Duration::minutes(20);
+    let moved = crate::SyncPresentation {
+        sync_id: "peer-lww-neutral".to_string(),
+        library_name: "New".to_string(),
+        name: "Neutral Song".to_string(),
+        updated_at: moved_updated_at,
+        deleted_at: None,
+        slides: vec![slide(0, "x")],
+    };
+    let (outcome, id) = repo
+        .apply_sync_presentation(&moved, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Updated);
+    let pres_row = row(&repo, id.expect("update returns the existing id")).await;
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "sanity: forced tombstone applied locally"
+    );
+
+    // Simulate a PEER that still holds this exact song LIVE, at the SAME
+    // clock we just forced it at -- "the library-level tombstone hasn't
+    // reached this peer yet". (Calling the helper via its module path, not
+    // by name, since `repo` is already shadowed by the local variable above.)
+    let peer_repo = super::sync_test_support::repo().await;
+    peer_repo.create_library("New").await.unwrap();
+    peer_repo
+        .apply_sync_presentation(
+            &crate::SyncPresentation {
+                sync_id: "peer-lww-neutral".to_string(),
+                library_name: "New".to_string(),
+                name: "Neutral Song".to_string(),
+                updated_at: moved_updated_at,
+                deleted_at: None,
+                slides: vec![slide(0, "x")],
+            },
+            &HashSet::new(),
+        )
+        .await
+        .unwrap();
+
+    // Apply OUR forced tombstone (as the peer would receive it via sync)
+    // onto the peer's repo.
+    let our_forced = crate::SyncPresentation {
+        sync_id: "peer-lww-neutral".to_string(),
+        library_name: "New".to_string(),
+        name: "Neutral Song".to_string(),
+        updated_at: pres_row.updated_at.into(),
+        deleted_at: pres_row.deleted_at.map(Into::into),
+        slides: vec![slide(0, "x")],
+    };
+    let (peer_outcome, _) = peer_repo
+        .apply_sync_presentation(&our_forced, &HashSet::new())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        peer_outcome,
+        crate::SyncApplyOutcome::SkippedNotNewer,
+        "the forced tombstone's clock EQUALS the peer's own live copy's \
+         clock -- the strict `>` LWW gate must skip it, never letting the \
+         forced row beat a live copy directly"
+    );
+    let peer_pres_id = peer_repo
+        .find_presentation_id_by_sync_id("peer-lww-neutral")
+        .await
+        .unwrap()
+        .expect("peer holds the song");
+    let peer_row = row(&peer_repo, peer_pres_id).await;
+    assert!(
+        peer_row.deleted_at.is_none(),
+        "the peer's live copy must remain untouched -- data loss is \
+         exactly a forced tombstone silently beating a live copy"
+    );
+}
+
+#[tokio::test]
+async fn forced_tombstone_cleans_playlist_entries_and_clears_stage_layout_markers() {
+    // #646 finding 3: a force-tombstoned song must be cleaned the SAME way
+    // `delete_library`/`delete_presentation` clean a real local delete --
+    // playlist references removed, stage-layout markers cleared (never
+    // remapped onto the new slides of a row that is now hidden).
+    let repo = repo().await;
+    repo.create_library("Old").await.unwrap();
+
+    let initial = peer_song("peer-cascade", "Cascade Song", "verse one", 30);
+    let (outcome, id) = repo
+        .apply_sync_presentation(&initial, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_id = id.expect("created presentation has an id");
+
+    let playlist = repo.create_playlist("Sunday", false).await.unwrap();
+    playlist_entry::Entity::insert(playlist_entry::ActiveModel {
+        id: sea_orm::Set(uuid::Uuid::new_v4().to_string()),
+        playlist_id: sea_orm::Set(playlist.id.to_string()),
+        entry_type: sea_orm::Set("presentation".to_string()),
+        presentation_id: sea_orm::Set(Some(pres_id.to_string())),
+        position: sea_orm::Set(0),
+        midi_note: sea_orm::Set(None),
+        label: sea_orm::Set(None),
+    })
+    .exec(&repo.db)
+    .await
+    .unwrap();
+
+    let (_, _, presentation) = repo
+        .fetch_presentation_detail(pres_id)
+        .await
+        .unwrap()
+        .expect("presentation exists");
+    let slide_id = presentation.slides[0].id;
+    repo.set_slide_stage_layout(pres_id, slide_id, "fulltext")
+        .await
+        .unwrap();
+    assert!(
+        repo.get_slide_stage_layout(slide_id)
+            .await
+            .unwrap()
+            .is_some(),
+        "sanity: marker set"
+    );
+
+    let new_lib = repo.create_library("New").await.unwrap();
+    repo.delete_library(new_lib.id).await.unwrap();
+
+    let moved = crate::SyncPresentation {
+        sync_id: "peer-cascade".to_string(),
+        library_name: "New".to_string(),
+        name: "Cascade Song".to_string(),
+        updated_at: chrono::Utc::now() - chrono::Duration::minutes(5),
+        deleted_at: None,
+        slides: vec![slide(0, "verse one")],
+    };
+    let (outcome, _) = repo
+        .apply_sync_presentation(&moved, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Updated);
+    let pres_row = row(&repo, pres_id).await;
+    assert!(pres_row.deleted_at.is_some(), "sanity: force-tombstoned");
+
+    let remaining_entries = playlist_entry::Entity::find()
+        .filter(playlist_entry::Column::PresentationId.eq(pres_id.to_string()))
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert!(
+        remaining_entries.is_empty(),
+        "playlist entries referencing the force-tombstoned song must be removed"
+    );
+
+    let remaining_markers = slide_stage_layout::Entity::find()
+        .filter(slide_stage_layout::Column::PresentationId.eq(pres_id.to_string()))
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert!(
+        remaining_markers.is_empty(),
+        "stage-layout markers for the force-tombstoned song must be \
+         cleared, never remapped onto its replacement slides"
+    );
+}

--- a/crates/presenter-persistence/src/repository/sync_restore_review_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_restore_review_tests.rs
@@ -1,0 +1,80 @@
+//! #646 finding: `restore_presentation` must distinguish "the parent
+//! library row is entirely missing" (404) from "the parent library is
+//! still tombstoned" (409) — the old `is_none_or` folded both into the same
+//! `Conflict`. Kept in its own sibling file rather than growing
+//! `sync_trash_tests.rs` (853 prod lines) toward the 1000-line hard cap.
+use super::sync_test_support::{row, slide};
+use crate::entities::library;
+use crate::RepositoryError;
+
+/// Build a Repository on a DEDICATED single-connection in-memory database so
+/// a raw `PRAGMA foreign_keys = OFF` reliably applies to the SAME connection
+/// that then hard-deletes a library row — letting a test construct a
+/// presentation whose `library_id` points at NO row at all, a state the
+/// FK-enforced schema makes unreachable through any normal write path
+/// (mirrors `search_trash_tests.rs`'s `repo_allowing_fk_bypass`).
+async fn repo_allowing_fk_bypass() -> crate::Repository {
+    use presenter_migration::MigratorTrait;
+    use sea_orm::{ConnectOptions, Database};
+    let mut opts = ConnectOptions::new("sqlite::memory:");
+    opts.max_connections(1).min_connections(1);
+    let db = Database::connect(opts).await.expect("connect");
+    crate::Repository::apply_sqlite_pragmas(&db)
+        .await
+        .expect("pragmas");
+    presenter_migration::Migrator::up(&db, None)
+        .await
+        .expect("migrate");
+    crate::Repository { db }
+}
+
+#[tokio::test]
+async fn restore_presentation_returns_not_found_when_the_parent_library_row_is_entirely_missing() {
+    // #646: the OLD `is_none_or` folded "library row missing entirely" into
+    // the SAME Conflict/409 as "library still tombstoned" -- a missing row
+    // is a DIFFERENT, NotFound-shaped (404) situation.
+    let repo = repo_allowing_fk_bypass().await;
+    let lib = repo.create_library("Songs").await.unwrap();
+    let (_, _, song) = repo
+        .create_presentation(lib.id, "Orphaned Trash", Some(&[slide(0, "a")]))
+        .await
+        .unwrap();
+    repo.delete_presentation(song.id).await.unwrap();
+
+    // Hard-delete ONLY the library row, bypassing the FK's own ON DELETE
+    // CASCADE (which would otherwise remove the still-trashed presentation
+    // right along with it) -- the presentation row is left dangling,
+    // exactly the state `restore_presentation` must defend against.
+    use sea_orm::{ConnectionTrait, EntityTrait};
+    repo.db
+        .execute_unprepared("PRAGMA foreign_keys = OFF")
+        .await
+        .unwrap();
+    library::Entity::delete_by_id(lib.id.to_string())
+        .exec(&repo.db)
+        .await
+        .unwrap();
+    repo.db
+        .execute_unprepared("PRAGMA foreign_keys = ON")
+        .await
+        .unwrap();
+
+    let err = repo
+        .restore_presentation(song.id)
+        .await
+        .expect_err("restore must refuse when the parent library row is gone");
+    assert!(
+        matches!(
+            err.downcast_ref::<RepositoryError>(),
+            Some(RepositoryError::NotFound(_))
+        ),
+        "a missing library row is NotFound (404), not Conflict (409) -- got: {err}"
+    );
+
+    let still_trashed = row(&repo, song.id).await;
+    assert!(
+        still_trashed.deleted_at.is_some(),
+        "a refused restore must leave the presentation exactly as tombstoned \
+         as before -- no partial mutation"
+    );
+}


### PR DESCRIPTION
## Review-fix batch for PR #645 findings

Closes #646

### What

Adversarial post-merge review of PR #645 (tombstone batch #634+#635+#636) found one critical and several secondary defects — all fixed here per the settled design on #646:

- **🔴 Forced tombstone back-dating (`sync_apply.rs`):** the #634 forced tombstone was stamped entirely with the library's (possibly ≥30-day-old) tombstone time — it would propagate to the peer, beat a legitimately live copy via LWW, and could be pruned on both sides with zero trash window. Now: `deleted_at` = library tombstone time (honest cause), `updated_at` = the incoming presentation's own clock → LWW-neutral, never propagates; deletion reaches the peer only through proper library-level reconciliation.
- **🟡 Rename disambiguation convergence (`library_sync.rs`):** the disambiguated name was written with the peer's clock (equal clocks → permanent name divergence). Now bumped to local `now()` so the disambiguated name wins the next round on both sites.
- **🟡 Search LIMIT starvation (`search.rs`):** tombstoned-library exclusion ran in Rust AFTER the SQL `LIMIT`, so excluded anomalies consumed result slots. Exclusion pushed into SQL before `.limit()` (both presentations and slides).
- **🔵** `restore_presentation`: probe+update now one transaction; missing library row → 404 (was conflated into 409).
- **🔵** Forced tombstone now also cleans `playlist_entry` rows + `slide_stage_layout` markers (parity with delete cascades).
- **🔵** Test hardening: exact disambiguated name pinned, missing-library-row slide drop pinned.

### How verified

- RED→GREEN per finding (see commit stack `2b1ac70b..11cc522f`); version bump 0.4.226 first commit.
- Pipeline run 31053287510 fully green.
- Design comment with per-finding rationale: #646.

### Follow-ups (filed, not in this PR)

- #647: sync wire protocol joins presentations to libraries by NAME (mis-filing/phantom libraries) — cross-cutting protocol change (#648 closed as its duplicate).
- #649: genuine incoming tombstones also skip playlist_entry cleanup — needs-user-decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
