### PR TITLE
Typed-refusal batch: #628 reorder 422, #629 stage-layout 404, #631 switch-order, #632 playlist FK 422

### DIFF
--- a/.claude/rules/sync-lww.md
+++ b/.claude/rules/sync-lww.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "crates/presenter-persistence/src/repository/sync*.rs"
+  - "crates/presenter-persistence/src/repository/library_sync*.rs"
+  - "crates/presenter-server/src/state/sync.rs"
+---
+
+# Sync/LWW invariants (#634/#636/#646 — learned the hard way)
+
+Two-site LWW sync (PP↔SNV), strict-`>` gate on `updated_at` (sync_id tie-break, #594).
+
+1. **A SYNTHETIC (locally manufactured) tombstone must be LWW-NEUTRAL.** When apply-side
+   integrity forces a row into a state the peer never sent (e.g. #634's forced tombstone of a
+   presentation arriving under a still-tombstoned library), stamp `updated_at` with the INCOMING
+   event's own clock — never a locally-derived newer clock. A manufactured newer clock propagates
+   and beats the peer's legitimately live copy; back-dated `deleted_at` older than PRUNE_HORIZON
+   (30 d) additionally bypasses the trash window entirely (the #646 🔴). Semantic state changes
+   reach the peer only through the proper channel (library-level reconciliation → peer's own
+   cascade), never as a side effect of a defensive local write.
+
+2. **A DELIBERATE local divergence must BUMP the clock to converge.** The mirror case: when a
+   site intentionally diverges from the wire event (e.g. #636's rename disambiguation writing
+   `Bar (2)`), it must stamp local `now()` — writing the peer's own clock creates equal clocks
+   and the strict-`>` gate then skips forever in BOTH directions (permanent divergence).
+
+   Rule of thumb: defensive/derived write → incoming clock (never propagates); intentional
+   correction → bumped clock (always propagates).
+
+3. **Library reconciliation is BEST-EFFORT** (`state/sync.rs` — silently skipped on 404/old
+   peer/decode error). Never design an apply-side fix that assumes the local library state is
+   current; the peer may have revived/renamed a library you still hold tombstoned.
+
+4. **Tombstone cascades must clean dependents everywhere**: `playlist_entry` rows +
+   `slide_stage_layout` markers — `delete_library`/`delete_presentation` and the forced-tombstone
+   path all do; a new tombstone-writing path must too (gap for genuine incoming tombstones: #649).
+
+5. Known open flaw: presentations join libraries by NAME on the wire (`SyncPresentation.library_name`)
+   → mis-filing/phantom libraries across rename races (#647, cross-cutting protocol change).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Leptos/WASM frontend gotchas (view! macro, keyed `<For>`) | `.claude/skills/ui/SKILL.md` |
 | Database schema, migrations, settings audit, library import | `.claude/skills/database/SKILL.md` |
 | Repository refusal → HTTP 404/409/422 typed pattern (RepositoryError) | `.claude/rules/repository-error-pattern.md` (auto-loads on `repository/**`, `router/**`, `state/**`) |
+| Sync/LWW invariants (synthetic tombstones, clock bumps, best-effort recon) | `.claude/rules/sync-lww.md` (auto-loads on `repository/sync*`, `library_sync*`, `state/sync.rs`) |
 
 ## Always-Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.226"
+version = "0.4.227"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.226"
+version = "0.4.227"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -136,6 +136,49 @@ impl Repository {
         }
     }
 
+    /// #632: `presentation_id` is the twin FK to `playlist_id` above
+    /// (`fk_playlist_entries_presentation`), but had no equivalent pre-write
+    /// check — a `Presentation`-kind entry naming an unknown presentation
+    /// reached the raw INSERT unchecked and tripped the SQLite FK
+    /// constraint (`PRAGMA foreign_keys = ON`) -> DbErr -> 500. `presentation_id`
+    /// is BODY-referenced (the entries array), not the URL, so the refusal is
+    /// `TargetNotFound` (422), not `NotFound` (404) — the router maps it
+    /// alongside `NotFound`. Deliberately does NOT filter on `deleted_at IS
+    /// NULL`: a soft-deleted presentation's row still physically exists, so
+    /// it would NOT trip the FK constraint either — this check matches
+    /// exactly what the FK itself would reject, no stricter.
+    async fn ensure_presentation_targets_exist(
+        &self,
+        entries: &[presenter_core::PlaylistEntry],
+    ) -> anyhow::Result<()> {
+        let mut ids: Vec<String> = entries
+            .iter()
+            .filter_map(|entry| match &entry.kind {
+                PlaylistEntryKind::Presentation {
+                    presentation_id, ..
+                } => Some(presentation_id.to_string()),
+                PlaylistEntryKind::Separator { .. } => None,
+            })
+            .collect();
+        if ids.is_empty() {
+            return Ok(());
+        }
+        ids.sort();
+        ids.dedup();
+        let existing = presentation_entity::Entity::find()
+            .filter(presentation_entity::Column::Id.is_in(ids.clone()))
+            .count(&self.db)
+            .await?;
+        if existing as usize == ids.len() {
+            Ok(())
+        } else {
+            Err(RepositoryError::TargetNotFound(
+                "one or more playlist entries reference an unknown presentation",
+            )
+            .into())
+        }
+    }
+
     #[instrument(skip_all)]
     pub async fn delete_playlist(&self, playlist_id: PlaylistId) -> anyhow::Result<()> {
         playlist::Entity::delete_by_id(playlist_id.to_string())
@@ -154,6 +197,8 @@ impl Repository {
         // trips `fk_playlist_entries_playlist` on the INSERT below (PRAGMA foreign_keys = ON) ->
         // raw DbErr -> 500. An empty slice skipped the insert loop and never exercised that path.
         self.ensure_playlist_exists(playlist_id).await?;
+        // #632: the twin FK check for `presentation_id` (see doc comment above).
+        self.ensure_presentation_targets_exist(entries).await?;
 
         let txn = self.db.begin().await?;
 

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -56,11 +56,16 @@ pub(super) enum PlaylistEntryPayload {
 /// Maps a repository refusal to its HTTP status via the TYPED
 /// `RepositoryError` variant returned by the persistence layer — never a
 /// string match on the `Display` text (#586, mirrors `router/libraries.rs`'s
-/// `map_repository_not_found`, #584). Any other error falls through to the
-/// default 500 mapping.
+/// `map_repository_not_found`, #584). `NotFound` (the URL's `playlist_id`
+/// itself is missing) maps to 404; `TargetNotFound` (a body-referenced
+/// `presentation_id` inside `entries` is missing, #632) maps to 422. Any
+/// other error falls through to the default 500 mapping.
 fn map_repository_not_found(err: anyhow::Error) -> AppError {
     match err.downcast_ref::<presenter_persistence::RepositoryError>() {
         Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        Some(presenter_persistence::RepositoryError::TargetNotFound(msg)) => {
+            AppError::unprocessable(*msg)
+        }
         _ => err.into(),
     }
 }

--- a/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
+++ b/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
@@ -185,6 +185,29 @@ async fn reorder_on_a_vanished_presentation_is_a_404() {
 }
 
 #[tokio::test]
+async fn reorder_with_fewer_slide_ids_than_exist_is_a_422() {
+    // #628: the length-mismatch guard directly above the per-id lookup guard
+    // (`edit_ops.rs:446`) was left as a bare `anyhow!`, unlike its sibling
+    // (`:451`, covered by `reorder_naming_an_unknown_slide_in_the_body_is_a_422`
+    // below), so a stale/short body (e.g. after a concurrent edit shrank the
+    // slide list) fell through to a 500 instead of the intended 422. Sending
+    // only ONE of the seeded presentation's two slide ids hits the
+    // length-mismatch guard specifically (not the per-id lookup).
+    let state = AppState::in_memory().await.unwrap();
+    let (pres_id, [real_a, _real_b]) = seed(&state).await;
+    let app = build_router(state);
+    let body = serde_json::json!({ "slideIds": [real_a] });
+    let resp = request(
+        &app,
+        "POST",
+        &format!("/presentations/{pres_id}/slides/reorder"),
+        Some(body),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn reorder_naming_an_unknown_slide_in_the_body_is_a_422() {
     // The `slideIds` are BODY-referenced (not in the URL path), so a slide id
     // that does not belong to the presentation is a body-referenced missing

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -51,20 +51,25 @@ pub(super) async fn set_slide_stage_layout(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Maps a `assign_slide_stage_layout` error to its HTTP status via the TYPED
-/// `StageLayoutRefusal` — never a blanket `AppError::bad_request` (#615: that
-/// hid a genuine internal failure, e.g. a missing presentation or a DB error,
-/// as a benign client-side 400). Same shape as #588's
-/// `map_stage_layout_refusal` in `router/stage.rs`, but maps to
-/// `bad_request_message` (400) — the SAME client-error status this route has
-/// ALWAYS returned for bad layout codes — so only the fallthrough to 500
-/// changes, not the typed-refusal status. Any other error falls through to
-/// the router's default 500 mapping.
+/// Maps a `assign_slide_stage_layout` error to its HTTP status via TWO typed
+/// error types — never a blanket `AppError::bad_request` (#615: that hid a
+/// genuine internal failure, e.g. a DB error, as a benign client-side 400).
+/// `StageLayoutRefusal` (bad/unknown layout code) maps to `bad_request_message`
+/// (400) — the SAME client-error status this route has ALWAYS returned for
+/// bad layout codes. `RepositoryError::NotFound` (a missing `presentation_id`
+/// or `slide_id` — both URL-path resources) maps to `not_found` (404, #629):
+/// before #629 these were bare `anyhow!`s that also fell through to 500. Any
+/// other error still falls through to the router's default 500 mapping.
 fn map_slide_stage_layout_error(err: anyhow::Error) -> AppError {
-    match err.downcast_ref::<StageLayoutRefusal>() {
-        Some(refusal) => AppError::bad_request_message(refusal.to_string()),
-        None => err.into(),
+    if let Some(refusal) = err.downcast_ref::<StageLayoutRefusal>() {
+        return AppError::bad_request_message(refusal.to_string());
     }
+    if let Some(presenter_persistence::RepositoryError::NotFound(msg)) =
+        err.downcast_ref::<presenter_persistence::RepositoryError>()
+    {
+        return AppError::not_found(*msg);
+    }
+    err.into()
 }
 
 #[instrument(skip_all)]

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -176,36 +176,46 @@ mod tests {
         );
     }
 
-    /// #615: a genuine internal failure (here: a non-existent presentation
-    /// causes `assign_slide_stage_layout` to `bail!("presentation not
-    /// found")`, an untyped `anyhow::Error` that is NOT a
-    /// `StageLayoutRefusal`) must answer 500 — never 400. Before the fix,
-    /// the blanket `.map_err(AppError::bad_request)` masked this as a
-    /// client error.
+    /// #629 (was wrong before this fix): the ORIGINAL version of this test
+    /// used a fake/non-existent presentation UUID and asserted 500 — but a
+    /// missing presentation is a MISSING URL RESOURCE, not an internal
+    /// failure, and cementing 500 as its "correct" response is exactly the
+    /// regression #629 reports (see the sibling 404 tests below for the
+    /// actual fix). A genuine internal failure — unrelated to any missing id
+    /// or bad layout code — is a real presentation + real slide whose
+    /// `slide_stage_layouts` table has been dropped out from under the
+    /// final upsert, so `set_slide_stage_layout`'s INSERT hits a raw DbErr.
     #[tokio::test]
     async fn put_returns_500_on_internal_failure_not_400() {
-        let (state, _presentation) = seeded_state().await;
-        // A valid-format UUID that doesn't correspond to any seeded
-        // presentation: `presentation_detail` returns `None`, the state
-        // method `bail!`s — a non-typed error that must fall through to 500.
-        let random_uuid = uuid::Uuid::new_v4();
-        let random_slide = presenter_core::SlideId::new();
+        let (state, presentation) = seeded_state().await;
+        let slide_id = presentation.slides[0].id;
+
+        let conn = state.repository().connection();
+        sea_orm::ConnectionTrait::execute(
+            conn,
+            sea_orm::Statement::from_string(
+                sea_orm::ConnectionTrait::get_database_backend(conn),
+                "DROP TABLE slide_stage_layouts".to_string(),
+            ),
+        )
+        .await
+        .unwrap();
 
         let result = set_slide_stage_layout(
             State(state),
-            Path((random_uuid.to_string(), random_slide.to_string())),
+            Path((presentation.id.to_string(), slide_id.to_string())),
             Json(SlideStageLayoutRequest {
                 layout_code: Some("fulltext".to_string()),
             }),
         )
         .await;
         let Err(err) = result else {
-            panic!("expected an error for a non-existent presentation, got Ok");
+            panic!("expected an error from the dropped table, got Ok");
         };
         assert_eq!(
             err.into_response().status(),
             StatusCode::INTERNAL_SERVER_ERROR,
-            "an internal failure must be 500, not 400 (#615)"
+            "a genuine internal failure must be 500, not 400 (#615) and not 404 (#629)"
         );
     }
 }

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -218,4 +218,57 @@ mod tests {
             "a genuine internal failure must be 500, not 400 (#615) and not 404 (#629)"
         );
     }
+
+    /// #629: `presentation_id` is a URL-path resource — a non-existent one
+    /// must be a 404, matching the same check's typed refusal everywhere
+    /// else in the codebase (`state/slides/edit_ops.rs`, `state/bible.rs`),
+    /// never fall through to the router's default 500.
+    #[tokio::test]
+    async fn put_returns_404_for_unknown_presentation() {
+        let (state, _presentation) = seeded_state().await;
+        let random_uuid = uuid::Uuid::new_v4();
+        let random_slide = presenter_core::SlideId::new();
+
+        let result = set_slide_stage_layout(
+            State(state),
+            Path((random_uuid.to_string(), random_slide.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("fulltext".to_string()),
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for a non-existent presentation, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "a non-existent presentation_id must be 404, not 500 (#629)"
+        );
+    }
+
+    /// #629: same as above, but for a `slide_id` that doesn't belong to an
+    /// otherwise-real presentation.
+    #[tokio::test]
+    async fn put_returns_404_for_unknown_slide() {
+        let (state, presentation) = seeded_state().await;
+        let random_slide = presenter_core::SlideId::new();
+
+        let result = set_slide_stage_layout(
+            State(state),
+            Path((presentation.id.to_string(), random_slide.to_string())),
+            Json(SlideStageLayoutRequest {
+                layout_code: Some("fulltext".to_string()),
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for a non-existent slide, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "a non-existent slide_id must be 404, not 500 (#629)"
+        );
+    }
 }

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -311,6 +311,58 @@ mod set_stage_layout_error_mapping_tests {
         );
     }
 
+    /// #631: a failure while assembling the fresh stage snapshot must NOT
+    /// have already applied, persisted, and broadcast the layout switch — a
+    /// client that receives this exact 500 must find NOTHING changed. Same
+    /// corrupted-timers-row setup as the sibling test above, but the
+    /// corruption happens BEFORE the switch attempt (not after), so the
+    /// failure surfaces from the pre-switch snapshot-context build rather
+    /// than from a step that runs after the switch already committed.
+    #[tokio::test]
+    async fn set_stage_layout_failure_does_not_apply_the_switch() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        // Seed the timers row via an initial valid switch.
+        let _ = set_stage_layout(
+            State(state.clone()),
+            Json(StageLayoutUpdateRequest {
+                code: "timer".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Corrupt it so the NEXT switch's snapshot-context build fails.
+        let conn = state.repository().connection();
+        sea_orm::ConnectionTrait::execute(
+            conn,
+            sea_orm::Statement::from_string(
+                sea_orm::ConnectionTrait::get_database_backend(conn),
+                "UPDATE timers SET countdown_state = 'corrupted-state'".to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let result = set_stage_layout(
+            State(state.clone()),
+            Json(StageLayoutUpdateRequest {
+                code: "preach".to_string(),
+            }),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "expected the corrupted-state failure to surface as an error"
+        );
+        assert_eq!(
+            state.stage_layout_code().await,
+            "timer",
+            "#631: a failed switch must not have applied the layout change — \
+             the client's 500 must mean nothing changed"
+        );
+    }
+
     /// An unknown/invalid layout code must still answer 404 — the acceptance
     /// criterion #588 must NOT regress.
     #[tokio::test]

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -3131,6 +3131,42 @@ async fn replace_playlist_entries_endpoint_missing_playlist_returns_404() {
 }
 
 #[tokio::test]
+async fn replace_playlist_entries_endpoint_unknown_presentation_id_is_a_422() {
+    // #632: `ensure_playlist_exists` (#610) guards the `fk_playlist_entries_playlist`
+    // FK, but the twin FK on `presentation_id` has no equivalent guard — an entry
+    // referencing an unknown presentation trips the raw `fk_playlist_entries_presentation`
+    // constraint on INSERT -> DbErr -> 500. presentation_id is BODY-referenced (not the
+    // URL), so the correct typed refusal is TargetNotFound -> 422, matching the
+    // established body-referenced-missing-target convention.
+    let state = AppState::in_memory().await.unwrap();
+    let playlist = state
+        .create_playlist("FK Test Playlist", false)
+        .await
+        .unwrap();
+    let app = build_router(state);
+
+    let random_presentation_id = uuid::Uuid::new_v4();
+    let body = json!({
+        "entries": [
+            { "type": "presentation", "presentationId": random_presentation_id }
+        ]
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/playlists/{}/entries", playlist.id))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
 async fn restore_presentation_endpoint_never_trashed_returns_404() {
     // #608 item 4: `restore_presentation_endpoint_missing_trashed_presentation_returns_404`
     // above claims to cover "an unknown id AND a never-trashed presentation" but only drives the

--- a/crates/presenter-server/src/state/broadcasting.rs
+++ b/crates/presenter-server/src/state/broadcasting.rs
@@ -108,7 +108,11 @@ impl AppState {
         Ok(())
     }
 
-    async fn publish_stage_context(&self, context: &StageContext) -> anyhow::Result<()> {
+    /// `pub(super)` (not private) so `stage_display.rs`'s `switch_stage_layout`
+    /// can publish an already-built context AFTER the layout switch commits
+    /// (#631) — same cross-module-within-`state`-tree visibility
+    /// `build_stage_context` below already uses.
+    pub(super) async fn publish_stage_context(&self, context: &StageContext) -> anyhow::Result<()> {
         let code = self.stage_layout_code().await;
         let context = self.enrich_stage_context(context).await;
 

--- a/crates/presenter-server/src/state/slide_stage_layout.rs
+++ b/crates/presenter-server/src/state/slide_stage_layout.rs
@@ -7,6 +7,7 @@
 
 use super::AppState;
 use presenter_core::{PresentationId, SlideId};
+use presenter_persistence::RepositoryError;
 use std::collections::HashMap;
 
 impl AppState {
@@ -19,11 +20,15 @@ impl AppState {
         slide_id: SlideId,
         layout_code: Option<&str>,
     ) -> anyhow::Result<()> {
+        // #629: presentation_id/slide_id are URL-path resources — a missing
+        // one is a typed 404, matching the same check everywhere else in the
+        // codebase (state/slides/edit_ops.rs, state/bible.rs), never a bare
+        // anyhow! that falls through to the router's default 500.
         let Some((_, _, presentation)) = self.presentation_detail(presentation_id).await? else {
-            anyhow::bail!("presentation not found");
+            return Err(RepositoryError::NotFound("presentation not found").into());
         };
         if !presentation.slides.iter().any(|slide| slide.id == slide_id) {
-            anyhow::bail!("slide not found in presentation");
+            return Err(RepositoryError::NotFound("slide not found").into());
         }
 
         match layout_code {

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -444,7 +444,11 @@ impl AppState {
             map.insert(slide.id, slide);
         }
         if order.len() != map.len() {
-            return Err(anyhow::anyhow!("slide order length mismatch"));
+            // #628: typed refusal, matching the per-id lookup guard below —
+            // a stale/short body (e.g. after a concurrent edit shrank the
+            // slide list) is a body-referenced mismatch, not an internal
+            // fault. A bare anyhow! here fell through to a 500.
+            return Err(RepositoryError::TargetNotFound("slide order length mismatch").into());
         }
         let mut slides = Vec::with_capacity(order.len());
         for id in order {

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -1,6 +1,6 @@
 //! Stage display methods for `AppState`.
 
-use super::stage::build_stage_snapshot;
+use super::stage::{build_stage_snapshot, StageContext};
 use super::AppState;
 use crate::live::LiveEvent;
 use presenter_core::{
@@ -148,6 +148,27 @@ impl AppState {
         publish_snapshots: bool,
     ) -> anyhow::Result<StageDisplayLayout> {
         let layout = Self::validate_operator_selectable(code)?;
+
+        // Fast path: skip the DB read below entirely when the layout is
+        // already selected (the common "click the same layout again" case).
+        // The authoritative no-op check under the write-lock guard further
+        // down is unchanged.
+        if self.stage_layout_code().await == layout.code {
+            return Ok(layout);
+        }
+
+        // #631: build the stage snapshot context — the ONE fallible step in
+        // this whole switch — BEFORE any side effect. If it fails, the
+        // caller gets a genuine error and NOTHING has changed: no RwLock
+        // write, no persist, no broadcast. Previously this build happened
+        // AFTER the switch had already been applied, persisted, and
+        // broadcast (LiveEvent::StageLayout), so a failure here (e.g. a
+        // corrupted timers row) misreported an already-successful layout
+        // switch as a 500 to the caller.
+        let context = self
+            .context_for_pending_switch(&layout, publish_snapshots)
+            .await?;
+
         {
             let mut guard = self.stage_layout.write().await;
             if *guard == layout.code {
@@ -155,10 +176,40 @@ impl AppState {
             }
             *guard = layout.code.clone();
         }
-        // Persist the new layout so it survives a restart/deploy (#384). The
-        // in-memory RwLock above is the live source of truth for broadcasts;
-        // the DB write only seeds the RwLock on the next startup. A failed
-        // write must NOT abort the live layout switch, so log and continue.
+        self.persist_and_broadcast_switch(&layout, context).await;
+        Ok(layout)
+    }
+
+    /// The one fallible step of a layout switch (`#631`) — a DB read that
+    /// depends only on the CURRENT stage state, never on the layout being
+    /// switched TO, so it is safe to compute before any side effect. `None`
+    /// when no snapshot broadcast is needed at all (the api layout drives
+    /// its own snapshot separately; `publish_snapshots = false` callers
+    /// broadcast their own resolution right after, #515).
+    async fn context_for_pending_switch(
+        &self,
+        layout: &StageDisplayLayout,
+        publish_snapshots: bool,
+    ) -> anyhow::Result<Option<StageContext>> {
+        if layout.code == API_STAGE_LAYOUT_CODE || !publish_snapshots {
+            return Ok(None);
+        }
+        self.build_stage_context().await
+    }
+
+    /// Persist + broadcast a switch that has ALREADY been applied to the
+    /// in-memory RwLock. Both steps are best-effort: the switch itself
+    /// already committed, so neither a persist failure nor a broadcast
+    /// failure may turn an already-successful switch into a caller-visible
+    /// error (#384 for persist, #631 for the snapshot broadcast).
+    async fn persist_and_broadcast_switch(
+        &self,
+        layout: &StageDisplayLayout,
+        context: Option<StageContext>,
+    ) {
+        // Persist so the layout survives a restart/deploy (#384). The
+        // in-memory RwLock is the live source of truth for broadcasts; the
+        // DB write only seeds the RwLock on the next startup.
         if let Err(err) = self
             .repository()
             .set_app_setting(STAGE_LAYOUT_KEY, &layout.code)
@@ -184,10 +235,19 @@ impl AppState {
             // marker path also short-circuits on the api layout.
             let snapshot = self.api_stage_snapshot().await;
             self.live_hub.publish(LiveEvent::Stage { snapshot });
-        } else if publish_snapshots {
-            self.broadcast_stage_snapshots().await?;
+        } else if let Some(context) = context {
+            // #631: publish the ALREADY-BUILT context — this only maps it
+            // onto a snapshot and publishes (effectively infallible once
+            // `context` exists).
+            if let Err(err) = self.publish_stage_context(&context).await {
+                tracing::warn!(
+                    ?err,
+                    code = %layout.code,
+                    "failed to publish stage snapshot after layout switch — \
+                     the switch itself already committed"
+                );
+            }
         }
-        Ok(layout)
     }
 
     pub async fn stage_displays(&self) -> anyhow::Result<Vec<StageDisplayLayout>> {


### PR DESCRIPTION
## Typed-refusal batch — #628 + #629 + #631 + #632

Closes #628
Closes #629
Closes #631
Closes #632

### What

- **#628:** `reorder_slides` with a stale client body (length mismatch) returned 500 — now a typed `RepositoryError::TargetNotFound` → 422 (`state/slides/edit_ops.rs`), matching the sibling per-id guard.
- **#629:** `slide_stage_layout` PUT with a missing presentation/slide regressed 400→500, and an existing test cemented the wrong behavior — now `RepositoryError::NotFound` → 404; the wrong test was repurposed (own commit, justified) to a genuine dropped-table internal failure.
- **#631:** `set_stage_layout` could return 500 AFTER the switch was applied, persisted and broadcast — the fallible stage-snapshot context is now built BEFORE the RwLock write/persist/broadcast (`state/stage_display.rs`, split into `context_for_pending_switch` + `persist_and_broadcast_switch`).
- **#632:** playlist entries referencing an unknown `presentation_id` hit the FK as 500 — new `ensure_presentation_targets_exist` guard (`repository/playlist.rs`) → 422, mirroring `ensure_playlist_exists` (#610).

### How verified

- RED→GREEN per ticket: `eaac4c35`→`b8e9e988` (#628), `f35a19fa`→`f48a1163` (#629, wrong-test-fix `bf3ebab0` in its own commit), `7e700894`→`71e87b17` (#631), `dbc157fb`→`f64582d6` (#632).
- Version bump 0.4.227 first commit (`1fe73b2c`).
- Pipeline run 31057963617 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Design comments with root cause + chosen approach on each ticket before code.
- Also carries `bc2839b8` (docs: sync-lww invariants playbook rule from the #646 review cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
