### PR TITLE
Review-fix batch #652: stale-broadcast probe, tombstone guard, txn guards, stage/state typed refusals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.227"
+version = "0.4.228"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.227"
+version = "0.4.228"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -143,10 +143,17 @@ impl Repository {
     /// constraint (`PRAGMA foreign_keys = ON`) -> DbErr -> 500. `presentation_id`
     /// is BODY-referenced (the entries array), not the URL, so the refusal is
     /// `TargetNotFound` (422), not `NotFound` (404) — the router maps it
-    /// alongside `NotFound`. Deliberately does NOT filter on `deleted_at IS
-    /// NULL`: a soft-deleted presentation's row still physically exists, so
-    /// it would NOT trip the FK constraint either — this check matches
-    /// exactly what the FK itself would reject, no stricter.
+    /// alongside `NotFound`.
+    ///
+    /// #652 F2: DOES filter on `deleted_at IS NULL` (reversing the original
+    /// #632 rationale) — a trashed presentation's row still physically
+    /// exists so it would NOT trip the raw FK constraint either, but a
+    /// trashed target IS the "body-referenced target does not exist" case
+    /// this 422 already describes. Without the filter, a stale editor's
+    /// full-array PUT could silently re-persist a trashed song as a
+    /// nameless, un-triggerable ghost entry — undoing #555's "a deleted song
+    /// leaves every playlist" (the same filter the name lookup in this file
+    /// already applies).
     async fn ensure_presentation_targets_exist(
         &self,
         entries: &[presenter_core::PlaylistEntry],
@@ -167,6 +174,7 @@ impl Repository {
         ids.dedup();
         let existing = presentation_entity::Entity::find()
             .filter(presentation_entity::Column::Id.is_in(ids.clone()))
+            .filter(presentation_entity::Column::DeletedAt.is_null())
             .count(&self.db)
             .await?;
         if existing as usize == ids.len() {

--- a/crates/presenter-persistence/src/repository/playlist.rs
+++ b/crates/presenter-persistence/src/repository/playlist.rs
@@ -4,8 +4,8 @@ use crate::entities::{
 use chrono::Utc;
 use presenter_core::{playlist::PlaylistEntryKind, Playlist, PlaylistId, PresentationId};
 use sea_orm::{
-    sea_query::Expr, sea_query::OnConflict, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter,
-    QueryOrder, Set, TransactionTrait,
+    sea_query::Expr, sea_query::OnConflict, ColumnTrait, ConnectionTrait, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use std::collections::{HashMap, HashSet};
 use tracing::instrument;
@@ -90,7 +90,7 @@ impl Repository {
         playlist_id: PlaylistId,
         favorite: bool,
     ) -> anyhow::Result<()> {
-        self.ensure_playlist_exists(playlist_id).await?;
+        self.ensure_playlist_exists(&self.db, playlist_id).await?;
         self.set_playlist_favorite_internal(playlist_id, favorite)
             .await
     }
@@ -122,10 +122,18 @@ impl Repository {
         Ok(())
     }
 
-    async fn ensure_playlist_exists(&self, playlist_id: PlaylistId) -> anyhow::Result<()> {
+    /// #652 F3: takes the connection generically so callers that need the
+    /// check to run INSIDE their own transaction (`replace_playlist_entries`)
+    /// can pass `&txn`; callers with no transaction of their own pass
+    /// `&self.db` (`set_playlist_favorite`).
+    async fn ensure_playlist_exists(
+        &self,
+        conn: &impl ConnectionTrait,
+        playlist_id: PlaylistId,
+    ) -> anyhow::Result<()> {
         let count = playlist::Entity::find()
             .filter(playlist::Column::Id.eq(playlist_id.to_string()))
-            .count(&self.db)
+            .count(conn)
             .await?;
         if count > 0 {
             Ok(())
@@ -154,8 +162,15 @@ impl Repository {
     /// nameless, un-triggerable ghost entry — undoing #555's "a deleted song
     /// leaves every playlist" (the same filter the name lookup in this file
     /// already applies).
+    ///
+    /// #652 F3: takes the connection generically — `replace_playlist_entries`
+    /// passes `&txn` so this guard runs INSIDE the same transaction as the
+    /// delete+insert below it, closing the window where a concurrent hard
+    /// delete (sync apply / purge) between a guard on `&self.db` and the
+    /// insert could still trip the raw FK 500 this guard exists to prevent.
     async fn ensure_presentation_targets_exist(
         &self,
+        conn: &impl ConnectionTrait,
         entries: &[presenter_core::PlaylistEntry],
     ) -> anyhow::Result<()> {
         let mut ids: Vec<String> = entries
@@ -172,12 +187,15 @@ impl Repository {
         }
         ids.sort();
         ids.dedup();
+        // #652 F10: capture the length before `ids` moves into `.is_in(ids)`
+        // — cloning just to keep `ids.len()` alive afterward was needless.
+        let expected = ids.len();
         let existing = presentation_entity::Entity::find()
-            .filter(presentation_entity::Column::Id.is_in(ids.clone()))
+            .filter(presentation_entity::Column::Id.is_in(ids))
             .filter(presentation_entity::Column::DeletedAt.is_null())
-            .count(&self.db)
+            .count(conn)
             .await?;
-        if existing as usize == ids.len() {
+        if existing as usize == expected {
             Ok(())
         } else {
             Err(RepositoryError::TargetNotFound(
@@ -201,14 +219,22 @@ impl Repository {
         playlist_id: PlaylistId,
         entries: &[presenter_core::PlaylistEntry],
     ) -> anyhow::Result<()> {
+        // #652 F3: begin the transaction FIRST and run BOTH existence guards
+        // against `&txn` — running them on `&self.db` before the txn began
+        // (pre-#652) left a window where a concurrent hard delete (sync
+        // apply / purge) between a guard and the insert below could still
+        // trip the raw FK 500 these guards exist to prevent. A guard failure
+        // returns via `?` before `txn.commit()`, so the transaction is
+        // dropped and rolled back — no delete_many/insert below has run yet.
+        let txn = self.db.begin().await?;
+
         // #610: without this check, an unknown `playlist_id` with a NON-EMPTY `entries` slice
         // trips `fk_playlist_entries_playlist` on the INSERT below (PRAGMA foreign_keys = ON) ->
         // raw DbErr -> 500. An empty slice skipped the insert loop and never exercised that path.
-        self.ensure_playlist_exists(playlist_id).await?;
+        self.ensure_playlist_exists(&txn, playlist_id).await?;
         // #632: the twin FK check for `presentation_id` (see doc comment above).
-        self.ensure_presentation_targets_exist(entries).await?;
-
-        let txn = self.db.begin().await?;
+        self.ensure_presentation_targets_exist(&txn, entries)
+            .await?;
 
         playlist_entry::Entity::delete_many()
             .filter(playlist_entry::Column::PlaylistId.eq(playlist_id.to_string()))

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -200,6 +200,19 @@ pub(super) async fn replace_playlist_entries(
             }
         })
         .collect::<Result<Vec<_>, _>>()?;
+
+    // #652 F9: reject a payload with a duplicate `entryId` HERE — pure body
+    // validation, before the request ever reaches state/repository. Left
+    // unchecked, a repeated id reaches the repository's raw INSERT unchanged
+    // and trips a PK violation on the second row -> 500 (hardening; no UI
+    // path emits this today).
+    let mut seen_ids = std::collections::HashSet::with_capacity(entries.len());
+    for entry in &entries {
+        if !seen_ids.insert(entry.id) {
+            return Err(AppError::unprocessable("duplicate playlist entry id"));
+        }
+    }
+
     let playlist = state
         .replace_playlist_entries(PlaylistId::from_uuid(id), entries)
         .await

--- a/crates/presenter-server/src/router/playlists.rs
+++ b/crates/presenter-server/src/router/playlists.rs
@@ -207,3 +207,50 @@ pub(super) async fn replace_playlist_entries(
     let enriched = state.enrich_playlist_with_names(playlist).await?;
     Ok(Json(enriched))
 }
+
+#[cfg(test)]
+mod duplicate_entry_id_tests {
+    use super::*;
+    use axum::extract::{Path, State};
+    use axum::response::IntoResponse;
+
+    /// #652 F9: a replace payload with two entries sharing the SAME explicit
+    /// `entryId` reaches the repository's raw INSERT unchanged and trips a
+    /// PK violation -> 500 (hardening; no UI path emits this today).
+    /// Settled design: reject it in the ROUTER handler — pure body
+    /// validation, no repository call at all — before the request ever
+    /// reaches state.
+    #[tokio::test]
+    async fn replace_entries_rejects_duplicate_entry_id() {
+        let state = AppState::in_memory().await.unwrap();
+        let playlist = state.create_playlist("Dup Test", false).await.unwrap();
+        let shared_id = Uuid::new_v4();
+
+        let result = replace_playlist_entries(
+            State(state),
+            Path(playlist.id.into_uuid()),
+            Json(UpdatePlaylistEntriesRequest {
+                entries: vec![
+                    PlaylistEntryPayload::Separator {
+                        entry_id: Some(shared_id),
+                        name: "A".to_string(),
+                    },
+                    PlaylistEntryPayload::Separator {
+                        entry_id: Some(shared_id),
+                        name: "B".to_string(),
+                    },
+                ],
+            }),
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("expected a duplicate-entry-id refusal, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "a duplicate playlist entry id must be 422, not a raw PK-violation 500 (#652 F9)"
+        );
+    }
+}

--- a/crates/presenter-server/src/router/presentations.rs
+++ b/crates/presenter-server/src/router/presentations.rs
@@ -100,13 +100,17 @@ pub(super) async fn get_presentation_detail(
 /// string match on the `Display` text (#584; mirrors `libraries.rs`'s
 /// `map_repository_not_found`). `NotFound` (the URL resource itself is
 /// missing) maps to 404; `TargetNotFound` (a body-referenced resource is
-/// missing) maps to 422. Any other error falls through to the default 500.
+/// missing) maps to 422; `Conflict` (the resource exists but its current
+/// state forbids the operation — e.g. #652 F5's reorder length mismatch)
+/// maps to 409, mirroring `PasteSlidesError::AnchorVanished` below. Any
+/// other error falls through to the default 500.
 fn map_repository_error(err: anyhow::Error) -> AppError {
     match err.downcast_ref::<presenter_persistence::RepositoryError>() {
         Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
         Some(presenter_persistence::RepositoryError::TargetNotFound(msg)) => {
             AppError::unprocessable(*msg)
         }
+        Some(presenter_persistence::RepositoryError::Conflict(msg)) => AppError::conflict(*msg),
         _ => err.into(),
     }
 }

--- a/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
+++ b/crates/presenter-server/src/router/presentations_slide_edit_tests.rs
@@ -185,14 +185,19 @@ async fn reorder_on_a_vanished_presentation_is_a_404() {
 }
 
 #[tokio::test]
-async fn reorder_with_fewer_slide_ids_than_exist_is_a_422() {
+async fn reorder_with_fewer_slide_ids_than_exist_is_a_409() {
     // #628: the length-mismatch guard directly above the per-id lookup guard
-    // (`edit_ops.rs:446`) was left as a bare `anyhow!`, unlike its sibling
-    // (`:451`, covered by `reorder_naming_an_unknown_slide_in_the_body_is_a_422`
+    // in `reorder_slides` was left as a bare `anyhow!`, unlike its sibling
+    // (covered by `reorder_naming_an_unknown_slide_in_the_body_is_a_422`
     // below), so a stale/short body (e.g. after a concurrent edit shrank the
-    // slide list) fell through to a 500 instead of the intended 422. Sending
-    // only ONE of the seeded presentation's two slide ids hits the
-    // length-mismatch guard specifically (not the per-id lookup).
+    // slide list) fell through to a 500 instead of a typed refusal.
+    //
+    // #652 F5: reclassified 422 -> 409 — a length mismatch is a STALE-SET
+    // conflict (the body was built against a slide count that has since
+    // changed), not a missing-target refusal; the client should refresh and
+    // retry, mirroring `PasteSlidesError::AnchorVanished`'s 409. Sending only
+    // ONE of the seeded presentation's two slide ids hits the length-
+    // mismatch guard specifically (not the per-id lookup).
     let state = AppState::in_memory().await.unwrap();
     let (pres_id, [real_a, _real_b]) = seed(&state).await;
     let app = build_router(state);
@@ -204,7 +209,7 @@ async fn reorder_with_fewer_slide_ids_than_exist_is_a_422() {
         Some(body),
     )
     .await;
-    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test]
@@ -214,8 +219,9 @@ async fn reorder_naming_an_unknown_slide_in_the_body_is_a_422() {
     // target → 422 (TargetNotFound), not 404 — matching the established
     // `paste_slides` UnknownSlides→422 convention in the same module. The
     // bogus id is sent ALONGSIDE a real one with matching length so the
-    // request reaches the per-slide lookup (`:452`), not the earlier
-    // length-mismatch guard (`:446`).
+    // request reaches the per-slide lookup in `reorder_slides`, not the
+    // earlier length-mismatch guard
+    // (`reorder_with_fewer_slide_ids_than_exist_is_a_409`, now 409 — #652 F5).
     let state = AppState::in_memory().await.unwrap();
     let (pres_id, [real_a, _real_b]) = seed(&state).await;
     let app = build_router(state);

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -276,4 +276,24 @@ mod tests {
             "a non-existent slide_id must be 404, not 500 (#629)"
         );
     }
+
+    /// #652 F8: GET and PUT must agree on an unknown presentation — they
+    /// name the SAME URL resource. PUT already 404s (see
+    /// `put_returns_404_for_unknown_presentation` above); GET currently
+    /// returns a misleading 200 `{}` instead.
+    #[tokio::test]
+    async fn get_returns_404_for_unknown_presentation() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        let random_uuid = uuid::Uuid::new_v4();
+
+        let result = list_slide_stage_layouts(State(state), Path(random_uuid.to_string())).await;
+        let Err(err) = result else {
+            panic!("expected an error for a non-existent presentation, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "GET on an unknown presentation must be 404, matching PUT (#652 F8)"
+        );
+    }
 }

--- a/crates/presenter-server/src/router/slide_stage_layout.rs
+++ b/crates/presenter-server/src/router/slide_stage_layout.rs
@@ -78,9 +78,14 @@ pub(super) async fn list_slide_stage_layouts(
     Path(presentation_id): Path<String>,
 ) -> Result<Json<HashMap<String, String>>, AppError> {
     let presentation_uuid = super::parse_uuid("presentationId", &presentation_id)?;
+    // #652 F8: reuse the SAME error-mapping helper the PUT handler above
+    // uses — `slide_stage_layouts` now raises the same typed
+    // `RepositoryError::NotFound` for an unknown presentation, so GET and
+    // PUT agree on the same URL resource (404, not 200 `{}`).
     let map = state
         .slide_stage_layouts(PresentationId::from_uuid(presentation_uuid))
-        .await?;
+        .await
+        .map_err(map_slide_stage_layout_error)?;
     Ok(Json(map))
 }
 

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -256,12 +256,13 @@ mod set_stage_layout_error_mapping_tests {
     use axum::response::IntoResponse;
 
     /// An internal failure unrelated to the layout code itself (here: a
-    /// corrupted `timers` row surfaced while `broadcast_stage_snapshots`
-    /// rebuilds the stage context after a VALID layout switch) must answer
-    /// 500 — never 404. Before the #588 fix, `set_stage_layout` mapped every
-    /// error from `set_stage_layout_code` to `AppError::not_found`, so this
-    /// genuine server fault was reported to the client as "layout not
-    /// found".
+    /// corrupted `timers` row surfaced while the PRE-SWITCH validation probe
+    /// — `context_for_pending_switch` building the stage context BEFORE the
+    /// switch itself commits, #631/#652 F1 — rebuilds the stage context)
+    /// must answer 500 — never 404. Before the #588 fix, `set_stage_layout`
+    /// mapped every error from `set_stage_layout_code` to
+    /// `AppError::not_found`, so this genuine server fault was reported to
+    /// the client as "layout not found".
     #[tokio::test]
     async fn set_stage_layout_returns_500_on_internal_failure_not_404() {
         let state = crate::state::AppState::in_memory().await.unwrap();
@@ -292,7 +293,8 @@ mod set_stage_layout_error_mapping_tests {
 
         // Switch to a DIFFERENT valid, operator-selectable code so the
         // early-return-on-unchanged-code guard doesn't short-circuit before
-        // `broadcast_stage_snapshots` runs.
+        // the pre-switch validation probe (`context_for_pending_switch`)
+        // runs.
         let result = set_stage_layout(
             State(state),
             Json(StageLayoutUpdateRequest {
@@ -318,8 +320,15 @@ mod set_stage_layout_error_mapping_tests {
     /// corruption happens BEFORE the switch attempt (not after), so the
     /// failure surfaces from the pre-switch snapshot-context build rather
     /// than from a step that runs after the switch already committed.
+    ///
+    /// #652 F1: extended to also assert the PERSISTED layout setting and the
+    /// `LiveEvent::StageLayout` broadcast are untouched — the original test
+    /// only asserted the in-memory code (review finding F6).
     #[tokio::test]
     async fn set_stage_layout_failure_does_not_apply_the_switch() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
         let state = crate::state::AppState::in_memory().await.unwrap();
         // Seed the timers row via an initial valid switch.
         let _ = set_stage_layout(
@@ -343,6 +352,11 @@ mod set_stage_layout_error_mapping_tests {
         .await
         .unwrap();
 
+        // Subscribe AFTER the corruption, BEFORE the failing attempt, so a
+        // spurious `LiveEvent::StageLayout` from the failed switch would be
+        // observed here.
+        let mut rx = state.live_hub().subscribe();
+
         let result = set_stage_layout(
             State(state.clone()),
             Json(StageLayoutUpdateRequest {
@@ -360,6 +374,20 @@ mod set_stage_layout_error_mapping_tests {
             "timer",
             "#631: a failed switch must not have applied the layout change — \
              the client's 500 must mean nothing changed"
+        );
+        assert_eq!(
+            state
+                .repository()
+                .get_app_setting(crate::state::stage_display::STAGE_LAYOUT_KEY)
+                .await
+                .unwrap(),
+            Some("timer".to_string()),
+            "#652 F1: a failed switch must not have persisted the new layout code either"
+        );
+        let no_event = timeout(Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            no_event.is_err(),
+            "#652 F1: a failed switch must not have published LiveEvent::StageLayout either"
         );
     }
 

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -112,6 +112,24 @@ pub(super) struct StageStateRequest {
     pub(super) entry_index: Option<u32>,
 }
 
+/// Maps an `update_stage_state` refusal to its HTTP status via the TYPED
+/// `RepositoryError` variant — never the blanket `.map_err(AppError::bad_request)`
+/// this replaces (#652 F4, the #615 anti-pattern: a genuine internal fault
+/// used to answer 400, and an unknown/trashed `presentationId` answered 400
+/// instead of 404). `NotFound` (the triggered presentation no longer exists)
+/// maps to 404; `TargetNotFound` (the body's `currentSlideId`/`nextSlideId`
+/// doesn't belong to that presentation) maps to 422. Any other error falls
+/// through to the router's default 500 mapping.
+fn map_repository_not_found(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<presenter_persistence::RepositoryError>() {
+        Some(presenter_persistence::RepositoryError::NotFound(msg)) => AppError::not_found(*msg),
+        Some(presenter_persistence::RepositoryError::TargetNotFound(msg)) => {
+            AppError::unprocessable(*msg)
+        }
+        _ => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(super) async fn update_stage_state(
     State(state): State<AppState>,
@@ -138,7 +156,7 @@ pub(super) async fn update_stage_state(
             payload.entry_index,
         )
         .await
-        .map_err(AppError::bad_request)?;
+        .map_err(map_repository_not_found)?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/presenter-server/src/router/stage.rs
+++ b/crates/presenter-server/src/router/stage.rs
@@ -413,3 +413,117 @@ mod set_stage_layout_error_mapping_tests {
         );
     }
 }
+
+/// #652 F4: `POST /stage/state` blanket-mapped EVERY error to 400 (the #615
+/// anti-pattern) via `.map_err(AppError::bad_request)` — an unknown/trashed
+/// `presentationId` answered 400 instead of 404, a body-referenced slide id
+/// answered 400 instead of 422, and a genuine internal failure answered 400
+/// instead of 500 (client blamed for a server fault).
+#[cfg(test)]
+mod update_stage_state_error_mapping_tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+
+    #[tokio::test]
+    async fn update_stage_state_returns_404_for_unknown_presentation() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        let random_presentation = uuid::Uuid::new_v4();
+        let random_slide = uuid::Uuid::new_v4();
+
+        let result = update_stage_state(
+            State(state),
+            Json(StageStateRequest {
+                presentation_id: random_presentation.to_string(),
+                current_slide_id: random_slide.to_string(),
+                next_slide_id: None,
+                playlist_id: None,
+                entry_index: None,
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for a non-existent presentation, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::NOT_FOUND,
+            "an unknown presentationId must be 404, not 400 (#652 F4)"
+        );
+    }
+
+    /// A genuine internal fault (here: the `stage_state` table dropped out
+    /// from under the upsert) unrelated to the request body must answer 500
+    /// — never 400.
+    #[tokio::test]
+    async fn update_stage_state_returns_500_on_internal_failure_not_400() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        crate::state::seed_sample_library(&state).await.unwrap();
+        let libraries = state.libraries().await.unwrap();
+        let presentation = &libraries[0].presentations[0];
+        let current_slide = presentation.slides[0].id;
+
+        let conn = state.repository().connection();
+        sea_orm::ConnectionTrait::execute(
+            conn,
+            sea_orm::Statement::from_string(
+                sea_orm::ConnectionTrait::get_database_backend(conn),
+                "DROP TABLE stage_state".to_string(),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let result = update_stage_state(
+            State(state),
+            Json(StageStateRequest {
+                presentation_id: presentation.id.to_string(),
+                current_slide_id: current_slide.to_string(),
+                next_slide_id: None,
+                playlist_id: None,
+                entry_index: None,
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error from the dropped table, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a genuine internal failure must be 500, not 400 (#652 F4)"
+        );
+    }
+
+    /// A `currentSlideId` that doesn't belong to the presentation is a
+    /// body-referenced missing target — 422, not 400 (traced alongside the
+    /// presentation-not-found bail per the settled design's "trace every
+    /// caller" instruction).
+    #[tokio::test]
+    async fn update_stage_state_returns_422_for_slide_not_in_presentation() {
+        let state = crate::state::AppState::in_memory().await.unwrap();
+        crate::state::seed_sample_library(&state).await.unwrap();
+        let libraries = state.libraries().await.unwrap();
+        let presentation = &libraries[0].presentations[0];
+
+        let result = update_stage_state(
+            State(state),
+            Json(StageStateRequest {
+                presentation_id: presentation.id.to_string(),
+                current_slide_id: SlideId::new().to_string(),
+                next_slide_id: None,
+                playlist_id: None,
+                entry_index: None,
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected an error for a slide not in the presentation, got Ok");
+        };
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "a currentSlideId not in the presentation must be 422, not 400 (#652 F4)"
+        );
+    }
+}

--- a/crates/presenter-server/src/router/tests.rs
+++ b/crates/presenter-server/src/router/tests.rs
@@ -3167,6 +3167,56 @@ async fn replace_playlist_entries_endpoint_unknown_presentation_id_is_a_422() {
 }
 
 #[tokio::test]
+async fn replace_playlist_entries_endpoint_tombstoned_presentation_is_a_422() {
+    // #652 F2: `ensure_presentation_targets_exist` (#632) had no `DeletedAt`
+    // filter, unlike the twin name-lookup in the same file — a trashed
+    // presentation's row still physically exists (soft delete), so a stale
+    // editor's full-array PUT re-persisting it as an entry silently
+    // resurrected it into the playlist, undoing #555's "a deleted song
+    // leaves every playlist". A trashed target IS the "body-referenced
+    // target does not exist" case the 422 already describes.
+    let state = AppState::in_memory().await.unwrap();
+    let library = state
+        .create_library("F2 Tombstone Test Library")
+        .await
+        .unwrap();
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "To Be Trashed", None)
+        .await
+        .unwrap();
+    state.delete_presentation(presentation.id).await.unwrap();
+    let playlist = state
+        .create_playlist("Stale Editor Playlist", false)
+        .await
+        .unwrap();
+    let app = build_router(state);
+
+    let body = json!({
+        "entries": [
+            { "type": "presentation", "presentationId": presentation.id }
+        ]
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(axum::http::Method::PUT)
+                .uri(format!("/playlists/{}/entries", playlist.id))
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a trashed presentation referenced in the entries array must be rejected, not \
+         silently re-persisted into the playlist (#652 F2)"
+    );
+}
+
+#[tokio::test]
 async fn restore_presentation_endpoint_never_trashed_returns_404() {
     // #608 item 4: `restore_presentation_endpoint_missing_trashed_presentation_returns_404`
     // above claims to cover "an unknown id AND a never-trashed presentation" but only drives the

--- a/crates/presenter-server/src/state/slide_stage_layout.rs
+++ b/crates/presenter-server/src/state/slide_stage_layout.rs
@@ -62,10 +62,18 @@ impl AppState {
 
     /// All markers of a presentation as `slide_id → layout_code` (operator UI
     /// indicators).
+    ///
+    /// #652 F8: checks presentation existence FIRST — the same check
+    /// `assign_slide_stage_layout` (PUT) already performs — so GET and PUT
+    /// agree on the SAME URL resource. Without it, an unknown/trashed
+    /// presentation returned a misleading 200 `{}` instead of 404.
     pub async fn slide_stage_layouts(
         &self,
         presentation_id: PresentationId,
     ) -> anyhow::Result<HashMap<String, String>> {
+        if self.presentation_detail(presentation_id).await?.is_none() {
+            return Err(RepositoryError::NotFound("presentation not found").into());
+        }
         self.repository
             .list_slide_stage_layouts(presentation_id)
             .await

--- a/crates/presenter-server/src/state/slides/edit_ops.rs
+++ b/crates/presenter-server/src/state/slides/edit_ops.rs
@@ -444,11 +444,16 @@ impl AppState {
             map.insert(slide.id, slide);
         }
         if order.len() != map.len() {
-            // #628: typed refusal, matching the per-id lookup guard below —
-            // a stale/short body (e.g. after a concurrent edit shrank the
-            // slide list) is a body-referenced mismatch, not an internal
-            // fault. A bare anyhow! here fell through to a 500.
-            return Err(RepositoryError::TargetNotFound("slide order length mismatch").into());
+            // #628: typed refusal — a bare anyhow! here fell through to 500.
+            // #652 F5: reclassified from `TargetNotFound` (422) to
+            // `Conflict` (409) — this is a STALE-SET conflict (the body was
+            // built against a slide count that has since changed via a
+            // concurrent edit), not a body-referenced missing target; the
+            // client should refresh and retry, mirroring
+            // `PasteSlidesError::AnchorVanished`'s 409. The per-id lookup
+            // guard below (a genuinely UNKNOWN slide id) stays
+            // `TargetNotFound`/422.
+            return Err(RepositoryError::Conflict("slide order length mismatch").into());
         }
         let mut slides = Vec::with_capacity(order.len());
         for id in order {

--- a/crates/presenter-server/src/state/stage_display.rs
+++ b/crates/presenter-server/src/state/stage_display.rs
@@ -165,9 +165,19 @@ impl AppState {
         // broadcast (LiveEvent::StageLayout), so a failure here (e.g. a
         // corrupted timers row) misreported an already-successful layout
         // switch as a 500 to the caller.
-        let context = self
+        //
+        // #652 F1: this build is now a VALIDATION PROBE ONLY — its result is
+        // discarded (`.is_some()`), never threaded through to the publish
+        // below. Reusing the pre-built context for the publish widened the
+        // stale-broadcast window: a stage trigger landing between this probe
+        // and the persist/broadcast below could publish its own fresh
+        // snapshot, only for THIS switch to then overwrite it with the
+        // stale, pre-built one. `persist_and_broadcast_switch` re-derives a
+        // FRESH context via `broadcast_stage_snapshots()` instead.
+        let needs_snapshot_broadcast = self
             .context_for_pending_switch(&layout, publish_snapshots)
-            .await?;
+            .await?
+            .is_some();
 
         {
             let mut guard = self.stage_layout.write().await;
@@ -176,7 +186,8 @@ impl AppState {
             }
             *guard = layout.code.clone();
         }
-        self.persist_and_broadcast_switch(&layout, context).await;
+        self.persist_and_broadcast_switch(&layout, needs_snapshot_broadcast)
+            .await;
         Ok(layout)
     }
 
@@ -186,6 +197,10 @@ impl AppState {
     /// when no snapshot broadcast is needed at all (the api layout drives
     /// its own snapshot separately; `publish_snapshots = false` callers
     /// broadcast their own resolution right after, #515).
+    ///
+    /// #652 F1: the caller only inspects `.is_some()` — the built
+    /// `StageContext` itself is a validation PROBE and is never published
+    /// (see `switch_stage_layout`).
     async fn context_for_pending_switch(
         &self,
         layout: &StageDisplayLayout,
@@ -202,10 +217,18 @@ impl AppState {
     /// already committed, so neither a persist failure nor a broadcast
     /// failure may turn an already-successful switch into a caller-visible
     /// error (#384 for persist, #631 for the snapshot broadcast).
+    ///
+    /// `needs_snapshot_broadcast` is the OUTCOME of the pre-switch
+    /// validation probe (`context_for_pending_switch`), never its actual
+    /// `StageContext` value (#652 F1) — when a broadcast is needed, this
+    /// re-derives a FRESH context via `broadcast_stage_snapshots()` rather
+    /// than publishing the (potentially now-stale) probed one, so a stage
+    /// trigger that landed in the probe-to-persist window is never
+    /// overwritten by this switch's stale snapshot.
     async fn persist_and_broadcast_switch(
         &self,
         layout: &StageDisplayLayout,
-        context: Option<StageContext>,
+        needs_snapshot_broadcast: bool,
     ) {
         // Persist so the layout survives a restart/deploy (#384). The
         // in-memory RwLock is the live source of truth for broadcasts; the
@@ -235,11 +258,10 @@ impl AppState {
             // marker path also short-circuits on the api layout.
             let snapshot = self.api_stage_snapshot().await;
             self.live_hub.publish(LiveEvent::Stage { snapshot });
-        } else if let Some(context) = context {
-            // #631: publish the ALREADY-BUILT context — this only maps it
-            // onto a snapshot and publishes (effectively infallible once
-            // `context` exists).
-            if let Err(err) = self.publish_stage_context(&context).await {
+        } else if needs_snapshot_broadcast {
+            // #652 F1: re-derive a FRESH context here rather than reusing
+            // the probe's (potentially stale) result.
+            if let Err(err) = self.broadcast_stage_snapshots().await {
                 tracing::warn!(
                     ?err,
                     code = %layout.code,

--- a/crates/presenter-server/src/state/stage_state.rs
+++ b/crates/presenter-server/src/state/stage_state.rs
@@ -9,6 +9,7 @@ use super::stage::{
 };
 use super::AppState;
 use presenter_core::{PlaylistId, PresentationId, Slide, SlideId, StageState};
+use presenter_persistence::RepositoryError;
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -25,18 +26,30 @@ impl AppState {
         let start = Instant::now();
 
         let validate_start = Instant::now();
+        // #652 F4: `presentation_id` is the trigger's SUBJECT — a missing one
+        // is the typed refusal (#584 pattern) the router downcasts to 404,
+        // never a bare `anyhow!` that falls through to the router's default
+        // 500 mapping.
         let Some((_, library_name, presentation)) =
             self.presentation_detail(presentation_id).await?
         else {
-            anyhow::bail!("presentation not found");
+            return Err(RepositoryError::NotFound("presentation not found").into());
         };
 
+        // #652 F4: `currentSlideId`/`nextSlideId` are BODY-referenced (not
+        // the URL) — a stale client sending an id that doesn't belong to
+        // this presentation is a body-referenced missing target, matching
+        // the established convention used by `paste_slides`/`reorder_slides`
+        // (422), not a bare `anyhow!` that fell through to 500 (or, before
+        // this fix, was blanket-mapped to 400 at the router).
         if !presentation
             .slides
             .iter()
             .any(|slide| slide.id == current_slide_id)
         {
-            anyhow::bail!("current slide not found in presentation");
+            return Err(
+                RepositoryError::TargetNotFound("current slide not found in presentation").into(),
+            );
         }
 
         if let Some(next_slide_id) = next_slide_id {
@@ -45,7 +58,10 @@ impl AppState {
                 .iter()
                 .any(|slide| slide.id == next_slide_id)
             {
-                anyhow::bail!("next slide not found in presentation");
+                return Err(RepositoryError::TargetNotFound(
+                    "next slide not found in presentation",
+                )
+                .into());
             }
         }
         let t_validate_ms = validate_start.elapsed().as_secs_f64() * 1000.0;


### PR DESCRIPTION
## Review-fix batch for PR #651 findings

Closes #652

### What

Adversarial post-merge review of PR #651 (typed-refusal batch #628+#629+#631+#632) found 0 🔴 4 🟡 6 🔵 — all fixed here per the settled design on #652:

- **🟡 F1 (`state/stage_display.rs`):** the #631 fix published a stage context captured BEFORE the lock + persist, widening the stale-broadcast window (a concurrent trigger's fresh broadcast could be overwritten by the pre-built stale one). The pre-build is now a pure validation probe (fail fast — #631's "500 means nothing changed" holds) and the publish re-derives a fresh context via `broadcast_stage_snapshots()`. Taking `stage_trigger_lock` was verified UNSAFE (self-deadlock via `update_stage_state → apply_slide_stage_layout_marker → switch_stage_layout`) and skipped per the design's fallback.
- **🟡 F2 (`repository/playlist.rs`):** the #632 guard accepted tombstoned presentations — a stale full-array PUT could re-persist a trashed song as a nameless ghost entry. Guard now filters `DeletedAt.is_null()` → 422.
- **🟡 F3 (`repository/playlist.rs`):** the #632 existence guards ran outside the transaction (check-then-insert race vs hard delete → raw FK 500). Guards now run inside the same txn as the replace.
- **🟡 F4 (`state/stage_state.rs` + `router/stage.rs`):** `POST /stage/state` mapped EVERY error to 400 (the #615 anti-pattern) — unknown presentation now a typed 404, body-referenced missing slides 422, genuine faults fall through to 500.
- **🔵 F5:** `reorder_slides` length mismatch reclassified `TargetNotFound`/422 → `RepositoryError::Conflict`/409 (stale-set conflict, matching the file's own `AnchorVanished` precedent); per-id missing stays 422.
- **🔵 F8:** GET `list_slide_stage_layouts` now 404s an unknown presentation (was 200 `{}` while the PUT 404s — same URL resource, two answers).
- **🔵 F9:** duplicate `entryId` in a replace payload rejected 422 in the router (was PK violation → 500).
- **🔵 F6/F10:** stale doc comments + rotted line refs fixed; needless `ids.clone()` dropped.
- F7 (corrupt timers row blocks layout switching — intended fail-loud) recorded on #631, no code change.

### How verified

- RED→GREEN per behavior-changing finding (commit stack `e7c1ce0b..c0e525f7`); version bump 0.4.228 first commit.
- Pipeline run 31063027235 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Design comment with per-finding rationale + F1 lock-safety proof: #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
