### PR TITLE
Sync batch: tombstone ordering (#626) + playlist_entry cleanup on incoming tombstones (#649) — v0.4.231

### DIFF
--- a/.claude/rules/sync-lww.md
+++ b/.claude/rules/sync-lww.md
@@ -31,8 +31,11 @@ Two-site LWW sync (PP↔SNV), strict-`>` gate on `updated_at` (sync_id tie-break
    current; the peer may have revived/renamed a library you still hold tombstoned.
 
 4. **Tombstone cascades must clean dependents everywhere**: `playlist_entry` rows +
-   `slide_stage_layout` markers — `delete_library`/`delete_presentation` and the forced-tombstone
-   path all do; a new tombstone-writing path must too (gap for genuine incoming tombstones: #649).
+   `slide_stage_layout` markers — `delete_library`/`delete_presentation`, the forced-tombstone
+   path, AND a genuine (non-forced) incoming tombstone (#649, fixed) all do, via the shared
+   `clean_playlist_entries_for_tombstone` helper (`sync_apply_tombstone_cleanup.rs`) gated on
+   `effective_deleted_at.is_some()` in `write_synced_row` — a new tombstone-writing path must
+   call it too.
 
 5. Known open flaw: presentations join libraries by NAME on the wire (`SyncPresentation.library_name`)
    → mis-filing/phantom libraries across rename races (#647, cross-cutting protocol change).

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -232,7 +232,15 @@ correctly (past `#[cfg(test)] mod tests;`). Two pre-existing-debt landmines:
 
 - **File-size (>1000 prod lines) + fn-length (>120 lines, tests NOT exempt):** TOUCHING an
   already-over-cap file/function pulls it into the diff and HARD-FAILS your PR — even if your edit
-  is unrelated. Known offender STILL open: `state/mod.rs` (~1117 prod lines, #486). `resolume/tests.rs`
+  is unrelated. **#654/#656 correction: the STRICT gate fails changed files already at the 800-line
+  TARGET, not only the 1000 hard cap** — a ONE-LINE addition (a `mod x;` declaration) to an
+  868-line `state/mod.rs` hard-failed the PR ("exceeds target size (800 lines)"). Budget prod-lines
+  to ≤790 on every file your diff touches. Same batch's fn-growth trap: inlining a feature into an
+  existing 100-119-line fn (`run_tracker` 110→126, `from_config` 119→122) flips it past the 120
+  hard cap — extract a helper proactively when a touched fn is already >100 lines. And a meta-test
+  that source-scans a directory (`state/*.rs`) counts its OWN pattern occurrences in test files —
+  exclude `tests.rs`/`*_tests.rs` from such scans. Known offender: `state/mod.rs` (was ~1117, #486;
+  re-split in #656 to 783 — near the 800 target, split further before adding). `resolume/tests.rs`
   was fixed in #487 (shared `mount_composition`/`mount_params`/`mount_clips`/`mount_full_composition`/
   `build_driver` helpers + `stage_all`/`stage_main_meta` builders → all fns now ≤120). Check before
   editing: `bash scripts/dev/count_prod_lines.sh <file>` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.230"
+version = "0.4.231"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.230"
+version = "0.4.231"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/mod.rs
+++ b/crates/presenter-persistence/src/repository/mod.rs
@@ -22,6 +22,7 @@ mod sync;
 mod sync_apply;
 #[cfg(test)]
 mod sync_apply_review_tests;
+mod sync_apply_tombstone_cleanup;
 #[cfg(test)]
 mod sync_restore_review_tests;
 #[cfg(test)]

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -635,17 +635,14 @@ impl Repository {
             .exec(conn)
             .await?;
 
-        if forced_delete.is_some() {
-            // #646 finding 3: clean playlist references the SAME way
+        if effective_deleted_at.is_some() {
+            // #646 finding 3 + #649: clean playlist references the SAME way
             // `delete_library`/`delete_presentation` do on a real local
-            // delete. Markers are handled below via `replace_slides`.
-            // Scoped to the FORCED case per the settled design -- a
-            // GENUINE incoming tombstone's own gap is filed as #649.
-            use crate::entities::playlist_entry;
-            playlist_entry::Entity::delete_many()
-                .filter(playlist_entry::Column::PresentationId.eq(local_id.to_string()))
-                .exec(conn)
-                .await?;
+            // delete -- for BOTH a forced tombstone (library cascade) and a
+            // GENUINE, non-forced tombstone the peer sent us. Markers are
+            // handled below via `replace_slides`. See
+            // `sync_apply_tombstone_cleanup.rs`.
+            Self::clean_playlist_entries_for_tombstone(conn, local_id).await?;
         }
 
         Self::replace_slides(conn, local_id, incoming, effective_deleted_at.is_some()).await

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -1069,6 +1069,77 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn tombstone_helpers_agree_on_same_named_tombstone_with_different_deleted_at() {
+        // #626 regression: the #595 test above only proves agreement when
+        // BOTH same-named tombstones share the EXACT same `deleted_at` --
+        // in that case DeletedAt ASC can't discriminate between them and
+        // the query falls through to UpdatedAt DESC, which happens to
+        // agree with `ensure_library`. An ordinary delete/recreate/delete
+        // cycle leaves DIFFERENT `deleted_at` values per attempt: here the
+        // most-recently-UPDATED row is deliberately NOT the earliest-
+        // DELETED row, so the OLD `ensure_library_for_tombstone` (DeletedAt
+        // ASC primary sort) and `ensure_library` (UpdatedAt DESC) pick
+        // DIFFERENT rows.
+        use crate::entities::library;
+        use sea_orm::{EntityTrait, Set, TransactionTrait};
+
+        let repo = super::Repository::connect_in_memory()
+            .await
+            .expect("in-memory db");
+        let base = Utc::now();
+
+        // "lib-recent-update": most recently UPDATED, but NOT the earliest
+        // deleted (deleted only 10 min ago) -- ensure_library (UpdatedAt
+        // DESC) must pick this one.
+        // "lib-earliest-delete": updated 2h ago, but deleted earliest (5h
+        // ago) -- the OLD ensure_library_for_tombstone (DeletedAt ASC
+        // primary) wrongly picks this one instead.
+        for (id, updated_offset_min, deleted_offset_min, sync_val) in [
+            ("lib-recent-update", 0_i64, 10_i64, "sync-aaa"),
+            ("lib-earliest-delete", 120_i64, 300_i64, "sync-bbb"),
+        ] {
+            library::Entity::insert(library::ActiveModel {
+                id: Set(id.to_string()),
+                name: Set("Songs".to_string()),
+                search_name: Set("songs".to_string()),
+                created_at: Set((base - Duration::hours(6)).into()),
+                updated_at: Set((base - Duration::minutes(updated_offset_min)).into()),
+                sync_id: Set(sync_val.to_string()),
+                deleted_at: Set(Some((base - Duration::minutes(deleted_offset_min)).into())),
+            })
+            .exec(&repo.db)
+            .await
+            .expect("insert tombstone");
+        }
+
+        let txn1 = repo.db.begin().await.expect("begin txn");
+        let id_from_tombstone_helper =
+            super::Repository::ensure_library_for_tombstone(&txn1, "Songs")
+                .await
+                .expect("resolve via tombstone helper");
+        txn1.rollback().await.expect("rollback");
+
+        // presentation_updated_at older than every tombstone -> no revival.
+        let txn2 = repo.db.begin().await.expect("begin txn");
+        let (id_from_live_helper, forced_delete) =
+            super::Repository::ensure_library(&txn2, "Songs", base - Duration::hours(7))
+                .await
+                .expect("resolve via live helper");
+        txn2.rollback().await.expect("rollback");
+        assert!(
+            forced_delete.is_some(),
+            "presentation_updated_at is older than every tombstone -- stays tombstoned"
+        );
+
+        assert_eq!(
+            id_from_tombstone_helper, id_from_live_helper,
+            "both tombstone helpers must resolve to the same library row even when \
+             deleted_at values differ; tombstone helper picked {id_from_tombstone_helper}, \
+             live helper picked {id_from_live_helper}"
+        );
+    }
+
     #[test]
     fn lww_matrix() {
         let now = Utc::now();

--- a/crates/presenter-persistence/src/repository/sync_apply.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply.rs
@@ -359,31 +359,11 @@ impl Repository {
         if let Some(id) = Self::find_library_id(txn, library_name).await? {
             return Ok((id, None));
         }
-        // Order by UpdatedAt DESC, SyncId DESC: repeated delete/recreate
-        // cycles of the same-named library leave MULTIPLE tombstoned rows
-        // behind (the partial unique index only guards LIVE rows — see
-        // idx_libraries_name_live_unique), and `.one()` with no explicit
-        // order picks an arbitrary one. Always deciding against the MOST
-        // RECENT tombstone is the one that's actually relevant to this
-        // race; an older, already-superseded tombstone would compare the
-        // presentation against the wrong timestamp entirely. `SyncId` is
-        // the tie-breaker for an EXACT `updated_at` collision (two rapid
-        // delete/recreate cycles can land on the same wall-clock
-        // millisecond) — it MUST be a peer-stable key, never a local-only
-        // one like the row `Id` (`find_live_by_name_candidate`'s own
-        // secondary sort), or two peers holding the same two tombstoned
-        // rows could break the tie in DIFFERENT directions and pick a
-        // DIFFERENT "most recent" tombstone each — reintroducing the exact
-        // divergence class this fix closes. `sync_id` converges identically
-        // on both sides once synced, so ordering by it is deterministic
-        // peer-to-peer.
-        if let Some(tombstoned) = library::Entity::find()
-            .filter(library::Column::Name.eq(library_name.to_string()))
-            .filter(library::Column::DeletedAt.is_not_null())
-            .order_by_desc(library::Column::UpdatedAt)
-            .order_by_desc(library::Column::SyncId)
-            .one(txn)
-            .await?
+        // #626: resolved via the SHARED `find_most_recent_tombstoned_library`
+        // helper — see its doc comment for why this must be the ONE query
+        // both this function and `ensure_library_for_tombstone` use.
+        if let Some(tombstoned) =
+            Self::find_most_recent_tombstoned_library(txn, library_name).await?
         {
             let library_updated: DateTime<Utc> = tombstoned.updated_at.into();
             if presentation_updated_at > library_updated {
@@ -427,9 +407,37 @@ impl Repository {
         Ok((id, None))
     }
 
+    /// The most recently updated TOMBSTONED library row named `library_name`,
+    /// or `None` if none exists. Ties break by `SyncId` DESC (peer-stable —
+    /// never the local-only `Id`, or two peers could break a tie in
+    /// DIFFERENT directions and diverge).
+    ///
+    /// Shared by `ensure_library` and `ensure_library_for_tombstone` so the
+    /// two can never independently order the same tombstones differently
+    /// (#626: the latter used to run its OWN `DeletedAt ASC`-primary query,
+    /// which only agreed with this one when every same-named tombstone
+    /// shared the exact same `deleted_at` — #595's own test covered only
+    /// that case. An ordinary delete/recreate cycle leaves DIFFERENT
+    /// `deleted_at` values per attempt, and the two independently-sorted
+    /// queries then picked DIFFERENT rows).
+    async fn find_most_recent_tombstoned_library(
+        txn: &sea_orm::DatabaseTransaction,
+        library_name: &str,
+    ) -> anyhow::Result<Option<library::Model>> {
+        Ok(library::Entity::find()
+            .filter(library::Column::Name.eq(library_name.to_string()))
+            .filter(library::Column::DeletedAt.is_not_null())
+            .order_by_desc(library::Column::UpdatedAt)
+            .order_by_desc(library::Column::SyncId)
+            .one(txn)
+            .await?)
+    }
+
     /// #578: resolve a library id for a brand-new TOMBSTONED presentation
     /// WITHOUT creating an empty LIVE library shell. Attach to any existing
-    /// same-named library (live preferred, then tombstoned); if none exists,
+    /// same-named library (a LIVE one always wins via `find_library_id`;
+    /// otherwise the most recently updated TOMBSTONED one via the shared
+    /// `find_most_recent_tombstoned_library` helper — #626); if none exists,
     /// create a TOMBSTONED library (its identity converges separately via the
     /// peer's library manifest). Used only by `apply_unknown_sync_id` for a
     /// tombstone — a live entry keeps using `ensure_library`.
@@ -437,21 +445,10 @@ impl Repository {
         txn: &sea_orm::DatabaseTransaction,
         library_name: &str,
     ) -> anyhow::Result<String> {
-        // order_by DeletedAt ASC → live rows (NULL sorts first in SQLite) win
-        // over a tombstoned same-named row when both exist. Secondary sort
-        // (#595): UpdatedAt DESC + SyncId DESC — the SAME tiebreak
-        // `ensure_library` uses for tombstones, so both helpers resolve to
-        // the SAME row when multiple same-named tombstones exist. Without
-        // this, equal deleted_at values fall back to rowid order and the
-        // two helpers can pick DIFFERENT tombstones.
-        if let Some(row) = library::Entity::find()
-            .filter(library::Column::Name.eq(library_name.to_string()))
-            .order_by_asc(library::Column::DeletedAt)
-            .order_by_desc(library::Column::UpdatedAt)
-            .order_by_desc(library::Column::SyncId)
-            .one(txn)
-            .await?
-        {
+        if let Some(id) = Self::find_library_id(txn, library_name).await? {
+            return Ok(id);
+        }
+        if let Some(row) = Self::find_most_recent_tombstoned_library(txn, library_name).await? {
             return Ok(row.id);
         }
         let id = uuid::Uuid::new_v4().to_string();

--- a/crates/presenter-persistence/src/repository/sync_apply_review_tests.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_review_tests.rs
@@ -262,3 +262,71 @@ async fn forced_tombstone_cleans_playlist_entries_and_clears_stage_layout_marker
          cleared, never remapped onto its replacement slides"
     );
 }
+
+#[tokio::test]
+async fn genuine_incoming_tombstone_cleans_playlist_entries() {
+    // #649: a GENUINE peer-initiated tombstone (the peer deleted the song
+    // for real -- no library cascade involved, unlike the #646 forced case
+    // above) must clean `playlist_entry` rows the same way a local delete
+    // (`delete_presentation`) does. Before the fix, `write_synced_row` only
+    // ran the playlist-entry cleanup when `forced_delete.is_some()`, so this
+    // ordinary case -- matched by `sync_id`, `incoming.deleted_at: Some(_)`,
+    // no library cascade -- left the reference behind.
+    let repo = repo().await;
+    repo.create_library("Songs").await.unwrap();
+
+    let initial = peer_song("peer-genuine-tombstone", "Genuine Song", "verse one", 30);
+    let (outcome, id) = repo
+        .apply_sync_presentation(&initial, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Created);
+    let pres_id = id.expect("created presentation has an id");
+
+    let playlist = repo.create_playlist("Sunday", false).await.unwrap();
+    playlist_entry::Entity::insert(playlist_entry::ActiveModel {
+        id: sea_orm::Set(uuid::Uuid::new_v4().to_string()),
+        playlist_id: sea_orm::Set(playlist.id.to_string()),
+        entry_type: sea_orm::Set("presentation".to_string()),
+        presentation_id: sea_orm::Set(Some(pres_id.to_string())),
+        position: sea_orm::Set(0),
+        midi_note: sea_orm::Set(None),
+        label: sea_orm::Set(None),
+    })
+    .exec(&repo.db)
+    .await
+    .unwrap();
+
+    // The peer's own, real deletion of this song -- same library, no
+    // cascade, `deleted_at: Some(_)` -- strictly newer than the initial
+    // apply so it's accepted.
+    let tombstone = crate::SyncPresentation {
+        sync_id: "peer-genuine-tombstone".to_string(),
+        library_name: "Songs".to_string(),
+        name: "Genuine Song".to_string(),
+        updated_at: chrono::Utc::now() - chrono::Duration::minutes(5),
+        deleted_at: Some(chrono::Utc::now() - chrono::Duration::minutes(5)),
+        slides: vec![slide(0, "verse one")],
+    };
+    let (outcome, _) = repo
+        .apply_sync_presentation(&tombstone, &HashSet::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome, crate::SyncApplyOutcome::Updated);
+    let pres_row = row(&repo, pres_id).await;
+    assert!(
+        pres_row.deleted_at.is_some(),
+        "sanity: genuinely tombstoned"
+    );
+
+    let remaining_entries = playlist_entry::Entity::find()
+        .filter(playlist_entry::Column::PresentationId.eq(pres_id.to_string()))
+        .all(&repo.db)
+        .await
+        .unwrap();
+    assert!(
+        remaining_entries.is_empty(),
+        "playlist entries referencing a genuinely (non-forced) tombstoned \
+         song must be removed, same as a local delete"
+    );
+}

--- a/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
@@ -1,0 +1,28 @@
+//! Playlist-entry cleanup for a sync-apply write that lands (or stays) as a
+//! tombstone (#649). Split out of `sync_apply.rs` into its own
+//! self-contained `impl Repository` block — same pattern as
+//! `android_stage.rs`/`resolume.rs`/`video_source.rs` — rather than growing
+//! `sync_apply.rs`, which is already at the file-size gate's target cap.
+use super::Repository;
+use crate::entities::playlist_entry;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+impl Repository {
+    /// Delete every `playlist_entry` row referencing `presentation_id` —
+    /// mirrors `delete_presentation`'s local-delete cleanup
+    /// (`presentation.rs`) for a `write_synced_row` write landing as a
+    /// tombstone, whether FORCED by a #634/#646 library cascade or a
+    /// GENUINE, non-forced tombstone the peer sent us (#649's gap: the old
+    /// code only ran this cleanup for the forced case). Idempotent — a
+    /// re-sync of an already-tombstoned row simply deletes zero rows.
+    pub(super) async fn clean_playlist_entries_for_tombstone<C: sea_orm::ConnectionTrait>(
+        conn: &C,
+        presentation_id: &str,
+    ) -> anyhow::Result<()> {
+        playlist_entry::Entity::delete_many()
+            .filter(playlist_entry::Column::PresentationId.eq(presentation_id.to_string()))
+            .exec(conn)
+            .await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Sync batch: tombstone ordering + playlist_entry cleanup (v0.4.231)

Closes #626
Closes #649

### What

- **#626 — tombstone-ordering divergence on delete/recreate.** `ensure_library_for_tombstone` sorted candidate tombstones by `DeletedAt ASC` primary while `ensure_library` sorted by `UpdatedAt DESC` — the two helpers only agreed when `deleted_at` values happened to be equal (the #595 test's blind spot), so same-named tombstones with unequal timestamps could resolve to DIFFERENT libraries depending on which code path ran. Fix: extracted a shared `find_most_recent_tombstoned_library` helper both callers now use — divergence is now structurally impossible, not just tested-against.
- **#649 — genuine incoming tombstones never cleaned `playlist_entry` rows.** `write_synced_row`'s playlist cleanup was gated on `forced_delete.is_some()` (synthetic tombstones only) instead of `effective_deleted_at.is_some()` — a real tombstone arriving from the peer soft-deleted the presentation but left its playlist entries dangling, unlike a local delete. Now every tombstone write cleans `playlist_entry`, consistent with `.claude/rules/sync-lww.md` invariant 4 (rule doc updated in the same batch).

### How verified

- RED→GREEN per ticket (commit stack `6c8b3f41..ceeca6da`); version bump 0.4.231 first commit.
- Pipeline run 31096468085 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Design comments with root-cause + alternative rejected: #626, #649.
- New sibling file `sync_apply_tombstone_cleanup.rs` (28 lines); `sync_apply.rs` 995 → 989 prod lines (net decrease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
