### PR TITLE
AbleSet review-fix batch: pre-service setlist, frozen report, gap-ack 422, log-spam under lock (v0.4.230)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.229"
+version = "0.4.230"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.229"
+version = "0.4.230"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-core/src/ableset.rs
+++ b/crates/presenter-core/src/ableset.rs
@@ -230,23 +230,80 @@ pub fn strip_song_prefix(name: &str, length: u8) -> &str {
     trimmed[length as usize..].trim_start()
 }
 
+/// Folds a small set of non-decomposable Latin letters (#655 F13) — ł, ø, đ,
+/// ħ, ŧ (and their uppercase forms) are single base glyphs with a stroke,
+/// not a base letter plus a combining mark, so NFD decomposition followed by
+/// combining-mark removal never touches them. Any other character passes
+/// through unchanged. Applied AFTER mark-stripping in
+/// `normalize_title_for_mismatch`, same as a diacritic would be.
+fn fold_non_decomposable_letter(ch: char) -> char {
+    match ch {
+        'ł' | 'Ł' => 'l',
+        'ø' | 'Ø' => 'o',
+        'đ' | 'Đ' => 'd',
+        'ħ' | 'Ħ' => 'h',
+        'ŧ' | 'Ŧ' => 't',
+        other => other,
+    }
+}
+
+/// Collapses whitespace runs for `normalize_title_for_mismatch` (#655
+/// F11/F12, re-settled design): a run bordered by a digit on BOTH sides is
+/// formatting noise (a thousands-grouping space, e.g. "10 000" -> "10000")
+/// and is removed entirely; every other whitespace run — including one
+/// bordered by a digit on only one side — collapses to a single space, never
+/// erased, so a genuine word boundary is preserved. `title` is expected to
+/// already have punctuation filtered out (see caller), so "digit" here means
+/// any ASCII digit immediately adjacent in the filtered string.
+fn collapse_whitespace_digit_aware(title: &str) -> String {
+    let chars: Vec<char> = title.chars().collect();
+    let mut result = String::with_capacity(title.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i].is_whitespace() {
+            let mut j = i;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            let prev_is_digit = result
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_ascii_digit());
+            let next_is_digit = chars.get(j).is_some_and(|c| c.is_ascii_digit());
+            if !(prev_is_digit && next_is_digit) {
+                result.push(' ');
+            }
+            i = j;
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+    result
+}
+
 /// Normalise a song title for the AbleSet<->Presenter mismatch comparison
-/// (#601): diacritic-, whitespace-, punctuation-, and case-insensitive.
-/// Whitespace is treated as FORMATTING variance, the same class as
-/// diacritics — the original settled design kept inner whitespace
-/// significant, but that misclassified the exact `10000 armad` vs
-/// `10 000 armád` prod SNV case (a diacritic-only difference in every
-/// respect except spacing) as a genuine mismatch, producing a false-positive
-/// warning. Titles that differ ONLY by inner spacing are now silent, same as
-/// a diacritic-only difference; a genuinely different title stays reported
-/// regardless of its spacing.
+/// (#601, re-settled by #655 F11/F12): diacritic-, punctuation-, and
+/// case-insensitive, plus the non-decomposable-letter fold (F13). Whitespace
+/// is digit-aware: a run BETWEEN DIGITS is formatting noise and is removed
+/// (e.g. the prod SNV `10000 armad` vs `10 000 armád` case); every other
+/// whitespace run collapses to a single space but is never erased, so a
+/// genuine word-boundary difference still compares as a mismatch. An earlier
+/// design stripped ALL whitespace unconditionally under CI pressure — that
+/// went too far and erased word boundaries; this replaces it.
 #[must_use]
 pub fn normalize_title_for_mismatch(title: &str) -> String {
     let no_diacritics: String = title.nfd().filter(|ch| !is_combining_mark(*ch)).collect();
-    no_diacritics
+    let folded: String = no_diacritics
         .chars()
-        .filter(|ch| ch.is_alphanumeric())
-        .collect::<String>()
+        .map(fold_non_decomposable_letter)
+        .collect();
+    let filtered: String = folded
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || ch.is_whitespace())
+        .collect();
+    collapse_whitespace_digit_aware(&filtered)
+        .trim()
         .to_lowercase()
 }
 

--- a/crates/presenter-core/src/ableset.rs
+++ b/crates/presenter-core/src/ableset.rs
@@ -175,6 +175,13 @@ pub struct AbleSetStatusSnapshot {
     /// resolution/projection, it is a pre-service checklist only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mismatches: Vec<AbleSetTitleMismatch>,
+    /// Total number of AbleSet<->Presenter mismatches BEFORE truncation to
+    /// the bounded `mismatches` list above (#655 F15) — the inline list caps
+    /// at 25 entries for a 5s-polled status endpoint; this field tells the
+    /// operator how many more exist beyond what is shown. `#[serde(default)]`
+    /// for the UI round-trip (same precedent as `recent_attempts`, #600).
+    #[serde(default)]
+    pub mismatch_count: usize,
 }
 
 /// One AbleSet<->Presenter numbering disagreement for `GET

--- a/crates/presenter-core/src/ableset.rs
+++ b/crates/presenter-core/src/ableset.rs
@@ -325,16 +325,71 @@ mod tests {
     }
 
     #[test]
-    fn normalize_title_for_mismatch_treats_inner_whitespace_as_insignificant() {
-        // Design revision (CI fix on top of #601): the #601 SNV boundary
-        // case "10000 armad" vs "10 000 armád" is a diacritic-only pair with
-        // incidental spacing — it must be silently equal, same as any other
-        // whitespace/diacritic formatting variance, not flagged as a
-        // genuine mismatch. This replaces the original conservative
-        // "whitespace stays significant" assertion this test used to make.
+    fn normalize_title_for_mismatch_removes_whitespace_only_between_digits() {
+        // Re-settled design (#655 F11/F12), replacing BOTH prior designs: the
+        // ORIGINAL design kept all inner whitespace significant (too narrow —
+        // missed the #601 SNV "10000 armad" vs "10 000 armád" case); the
+        // `fix(ci)` commit on top of it went too far under CI pressure and
+        // stripped ALL whitespace, erasing genuine word boundaries. The
+        // re-settled design: a whitespace run BETWEEN DIGITS ("10 000"
+        // grouping) is formatting noise and is removed, same class as a
+        // diacritic-only difference; every OTHER whitespace run collapses to
+        // a single space but is never removed.
         assert_eq!(
-            normalize_title_for_mismatch("10000 armad"),
-            normalize_title_for_mismatch("10 000 armád")
+            normalize_title_for_mismatch("102 10 000 armád"),
+            normalize_title_for_mismatch("102 10000 armad"),
+            "a whitespace run between two digits must be treated as formatting noise"
+        );
+    }
+
+    #[test]
+    fn normalize_title_for_mismatch_still_differs_when_non_digit_spacing_differs() {
+        // Counterpart to the test above: a whitespace run that is NOT
+        // between two digits is a genuine word boundary, not formatting
+        // noise — two titles differing only by whether that boundary has a
+        // space must still compare as different. This is exactly the
+        // over-broad-stripping regression the `fix(ci)` design introduced
+        // (and this re-settled design fixes): stripping ALL whitespace would
+        // make "Arriba Song" and "ArribaSong" compare equal.
+        assert_ne!(
+            normalize_title_for_mismatch("Arriba Song"),
+            normalize_title_for_mismatch("ArribaSong"),
+            "a non-digit whitespace boundary must not be silently erased"
+        );
+    }
+
+    #[test]
+    fn normalize_title_for_mismatch_folds_non_decomposable_letters() {
+        // #655 F13: ł, ø, đ, ħ, ŧ (and their uppercase forms) are single base
+        // glyphs with a stroke, not a base letter + combining mark — NFD
+        // mark-stripping alone does not touch them. A tiny explicit fold
+        // table closes the gap so these still compare equal to their plain
+        // Latin counterpart, the same way a diacritic (mark-based) letter
+        // already does.
+        assert_eq!(
+            normalize_title_for_mismatch("Łódź"),
+            normalize_title_for_mismatch("Lodz"),
+            "ł/Ł must fold to l/L"
+        );
+        assert_eq!(
+            normalize_title_for_mismatch("Øresund"),
+            normalize_title_for_mismatch("Oresund"),
+            "ø/Ø must fold to o/O"
+        );
+        assert_eq!(
+            normalize_title_for_mismatch("Đorđe"),
+            normalize_title_for_mismatch("Dorde"),
+            "đ/Đ must fold to d/D"
+        );
+        assert_eq!(
+            normalize_title_for_mismatch("Ħamrun"),
+            normalize_title_for_mismatch("Hamrun"),
+            "ħ/Ħ must fold to h/H"
+        );
+        assert_eq!(
+            normalize_title_for_mismatch("Ŧullio"),
+            normalize_title_for_mismatch("Tullio"),
+            "ŧ/Ŧ must fold to t/T"
         );
     }
 

--- a/crates/presenter-core/src/contract_tests.rs
+++ b/crates/presenter-core/src/contract_tests.rs
@@ -401,6 +401,7 @@ mod tests {
             cache_last_error: None,
             recent_attempts: Vec::new(),
             mismatches: Vec::new(),
+            mismatch_count: 0,
         };
         let json = serde_json::to_string(&snapshot).expect("serialize");
         assert!(json.contains("followEnabled"), "expected camelCase: {json}");
@@ -448,6 +449,7 @@ mod tests {
             cache_last_error: None,
             recent_attempts: Vec::new(),
             mismatches: Vec::new(),
+            mismatch_count: 0,
         };
         let json = serde_json::to_string(&snapshot).expect("serialize");
         assert!(json.contains("lastError"), "expected camelCase: {json}");

--- a/crates/presenter-server/src/ableset.rs
+++ b/crates/presenter-server/src/ableset.rs
@@ -472,6 +472,54 @@ fn setlist_fingerprint(songs: &[SetlistSong]) -> u64 {
     hasher.finish()
 }
 
+/// #655 F1: the setlist LIST can change (loaded, reordered, songs
+/// skipped/unskipped) independent of the active song -- a setlist loaded
+/// before the service starts never has an active song at all, so gating the
+/// rebuild on the active-song id alone left it permanently empty
+/// pre-service. Fingerprint-compares the current tick's setlist against the
+/// last tick's and rebuilds the cached `status.setlist_songs` only when it
+/// actually changed, to avoid unnecessary allocations every 250ms.
+///
+/// Extracted from `run_tracker` (#655 F17) to keep it under the
+/// function-length cap. Pure motion: the caller still updates
+/// `prev_setlist_fingerprint` and fires `setlist_changed_tx` itself, AFTER
+/// releasing the status write lock, exactly as before this extraction —
+/// this fn only returns `(list_changed, new_fingerprint)` so the caller can
+/// do that unchanged.
+fn refresh_setlist_songs(
+    status: &mut AbleSetStatusInner,
+    setlist: &SetlistResponse,
+    prev_setlist_fingerprint: Option<u64>,
+) -> (bool, u64) {
+    let new_fingerprint = setlist_fingerprint(&setlist.songs);
+    let list_changed = prev_setlist_fingerprint != Some(new_fingerprint);
+
+    if list_changed {
+        // Rebuild cached song list only when the list actually changed to
+        // avoid unnecessary allocations every 250ms.
+        status.setlist_songs = setlist
+            .songs
+            .iter()
+            .map(|s| {
+                let name = s
+                    .meta
+                    .as_ref()
+                    .and_then(|m| m.name.as_ref().cloned().or_else(|| m.raw.clone()))
+                    .or_else(|| s.cue.as_ref().and_then(|c| c.name.clone()))
+                    .unwrap_or_default();
+                let skipped = s.internal_meta.as_ref().map_or(false, |m| m.skipped);
+                SetlistCachedSong {
+                    id: s.id.clone().unwrap_or_default(),
+                    name,
+                    skipped,
+                }
+            })
+            .collect();
+    }
+
+    (list_changed, new_fingerprint)
+}
+
 async fn run_tracker(
     inner: Arc<AbleSetInner>,
     config: AbleSetTrackerConfig,
@@ -498,31 +546,13 @@ async fn run_tracker(
                     Ok(Some(setlist)) => {
                         let new_active_id = setlist.active_song_id.clone();
                         let song_changed = new_active_id != prev_active_id;
-                        // #655 F1: the setlist LIST can change (loaded, reordered,
-                        // songs skipped/unskipped) independent of the active song
-                        // -- a setlist loaded before the service starts never has
-                        // an active song at all, so gating the rebuild on
-                        // song_changed alone left it permanently empty pre-service.
-                        let new_fingerprint = setlist_fingerprint(&setlist.songs);
-                        let list_changed = prev_setlist_fingerprint != Some(new_fingerprint);
                         let mut status = inner.status.write().await;
-
-                        if list_changed {
-                            // Rebuild cached song list only when the list actually
-                            // changed to avoid unnecessary allocations every 250ms.
-                            status.setlist_songs = setlist.songs.iter().map(|s| {
-                                let name = s.meta.as_ref()
-                                    .and_then(|m| m.name.as_ref().cloned().or_else(|| m.raw.clone()))
-                                    .or_else(|| s.cue.as_ref().and_then(|c| c.name.clone()))
-                                    .unwrap_or_default();
-                                let skipped = s.internal_meta.as_ref().map_or(false, |m| m.skipped);
-                                SetlistCachedSong {
-                                    id: s.id.clone().unwrap_or_default(),
-                                    name,
-                                    skipped,
-                                }
-                            }).collect();
-                        }
+                        // #655 F1/F17: fingerprint-compares the setlist LIST itself
+                        // (independent of the active song) and rebuilds
+                        // status.setlist_songs on a real change — see
+                        // refresh_setlist_songs's doc comment for the full "why".
+                        let (list_changed, new_fingerprint) =
+                            refresh_setlist_songs(&mut status, &setlist, prev_setlist_fingerprint);
 
                         if let Some(active_id) = &setlist.active_song_id {
                             let mut found = false;

--- a/crates/presenter-server/src/ableset.rs
+++ b/crates/presenter-server/src/ableset.rs
@@ -279,6 +279,7 @@ impl AbleSetBridge {
             cache_last_error: None,
             recent_attempts: Vec::new(),
             mismatches: Vec::new(),
+            mismatch_count: 0,
         }
     }
 
@@ -388,6 +389,7 @@ fn mock_status_from_state(state: &MockAbleSetState) -> AbleSetStatusSnapshot {
             cache_last_error: None,
             recent_attempts: Vec::new(),
             mismatches: Vec::new(),
+            mismatch_count: 0,
         }
     } else {
         AbleSetStatusSnapshot {
@@ -406,6 +408,7 @@ fn mock_status_from_state(state: &MockAbleSetState) -> AbleSetStatusSnapshot {
             cache_last_error: None,
             recent_attempts: Vec::new(),
             mismatches: Vec::new(),
+            mismatch_count: 0,
         }
     }
 }

--- a/crates/presenter-server/src/ableset.rs
+++ b/crates/presenter-server/src/ableset.rs
@@ -37,6 +37,13 @@ struct AbleSetInner {
     status: RwLock<AbleSetStatusInner>,
     tracker: Mutex<Option<TrackerGuard>>,
     song_changed_tx: tokio::sync::broadcast::Sender<()>,
+    /// Fires whenever the tracked SETLIST (song list/order/skip-flags)
+    /// changes, independent of whether the active song changed (#655 F1/F2)
+    /// — a setlist can be loaded, reordered, or edited before the service
+    /// starts, well before any song becomes active. `state::mod`'s
+    /// `spawn_ableset_setlist_change_refresh` subscribes to this to keep the
+    /// #601 mismatch report from freezing at boot.
+    setlist_changed_tx: tokio::sync::broadcast::Sender<()>,
 }
 
 struct AbleSetStatusInner {
@@ -145,6 +152,7 @@ impl AbleSetBridge {
                 }),
                 tracker: Mutex::new(None),
                 song_changed_tx: tokio::sync::broadcast::channel(16).0,
+                setlist_changed_tx: tokio::sync::broadcast::channel(16).0,
             }),
         }
     }
@@ -152,6 +160,14 @@ impl AbleSetBridge {
     /// Returns a receiver that fires whenever the active song changes.
     pub fn subscribe_song_changes(&self) -> tokio::sync::broadcast::Receiver<()> {
         self.inner.song_changed_tx.subscribe()
+    }
+
+    /// Returns a receiver that fires whenever the tracked SETLIST changes
+    /// (#655 F1/F2) — song list membership, order, or skip flags, independent
+    /// of whether the active song changed. Used to keep the #601 mismatch
+    /// report from freezing at the last active-song change.
+    pub fn subscribe_setlist_changes(&self) -> tokio::sync::broadcast::Receiver<()> {
+        self.inner.setlist_changed_tx.subscribe()
     }
 
     pub async fn apply_settings(&self, mut settings: AbleSetSettings) -> anyhow::Result<()> {
@@ -429,6 +445,30 @@ impl AbleSetClient for MockAbleSetClient {
     }
 }
 
+/// Cheap per-tick fingerprint of the raw AbleSet setlist (#655 F1) — hashes
+/// id/name/skipped-flag for every song WITHOUT cloning any strings, so it can
+/// run on every 250ms poll tick regardless of whether anything changed. Only
+/// a fingerprint CHANGE triggers the allocation-heavy `setlist_songs` rebuild
+/// below (preserves the original allocation guard); comparing this instead of
+/// only the active-song id is what lets a setlist loaded/reordered/edited
+/// BEFORE the service starts (no active song yet) still be detected.
+fn setlist_fingerprint(songs: &[SetlistSong]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for song in songs {
+        song.id.hash(&mut hasher);
+        let name: Option<&str> = song
+            .meta
+            .as_ref()
+            .and_then(|m| m.name.as_deref().or(m.raw.as_deref()))
+            .or_else(|| song.cue.as_ref().and_then(|c| c.name.as_deref()));
+        name.hash(&mut hasher);
+        let skipped = song.internal_meta.as_ref().is_some_and(|m| m.skipped);
+        skipped.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 async fn run_tracker(
     inner: Arc<AbleSetInner>,
     config: AbleSetTrackerConfig,
@@ -441,6 +481,7 @@ async fn run_tracker(
         song_prefix_length,
     } = config;
     let mut prev_active_id: Option<String> = None;
+    let mut prev_setlist_fingerprint: Option<u64> = None;
     let mut interval = interval(Duration::from_millis(POLL_INTERVAL_MS));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -454,11 +495,18 @@ async fn run_tracker(
                     Ok(Some(setlist)) => {
                         let new_active_id = setlist.active_song_id.clone();
                         let song_changed = new_active_id != prev_active_id;
+                        // #655 F1: the setlist LIST can change (loaded, reordered,
+                        // songs skipped/unskipped) independent of the active song
+                        // -- a setlist loaded before the service starts never has
+                        // an active song at all, so gating the rebuild on
+                        // song_changed alone left it permanently empty pre-service.
+                        let new_fingerprint = setlist_fingerprint(&setlist.songs);
+                        let list_changed = prev_setlist_fingerprint != Some(new_fingerprint);
                         let mut status = inner.status.write().await;
 
-                        if song_changed {
-                            // Rebuild cached song list only when the active song
-                            // changes to avoid unnecessary allocations every 250ms
+                        if list_changed {
+                            // Rebuild cached song list only when the list actually
+                            // changed to avoid unnecessary allocations every 250ms.
                             status.setlist_songs = setlist.songs.iter().map(|s| {
                                 let name = s.meta.as_ref()
                                     .and_then(|m| m.name.as_ref().cloned().or_else(|| m.raw.clone()))
@@ -477,11 +525,11 @@ async fn run_tracker(
                             let mut found = false;
                             for (idx, song) in setlist.songs.iter().enumerate() {
                                 if song.id.as_deref() == Some(active_id.as_str()) {
-                                    let name = if song_changed {
-                                        status.setlist_songs[idx].name.clone()
-                                    } else if let Some(last) = &status.last_song {
-                                        last.name.clone()
-                                    } else {
+                                    // `status.setlist_songs` is always current here:
+                                    // freshly rebuilt above if the list changed, or
+                                    // left as-is from a prior tick whose fingerprint
+                                    // proves it is still identical to `setlist.songs`.
+                                    let Some(name) = status.setlist_songs.get(idx).map(|s| s.name.clone()) else {
                                         continue;
                                     };
                                     if let Some(prefix) = extract_song_prefix(&name, song_prefix_length) {
@@ -515,6 +563,10 @@ async fn run_tracker(
                             status.last_error = None;
                         }
                         drop(status);
+                        if list_changed {
+                            prev_setlist_fingerprint = Some(new_fingerprint);
+                            let _ = inner.setlist_changed_tx.send(());
+                        }
                         if song_changed {
                             prev_active_id = new_active_id;
                             let _ = inner.song_changed_tx.send(());
@@ -525,6 +577,10 @@ async fn run_tracker(
                         status.last_song = None;
                         status.setlist_songs.clear();
                         status.last_error = None;
+                        drop(status);
+                        if prev_setlist_fingerprint.take().is_some() {
+                            let _ = inner.setlist_changed_tx.send(());
+                        }
                     }
                     Err(err) => {
                         let mut status = inner.status.write().await;
@@ -713,13 +769,15 @@ mod tests {
         let mock_server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/api/setlist"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "activeSongId": null,
-                "songs": [
-                    { "id": "s1", "meta": { "name": "017 Viem, ze Ty Pan" } },
-                    { "id": "s2", "meta": { "name": "018 Another Song" } }
-                ]
-            })))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "activeSongId": null,
+                    "songs": [
+                        { "id": "s1", "meta": { "name": "017 Viem, ze Ty Pan" } },
+                        { "id": "s2", "meta": { "name": "018 Another Song" } }
+                    ]
+                })),
+            )
             .mount(&mock_server)
             .await;
 

--- a/crates/presenter-server/src/ableset.rs
+++ b/crates/presenter-server/src/ableset.rs
@@ -699,6 +699,65 @@ mod tests {
         assert_eq!(next, None);
     }
 
+    /// #655 F1 — RED (this commit): a setlist loaded before the service
+    /// starts (nothing playing yet, `activeSongId: null`) must populate
+    /// `setlist_song_titles()` immediately — this is #601's primary
+    /// pre-service-checklist use case. Before the fix, `run_tracker` only
+    /// rebuilds `setlist_songs` inside `if song_changed`, and
+    /// `prev_active_id` starts `None`; with no active song ever reported,
+    /// `new_active_id (None) != prev_active_id (None)` is always `false`, so
+    /// the rebuild never runs and the mismatch report stays "all gaps"
+    /// indefinitely, until the first song is played (too late).
+    #[tokio::test]
+    async fn setlist_populates_before_any_active_song_is_played() {
+        let mock_server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/setlist"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activeSongId": null,
+                "songs": [
+                    { "id": "s1", "meta": { "name": "017 Viem, ze Ty Pan" } },
+                    { "id": "s2", "meta": { "name": "018 Another Song" } }
+                ]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let bridge = AbleSetBridge::new();
+        let addr = mock_server.address();
+        let settings = AbleSetSettings::new(
+            true,
+            addr.ip().to_string(),
+            39051,
+            addr.port(),
+            "Hymnal".to_string(),
+            3,
+            Utc::now(),
+            Utc::now(),
+        );
+        bridge.apply_settings(settings).await.unwrap();
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if !bridge.setlist_song_titles().await.is_empty() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "setlist_song_titles() must populate from a loaded setlist even with \
+                 no active song (activeSongId: null) — #655 F1"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let titles = bridge.setlist_song_titles().await;
+        assert_eq!(
+            titles.len(),
+            2,
+            "both setlist songs must be present pre-service: {titles:?}"
+        );
+    }
+
     #[tokio::test]
     async fn setlist_song_titles_excludes_skipped_and_no_prefix_songs() {
         // #601: the mismatch report is built from this list, so it must

--- a/crates/presenter-server/src/osc/handler.rs
+++ b/crates/presenter-server/src/osc/handler.rs
@@ -14,6 +14,7 @@ use tokio::{
 };
 use tracing::{debug, info, warn};
 
+use crate::state::ableset::AbleSetResolution;
 use crate::state::AppState;
 
 use super::parser::{extract_note_velocity, Extracted};
@@ -236,13 +237,30 @@ async fn trigger_slide(
         return Ok(());
     };
 
-    let Some(presentation_id) = app_state.resolve_ableset_presentation(&song.prefix).await? else {
-        warn!(
-            prefix = %song.prefix,
-            song = %song.name,
-            "AbleSet prefix missing in library — resolution miss"
-        );
-        return Ok(());
+    // #655 F16: the tri-state resolution lets this log the ACCURATE reason
+    // instead of always claiming "prefix missing in library" even when the
+    // integration is simply disabled.
+    let presentation_id = match app_state
+        .resolve_ableset_presentation_detailed(&song.prefix)
+        .await?
+    {
+        AbleSetResolution::Resolved(id) => id,
+        AbleSetResolution::Disabled => {
+            debug!(
+                prefix = %song.prefix,
+                song = %song.name,
+                "AbleSet OSC trigger skipped — AbleSet integration is disabled"
+            );
+            return Ok(());
+        }
+        AbleSetResolution::NoMatch => {
+            warn!(
+                prefix = %song.prefix,
+                song = %song.name,
+                "AbleSet prefix missing in library — resolution miss"
+            );
+            return Ok(());
+        }
     };
 
     let detail = app_state

--- a/crates/presenter-server/src/router/integrations/ableset.rs
+++ b/crates/presenter-server/src/router/integrations/ableset.rs
@@ -32,6 +32,19 @@ pub(crate) struct UnacknowledgeAbleSetMismatchPayload {
     pub(super) number: String,
 }
 
+/// Maps an ack/unack refusal to its HTTP status via the TYPED
+/// `AbleSetAckRefusal` domain error (#655 F4/F9) — a one-sided structural
+/// gap, an invalid number, or a full acknowledgement store all answer 422,
+/// never a blanket 200 or 500. Any other error falls through to the
+/// router's default 500 mapping. Per
+/// `.claude/rules/repository-error-pattern.md`'s domain-error pattern.
+fn map_ableset_ack_refusal(err: anyhow::Error) -> AppError {
+    match err.downcast_ref::<crate::state::ableset_ack::AbleSetAckRefusal>() {
+        Some(refusal) => AppError::unprocessable(refusal.to_string()),
+        None => err.into(),
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn get_ableset_settings(
     State(state): State<AppState>,
@@ -70,10 +83,12 @@ pub(crate) async fn set_ableset_follow(
     Ok(Json(snapshot))
 }
 
-/// #601: "visible/revocable" per the settled design. Idempotent — there is
-/// no NotFound case (acknowledging a number that isn't currently mismatched
-/// just sits unused until it applies), so a genuine failure here is a real
-/// internal fault and falls through to the router's default 500.
+/// #601: "visible/revocable" per the settled design. Idempotent for an
+/// UNKNOWN (but validly-shaped) number — acknowledging one that isn't
+/// currently mismatched just sits unused until it applies. A structural gap,
+/// a malformed number, or a full store (#655 F4/F9) answer 422 via
+/// `map_ableset_ack_refusal`; any other failure is a real internal fault and
+/// falls through to the router's default 500.
 #[instrument(skip_all)]
 pub(crate) async fn acknowledge_ableset_mismatch(
     State(state): State<AppState>,
@@ -85,7 +100,8 @@ pub(crate) async fn acknowledge_ableset_mismatch(
             &payload.ableset_title,
             &payload.presenter_title,
         )
-        .await?;
+        .await
+        .map_err(map_ableset_ack_refusal)?;
     Ok(Json(snapshot))
 }
 
@@ -96,6 +112,7 @@ pub(crate) async fn unacknowledge_ableset_mismatch(
 ) -> Result<Json<crate::ableset::AbleSetStatusSnapshot>, AppError> {
     let snapshot = state
         .unacknowledge_ableset_mismatch(&payload.number)
-        .await?;
+        .await
+        .map_err(map_ableset_ack_refusal)?;
     Ok(Json(snapshot))
 }

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -4,6 +4,7 @@ use presenter_core::{
     AbleSetTitleMismatch, PresentationId,
 };
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::Ordering;
 use tracing::{info, warn};
 
 use super::ableset_ack::AckMap;
@@ -47,6 +48,20 @@ pub(crate) struct AbleSetResolutionAttempt {
     /// Whether the prefix resolved to a known presentation (`true`) or was a
     /// cache miss (`false`).
     pub(crate) found: bool,
+}
+
+/// Internal tri-state result of an AbleSet prefix resolution attempt (#655
+/// F16) — lets `osc::handler::trigger_slide` log the ACCURATE reason a
+/// trigger produced no presentation instead of always claiming "prefix
+/// missing in library" even when the integration was simply disabled. The
+/// public `resolve_ableset_presentation` (used by the existing ~15 call
+/// sites/tests) keeps its `Option<PresentationId>` signature unchanged —
+/// this is an additive internal API, not a breaking one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbleSetResolution {
+    Resolved(PresentationId),
+    Disabled,
+    NoMatch,
 }
 
 #[derive(Default)]
@@ -249,6 +264,13 @@ impl AppState {
             .upsert_ableset_settings(&draft, source, actor)
             .await?;
         self.ableset_bridge.apply_settings(settings.clone()).await?;
+        if settings.enabled {
+            // #655 F16: re-arm the edge-triggered disabled-WARN so the NEXT
+            // disable is logged again, instead of staying silently
+            // suppressed forever by a flag left over from a previous disable.
+            self.ableset_disabled_warn_shown
+                .store(false, Ordering::SeqCst);
+        }
         {
             let mut cache = self.caches.ableset.write().await;
             cache.invalidate();
@@ -293,25 +315,56 @@ impl AppState {
         self.ableset_bridge.song_snapshot().await
     }
 
+    /// #655 F16: kept as a thin `Option<PresentationId>` wrapper over
+    /// [`Self::resolve_ableset_presentation_detailed`] so the ~15 existing
+    /// call sites/tests need no change. Production code (`osc::handler`) now
+    /// calls the `_detailed` tri-state directly for accurate logging; this
+    /// wrapper's only remaining callers are tests, hence the dead-code
+    /// allowance outside `cfg(test)`.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub async fn resolve_ableset_presentation(
         &self,
         prefix: &str,
     ) -> anyhow::Result<Option<PresentationId>> {
+        Ok(
+            match self.resolve_ableset_presentation_detailed(prefix).await? {
+                AbleSetResolution::Resolved(id) => Some(id),
+                AbleSetResolution::Disabled | AbleSetResolution::NoMatch => None,
+            },
+        )
+    }
+
+    /// Tri-state resolution (#655 F16) — see [`AbleSetResolution`]. Lets
+    /// `osc::handler::trigger_slide` distinguish "integration disabled" from
+    /// a genuine cache miss and log the accurate reason for each, instead of
+    /// always claiming "prefix missing in library".
+    pub(crate) async fn resolve_ableset_presentation_detailed(
+        &self,
+        prefix: &str,
+    ) -> anyhow::Result<AbleSetResolution> {
         let key = prefix.trim();
         if key.is_empty() {
-            return Ok(None);
+            return Ok(AbleSetResolution::NoMatch);
         }
         let settings = self.ableset_bridge.status_snapshot().await;
         if !settings.enabled {
-            // #623: #600 named this exact early return as the one that
-            // "fails EVERY song with no log" — an operator who forgot to
-            // (re-)enable the integration otherwise sees only silent
-            // no-ops on every incoming song change.
-            warn!(
-                prefix = key,
-                "AbleSet resolution skipped — AbleSet integration is disabled"
-            );
-            return Ok(None);
+            // #655 F16: edge-triggered — WARN only on the enabled->disabled
+            // transition (previously this fired on EVERY OSC event while
+            // disabled — up to once per slide advance — with zero new
+            // information after the first).
+            if !self
+                .ableset_disabled_warn_shown
+                .swap(true, Ordering::SeqCst)
+            {
+                warn!(
+                    prefix = key,
+                    "AbleSet resolution skipped — AbleSet integration is disabled"
+                );
+            }
+            // #655 F16: record the attempt even on the disabled path so
+            // `recentAttempts` shows evidence instead of silence.
+            self.caches.ableset.write().await.record_attempt(key, false);
+            return Ok(AbleSetResolution::Disabled);
         }
         self.ensure_ableset_cache(&settings).await?;
         let lookup = key.to_ascii_lowercase();
@@ -339,7 +392,10 @@ impl AppState {
             }
         }
 
-        Ok(result)
+        Ok(match result {
+            Some(id) => AbleSetResolution::Resolved(id),
+            None => AbleSetResolution::NoMatch,
+        })
     }
 
     async fn ensure_ableset_cache(&self, settings: &AbleSetStatusSnapshot) -> anyhow::Result<()> {

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -15,6 +15,25 @@ use crate::ableset::AbleSetStatusSnapshot;
 /// memory on a long-running instance.
 const MAX_RECENT_ATTEMPTS: usize = 20;
 
+/// Bounded retry count for a single `refresh_ableset_cache` call (#655 F7):
+/// a #639 CAS rejection means a concurrent invalidate won the race, not that
+/// the fetched data is wrong — retrying the SAME logical rebuild lets it win
+/// against a one-off collision instead of silently dropping the current
+/// resolution attempt (a regression the #639 fix introduced: pre-#639 a lost
+/// race at least projected stale-but-usually-correct data; post-#639 it
+/// projected nothing until the NEXT trigger).
+const MAX_REFRESH_ATTEMPTS: u8 = 3;
+
+/// Number of sample mismatches carried in the #655 F5b summary WARN — the
+/// full list is still available in full on the status endpoint (bounded
+/// separately, see `cap_mismatches_for_status`).
+const MISMATCH_LOG_SAMPLE_SIZE: usize = 5;
+
+/// Cooldown window for the `entries.is_empty()` retry escape hatch in
+/// `ensure_ableset_cache` (#655 F5a) — a library-name typo means EVERY
+/// resolve call would otherwise re-trigger a full DB rescan + WARN burst.
+const FAILED_REBUILD_RETRY_COOLDOWN: chrono::Duration = chrono::Duration::seconds(5);
+
 /// A single AbleSet song-resolution attempt, retained for diagnostic purposes
 /// (#600). Surfaced read-only via `/integrations/ableset/status` so operators
 /// can answer "it didn't work 30 min ago" from data instead of memory.
@@ -62,6 +81,12 @@ pub(crate) struct AbleSetLibraryCache {
     /// `invalidate_entries` — an ack is keyed on song NUMBER, not on which
     /// library is currently tracked.
     pub(crate) acks: AckMap,
+    /// Timestamp of the last rebuild attempt that produced ZERO entries
+    /// (#655 F5a) — consulted by `ensure_ableset_cache`'s `entries.is_empty()`
+    /// retry escape hatch so a persistently broken configuration (e.g. a
+    /// library-name typo) doesn't re-trigger a full DB rescan on every single
+    /// resolve call.
+    pub(crate) last_failed_rebuild_attempt: Option<DateTime<Utc>>,
 }
 
 impl AbleSetLibraryCache {
@@ -73,6 +98,7 @@ impl AbleSetLibraryCache {
         self.last_error = None;
         self.mismatches.clear();
         self.presenter_titles.clear();
+        self.last_failed_rebuild_attempt = None;
         self.generation = self.generation.wrapping_add(1);
     }
 
@@ -86,6 +112,7 @@ impl AbleSetLibraryCache {
         self.entries.clear();
         self.mismatches.clear();
         self.presenter_titles.clear();
+        self.last_failed_rebuild_attempt = None;
         self.generation = self.generation.wrapping_add(1);
     }
 
@@ -138,6 +165,13 @@ impl AbleSetLibraryCache {
     /// invalidate.
     pub(crate) fn generation(&self) -> u64 {
         self.generation
+    }
+
+    /// Whether the most recent rebuild attempt produced zero entries within
+    /// the retry cooldown window (#655 F5a).
+    pub(crate) fn recently_failed_rebuild(&self) -> bool {
+        self.last_failed_rebuild_attempt
+            .is_some_and(|at| Utc::now().signed_duration_since(at) < FAILED_REBUILD_RETRY_COOLDOWN)
     }
 
     /// Install a freshly-fetched refresh, but only if `expected_generation`
@@ -311,8 +345,17 @@ impl AppState {
     async fn ensure_ableset_cache(&self, settings: &AbleSetStatusSnapshot) -> anyhow::Result<()> {
         let needs_refresh = {
             let cache = self.caches.ableset.read().await;
-            !cache.matches(&settings.library_name, settings.song_prefix_length)
-                || cache.entries.is_empty()
+            if !cache.matches(&settings.library_name, settings.song_prefix_length) {
+                true
+            } else if cache.entries.is_empty() {
+                // #655 F5a: don't re-attempt a rebuild that JUST failed to
+                // produce any entries within the cooldown window — without
+                // this, a library-name typo means every single resolve call
+                // re-triggers a full DB rescan + WARN burst.
+                !cache.recently_failed_rebuild()
+            } else {
+                false
+            }
         };
         if needs_refresh {
             self.refresh_ableset_cache(settings).await?;
@@ -322,27 +365,60 @@ impl AppState {
 
     /// Rebuild the resolved `prefix -> presentation` cache from the DB, plus
     /// the #601 title-mismatch report, and install both atomically under a
-    /// #639 compare-and-swap guard against a concurrent invalidate.
+    /// #639 compare-and-swap guard against a concurrent invalidate. #655 F7:
+    /// retries the single-attempt build+install up to `MAX_REFRESH_ATTEMPTS`
+    /// times when a concurrent invalidate wins the CAS race — the #639 fix
+    /// correctly avoided resurrecting stale data on a lost race, but
+    /// silently dropping the CURRENT resolution attempt on every single
+    /// collision was itself a regression (pre-#639, a lost race at least
+    /// projected stale-but-usually-correct data; post-#639-only it projected
+    /// nothing until the next trigger). Retrying lets the same logical
+    /// rebuild attempt win against a one-off collision.
     pub(super) async fn refresh_ableset_cache(
         &self,
         settings: &AbleSetStatusSnapshot,
     ) -> anyhow::Result<()> {
-        let expected_generation = self.caches.ableset.read().await.generation();
+        for attempt in 1..=MAX_REFRESH_ATTEMPTS {
+            if self.refresh_ableset_cache_once(settings).await? {
+                return Ok(());
+            }
+            if attempt == MAX_REFRESH_ATTEMPTS {
+                warn!(
+                    library_name = %settings.library_name,
+                    attempts = MAX_REFRESH_ATTEMPTS,
+                    "AbleSet cache rebuild kept losing the race with a concurrent invalidate (#639/#655 F7) — \
+                     giving up for this trigger; the next resolution attempt will retry cleanly"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Fetch the tracked library and resolve it into the `prefix ->
+    /// presentation` / `prefix -> title` maps. Extracted from
+    /// `refresh_ableset_cache_once` to keep that function under the repo's
+    /// per-function line cap. The none-found branch logs the #623 "library
+    /// not found" WARN — previously silent, only recorded into `last_error`,
+    /// even though a missing library means EVERY resolution will miss
+    /// forever until someone notices.
+    async fn resolve_ableset_library_entries(
+        &self,
+        library_name: &str,
+        prefix_length: u8,
+    ) -> anyhow::Result<(
+        HashMap<String, PresentationId>,
+        HashMap<String, String>,
+        Option<String>,
+    )> {
         let summaries = self.repository.list_library_summaries(None).await?;
         let target = summaries
             .into_iter()
-            .find(|summary| summary.name.eq_ignore_ascii_case(&settings.library_name));
-
-        let (entries, presenter_titles, error) = match target {
-            Some(summary) => {
-                build_ableset_entries(summary.presentations, settings.song_prefix_length)
-            }
+            .find(|summary| summary.name.eq_ignore_ascii_case(library_name));
+        Ok(match target {
+            Some(summary) => build_ableset_entries(summary.presentations, prefix_length),
             None => {
-                // #623: previously silent — only recorded into `last_error`,
-                // never logged, even though a missing library means EVERY
-                // resolution will miss forever until someone notices.
                 warn!(
-                    library_name = %settings.library_name,
+                    library_name = %library_name,
                     "AbleSet cache rebuild found no library with this name — \
                      resolution will keep missing every song"
                 );
@@ -352,28 +428,59 @@ impl AppState {
                     Some("library not found".to_string()),
                 )
             }
+        })
+    }
+
+    /// Single build+CAS-install attempt, extracted so `refresh_ableset_cache`
+    /// can retry it (#655 F7) without duplicating the DB-fetch + install
+    /// sequence. Returns whether the install succeeded — `false` means a
+    /// concurrent invalidate won the #639 CAS race and the caller decides
+    /// whether to retry.
+    async fn refresh_ableset_cache_once(
+        &self,
+        settings: &AbleSetStatusSnapshot,
+    ) -> anyhow::Result<bool> {
+        // #655 F8: read the bridge-side setlist BEFORE capturing the
+        // generation — a cheap in-memory read (no DB) — and snapshot the
+        // cached ack mirror under the SAME lock acquisition as the
+        // generation capture. Together this shrinks the #639 CAS window
+        // down to just the one remaining unavoidable DB fetch below
+        // (`list_library_summaries`) instead of also spanning an ack-store
+        // DB read that used to happen after the capture.
+        let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
+        let (expected_generation, acks) = {
+            let cache = self.caches.ableset.read().await;
+            (cache.generation(), cache.acks().clone())
         };
 
-        let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
-        // #655 F8: read the cached ack mirror instead of the DB — the mirror
-        // is kept current by acknowledge/unacknowledge/prune, and NOT
-        // reloading it here removes a DB await that used to sit inside the
-        // #639 CAS window (between the generation capture above and the
-        // install below), narrowing that window to just the one remaining
-        // unavoidable fetch (`list_library_summaries`).
-        let acks = self.caches.ableset.read().await.acks().clone();
-        let mismatches = super::ableset_mismatch::compute_ableset_mismatches(
-            &presenter_titles,
-            &ableset_songs,
-            settings.song_prefix_length,
-            &acks,
-        );
+        let (entries, presenter_titles, error) = self
+            .resolve_ableset_library_entries(&settings.library_name, settings.song_prefix_length)
+            .await?;
 
-        // #655 F9b: prune acks no longer present on EITHER side — only when
-        // both sides are non-empty (a real comparison), so an empty/disabled
-        // tick never wrongly prunes acks for numbers that simply weren't
-        // compared this round.
-        if !presenter_titles.is_empty() && !ableset_songs.is_empty() {
+        // #655 F3: an empty/disabled tracked setlist previously reported as
+        // a misleading WARN burst ("166 gaps") — an absent/empty setlist
+        // carries no information about which numbers "should" exist, so
+        // skip mismatch computation entirely and log ONE INFO instead.
+        let short_circuited = !settings.enabled || !settings.tracking || ableset_songs.is_empty();
+        let mismatches = if short_circuited {
+            info!(
+                library_name = %settings.library_name,
+                "AbleSet setlist empty or integration disabled — mismatch check idle (#655 F3)"
+            );
+            Vec::new()
+        } else {
+            super::ableset_mismatch::compute_ableset_mismatches(
+                &presenter_titles,
+                &ableset_songs,
+                settings.song_prefix_length,
+                &acks,
+            )
+        };
+
+        if !short_circuited {
+            // #655 F9b: prune acks no longer present on EITHER side — only
+            // valid when a real comparison ran (never on the short-circuit
+            // above, where "absent" carries no information about anything).
             self.prune_stale_ableset_acks(&presenter_titles, &ableset_songs)
                 .await;
         }
@@ -389,55 +496,85 @@ impl AppState {
             mismatches,
             presenter_titles,
         );
-        log_ableset_rebuild_result(
-            installed,
-            &settings.library_name,
-            settings.song_prefix_length,
-            entries_found,
-            cache.mismatches(),
-        );
-        Ok(())
+        if entries_found == 0 {
+            // #655 F5a: anchor for the `ensure_ableset_cache` retry cooldown.
+            cache.last_failed_rebuild_attempt = Some(Utc::now());
+        }
+        // #655 F6: copy out the counts + a bounded sample, THEN drop the
+        // write lock before logging. The previous per-mismatch WARN loop ran
+        // while STILL holding this lock — up to 166 blocking stdout writes
+        // per rebuild stalling the live projection path behind it.
+        let log_data = installed.then(|| summarize_mismatches(cache.mismatches()));
+        drop(cache);
+
+        if let Some(summary) = log_data {
+            log_ableset_rebuild_summary(
+                &settings.library_name,
+                settings.song_prefix_length,
+                entries_found,
+                &summary,
+            );
+        }
+        Ok(installed)
     }
 }
 
-/// Log the outcome of a `refresh_ableset_cache` install — extracted to keep
-/// that function under the repo's per-function line cap. `installed = false`
-/// is the #639 race-lost path (a concurrent invalidate won); `true` is the
-/// normal path, which also emits the #601 per-mismatch WARN and #623's
-/// previously-missing cache-rebuild INFO.
-fn log_ableset_rebuild_result(
-    installed: bool,
+/// #655 F5b: bounded summary of a mismatch list for logging — replaces the
+/// old per-mismatch WARN loop (up to 166 lines on a badly mis-numbered
+/// setlist) with ONE line carrying the counts and a small sample. The full
+/// list stays available on the status endpoint (capped separately at 25 —
+/// see `cap_mismatches_for_status`).
+struct MismatchSummary {
+    total: usize,
+    gaps: usize,
+    title_disagreements: usize,
+    sample: Vec<AbleSetTitleMismatch>,
+}
+
+/// #655 F5b/F3: splits a mismatch list into structural gaps (one side
+/// missing entirely — F3's "split the WARN into two distinct messages")
+/// versus genuine title disagreements (both sides present but differ), plus
+/// a small ordered sample for the summary WARN.
+fn summarize_mismatches(mismatches: &[AbleSetTitleMismatch]) -> MismatchSummary {
+    let gaps = mismatches
+        .iter()
+        .filter(|m| m.ableset_title.is_empty() || m.presenter_title.is_empty())
+        .count();
+    MismatchSummary {
+        total: mismatches.len(),
+        gaps,
+        title_disagreements: mismatches.len() - gaps,
+        sample: mismatches
+            .iter()
+            .take(MISMATCH_LOG_SAMPLE_SIZE)
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Log the outcome of a successful `refresh_ableset_cache_once` install —
+/// extracted to keep that function under the repo's per-function line cap.
+/// Silent on the mismatch WARN when there is nothing to report.
+fn log_ableset_rebuild_summary(
     library_name: &str,
     prefix_length: u8,
     entries_found: usize,
-    mismatches: &[AbleSetTitleMismatch],
+    summary: &MismatchSummary,
 ) {
-    if !installed {
-        // #639: the cache is already whatever the racing invalidate left it
-        // as (entries/mismatches cleared) — discarding here, instead of
-        // overwriting, is what stops the invalidate from being silently
-        // lost. The next `ensure_ableset_cache` call sees `entries.is_empty()`
-        // and retries without racing.
-        warn!(
-            library_name = library_name,
-            "AbleSet cache rebuild lost a race with a concurrent invalidate (#639) — \
-             discarding stale fetch; the next resolution attempt will retry cleanly"
-        );
-        return;
-    }
     // #623: the rebuild itself was previously silent end-to-end.
     info!(
         library_name = library_name,
         prefix_length = prefix_length,
         entries_found = entries_found,
-        mismatch_count = mismatches.len(),
+        mismatch_count = summary.total,
         "AbleSet cache rebuild complete"
     );
-    for mismatch in mismatches {
+    if summary.total > 0 {
         warn!(
-            number = %mismatch.number,
-            ableset_title = %mismatch.ableset_title,
-            presenter_title = %mismatch.presenter_title,
+            mismatch_count = summary.total,
+            gaps = summary.gaps,
+            title_disagreements = summary.title_disagreements,
+            sample = ?summary.sample,
             "AbleSet/Presenter numbering disagreement — verify before the service (#601)"
         );
     }

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -584,7 +584,12 @@ fn log_ableset_rebuild_summary(
 /// `prefix -> title` map (the latter feeds the #601 mismatch report) from a
 /// resolved library's presentations. Extracted from `refresh_ableset_cache`
 /// to keep that function under the repo's per-function line cap. Returns
-/// `error` set when the library has no presentation with a valid prefix.
+/// `error` set when the library has no presentation with a valid prefix, OR
+/// (#655 F14) when two or more presentations collide on the SAME numeric
+/// prefix — a silent `HashMap::insert` overwrite there means whichever
+/// presentation is scanned LAST wins non-deterministically, with zero
+/// operator visibility. A collision takes priority over the "no valid
+/// prefix" message since it is the more actionable diagnosis.
 fn build_ableset_entries(
     presentations: Vec<presenter_core::PresentationSummary>,
     prefix_length: u8,
@@ -595,16 +600,33 @@ fn build_ableset_entries(
 ) {
     let mut entries = HashMap::new();
     let mut presenter_titles = HashMap::new();
+    let mut colliding_numbers = Vec::new();
     for presentation in presentations {
         if let Some(prefix) = extract_song_prefix(&presentation.name, prefix_length) {
             let key = prefix.to_ascii_lowercase();
             presenter_titles.insert(key.clone(), presentation.name.clone());
-            entries.insert(key, presentation.id);
+            if entries.insert(key.clone(), presentation.id).is_some() {
+                colliding_numbers.push(key);
+            }
         }
     }
-    let error = entries
-        .is_empty()
-        .then_some("no presentations with valid prefix".to_string());
+    let error = if colliding_numbers.is_empty() {
+        entries
+            .is_empty()
+            .then_some("no presentations with valid prefix".to_string())
+    } else {
+        colliding_numbers.sort();
+        colliding_numbers.dedup();
+        warn!(
+            numbers = ?colliding_numbers,
+            "AbleSet cache rebuild found presentations with DUPLICATE song numbers — \
+             resolution for these numbers is non-deterministic (#655 F14)"
+        );
+        Some(format!(
+            "duplicate song number(s): {}",
+            colliding_numbers.join(", ")
+        ))
+    };
     (entries, presenter_titles, error)
 }
 

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -435,6 +435,50 @@ fn build_ableset_entries(
 mod cache_tests {
     use super::*;
 
+    // #655 F15 — RED (this commit): `cap_mismatches_for_status` does not
+    // exist yet, so this fails to compile — the established pattern in this
+    // codebase for a new API being introduced (see the #601 strip_song_prefix
+    // precedent in presenter-core). GREEN adds the function and wires it
+    // into `ableset_status_snapshot`.
+    #[test]
+    fn cap_mismatches_for_status_caps_at_25_and_reports_total_count() {
+        let mismatches: Vec<AbleSetTitleMismatch> = (0..30)
+            .map(|i| AbleSetTitleMismatch {
+                number: format!("{i:03}"),
+                ableset_title: format!("AbleSet {i}"),
+                presenter_title: format!("Presenter {i}"),
+            })
+            .collect();
+
+        let (capped, total) = cap_mismatches_for_status(&mismatches);
+
+        assert_eq!(
+            capped.len(),
+            25,
+            "a 5s-polled status endpoint must cap the inline mismatch list at 25"
+        );
+        assert_eq!(
+            total, 30,
+            "the total count must reflect ALL mismatches, not just the capped slice"
+        );
+        assert_eq!(
+            capped[0].number, "000",
+            "the capped slice must be the FIRST 25, not an arbitrary subset"
+        );
+    }
+
+    #[test]
+    fn cap_mismatches_for_status_does_not_truncate_under_the_cap() {
+        let mismatches = vec![AbleSetTitleMismatch {
+            number: "001".to_string(),
+            ableset_title: "A".to_string(),
+            presenter_title: "B".to_string(),
+        }];
+        let (capped, total) = cap_mismatches_for_status(&mismatches);
+        assert_eq!(capped.len(), 1);
+        assert_eq!(total, 1);
+    }
+
     // #639 — RED (this commit): `generation`/`install_if_current` prove the
     // compare-and-swap that closes the TOCTOU window described in the issue
     // ("An invalidate request that lands in the window between the read and

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -214,7 +214,9 @@ impl AppState {
                 found: a.found,
             })
             .collect();
-        snapshot.mismatches = cache.mismatches().to_vec();
+        let (mismatches, mismatch_count) = cap_mismatches_for_status(cache.mismatches());
+        snapshot.mismatches = mismatches;
+        snapshot.mismatch_count = mismatch_count;
         snapshot
     }
 
@@ -429,6 +431,25 @@ fn build_ableset_entries(
         .is_empty()
         .then_some("no presentations with valid prefix".to_string());
     (entries, presenter_titles, error)
+}
+
+/// Cap the mismatch list surfaced on the 5s-polled `GET
+/// /integrations/ableset/status` endpoint at 25 entries (#655 F15) — an
+/// unbounded list scales with the size of the pre-service checklist gap,
+/// which can briefly be large right after a library switch. Returns the
+/// capped slice (the FIRST 25, stable order) plus the TRUE total count so
+/// the operator can tell "showing 25 of N".
+fn cap_mismatches_for_status(
+    mismatches: &[AbleSetTitleMismatch],
+) -> (Vec<AbleSetTitleMismatch>, usize) {
+    const MAX_STATUS_MISMATCHES: usize = 25;
+    let total = mismatches.len();
+    let capped = mismatches
+        .iter()
+        .take(MAX_STATUS_MISMATCHES)
+        .cloned()
+        .collect();
+    (capped, total)
 }
 
 #[cfg(test)]

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -331,7 +331,7 @@ impl AppState {
                     ?err,
                     "failed to load AbleSet mismatch acknowledgements — treating as none (#601)"
                 );
-                super::ableset_mismatch::AckMap::new()
+                super::ableset_ack::AckMap::new()
             }
         };
         let mismatches = super::ableset_mismatch::compute_ableset_mismatches(

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -609,4 +609,75 @@ mod cache_tests {
              refresh detects the race (#639)"
         );
     }
+
+    // #655 F5a — RED (this commit): `recently_failed_rebuild` does not exist
+    // yet. GREEN adds it and consults it from `ensure_ableset_cache`'s
+    // `entries.is_empty()` retry escape hatch.
+
+    #[test]
+    fn recently_failed_rebuild_is_false_with_no_prior_attempt() {
+        let cache = AbleSetLibraryCache::default();
+        assert!(!cache.recently_failed_rebuild());
+    }
+
+    #[test]
+    fn recently_failed_rebuild_is_true_immediately_after_a_failed_attempt() {
+        let mut cache = AbleSetLibraryCache::default();
+        cache.last_failed_rebuild_attempt = Some(Utc::now());
+        assert!(cache.recently_failed_rebuild());
+    }
+
+    #[test]
+    fn recently_failed_rebuild_expires_after_the_cooldown() {
+        let mut cache = AbleSetLibraryCache::default();
+        cache.last_failed_rebuild_attempt = Some(Utc::now() - chrono::Duration::seconds(10));
+        assert!(
+            !cache.recently_failed_rebuild(),
+            "a failed attempt older than the cooldown must no longer suppress a retry"
+        );
+    }
+
+    // #655 F5b — RED (this commit): `summarize_mismatches` does not exist
+    // yet. GREEN adds it and wires it into `refresh_ableset_cache`'s
+    // logging, replacing the old per-mismatch WARN loop.
+
+    #[test]
+    fn summarize_mismatches_splits_gaps_from_title_disagreements() {
+        let mismatches = vec![
+            AbleSetTitleMismatch {
+                number: "001".to_string(),
+                ableset_title: "A".to_string(),
+                presenter_title: String::new(), // gap
+            },
+            AbleSetTitleMismatch {
+                number: "002".to_string(),
+                ableset_title: String::new(), // gap
+                presenter_title: "B".to_string(),
+            },
+            AbleSetTitleMismatch {
+                number: "003".to_string(),
+                ableset_title: "C".to_string(),
+                presenter_title: "D".to_string(), // genuine disagreement
+            },
+        ];
+        let summary = summarize_mismatches(&mismatches);
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.gaps, 2);
+        assert_eq!(summary.title_disagreements, 1);
+        assert_eq!(summary.sample.len(), 3);
+    }
+
+    #[test]
+    fn summarize_mismatches_bounds_the_sample_to_five() {
+        let mismatches: Vec<AbleSetTitleMismatch> = (0..10)
+            .map(|i| AbleSetTitleMismatch {
+                number: format!("{i:03}"),
+                ableset_title: "A".to_string(),
+                presenter_title: "B".to_string(),
+            })
+            .collect();
+        let summary = summarize_mismatches(&mismatches);
+        assert_eq!(summary.total, 10);
+        assert_eq!(summary.sample.len(), 5, "the log sample must cap at 5");
+    }
 }

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -96,6 +96,19 @@ pub(crate) struct AbleSetLibraryCache {
     /// `invalidate_entries` — an ack is keyed on song NUMBER, not on which
     /// library is currently tracked.
     pub(crate) acks: AckMap,
+    /// Whether `acks` has been primed from the persisted store yet (#655 F8
+    /// deviation 4). The mirror above starts empty via `#[derive(Default)]`
+    /// on every process boot and is otherwise only ever written by
+    /// `acknowledge_ableset_mismatch` / `unacknowledge_ableset_mismatch` — so
+    /// without this flag, a freshly restarted process would silence NO
+    /// mismatch until an operator happened to touch an ack, re-reporting
+    /// every already-acknowledged mismatch after every restart.
+    /// `ensure_ableset_acks_loaded` (`ableset_ack.rs`) consults this to load
+    /// the mirror from `app_settings` exactly ONCE per process lifetime.
+    /// Survives `invalidate`/`invalidate_entries` for the same reason `acks`
+    /// itself does — an ack is keyed on song NUMBER, not on which library is
+    /// currently tracked.
+    pub(crate) acks_initialized: bool,
     /// Timestamp of the last rebuild attempt that produced ZERO entries
     /// (#655 F5a) — consulted by `ensure_ableset_cache`'s `entries.is_empty()`
     /// retry escape hatch so a persistently broken configuration (e.g. a
@@ -504,6 +517,12 @@ impl AppState {
         // (`list_library_summaries`) instead of also spanning an ack-store
         // DB read that used to happen after the capture.
         let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
+        // #655 F8 deviation 4: prime the ack mirror from the persisted store
+        // on its FIRST use this process — a no-op after the first call (see
+        // `ensure_ableset_acks_loaded`). Without this, a freshly restarted
+        // process reads the still-empty `#[derive(Default)]` mirror below and
+        // reports every already-acknowledged mismatch as brand new.
+        self.ensure_ableset_acks_loaded().await;
         let (expected_generation, acks) = {
             let cache = self.caches.ableset.read().await;
             (cache.generation(), cache.acks().clone())

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -817,4 +817,49 @@ mod cache_tests {
         assert_eq!(summary.total, 10);
         assert_eq!(summary.sample.len(), 5, "the log sample must cap at 5");
     }
+
+    // #655 F14 — RED (this commit): `build_ableset_entries` currently lets a
+    // duplicate song number silently overwrite via `HashMap::insert` — no
+    // error is set, so `error.expect(...)` below panics. GREEN detects the
+    // collision and sets `error`.
+    #[test]
+    fn build_ableset_entries_reports_duplicate_song_numbers() {
+        use presenter_core::PresentationSummary;
+
+        let presentations = vec![
+            PresentationSummary {
+                id: PresentationId::new(),
+                name: "017 First Song".to_string(),
+            },
+            PresentationSummary {
+                id: PresentationId::new(),
+                name: "017 Second Song".to_string(),
+            },
+        ];
+
+        let (entries, _presenter_titles, error) = build_ableset_entries(presentations, 3);
+        assert_eq!(
+            entries.len(),
+            1,
+            "the colliding number resolves to exactly one entry"
+        );
+        let error = error.expect("a duplicate song number must set an error");
+        assert!(
+            error.contains("017") && error.contains("duplicate"),
+            "error must name the colliding number: {error}"
+        );
+    }
+
+    #[test]
+    fn build_ableset_entries_reports_no_valid_prefix_when_none_collide() {
+        use presenter_core::PresentationSummary;
+
+        let presentations = vec![PresentationSummary {
+            id: PresentationId::new(),
+            name: "No Number Intro".to_string(),
+        }];
+        let (entries, _presenter_titles, error) = build_ableset_entries(presentations, 3);
+        assert!(entries.is_empty());
+        assert_eq!(error.as_deref(), Some("no presentations with valid prefix"));
+    }
 }

--- a/crates/presenter-server/src/state/ableset.rs
+++ b/crates/presenter-server/src/state/ableset.rs
@@ -6,6 +6,7 @@ use presenter_core::{
 use std::collections::{HashMap, VecDeque};
 use tracing::{info, warn};
 
+use super::ableset_ack::AckMap;
 use super::AppState;
 use crate::ableset::AbleSetStatusSnapshot;
 
@@ -47,6 +48,20 @@ pub(crate) struct AbleSetLibraryCache {
     /// recent successful rebuild (#601). Cleared alongside `entries` on
     /// invalidation — see `install_if_current` and the invalidate methods.
     pub(crate) mismatches: Vec<AbleSetTitleMismatch>,
+    /// `prefix -> full presentation name` from the most recent successful
+    /// rebuild (#655 F5c/F8) — lets an ack/unack recompute the mismatch
+    /// report WITHOUT a full DB rescan, and lets `refresh_ableset_cache`
+    /// avoid re-fetching it. Cleared alongside `entries` on invalidation.
+    pub(crate) presenter_titles: HashMap<String, String>,
+    /// Mirror of the persisted AbleSet mismatch-acknowledgement store (#655
+    /// F8) — updated ONLY by `acknowledge_ableset_mismatch` /
+    /// `unacknowledge_ableset_mismatch` / the F9b prune, never reloaded from
+    /// the DB inside a normal `refresh_ableset_cache` rebuild. This is what
+    /// narrows the #639 CAS window down to the one remaining unavoidable DB
+    /// fetch (the library summaries). Survives `invalidate`/
+    /// `invalidate_entries` — an ack is keyed on song NUMBER, not on which
+    /// library is currently tracked.
+    pub(crate) acks: AckMap,
 }
 
 impl AbleSetLibraryCache {
@@ -57,6 +72,7 @@ impl AbleSetLibraryCache {
         self.last_updated = None;
         self.last_error = None;
         self.mismatches.clear();
+        self.presenter_titles.clear();
         self.generation = self.generation.wrapping_add(1);
     }
 
@@ -69,6 +85,7 @@ impl AbleSetLibraryCache {
     pub(crate) fn invalidate_entries(&mut self) {
         self.entries.clear();
         self.mismatches.clear();
+        self.presenter_titles.clear();
         self.generation = self.generation.wrapping_add(1);
     }
 
@@ -105,6 +122,17 @@ impl AbleSetLibraryCache {
         &self.mismatches
     }
 
+    /// Read-only view of the `prefix -> title` map from the last successful
+    /// rebuild (#655 F5c).
+    pub(crate) fn presenter_titles(&self) -> &HashMap<String, String> {
+        &self.presenter_titles
+    }
+
+    /// Read-only view of the cached acknowledgement-store mirror (#655 F8).
+    pub(crate) fn acks(&self) -> &AckMap {
+        &self.acks
+    }
+
     /// Current generation counter (#639) — captured by a refresh BEFORE its
     /// async DB fetch, so its eventual install can detect a concurrent
     /// invalidate.
@@ -121,6 +149,7 @@ impl AbleSetLibraryCache {
     /// `ensure_ableset_cache` call sees `entries` still empty (the
     /// invalidate's own effect, left untouched) and retries cleanly.
     /// Returns whether the install happened.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn install_if_current(
         &mut self,
         expected_generation: u64,
@@ -129,6 +158,7 @@ impl AbleSetLibraryCache {
         entries: HashMap<String, PresentationId>,
         error: Option<String>,
         mismatches: Vec<AbleSetTitleMismatch>,
+        presenter_titles: HashMap<String, String>,
     ) -> bool {
         if self.generation != expected_generation {
             return false;
@@ -139,6 +169,7 @@ impl AbleSetLibraryCache {
         self.last_updated = Some(Utc::now());
         self.last_error = error;
         self.mismatches = mismatches;
+        self.presenter_titles = presenter_titles;
         true
     }
 
@@ -324,22 +355,28 @@ impl AppState {
         };
 
         let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
-        let acks = match self.load_ableset_mismatch_acks().await {
-            Ok(acks) => acks,
-            Err(err) => {
-                warn!(
-                    ?err,
-                    "failed to load AbleSet mismatch acknowledgements — treating as none (#601)"
-                );
-                super::ableset_ack::AckMap::new()
-            }
-        };
+        // #655 F8: read the cached ack mirror instead of the DB — the mirror
+        // is kept current by acknowledge/unacknowledge/prune, and NOT
+        // reloading it here removes a DB await that used to sit inside the
+        // #639 CAS window (between the generation capture above and the
+        // install below), narrowing that window to just the one remaining
+        // unavoidable fetch (`list_library_summaries`).
+        let acks = self.caches.ableset.read().await.acks().clone();
         let mismatches = super::ableset_mismatch::compute_ableset_mismatches(
             &presenter_titles,
             &ableset_songs,
             settings.song_prefix_length,
             &acks,
         );
+
+        // #655 F9b: prune acks no longer present on EITHER side — only when
+        // both sides are non-empty (a real comparison), so an empty/disabled
+        // tick never wrongly prunes acks for numbers that simply weren't
+        // compared this round.
+        if !presenter_titles.is_empty() && !ableset_songs.is_empty() {
+            self.prune_stale_ableset_acks(&presenter_titles, &ableset_songs)
+                .await;
+        }
 
         let entries_found = entries.len();
         let mut cache = self.caches.ableset.write().await;
@@ -350,6 +387,7 @@ impl AppState {
             entries,
             error,
             mismatches,
+            presenter_titles,
         );
         log_ableset_rebuild_result(
             installed,
@@ -522,6 +560,7 @@ mod cache_tests {
             HashMap::from([("001".to_string(), PresentationId::new())]),
             None,
             Vec::new(),
+            HashMap::new(),
         );
 
         assert!(
@@ -548,6 +587,7 @@ mod cache_tests {
             HashMap::from([("001".to_string(), id)]),
             None,
             Vec::new(),
+            HashMap::new(),
         );
 
         assert!(

--- a/crates/presenter-server/src/state/ableset_ack.rs
+++ b/crates/presenter-server/src/state/ableset_ack.rs
@@ -181,6 +181,32 @@ impl AppState {
         Ok(self.ableset_status_snapshot().await)
     }
 
+    /// #655 F8 deviation 4: lazily prime the in-memory ack mirror from the
+    /// persisted store EXACTLY ONCE per process lifetime — the mirror starts
+    /// empty on every boot (`#[derive(Default)]`) and, absent this, is only
+    /// ever populated as a side effect of `acknowledge_ableset_mismatch` /
+    /// `unacknowledge_ableset_mismatch`. Without a boot-time load, a freshly
+    /// restarted server silences NO mismatch until an operator happens to
+    /// touch an ack, re-reporting every already-acknowledged mismatch on
+    /// every restart — defeating the whole point of persisting acks (#601).
+    /// Called from `refresh_ableset_cache_once` before it reads the mirror.
+    /// Serialized under `ableset_ack_lock` (same lock/order as ack/unack) so
+    /// two concurrent callers can never both load; the double-checked read
+    /// keeps the common (already-initialized) case lock-free.
+    pub(super) async fn ensure_ableset_acks_loaded(&self) {
+        if self.caches.ableset.read().await.acks_initialized {
+            return;
+        }
+        let _guard = self.ableset_ack_lock.lock().await;
+        if self.caches.ableset.read().await.acks_initialized {
+            return; // a concurrent caller already won the race and loaded it
+        }
+        let acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
+        let mut cache = self.caches.ableset.write().await;
+        cache.acks = acks;
+        cache.acks_initialized = true;
+    }
+
     /// #655 F8: mirror the freshly-persisted ack map into the in-memory
     /// cache — `refresh_ableset_cache`'s heavy DB rescan no longer reloads
     /// acks from the DB on every rebuild, it reads this mirror instead,
@@ -196,6 +222,13 @@ impl AppState {
         let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
         let mut cache = self.caches.ableset.write().await;
         cache.acks = acks;
+        // The load just above (in `acknowledge_ableset_mismatch` /
+        // `unacknowledge_ableset_mismatch`) always reads the FULL persisted
+        // map, so the mirror is now fully in sync with the DB — mark it
+        // initialized so `ensure_ableset_acks_loaded` never redundantly
+        // reloads it on the next rebuild (#655 F8's "exactly one load per
+        // process lifetime" guarantee).
+        cache.acks_initialized = true;
         let mismatches = super::ableset_mismatch::compute_ableset_mismatches(
             cache.presenter_titles(),
             &ableset_songs,

--- a/crates/presenter-server/src/state/ableset_ack.rs
+++ b/crates/presenter-server/src/state/ableset_ack.rs
@@ -104,3 +104,33 @@ impl AppState {
         Ok(self.ableset_status_snapshot().await)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #655 F9d — RED (this commit): `validate_ableset_ack_number` does not
+    // exist yet, so this fails to compile. GREEN adds it and wires it into
+    // `acknowledge_ableset_mismatch`/`unacknowledge_ableset_mismatch`.
+
+    #[test]
+    fn validate_ableset_ack_number_accepts_exact_length_all_digits() {
+        assert!(validate_ableset_ack_number("017", 3).is_ok());
+    }
+
+    #[test]
+    fn validate_ableset_ack_number_rejects_empty() {
+        assert!(validate_ableset_ack_number("", 3).is_err());
+    }
+
+    #[test]
+    fn validate_ableset_ack_number_rejects_wrong_length() {
+        assert!(validate_ableset_ack_number("17", 3).is_err());
+        assert!(validate_ableset_ack_number("0017", 3).is_err());
+    }
+
+    #[test]
+    fn validate_ableset_ack_number_rejects_non_digits() {
+        assert!(validate_ableset_ack_number("01a", 3).is_err());
+    }
+}

--- a/crates/presenter-server/src/state/ableset_ack.rs
+++ b/crates/presenter-server/src/state/ableset_ack.rs
@@ -1,0 +1,106 @@
+//! AbleSet<->Presenter mismatch acknowledgement store (#601), split out of
+//! `ableset_mismatch.rs` (#655) — pure code motion in this commit, no
+//! behavior change. F4's domain refusal enum and F9's mutex/prune/cap/
+//! validation land in a follow-up commit on this same file, which is why
+//! the split happens first: it keeps that follow-up diff readable instead
+//! of interleaving "moved" and "changed" lines.
+
+use anyhow::Context;
+use std::collections::HashMap;
+use tracing::warn;
+
+use super::AppState;
+use crate::ableset::AbleSetStatusSnapshot;
+
+const ABLESET_MISMATCH_ACK_SETTING_KEY: &str = "ableset_mismatch_acks";
+
+/// An operator's explicit "yes, these two titles are the same song"
+/// acknowledgement for one song number. The settled design rejected a
+/// similarity threshold (a genuinely wrong pair could easily look similar,
+/// and a deliberate variant like "Alive with you KIDS" can look very
+/// different) — only an explicit human call is safe here. Bound to the
+/// EXACT title pair it was granted for: if either side's title later
+/// changes, the ack no longer matches and the warning returns (a later
+/// renumbering must never silently inherit an old "this is fine").
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AbleSetMismatchAck {
+    pub(crate) ableset_title: String,
+    pub(crate) presenter_title: String,
+}
+
+pub(crate) type AckMap = HashMap<String, AbleSetMismatchAck>;
+
+impl AppState {
+    /// Load the persisted acknowledgement map from the generic `app_settings`
+    /// key-value store — no schema migration needed, this is a JSON blob
+    /// under one well-known key. A corrupt/unparseable blob degrades to
+    /// "no acknowledgements" (loud rebuild warnings) rather than failing the
+    /// whole cache rebuild.
+    pub(super) async fn load_ableset_mismatch_acks(&self) -> anyhow::Result<AckMap> {
+        let Some(raw) = self
+            .repository
+            .get_app_setting(ABLESET_MISMATCH_ACK_SETTING_KEY)
+            .await?
+        else {
+            return Ok(AckMap::new());
+        };
+        Ok(serde_json::from_str(&raw).unwrap_or_else(|err| {
+            warn!(
+                ?err,
+                "corrupt AbleSet mismatch acknowledgement store — treating as empty (#601)"
+            );
+            AckMap::new()
+        }))
+    }
+
+    async fn save_ableset_mismatch_acks(&self, acks: &AckMap) -> anyhow::Result<()> {
+        let raw = serde_json::to_string(acks)
+            .context("failed to serialize AbleSet mismatch acknowledgements")?;
+        self.repository
+            .set_app_setting(ABLESET_MISMATCH_ACK_SETTING_KEY, &raw)
+            .await
+    }
+
+    async fn refresh_current_ableset_cache(&self) -> anyhow::Result<()> {
+        let settings = self.ableset_bridge.status_snapshot().await;
+        self.refresh_ableset_cache(&settings).await
+    }
+
+    /// Record (or overwrite) the operator's acknowledgement that `number`'s
+    /// two CURRENT titles are deliberately different names for the same
+    /// song, then rebuild the cache immediately so the mismatch report drops
+    /// it right away rather than waiting for the next unrelated rebuild.
+    pub async fn acknowledge_ableset_mismatch(
+        &self,
+        number: &str,
+        ableset_title: &str,
+        presenter_title: &str,
+    ) -> anyhow::Result<AbleSetStatusSnapshot> {
+        let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
+        acks.insert(
+            number.to_string(),
+            AbleSetMismatchAck {
+                ableset_title: ableset_title.to_string(),
+                presenter_title: presenter_title.to_string(),
+            },
+        );
+        self.save_ableset_mismatch_acks(&acks).await?;
+        self.refresh_current_ableset_cache().await?;
+        Ok(self.ableset_status_snapshot().await)
+    }
+
+    /// Revoke a prior acknowledgement (the report is "visible/revocable" per
+    /// the settled design) — the warning returns on the immediate rebuild
+    /// triggered here if the titles still disagree.
+    pub async fn unacknowledge_ableset_mismatch(
+        &self,
+        number: &str,
+    ) -> anyhow::Result<AbleSetStatusSnapshot> {
+        let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
+        acks.remove(number);
+        self.save_ableset_mismatch_acks(&acks).await?;
+        self.refresh_current_ableset_cache().await?;
+        Ok(self.ableset_status_snapshot().await)
+    }
+}

--- a/crates/presenter-server/src/state/ableset_ack.rs
+++ b/crates/presenter-server/src/state/ableset_ack.rs
@@ -1,27 +1,34 @@
 //! AbleSet<->Presenter mismatch acknowledgement store (#601), split out of
-//! `ableset_mismatch.rs` (#655) — pure code motion in this commit, no
-//! behavior change. F4's domain refusal enum and F9's mutex/prune/cap/
-//! validation land in a follow-up commit on this same file, which is why
-//! the split happens first: it keeps that follow-up diff readable instead
-//! of interleaving "moved" and "changed" lines.
+//! `ableset_mismatch.rs` (#655 — F4's domain refusal enum plus F9's mutex,
+//! prune, cap, and validation grew the ack-store side enough to push both
+//! concerns over the repo's per-file size cap; `ableset_mismatch.rs` keeps
+//! only the pure comparison logic). This file owns everything HTTP- and
+//! persistence-facing about acknowledgements.
+
+use std::collections::HashMap;
 
 use anyhow::Context;
-use std::collections::HashMap;
-use tracing::warn;
+use thiserror::Error;
+use tracing::{info, warn};
 
 use super::AppState;
 use crate::ableset::AbleSetStatusSnapshot;
 
 const ABLESET_MISMATCH_ACK_SETTING_KEY: &str = "ableset_mismatch_acks";
 
+/// Cap on the number of acknowledgements retained (#655 F9c) — an unbounded
+/// store on a long-running instance could otherwise grow forever across many
+/// library/setlist changes with no pruning trigger.
+const MAX_ABLESET_ACKS: usize = 500;
+
 /// An operator's explicit "yes, these two titles are the same song"
 /// acknowledgement for one song number. The settled design rejected a
 /// similarity threshold (a genuinely wrong pair could easily look similar,
 /// and a deliberate variant like "Alive with you KIDS" can look very
 /// different) — only an explicit human call is safe here. Bound to the
-/// EXACT title pair it was granted for: if either side's title later
-/// changes, the ack no longer matches and the warning returns (a later
-/// renumbering must never silently inherit an old "this is fine").
+/// title pair it was granted for (compared normalised — #655 F9e): a purely
+/// cosmetic edit on either side keeps the ack valid, but a genuine title
+/// change re-raises the warning.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AbleSetMismatchAck {
@@ -30,6 +37,51 @@ pub(crate) struct AbleSetMismatchAck {
 }
 
 pub(crate) type AckMap = HashMap<String, AbleSetMismatchAck>;
+
+/// A `POST /integrations/ableset/mismatches/{ack,unack}` request refused for
+/// a DOMAIN reason (#655 F4/F9) — never a blanket 200/500. The router
+/// (`router/integrations/ableset.rs`) downcasts on this TYPED error per
+/// `.claude/rules/repository-error-pattern.md`'s domain-error pattern.
+#[derive(Debug, Error)]
+pub(crate) enum AbleSetAckRefusal {
+    /// #655 F4: a one-sided numbering gap is a structural problem, not a
+    /// naming choice — it can never be silenced by an acknowledgement.
+    #[error(
+        "a one-sided numbering gap cannot be acknowledged — add or remove the number on the missing side"
+    )]
+    StructuralGap,
+    /// #655 F9d: `number` must be non-empty, all ASCII digits, and exactly
+    /// `song_prefix_length` digits long — anything else can never match a
+    /// real mismatch entry.
+    #[error(
+        "acknowledgement number must be {expected} digit(s), all ASCII digits (got {actual:?})"
+    )]
+    InvalidNumber { expected: u8, actual: String },
+    /// #655 F9c: bounds the store so a long-running instance cannot grow it
+    /// unbounded across many library/setlist changes.
+    #[error(
+        "acknowledgement store is full (500 entries max) — remove an old acknowledgement before adding a new one"
+    )]
+    StoreFull,
+}
+
+/// #655 F9d: `number` must be non-empty, all ASCII digits, and exactly
+/// `expected_len` digits long — the same shape `extract_song_prefix`
+/// produces, so a validated number can always be looked up against both
+/// sides of the mismatch report.
+fn validate_ableset_ack_number(number: &str, expected_len: u8) -> Result<(), AbleSetAckRefusal> {
+    let valid = !number.is_empty()
+        && number.len() == expected_len as usize
+        && number.chars().all(|c| c.is_ascii_digit());
+    if valid {
+        Ok(())
+    } else {
+        Err(AbleSetAckRefusal::InvalidNumber {
+            expected: expected_len,
+            actual: number.to_string(),
+        })
+    }
+}
 
 impl AppState {
     /// Load the persisted acknowledgement map from the generic `app_settings`
@@ -54,7 +106,7 @@ impl AppState {
         }))
     }
 
-    async fn save_ableset_mismatch_acks(&self, acks: &AckMap) -> anyhow::Result<()> {
+    pub(super) async fn save_ableset_mismatch_acks(&self, acks: &AckMap) -> anyhow::Result<()> {
         let raw = serde_json::to_string(acks)
             .context("failed to serialize AbleSet mismatch acknowledgements")?;
         self.repository
@@ -62,22 +114,37 @@ impl AppState {
             .await
     }
 
-    async fn refresh_current_ableset_cache(&self) -> anyhow::Result<()> {
-        let settings = self.ableset_bridge.status_snapshot().await;
-        self.refresh_ableset_cache(&settings).await
-    }
-
     /// Record (or overwrite) the operator's acknowledgement that `number`'s
     /// two CURRENT titles are deliberately different names for the same
-    /// song, then rebuild the cache immediately so the mismatch report drops
-    /// it right away rather than waiting for the next unrelated rebuild.
+    /// song. #655 F9a serializes the load->mutate->save cycle behind
+    /// `ableset_ack_lock` so two concurrent ack/unack calls can never lose
+    /// one's update to the other. #655 F5c: rebuilds the mismatch report
+    /// from the ALREADY-CACHED `presenter_titles` instead of forcing a full
+    /// DB rescan on every ack click (that used to be the log-spam
+    /// amplifier — an ack POST forcing a full rescan + WARN burst).
     pub async fn acknowledge_ableset_mismatch(
         &self,
         number: &str,
         ableset_title: &str,
         presenter_title: &str,
     ) -> anyhow::Result<AbleSetStatusSnapshot> {
+        let song_prefix_length = self
+            .ableset_bridge
+            .status_snapshot()
+            .await
+            .song_prefix_length;
+        validate_ableset_ack_number(number, song_prefix_length)?;
+        // #655 F4: a one-sided gap can never be acknowledged away — it is a
+        // structural problem (missing number), not a naming disagreement.
+        if ableset_title.is_empty() || presenter_title.is_empty() {
+            return Err(AbleSetAckRefusal::StructuralGap.into());
+        }
+
+        let _guard = self.ableset_ack_lock.lock().await;
         let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
+        if !acks.contains_key(number) && acks.len() >= MAX_ABLESET_ACKS {
+            return Err(AbleSetAckRefusal::StoreFull.into());
+        }
         acks.insert(
             number.to_string(),
             AbleSetMismatchAck {
@@ -86,32 +153,109 @@ impl AppState {
             },
         );
         self.save_ableset_mismatch_acks(&acks).await?;
-        self.refresh_current_ableset_cache().await?;
+        self.sync_ableset_ack_cache_and_recompute(acks).await;
         Ok(self.ableset_status_snapshot().await)
     }
 
     /// Revoke a prior acknowledgement (the report is "visible/revocable" per
-    /// the settled design) — the warning returns on the immediate rebuild
-    /// triggered here if the titles still disagree.
+    /// the settled design) — the warning returns on the immediate lightweight
+    /// recompute triggered here if the titles still disagree. Same
+    /// mutex/no-full-rescan treatment as `acknowledge_ableset_mismatch`
+    /// (#655 F9a/F5c).
     pub async fn unacknowledge_ableset_mismatch(
         &self,
         number: &str,
     ) -> anyhow::Result<AbleSetStatusSnapshot> {
+        let song_prefix_length = self
+            .ableset_bridge
+            .status_snapshot()
+            .await
+            .song_prefix_length;
+        validate_ableset_ack_number(number, song_prefix_length)?;
+
+        let _guard = self.ableset_ack_lock.lock().await;
         let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
         acks.remove(number);
         self.save_ableset_mismatch_acks(&acks).await?;
-        self.refresh_current_ableset_cache().await?;
+        self.sync_ableset_ack_cache_and_recompute(acks).await;
         Ok(self.ableset_status_snapshot().await)
+    }
+
+    /// #655 F8: mirror the freshly-persisted ack map into the in-memory
+    /// cache — `refresh_ableset_cache`'s heavy DB rescan no longer reloads
+    /// acks from the DB on every rebuild, it reads this mirror instead,
+    /// which is what narrows its #639 CAS window down to the one remaining
+    /// unavoidable DB fetch (the library summaries). #655 F5c: recomputes
+    /// the mismatch report from the cache's own `presenter_titles` snapshot
+    /// (populated by the last full rebuild) rather than re-fetching the
+    /// library from the DB — an ack/unack click is common enough during
+    /// pre-service review that forcing a full rescan on every one was the
+    /// log-spam amplifier this finding fixes.
+    async fn sync_ableset_ack_cache_and_recompute(&self, acks: AckMap) {
+        let settings = self.ableset_bridge.status_snapshot().await;
+        let ableset_songs = self.ableset_bridge.setlist_song_titles().await;
+        let mut cache = self.caches.ableset.write().await;
+        cache.acks = acks;
+        let mismatches = super::ableset_mismatch::compute_ableset_mismatches(
+            cache.presenter_titles(),
+            &ableset_songs,
+            settings.song_prefix_length,
+            cache.acks(),
+        );
+        cache.mismatches = mismatches;
+    }
+
+    /// #655 F9b: drop acknowledgements whose number is present on NEITHER
+    /// side any more — an ack for a song that has since been removed from
+    /// both the AbleSet setlist and the Presenter library is dead weight
+    /// that can never match anything again. Runs ONLY on a "real comparison"
+    /// (both `presenter_titles` and `ableset_songs` non-empty — never when
+    /// nothing is being compared, where "absent" carries no information
+    /// about which numbers genuinely still exist). Uses its own
+    /// load->mutate->save under the SAME mutex as ack/unack so a prune can
+    /// never race a concurrent acknowledgement into a lost update.
+    pub(super) async fn prune_stale_ableset_acks(
+        &self,
+        presenter_titles: &HashMap<String, String>,
+        ableset_songs: &[(String, String)],
+    ) {
+        let _guard = self.ableset_ack_lock.lock().await;
+        let mut acks = match self.load_ableset_mismatch_acks().await {
+            Ok(acks) => acks,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    "failed to load AbleSet mismatch acknowledgements for pruning — skipping (#655 F9)"
+                );
+                return;
+            }
+        };
+        let before = acks.len();
+        acks.retain(|number, _| {
+            presenter_titles.contains_key(number) || ableset_songs.iter().any(|(n, _)| n == number)
+        });
+        let pruned = before - acks.len();
+        if pruned == 0 {
+            return;
+        }
+        if let Err(err) = self.save_ableset_mismatch_acks(&acks).await {
+            warn!(
+                ?err,
+                "failed to persist pruned AbleSet mismatch acknowledgements (#655 F9)"
+            );
+            return;
+        }
+        info!(
+            pruned,
+            "pruned stale AbleSet mismatch acknowledgements no longer present on either side (#655 F9)"
+        );
+        self.caches.ableset.write().await.acks = acks;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // #655 F9d — RED (this commit): `validate_ableset_ack_number` does not
-    // exist yet, so this fails to compile. GREEN adds it and wires it into
-    // `acknowledge_ableset_mismatch`/`unacknowledge_ableset_mismatch`.
 
     #[test]
     fn validate_ableset_ack_number_accepts_exact_length_all_digits() {

--- a/crates/presenter-server/src/state/ableset_integration_tests.rs
+++ b/crates/presenter-server/src/state/ableset_integration_tests.rs
@@ -226,11 +226,8 @@ async fn ack_persists_and_silences_mismatch_then_unack_restores_it() {
     );
 }
 
-/// #655 F16 — RED (this commit): a resolution attempt while AbleSet is
-/// disabled currently returns early WITHOUT calling `record_attempt` — the
-/// ring buffer stays empty, so this assertion fails today. GREEN records
-/// the attempt on the disabled path too, so `recentAttempts` shows evidence
-/// instead of silence.
+/// #655 F16: a resolution attempt while AbleSet is disabled must still be
+/// recorded in the ring buffer.
 #[tokio::test]
 async fn disabled_resolution_still_records_attempt_in_ring_buffer() {
     let state = AppState::in_memory().await.unwrap();
@@ -246,4 +243,55 @@ async fn disabled_resolution_still_records_attempt_in_ring_buffer() {
         "a disabled-path resolution attempt must still be recorded, not silently dropped"
     );
     assert!(!snapshot.recent_attempts[0].found);
+}
+
+/// #655 F7/F10: races many concurrent resolves (each capable of triggering
+/// a rebuild) against concurrent explicit invalidations. Before F7, a
+/// rebuild that lost the #639 CAS race simply dropped its result with no
+/// retry; this proves the cache still converges to a correct, populated
+/// state after the contention settles instead of getting stuck permanently
+/// empty.
+#[tokio::test]
+async fn refresh_survives_concurrent_invalidate_races() {
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library("Hymnal").await.unwrap();
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "001 Amazing Grace", None)
+        .await
+        .unwrap();
+
+    let draft = AbleSetSettingsDraft {
+        enabled: true,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Hymnal".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(draft, SettingsAuditSource::HttpSetter, "test")
+        .await
+        .unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let resolve_state = state.clone();
+        handles.push(tokio::spawn(async move {
+            let _ = resolve_state.resolve_ableset_presentation("001").await;
+        }));
+        let invalidate_state = state.clone();
+        handles.push(tokio::spawn(async move {
+            invalidate_state.invalidate_ableset_cache().await;
+        }));
+    }
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let resolved = state.resolve_ableset_presentation("001").await.unwrap();
+    assert_eq!(
+        resolved,
+        Some(presentation.id),
+        "cache must converge to a correct, populated state after concurrent invalidate races (#655 F7)"
+    );
 }

--- a/crates/presenter-server/src/state/ableset_integration_tests.rs
+++ b/crates/presenter-server/src/state/ableset_integration_tests.rs
@@ -1,0 +1,227 @@
+//! #655 F10: `AppState`-level integration tests for the AbleSet mismatch
+//! acknowledgement HTTP/persistence surface — a gap left uncovered by
+//! `ableset_mismatch.rs`'s pure comparison-logic unit tests. Same pattern as
+//! `sync_integration_tests.rs`: real `AppState`, real (in-memory) DB, a real
+//! wiremock-backed AbleSet bridge where the pipeline genuinely needs one.
+
+use std::time::Duration;
+
+use presenter_core::AbleSetSettingsDraft;
+use presenter_persistence::SettingsAuditSource;
+
+use super::ableset_ack::AbleSetAckRefusal;
+use super::AppState;
+
+/// Apply AbleSet settings with a given `song_prefix_length`, disabled (no
+/// tracker/wiremock needed) — enough for the pure validation tests below,
+/// which only need `AppState::ableset_bridge`'s cached `song_prefix_length`.
+async fn set_prefix_length(state: &AppState, song_prefix_length: u8) {
+    let draft = AbleSetSettingsDraft {
+        enabled: false,
+        host: "ableset.invalid".to_string(),
+        osc_port: 39051,
+        http_port: 80,
+        library_name: "Hymnal".to_string(),
+        song_prefix_length,
+    };
+    state
+        .update_ableset_settings(draft, SettingsAuditSource::HttpSetter, "test")
+        .await
+        .unwrap();
+}
+
+fn expect_ack_refusal(err: anyhow::Error) -> AbleSetAckRefusal {
+    match err.downcast::<AbleSetAckRefusal>() {
+        Ok(refusal) => refusal,
+        Err(err) => panic!("expected a typed AbleSetAckRefusal, got: {err:?}"),
+    }
+}
+
+/// #655 F9d: a malformed number (wrong length here) must be refused before
+/// ever touching the ack store.
+#[tokio::test]
+async fn invalid_number_ack_is_refused() {
+    let state = AppState::in_memory().await.unwrap();
+    set_prefix_length(&state, 3).await;
+
+    let err = state
+        .acknowledge_ableset_mismatch("17", "A title", "B title")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            expect_ack_refusal(err),
+            AbleSetAckRefusal::InvalidNumber { .. }
+        ),
+        "a number of the wrong length must be refused as InvalidNumber"
+    );
+}
+
+/// #655 F9d: unacknowledge validates the number too, for the same reason.
+#[tokio::test]
+async fn invalid_number_unack_is_refused() {
+    let state = AppState::in_memory().await.unwrap();
+    set_prefix_length(&state, 3).await;
+
+    let err = state
+        .unacknowledge_ableset_mismatch("abc")
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        expect_ack_refusal(err),
+        AbleSetAckRefusal::InvalidNumber { .. }
+    ));
+}
+
+/// #655 F4: a one-sided structural gap (one title empty) can never be
+/// acknowledged away.
+#[tokio::test]
+async fn gap_ack_is_refused_as_structural() {
+    let state = AppState::in_memory().await.unwrap();
+    set_prefix_length(&state, 3).await;
+
+    let err = state
+        .acknowledge_ableset_mismatch("017", "", "017 Real Title")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(expect_ack_refusal(err), AbleSetAckRefusal::StructuralGap),
+        "a one-sided gap ack must be refused as StructuralGap, never accepted"
+    );
+}
+
+/// #655 F9c: the ack store is capped — the entry PAST the cap is refused.
+#[tokio::test]
+async fn ack_store_full_refuses_a_new_entry_past_the_cap() {
+    let state = AppState::in_memory().await.unwrap();
+    set_prefix_length(&state, 3).await;
+
+    for i in 0..500u32 {
+        let number = format!("{i:03}");
+        state
+            .acknowledge_ableset_mismatch(&number, "A", "B")
+            .await
+            .unwrap_or_else(|err| panic!("seeding ack {number} must succeed: {err:?}"));
+    }
+
+    // A number ALREADY in the store must still be updatable (not blocked by
+    // the cap it is already counted in).
+    state
+        .acknowledge_ableset_mismatch("000", "A2", "B2")
+        .await
+        .expect("updating an EXISTING ack must not be refused by the cap");
+
+    // A genuinely NEW number, with the store already full, must be refused.
+    let err = state
+        .acknowledge_ableset_mismatch("999", "A", "B")
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        expect_ack_refusal(err),
+        AbleSetAckRefusal::StoreFull
+    ));
+}
+
+/// #655 F9: a corrupt persisted ack blob must degrade to empty, never panic
+/// or propagate an error to the caller.
+#[tokio::test]
+async fn corrupt_ack_blob_degrades_to_empty_without_erroring() {
+    let state = AppState::in_memory().await.unwrap();
+    state
+        .repository()
+        .set_app_setting("ableset_mismatch_acks", "not valid json {{{")
+        .await
+        .unwrap();
+
+    let acks = state
+        .load_ableset_mismatch_acks()
+        .await
+        .expect("a corrupt blob must not error the caller");
+    assert!(
+        acks.is_empty(),
+        "a corrupt ack blob must degrade to empty, not panic or propagate"
+    );
+}
+
+/// #655 F5c/F8/F9e end-to-end: a genuine title disagreement is reported,
+/// acknowledging it silences it via the LIGHTWEIGHT recompute (no full DB
+/// rescan), and revoking the ack re-raises it.
+#[tokio::test]
+async fn ack_persists_and_silences_mismatch_then_unack_restores_it() {
+    let state = AppState::in_memory().await.unwrap();
+    let library = state.create_library("Hymnal").await.unwrap();
+    let (_, _, presentation, _) = state
+        .create_presentation(library.id, "017 Real Title", None)
+        .await
+        .unwrap();
+
+    let mock_server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/api/setlist"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activeSongId": null,
+                "songs": [{ "id": "s1", "meta": { "name": "017 Different Title" } }]
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+    let addr = mock_server.address();
+
+    let draft = AbleSetSettingsDraft {
+        enabled: true,
+        host: addr.ip().to_string(),
+        osc_port: 39051,
+        http_port: addr.port(),
+        library_name: "Hymnal".to_string(),
+        song_prefix_length: 3,
+    };
+    state
+        .update_ableset_settings(draft, SettingsAuditSource::HttpSetter, "test")
+        .await
+        .unwrap();
+
+    // Wait for the live tracker to actually poll the mock AbleSet server.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if !state.ableset_bridge.setlist_song_titles().await.is_empty() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "AbleSet setlist never populated from the mock server"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let resolved = state.resolve_ableset_presentation("017").await.unwrap();
+    assert_eq!(resolved, Some(presentation.id));
+
+    let before_ack = state.ableset_status_snapshot().await;
+    assert_eq!(
+        before_ack.mismatch_count, 1,
+        "the genuine title disagreement must be reported before any ack"
+    );
+
+    state
+        .acknowledge_ableset_mismatch("017", "017 Different Title", "017 Real Title")
+        .await
+        .expect("acknowledging a genuine (non-gap) mismatch must succeed");
+
+    let after_ack = state.ableset_status_snapshot().await;
+    assert_eq!(
+        after_ack.mismatch_count, 0,
+        "an acknowledged mismatch must be silenced immediately by the lightweight recompute"
+    );
+
+    state
+        .unacknowledge_ableset_mismatch("017")
+        .await
+        .expect("unacknowledging must succeed");
+
+    let after_unack = state.ableset_status_snapshot().await;
+    assert_eq!(
+        after_unack.mismatch_count, 1,
+        "revoking the ack must re-raise the warning on the next recompute"
+    );
+}

--- a/crates/presenter-server/src/state/ableset_integration_tests.rs
+++ b/crates/presenter-server/src/state/ableset_integration_tests.rs
@@ -245,6 +245,141 @@ async fn disabled_resolution_still_records_attempt_in_ring_buffer() {
     assert!(!snapshot.recent_attempts[0].found);
 }
 
+/// Build a `ServerConfig` pointed at a specific on-disk SQLite file so two
+/// successive `AppState::from_config` calls share the same database — i.e. a
+/// faithful "server restart" against persistent data. Local copy of
+/// `state::tests::config_for_db` (private per-module helper, not shared —
+/// matches the existing convention in this file of not reaching into sibling
+/// test modules).
+fn config_for_db(url: String) -> crate::config::ServerConfig {
+    crate::config::ServerConfig {
+        http: crate::config::HttpConfig { port: 0 },
+        database: crate::config::DatabaseConfig { url },
+        companion: crate::config::CompanionConfig::default(),
+        osc: crate::config::OscConfig::default(),
+        stage: crate::config::StageConfig {
+            heartbeat: crate::stage_connections::StageHeartbeatConfig::default_values(),
+        },
+        android: crate::config::AndroidConfig::default(),
+        network: crate::config::NetworkConfig::default(),
+        sync: crate::config::SyncConfig::default(),
+    }
+}
+
+/// Poll until the AbleSet bridge has fetched at least one song from the
+/// tracked (mocked) setlist — same wait loop as
+/// `ack_persists_and_silences_mismatch_then_unack_restores_it`, extracted so
+/// the restart test below can reuse it across both "boots".
+async fn wait_for_setlist(state: &AppState) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if !state.ableset_bridge.setlist_song_titles().await.is_empty() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "AbleSet setlist never populated from the mock server"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Regression for #655 F8 deviation 4 (disclosed by the prior worker): the
+/// in-memory ack mirror started EMPTY on every process boot and was only
+/// ever populated as a SIDE EFFECT of an ack/unack mutation
+/// (`sync_ableset_ack_cache_and_recompute`) — never primed from the
+/// persisted store on startup. So a freshly restarted server re-reported
+/// EVERY previously-acknowledged mismatch until an operator happened to
+/// touch an ack again, defeating the entire point of #601's persisted
+/// acknowledgement design (survive restarts). This constructs a SECOND
+/// `AppState` from the SAME on-disk DB (the `stage_layout_persists_across_restart`
+/// pattern in `state/tests.rs`) to prove an ack made in a PRIOR process is
+/// still honored in a freshly booted one, with no new ack/unack call.
+#[tokio::test]
+async fn ack_persists_across_restart_and_stays_silenced() {
+    let tmp = tempfile::NamedTempFile::new().expect("temp file");
+    let url = format!("sqlite://{}?mode=rwc", tmp.path().display());
+
+    let mock_server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/api/setlist"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activeSongId": null,
+                "songs": [{ "id": "s1", "meta": { "name": "017 Different Title" } }]
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+    let addr = mock_server.address();
+
+    // First "boot": create the library, observe the genuine mismatch, then
+    // acknowledge it. Dropping `state` at the end of this block is the
+    // "shutdown" half of the restart.
+    {
+        let state = AppState::from_config(config_for_db(url.clone()))
+            .await
+            .expect("from_config (first boot)");
+        let library = state.create_library("Hymnal").await.unwrap();
+        state
+            .create_presentation(library.id, "017 Real Title", None)
+            .await
+            .unwrap();
+
+        let draft = AbleSetSettingsDraft {
+            enabled: true,
+            host: addr.ip().to_string(),
+            osc_port: 39051,
+            http_port: addr.port(),
+            library_name: "Hymnal".to_string(),
+            song_prefix_length: 3,
+        };
+        state
+            .update_ableset_settings(draft, SettingsAuditSource::HttpSetter, "test")
+            .await
+            .unwrap();
+        wait_for_setlist(&state).await;
+        state.invalidate_ableset_cache().await;
+        state.resolve_ableset_presentation("017").await.unwrap();
+
+        let before_ack = state.ableset_status_snapshot().await;
+        assert_eq!(
+            before_ack.mismatch_count, 1,
+            "the genuine title disagreement must be reported before any ack"
+        );
+
+        state
+            .acknowledge_ableset_mismatch("017", "017 Different Title", "017 Real Title")
+            .await
+            .expect("acknowledging a genuine mismatch must succeed");
+        assert_eq!(
+            state.ableset_status_snapshot().await.mismatch_count,
+            0,
+            "acknowledging must silence the mismatch immediately"
+        );
+    }
+
+    // Second "boot" against the SAME DB file — this is the restart. The mock
+    // AbleSet server (and its setlist response) is unchanged, so the SAME
+    // title disagreement would be reported again — except it was already
+    // acknowledged in the PRIOR session, and that acknowledgement is
+    // persisted in the DB this new process just booted against.
+    let restarted = AppState::from_config(config_for_db(url))
+        .await
+        .expect("from_config (restart)");
+    wait_for_setlist(&restarted).await;
+    restarted.invalidate_ableset_cache().await;
+    restarted.resolve_ableset_presentation("017").await.unwrap();
+
+    let after_restart = restarted.ableset_status_snapshot().await;
+    assert_eq!(
+        after_restart.mismatch_count, 0,
+        "an acknowledgement persisted in a PRIOR session must silence the mismatch \
+         immediately after a restart, with no new ack/unack call in this process \
+         (#655 F8 deviation 4)"
+    );
+}
+
 /// #655 F7/F10: races many concurrent resolves (each capable of triggering
 /// a rebuild) against concurrent explicit invalidations. Before F7, a
 /// rebuild that lost the #639 CAS race simply dropped its result with no

--- a/crates/presenter-server/src/state/ableset_integration_tests.rs
+++ b/crates/presenter-server/src/state/ableset_integration_tests.rs
@@ -225,3 +225,25 @@ async fn ack_persists_and_silences_mismatch_then_unack_restores_it() {
         "revoking the ack must re-raise the warning on the next recompute"
     );
 }
+
+/// #655 F16 — RED (this commit): a resolution attempt while AbleSet is
+/// disabled currently returns early WITHOUT calling `record_attempt` — the
+/// ring buffer stays empty, so this assertion fails today. GREEN records
+/// the attempt on the disabled path too, so `recentAttempts` shows evidence
+/// instead of silence.
+#[tokio::test]
+async fn disabled_resolution_still_records_attempt_in_ring_buffer() {
+    let state = AppState::in_memory().await.unwrap();
+    // AbleSet is disabled by default on a fresh in-memory state
+    // (`AbleSetSettingsDraft::default()`).
+    let result = state.resolve_ableset_presentation("017").await.unwrap();
+    assert_eq!(result, None);
+
+    let snapshot = state.ableset_status_snapshot().await;
+    assert_eq!(
+        snapshot.recent_attempts.len(),
+        1,
+        "a disabled-path resolution attempt must still be recorded, not silently dropped"
+    );
+    assert!(!snapshot.recent_attempts[0].found);
+}

--- a/crates/presenter-server/src/state/ableset_mismatch.rs
+++ b/crates/presenter-server/src/state/ableset_mismatch.rs
@@ -1,5 +1,9 @@
-//! AbleSet<->Presenter song-number/title mismatch detection (#601) and its
-//! per-number operator acknowledgement store.
+//! Pure AbleSet<->Presenter song-number/title mismatch COMPARISON logic
+//! (#601). The acknowledgement store (persistence) lives in the sibling
+//! `ableset_ack.rs` (#655 — split out to keep both files under the repo's
+//! per-file size cap, same precedent as `state/background_tasks.rs`; F4's
+//! domain refusal enum and F9's mutex/prune/cap/validation land there in a
+//! follow-up commit).
 //!
 //! The song NUMBER is the only link between AbleSet and Presenter —
 //! `resolve_ableset_presentation` matches purely on the numeric prefix, so a
@@ -15,105 +19,9 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use anyhow::Context;
 use presenter_core::{normalize_title_for_mismatch, strip_song_prefix, AbleSetTitleMismatch};
-use tracing::warn;
 
-use super::AppState;
-use crate::ableset::AbleSetStatusSnapshot;
-
-const ABLESET_MISMATCH_ACK_SETTING_KEY: &str = "ableset_mismatch_acks";
-
-/// An operator's explicit "yes, these two titles are the same song"
-/// acknowledgement for one song number. The settled design rejected a
-/// similarity threshold (a genuinely wrong pair could easily look similar,
-/// and a deliberate variant like "Alive with you KIDS" can look very
-/// different) — only an explicit human call is safe here. Bound to the
-/// EXACT title pair it was granted for: if either side's title later
-/// changes, the ack no longer matches and the warning returns (a later
-/// renumbering must never silently inherit an old "this is fine").
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AbleSetMismatchAck {
-    pub(crate) ableset_title: String,
-    pub(crate) presenter_title: String,
-}
-
-pub(crate) type AckMap = HashMap<String, AbleSetMismatchAck>;
-
-impl AppState {
-    /// Load the persisted acknowledgement map from the generic `app_settings`
-    /// key-value store — no schema migration needed, this is a JSON blob
-    /// under one well-known key. A corrupt/unparseable blob degrades to
-    /// "no acknowledgements" (loud rebuild warnings) rather than failing the
-    /// whole cache rebuild.
-    pub(super) async fn load_ableset_mismatch_acks(&self) -> anyhow::Result<AckMap> {
-        let Some(raw) = self
-            .repository
-            .get_app_setting(ABLESET_MISMATCH_ACK_SETTING_KEY)
-            .await?
-        else {
-            return Ok(AckMap::new());
-        };
-        Ok(serde_json::from_str(&raw).unwrap_or_else(|err| {
-            warn!(
-                ?err,
-                "corrupt AbleSet mismatch acknowledgement store — treating as empty (#601)"
-            );
-            AckMap::new()
-        }))
-    }
-
-    async fn save_ableset_mismatch_acks(&self, acks: &AckMap) -> anyhow::Result<()> {
-        let raw = serde_json::to_string(acks)
-            .context("failed to serialize AbleSet mismatch acknowledgements")?;
-        self.repository
-            .set_app_setting(ABLESET_MISMATCH_ACK_SETTING_KEY, &raw)
-            .await
-    }
-
-    async fn refresh_current_ableset_cache(&self) -> anyhow::Result<()> {
-        let settings = self.ableset_bridge.status_snapshot().await;
-        self.refresh_ableset_cache(&settings).await
-    }
-
-    /// Record (or overwrite) the operator's acknowledgement that `number`'s
-    /// two CURRENT titles are deliberately different names for the same
-    /// song, then rebuild the cache immediately so the mismatch report drops
-    /// it right away rather than waiting for the next unrelated rebuild.
-    pub async fn acknowledge_ableset_mismatch(
-        &self,
-        number: &str,
-        ableset_title: &str,
-        presenter_title: &str,
-    ) -> anyhow::Result<AbleSetStatusSnapshot> {
-        let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
-        acks.insert(
-            number.to_string(),
-            AbleSetMismatchAck {
-                ableset_title: ableset_title.to_string(),
-                presenter_title: presenter_title.to_string(),
-            },
-        );
-        self.save_ableset_mismatch_acks(&acks).await?;
-        self.refresh_current_ableset_cache().await?;
-        Ok(self.ableset_status_snapshot().await)
-    }
-
-    /// Revoke a prior acknowledgement (the report is "visible/revocable" per
-    /// the settled design) — the warning returns on the immediate rebuild
-    /// triggered here if the titles still disagree.
-    pub async fn unacknowledge_ableset_mismatch(
-        &self,
-        number: &str,
-    ) -> anyhow::Result<AbleSetStatusSnapshot> {
-        let mut acks = self.load_ableset_mismatch_acks().await.unwrap_or_default();
-        acks.remove(number);
-        self.save_ableset_mismatch_acks(&acks).await?;
-        self.refresh_current_ableset_cache().await?;
-        Ok(self.ableset_status_snapshot().await)
-    }
-}
+use super::ableset_ack::AckMap;
 
 /// Compare the live AbleSet setlist against the resolved Presenter library
 /// and report per-number title disagreements the operator has not
@@ -192,6 +100,7 @@ fn mismatch_for_number(
 
 #[cfg(test)]
 mod tests {
+    use super::super::ableset_ack::AbleSetMismatchAck;
     use super::*;
 
     fn ack(ableset_title: &str, presenter_title: &str) -> AbleSetMismatchAck {

--- a/crates/presenter-server/src/state/ableset_mismatch.rs
+++ b/crates/presenter-server/src/state/ableset_mismatch.rs
@@ -73,7 +73,7 @@ fn mismatch_for_number(
                 != normalize_title_for_mismatch(strip_song_prefix(p, prefix_length));
             let acknowledged = acks
                 .get(number)
-                .is_some_and(|ack| ack.ableset_title == a && ack.presenter_title == p);
+                .is_some_and(|ack| ack_matches_current_titles(ack, a, p, prefix_length));
             if differs && !acknowledged {
                 Some(AbleSetTitleMismatch {
                     number: number.to_string(),
@@ -96,6 +96,29 @@ fn mismatch_for_number(
         }),
         (None, None) => None,
     }
+}
+
+/// Whether a stored acknowledgement still covers the CURRENT pair of titles
+/// (#655 F9e, re-settled): compares both sides through
+/// `normalize_title_for_mismatch` (the same fold used for the mismatch
+/// decision itself) rather than raw `==`. The ack is stored RAW (exactly the
+/// strings the operator saw on `GET status`), but a purely cosmetic change on
+/// either side (diacritics, extra whitespace, case) must not silently
+/// re-raise a warning the operator already dismissed — while a genuine title
+/// change (this function returning `false`) still must.
+fn ack_matches_current_titles(
+    ack: &super::ableset_ack::AbleSetMismatchAck,
+    current_ableset_title: &str,
+    current_presenter_title: &str,
+    prefix_length: u8,
+) -> bool {
+    normalize_title_for_mismatch(strip_song_prefix(&ack.ableset_title, prefix_length))
+        == normalize_title_for_mismatch(strip_song_prefix(current_ableset_title, prefix_length))
+        && normalize_title_for_mismatch(strip_song_prefix(&ack.presenter_title, prefix_length))
+            == normalize_title_for_mismatch(strip_song_prefix(
+                current_presenter_title,
+                prefix_length,
+            ))
 }
 
 #[cfg(test)]

--- a/crates/presenter-server/src/state/ableset_mismatch.rs
+++ b/crates/presenter-server/src/state/ableset_mismatch.rs
@@ -177,6 +177,26 @@ mod tests {
         );
     }
 
+    // #655 F9e — RED (this commit): the ack comparison is currently raw
+    // `==`, so a purely cosmetic edit (whitespace/case here) on either title
+    // WRONGLY re-raises a warning the operator already dismissed. GREEN
+    // switches the comparison to `normalize_title_for_mismatch` on both
+    // sides.
+    #[test]
+    fn ack_survives_a_purely_cosmetic_title_change() {
+        let presenter = HashMap::from([("088".to_string(), "088 Alive With  You".to_string())]);
+        let ableset = vec![("088".to_string(), "088 alive with you kids".to_string())];
+        let acks = AckMap::from([(
+            "088".to_string(),
+            ack("088 Alive with you KIDS", "088 Alive with you"),
+        )]);
+        let mismatches = compute_ableset_mismatches(&presenter, &ableset, 3, &acks);
+        assert!(
+            mismatches.is_empty(),
+            "a purely cosmetic title edit must not re-raise an acknowledged mismatch: {mismatches:?}"
+        );
+    }
+
     #[test]
     fn number_missing_from_presenter_is_always_reported_even_if_acked() {
         let presenter = HashMap::new();

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -173,6 +173,55 @@ pub(crate) fn should_auto_restore_ndi(manager_loaded: bool, encoder_available: b
     manager_loaded && encoder_available
 }
 
+/// Resolve the Companion feature-enabled flag and listen port from config
+/// overrides + persisted app settings, persisting any new/changed values
+/// back to the DB. Extracted from `from_config` (#655 F2's subscriber wiring
+/// pushed it over the function-length cap) to keep the constructor under
+/// the cap. Pure motion: takes the two `Copy` override fields rather than
+/// `&CompanionConfig` because `from_config` already partially moves
+/// `config.companion.token` out before this point.
+async fn resolve_companion_settings(
+    repo: &Repository,
+    enabled_override: Option<bool>,
+    port_override: Option<u16>,
+) -> anyhow::Result<(bool, u16)> {
+    let stored_companion = repo
+        .get_app_setting(COMPANION_FEATURE_KEY)
+        .await?
+        .and_then(|value| parse_bool_flag(&value))
+        .unwrap_or(false);
+
+    let companion_enabled = enabled_override.unwrap_or(stored_companion);
+
+    if let Some(value) = enabled_override {
+        repo.set_app_setting(COMPANION_FEATURE_KEY, if value { "1" } else { "0" })
+            .await?;
+    }
+
+    let raw_port = repo.get_app_setting(COMPANION_PORT_KEY).await?;
+    let mut persist_port = false;
+    let stored_port = raw_port
+        .as_deref()
+        .and_then(|value| value.parse::<u16>().ok())
+        .filter(|port| *port >= 1);
+    let mut companion_port = stored_port.unwrap_or(DEFAULT_COMPANION_PORT);
+    if stored_port.is_none() {
+        persist_port = true;
+    }
+
+    if let Some(port_override) = port_override {
+        companion_port = port_override;
+        persist_port = true;
+    }
+
+    if persist_port {
+        repo.set_app_setting(COMPANION_PORT_KEY, &companion_port.to_string())
+            .await?;
+    }
+
+    Ok((companion_enabled, companion_port))
+}
+
 impl AppState {
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn new(
@@ -265,42 +314,16 @@ impl AppState {
         let repo = Repository::connect(&DatabaseSettings::new(&db_url)).await?;
         let companion_token = config.companion.token;
 
-        let stored_companion = repo
-            .get_app_setting(COMPANION_FEATURE_KEY)
-            .await?
-            .and_then(|value| parse_bool_flag(&value))
-            .unwrap_or(false);
-
-        let companion_enabled = config
-            .companion
-            .enabled_override
-            .unwrap_or(stored_companion);
-
-        if let Some(value) = config.companion.enabled_override {
-            repo.set_app_setting(COMPANION_FEATURE_KEY, if value { "1" } else { "0" })
-                .await?;
-        }
-
-        let raw_port = repo.get_app_setting(COMPANION_PORT_KEY).await?;
-        let mut persist_port = false;
-        let stored_port = raw_port
-            .as_deref()
-            .and_then(|value| value.parse::<u16>().ok())
-            .filter(|port| *port >= 1);
-        let mut companion_port = stored_port.unwrap_or(DEFAULT_COMPANION_PORT);
-        if stored_port.is_none() {
-            persist_port = true;
-        }
-
-        if let Some(port_override) = config.companion.port_override {
-            companion_port = port_override;
-            persist_port = true;
-        }
-
-        if persist_port {
-            repo.set_app_setting(COMPANION_PORT_KEY, &companion_port.to_string())
-                .await?;
-        }
+        // Resolve the enabled flag + listen port from config overrides and
+        // persisted app settings (persisting anything new). Extracted to
+        // keep from_config under the function-length cap (#655 F2's
+        // subscriber wiring pushed it over 120 lines).
+        let (companion_enabled, companion_port) = resolve_companion_settings(
+            &repo,
+            config.companion.enabled_override,
+            config.companion.port_override,
+        )
+        .await?;
 
         let registry = ResolumeRegistry::new()?;
         let android_stage_registry = AndroidStageRegistry::new();

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -20,7 +20,7 @@
 //! If future changes require holding multiple locks, establish and document a consistent
 //! acquisition order (e.g., alphabetical by field name) to prevent deadlocks.
 
-mod ableset;
+pub(crate) mod ableset;
 pub(crate) mod ableset_ack;
 #[cfg(test)]
 mod ableset_integration_tests;
@@ -153,6 +153,11 @@ pub struct AppState {
     /// (load->mutate->save, and the F9b prune) so two concurrent
     /// ack/unack/prune calls can never lose one's update to the other.
     ableset_ack_lock: Arc<tokio::sync::Mutex<()>>,
+    /// #655 F16: edge-triggered "AbleSet integration is disabled" WARN —
+    /// set on the first disabled resolution attempt, cleared when settings
+    /// are next saved with `enabled: true`, so the warning logs once per
+    /// enabled->disabled transition instead of once per OSC event.
+    ableset_disabled_warn_shown: Arc<AtomicBool>,
 }
 
 /// Gate predicate for the startup NDI auto-restore branch.
@@ -245,6 +250,7 @@ impl AppState {
             sync: sync::SyncCoordinator::new(),
             presentation_locks: PresentationLockRegistry::new(),
             ableset_ack_lock: Arc::new(tokio::sync::Mutex::new(())),
+            ableset_disabled_warn_shown: Arc::new(AtomicBool::new(false)),
         };
         state.spawn_heartbeat_tasks();
         state

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -21,7 +21,7 @@
 //! acquisition order (e.g., alphabetical by field name) to prevent deadlocks.
 
 mod ableset;
-mod ableset_ack;
+pub(crate) mod ableset_ack;
 #[cfg(test)]
 mod ableset_integration_tests;
 mod ableset_mismatch;
@@ -149,6 +149,10 @@ pub struct AppState {
     /// snapshot-replace slide-edit op and the sync-apply call site — so
     /// the two can never interleave on the same presentation.
     presentation_locks: PresentationLockRegistry,
+    /// #655 F9a: serializes AbleSet mismatch-acknowledgement mutations
+    /// (load->mutate->save, and the F9b prune) so two concurrent
+    /// ack/unack/prune calls can never lose one's update to the other.
+    ableset_ack_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Gate predicate for the startup NDI auto-restore branch.
@@ -240,6 +244,7 @@ impl AppState {
             turn: TurnService::from_env(),
             sync: sync::SyncCoordinator::new(),
             presentation_locks: PresentationLockRegistry::new(),
+            ableset_ack_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
         state.spawn_heartbeat_tasks();
         state

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -21,6 +21,7 @@
 //! acquisition order (e.g., alphabetical by field name) to prevent deadlocks.
 
 mod ableset;
+mod ableset_ack;
 mod ableset_mismatch;
 mod api_stage;
 mod background_tasks;

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -22,6 +22,8 @@
 
 mod ableset;
 mod ableset_ack;
+#[cfg(test)]
+mod ableset_integration_tests;
 mod ableset_mismatch;
 mod api_stage;
 mod background_tasks;

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -356,6 +356,9 @@ impl AppState {
 
         // Re-broadcast stage snapshots whenever AbleSet switches songs.
         state.spawn_ableset_rebroadcast(&ableset_bridge);
+        // Refresh the AbleSet mismatch report whenever AbleSet's tracked
+        // setlist changes, not only on boot/ack (#655 F2).
+        state.spawn_ableset_setlist_change_refresh(&ableset_bridge);
 
         state
             .configure_companion_service(companion_enabled, companion_port)
@@ -435,6 +438,48 @@ impl AppState {
                             tracing::warn!(
                                 ?err,
                                 "failed to broadcast stage after AbleSet song change"
+                            );
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    /// Debounce window for the setlist-changed-triggered cache refresh (#655
+    /// F2) — coalesces a burst of AbleSet setlist-changed signals (e.g.
+    /// several reorders/edits in quick succession) into at most one
+    /// mismatch-cache rebuild per window, instead of one rebuild per signal.
+    const ABLESET_SETLIST_REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
+
+    /// Spawn the background task that refreshes the AbleSet mismatch cache
+    /// whenever AbleSet's tracked SETLIST changes (#655 F2) — song list
+    /// loaded, reordered, or a song's skip flag flipped. Without this, the
+    /// #601 mismatch report only recomputes on boot, a Presenter-side edit,
+    /// or an ack/unack: a setlist loaded at 09:30 (AbleSet was off/empty at
+    /// boot) would otherwise stay frozen at whatever the boot-time report
+    /// said, indefinitely. Extracted from `from_config` to keep that
+    /// constructor under the repo's per-function line cap, mirroring
+    /// `spawn_ableset_rebroadcast`.
+    fn spawn_ableset_setlist_change_refresh(&self, ableset_bridge: &AbleSetBridge) {
+        let mut rx = ableset_bridge.subscribe_setlist_changes();
+        let app = self.clone();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(()) => {
+                        // Debounce/coalesce: wait out the window, then drain
+                        // any further signals that arrived during it, so a
+                        // burst of setlist edits triggers exactly one rebuild.
+                        tokio::time::sleep(Self::ABLESET_SETLIST_REFRESH_DEBOUNCE).await;
+                        while rx.try_recv().is_ok() {}
+                        let settings = app.ableset_bridge.status_snapshot().await;
+                        if let Err(err) = app.refresh_ableset_cache(&settings).await {
+                            tracing::warn!(
+                                ?err,
+                                "failed to refresh AbleSet cache after a setlist change"
                             );
                         }
                     }

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -27,32 +27,55 @@ fn should_auto_restore_ndi_requires_manager_and_encoder() {
     assert!(!super::should_auto_restore_ndi(false, false));
 }
 
-/// Structural regression (deep-review 🔵 #7): the predicate is correct in
-/// isolation, but item 6's safety depends on EVERY auto-restore site
-/// consulting it. There are two sites, in two DIFFERENT files after the
-/// #486-style split of `state/mod.rs`: the one-shot startup restore stayed
-/// in `mod.rs` (`restore_active_ndi_source`), and the 30s background
-/// reconnect loop moved to `background_tasks.rs` (`spawn_background_tasks`).
-/// A refactor that drops one of the call sites would silently re-introduce
-/// the 2026-05-24 wedge failure mode without breaking any other test. This
-/// test pins the call sites lexically, one per file — if you legitimately
-/// refactor (e.g. extract to a shared helper, or move a site to yet another
-/// file), update the expected counts and the comment.
+/// Structural regression (deep-review 🔵 #7, generalized #655 F17): the
+/// predicate is correct in isolation, but item 6's safety depends on EVERY
+/// auto-restore site consulting it. There are two sites, in two DIFFERENT
+/// files after the #486-style split of `state/mod.rs`: the one-shot startup
+/// restore stayed in `mod.rs` (`restore_active_ndi_source`), and the 30s
+/// background reconnect loop moved to `background_tasks.rs`
+/// (`spawn_background_tasks`).
+///
+/// #655 F17: the ORIGINAL version of this test was a two-file ALLOW-LIST
+/// (`include_str!("mod.rs")` + `include_str!("background_tasks.rs")`) — it
+/// would stay green even if a THIRD call site appeared in some OTHER
+/// `state/*.rs` file, because that file was simply never scanned. This
+/// version walks the ENTIRE `state/` directory (`std::fs::read_dir`) and
+/// asserts the call-site count is a crate-wide invariant: EXACTLY 2 total,
+/// in EXACTLY these two files — a third call site anywhere else in
+/// `state/` now fails this test instead of silently escaping it.
 #[test]
 fn auto_restore_sites_invoke_encoder_gate_predicate() {
     const CALL: &str = "should_auto_restore_ndi(manager_loaded, encoder_available)";
-    let mod_rs = include_str!("mod.rs");
-    let background_tasks_rs = include_str!("background_tasks.rs");
-    let mod_rs_occurrences = mod_rs.matches(CALL).count();
-    let background_tasks_occurrences = background_tasks_rs.matches(CALL).count();
-    let total = mod_rs_occurrences + background_tasks_occurrences;
+    let state_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/state");
+    let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for entry in std::fs::read_dir(state_dir).expect("read the state/ directory") {
+        let path = entry.expect("state/ dir entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let contents = std::fs::read_to_string(&path).expect("read a state/*.rs file");
+        let occurrences = contents.matches(CALL).count();
+        if occurrences > 0 {
+            let file_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            counts.insert(file_name, occurrences);
+        }
+    }
+    let total: usize = counts.values().sum();
+    let expected: std::collections::BTreeMap<String, usize> = [
+        ("mod.rs".to_string(), 1),
+        ("background_tasks.rs".to_string(), 1),
+    ]
+    .into_iter()
+    .collect();
     assert_eq!(
-        (mod_rs_occurrences, background_tasks_occurrences),
-        (1, 1),
+        counts, expected,
         "expected exactly 1 call site to should_auto_restore_ndi(manager_loaded, encoder_available) \
          in state/mod.rs (one-shot startup restore) AND exactly 1 in state/background_tasks.rs \
-         (30s reconnect loop) — found {mod_rs_occurrences} in mod.rs and {background_tasks_occurrences} \
-         in background_tasks.rs (total {total}). \
+         (30s reconnect loop), and NOWHERE ELSE under state/ — found: {counts:?} (total {total}). \
          If a call site was intentionally removed, moved, or refactored, update this test \
          AND the supporting comments to match. Otherwise #333 item 6's protection \
          has a hole — restore the gate before merging."

--- a/crates/presenter-server/src/state/tests.rs
+++ b/crates/presenter-server/src/state/tests.rs
@@ -53,14 +53,30 @@ fn auto_restore_sites_invoke_encoder_gate_predicate() {
         if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
             continue;
         }
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+        // Exclude test files from the scan. This meta-test guards PROD call
+        // sites only — without this exclusion the whole-directory walk counts
+        // its OWN `CALL` string literal (this very file, tests.rs, mentions it
+        // above in doc comments / assert messages) and would falsely fail the
+        // moment a second reference to the string appeared here. `*_tests.rs` /
+        // `*_test.rs` also covers sibling test-module files under state/ (e.g.
+        // ableset_integration_tests.rs, sync_integration_tests.rs) so a future
+        // one mentioning the predicate name can't trip this the same way. Test
+        // code is not a call site #333 item 6's gate needs to protect — only
+        // prod code paths are.
+        if file_name == "tests.rs"
+            || file_name.ends_with("_tests.rs")
+            || file_name.ends_with("_test.rs")
+        {
+            continue;
+        }
         let contents = std::fs::read_to_string(&path).expect("read a state/*.rs file");
         let occurrences = contents.matches(CALL).count();
         if occurrences > 0 {
-            let file_name = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or_default()
-                .to_string();
             counts.insert(file_name, occurrences);
         }
     }


### PR DESCRIPTION
## Review-fix batch for PR #654 findings (v0.4.230)

Closes #655

### What

Adversarial post-merge review of PR #654 (AbleSet batch #601+#623+#639) found 2 🔴 9 🟡 6 🔵 — all fixed here per the settled designs on #655:

- **🔴 F1+F2:** the AbleSet setlist only populated when the ACTIVE SONG changed — a setlist loaded before the service compared as empty (all-gaps until the first song played, exactly too late for #601's pre-service checklist), and the mismatch report was frozen from boot until an unrelated event. Now: setlist fingerprint rebuild on every list change + setlist-changed signal → debounced mismatch recompute.
- **🟡 F3:** empty/disabled AbleSet side short-circuits to one INFO instead of a 166-gap WARN burst under a misleading "numbering disagreement" message; gap vs title-disagreement WARNs split.
- **🟡 F4:** one-sided-gap acknowledgement no longer returns 200 storing permanently-dead data — typed `AbleSetAckRefusal` domain enum → 422 (repository-error-pattern shape).
- **🟡 F5+F6:** log-spam amplifiers killed — 5s cooldown on failed-rebuild retries (was: full DB scan + WARN burst per OSC slide advance on a library-name typo), per-mismatch WARN loop collapsed to ONE summary line, logging moved OUTSIDE the cache write lock (was blocking the live projection path).
- **🟡 F7:** #639 CAS race-lost path no longer silently drops the current resolution (guaranteed missed trigger) — bounded 3-attempt retry.
- **🟡 F8:** #601's two extra awaits inside the #639 CAS window removed — ack map cached in the library cache (one-time boot load; persisted acks survive restarts), setlist titles read before generation capture.
- **🟡 F9:** ack store hardened — mutex-serialized mutations (lost-update fix), prune on real comparisons, 500-entry cap, number validation, normalized ack comparison.
- **🟡 F10:** integration test suite for the whole HTTP + persistence surface (was zero) incl. refresh-vs-invalidate concurrency test.
- **🟡 F11 + 🔵 F12:** normalizer design re-settled (recorded on #601): digit-aware whitespace collapse — "10 000"→"10000" silent, word boundaries preserved (replaces the strip-all-whitespace fix(ci) reversal).
- **🔵 F13–F17:** non-decomposable letter fold table (ł/ø/đ); duplicate-number collision WARN + last_error; status mismatches capped at 25 + `mismatchCount`; edge-triggered disabled WARN + accurate OSC log reason + record_attempt; encoder-gate meta-test walks all of state/ (excl. test files).

### How verified

- RED→GREEN per behavior-changing finding (commit stack `718c2ea2..e4df9534`, 27 commits); version bump 0.4.230 first commit.
- Pipeline run 31090249197 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Per-finding settled designs + implementation notes: #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
