### PR TITLE
Review-fix: startup backfill for pre-#649 orphaned playlist entries (#658) — v0.4.232

### DIFF
--- a/.claude/rules/sync-lww.md
+++ b/.claude/rules/sync-lww.md
@@ -35,7 +35,10 @@ Two-site LWW sync (PP↔SNV), strict-`>` gate on `updated_at` (sync_id tie-break
    path, AND a genuine (non-forced) incoming tombstone (#649, fixed) all do, via the shared
    `clean_playlist_entries_for_tombstone` helper (`sync_apply_tombstone_cleanup.rs`) gated on
    `effective_deleted_at.is_some()` in `write_synced_row` — a new tombstone-writing path must
-   call it too.
+   call it too. A tombstone that arrived BEFORE a cleanup gap was fixed never gets a second
+   chance to clean up on its own (its re-arrival is `SkippedNotNewer` under the strict `>` gate,
+   invariant 1) — `Repository::backfill_orphaned_playlist_entries` (same file) is the one-time
+   startup sweep that backfills that pre-fix residue on deployed DBs (#658).
 
 5. Known open flaw: presentations join libraries by NAME on the wire (`SyncPresentation.library_name`)
    → mis-filing/phantom libraries across rename races (#647, cross-cutting protocol change).

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -232,15 +232,17 @@ correctly (past `#[cfg(test)] mod tests;`). Two pre-existing-debt landmines:
 
 - **File-size (>1000 prod lines) + fn-length (>120 lines, tests NOT exempt):** TOUCHING an
   already-over-cap file/function pulls it into the diff and HARD-FAILS your PR — even if your edit
-  is unrelated. **#654/#656 correction: the STRICT gate fails changed files already at the 800-line
-  TARGET, not only the 1000 hard cap** — a ONE-LINE addition (a `mod x;` declaration) to an
-  868-line `state/mod.rs` hard-failed the PR ("exceeds target size (800 lines)"). Budget prod-lines
-  to ≤790 on every file your diff touches. Same batch's fn-growth trap: inlining a feature into an
+  is unrelated. **#654 post-mortem CORRECTION (verified against quality-check.sh source + run
+  31068027673 log): the 800-line TARGET is WARN-only even under `--strict` — only >1000 prod
+  lines hard-fails.** The round-1 "state/mod.rs exceeds target size (800): 868" line sat under
+  `[quality] Warnings:`; the job's actual Failure was the serde convention check
+  (`AbleSetMismatchAck` missing `#[serde(rename_all = "camelCase")]`). Do NOT split files
+  defensively at 800 — the hard budget is the 1000 cap (an 989-line direct edit passed in #626/#649). Same batch's fn-growth trap: inlining a feature into an
   existing 100-119-line fn (`run_tracker` 110→126, `from_config` 119→122) flips it past the 120
   hard cap — extract a helper proactively when a touched fn is already >100 lines. And a meta-test
   that source-scans a directory (`state/*.rs`) counts its OWN pattern occurrences in test files —
   exclude `tests.rs`/`*_tests.rs` from such scans. Known offender: `state/mod.rs` (was ~1117, #486;
-  re-split in #656 to 783 — near the 800 target, split further before adding). `resolume/tests.rs`
+  re-split in #656 to 783 — split again before it approaches the 1000 hard cap). `resolume/tests.rs`
   was fixed in #487 (shared `mount_composition`/`mount_params`/`mount_clips`/`mount_full_composition`/
   `build_driver` helpers + `stage_all`/`stage_main_meta` builders → all fns now ≤120). Check before
   editing: `bash scripts/dev/count_prod_lines.sh <file>` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.231"
+version = "0.4.232"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.231"
+version = "0.4.232"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
@@ -66,7 +66,7 @@ impl Repository {
 mod tests {
     use crate::entities::{playlist_entry, presentation as presentation_entity};
     use crate::repository::sync_test_support::repo;
-    use sea_orm::{sea_query::Expr, ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+    use sea_orm::{sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter, Set};
 
     /// #658 RED: seeds a tombstoned presentation with a dangling
     /// `playlist_entry` — the exact pre-#649 residue shape (the presentation
@@ -102,7 +102,7 @@ mod tests {
 
         let playlist = repo.create_playlist("Sunday", false).await.unwrap();
         let live_entry_id = uuid::Uuid::new_v4().to_string();
-        playlist_entry::ActiveModel {
+        playlist_entry::Entity::insert(playlist_entry::ActiveModel {
             id: Set(live_entry_id.clone()),
             playlist_id: Set(playlist.id.to_string()),
             entry_type: Set("presentation".to_string()),
@@ -110,13 +110,13 @@ mod tests {
             position: Set(0),
             midi_note: Set(None),
             label: Set(None),
-        }
-        .insert(&repo.db)
+        })
+        .exec(&repo.db)
         .await
         .unwrap();
 
         let dangling_entry_id = uuid::Uuid::new_v4().to_string();
-        playlist_entry::ActiveModel {
+        playlist_entry::Entity::insert(playlist_entry::ActiveModel {
             id: Set(dangling_entry_id.clone()),
             playlist_id: Set(playlist.id.to_string()),
             entry_type: Set("presentation".to_string()),
@@ -124,8 +124,8 @@ mod tests {
             position: Set(1),
             midi_note: Set(None),
             label: Set(None),
-        }
-        .insert(&repo.db)
+        })
+        .exec(&repo.db)
         .await
         .unwrap();
 

--- a/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
@@ -7,7 +7,8 @@
 //! gate's target cap (989 prod lines).
 use super::Repository;
 use crate::entities::playlist_entry;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use anyhow::Context;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 use tracing::instrument;
 
 impl Repository {
@@ -47,18 +48,24 @@ impl Repository {
     /// historical residue, it is not a recurring maintenance need.
     #[instrument(skip_all)]
     pub async fn backfill_orphaned_playlist_entries(&self) -> anyhow::Result<u64> {
-        // #658 RED: no sweep exists yet — this stub is exactly the gap this
-        // ticket closes: nothing currently revisits a `playlist_entry` left
-        // dangling by the pre-#649 tombstone bug. The GREEN commit replaces
-        // this with the real DELETE.
-        Ok(0)
+        let backend = self.db.get_database_backend();
+        let result = self
+            .db
+            .execute(sea_orm::Statement::from_string(
+                backend,
+                "DELETE FROM playlist_entries \
+                 WHERE presentation_id IN (SELECT id FROM presentations WHERE deleted_at IS NOT NULL)",
+            ))
+            .await
+            .context("failed to backfill orphaned playlist entries")?;
+        Ok(result.rows_affected())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::repository::sync_test_support::repo;
     use crate::entities::{playlist_entry, presentation as presentation_entity};
+    use crate::repository::sync_test_support::repo;
     use sea_orm::{sea_query::Expr, ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 
     /// #658 RED: seeds a tombstoned presentation with a dangling

--- a/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
+++ b/crates/presenter-persistence/src/repository/sync_apply_tombstone_cleanup.rs
@@ -1,11 +1,14 @@
 //! Playlist-entry cleanup for a sync-apply write that lands (or stays) as a
-//! tombstone (#649). Split out of `sync_apply.rs` into its own
-//! self-contained `impl Repository` block — same pattern as
-//! `android_stage.rs`/`resolume.rs`/`video_source.rs` — rather than growing
-//! `sync_apply.rs`, which is already at the file-size gate's target cap.
+//! tombstone (#649), plus the one-time startup backfill for entries the
+//! pre-#649 bug already left dangling on deployed DBs (#658). Split out of
+//! `sync_apply.rs` into its own self-contained `impl Repository` block —
+//! same pattern as `android_stage.rs`/`resolume.rs`/`video_source.rs` —
+//! rather than growing `sync_apply.rs`, which is already at the file-size
+//! gate's target cap (989 prod lines).
 use super::Repository;
 use crate::entities::playlist_entry;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use tracing::instrument;
 
 impl Repository {
     /// Delete every `playlist_entry` row referencing `presentation_id` —
@@ -24,5 +27,126 @@ impl Repository {
             .exec(conn)
             .await?;
         Ok(())
+    }
+
+    /// One-time startup backfill (#658): sweep `playlist_entry` rows a
+    /// GENUINE incoming tombstone left dangling BEFORE the #649 fix landed.
+    /// Pre-#649, `write_synced_row` only ran
+    /// `clean_playlist_entries_for_tombstone` for a forced tombstone, never a
+    /// genuine one — and that same tombstone re-arriving today is
+    /// `SkippedNotNewer` under the strict `>` LWW gate (identical clock,
+    /// `sync_apply.rs:114-121`), so the cleanup path can never re-fire for
+    /// it on its own. Safe to run unconditionally post-#649: every tombstone
+    /// path now cleans as it writes, so this only ever touches pre-existing
+    /// residue, never a legitimately live reference. Idempotent — a DB that
+    /// never hit the bug deletes zero rows every time it runs. Mirrors
+    /// `prune_orphan_slide_stage_layouts`'s single-statement sweep
+    /// (`slide_stage_layout.rs`). Called once at boot
+    /// (`state/mod.rs::from_config`) rather than on the periodic
+    /// trash-prune ticker (`background_tasks.rs`) — this backfills
+    /// historical residue, it is not a recurring maintenance need.
+    #[instrument(skip_all)]
+    pub async fn backfill_orphaned_playlist_entries(&self) -> anyhow::Result<u64> {
+        // #658 RED: no sweep exists yet — this stub is exactly the gap this
+        // ticket closes: nothing currently revisits a `playlist_entry` left
+        // dangling by the pre-#649 tombstone bug. The GREEN commit replaces
+        // this with the real DELETE.
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::sync_test_support::repo;
+    use crate::entities::{playlist_entry, presentation as presentation_entity};
+    use sea_orm::{sea_query::Expr, ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
+    /// #658 RED: seeds a tombstoned presentation with a dangling
+    /// `playlist_entry` — the exact pre-#649 residue shape (the presentation
+    /// row is tombstoned directly, bypassing `delete_presentation`, which
+    /// already cleans entries post-fix) — plus a live presentation's entry.
+    /// The sweep must remove only the dangling one.
+    #[tokio::test]
+    async fn backfill_removes_dangling_entries_but_keeps_live_ones() {
+        let repo = repo().await;
+        let library = repo.create_library("Songs").await.unwrap();
+
+        let (_, _, live) = repo
+            .create_presentation(library.id, "Live Song", None)
+            .await
+            .unwrap();
+        let (_, _, orphaned) = repo
+            .create_presentation(library.id, "Orphaned Song", None)
+            .await
+            .unwrap();
+
+        // Manufacture the pre-#649 residue: tombstone the presentation
+        // WITHOUT going through `delete_presentation` (which already cleans
+        // playlist entries post-fix), leaving its entry dangling.
+        presentation_entity::Entity::update_many()
+            .col_expr(
+                presentation_entity::Column::DeletedAt,
+                Expr::value(chrono::Utc::now().to_rfc3339()),
+            )
+            .filter(presentation_entity::Column::Id.eq(orphaned.id.to_string()))
+            .exec(&repo.db)
+            .await
+            .unwrap();
+
+        let playlist = repo.create_playlist("Sunday", false).await.unwrap();
+        let live_entry_id = uuid::Uuid::new_v4().to_string();
+        playlist_entry::ActiveModel {
+            id: Set(live_entry_id.clone()),
+            playlist_id: Set(playlist.id.to_string()),
+            entry_type: Set("presentation".to_string()),
+            presentation_id: Set(Some(live.id.to_string())),
+            position: Set(0),
+            midi_note: Set(None),
+            label: Set(None),
+        }
+        .insert(&repo.db)
+        .await
+        .unwrap();
+
+        let dangling_entry_id = uuid::Uuid::new_v4().to_string();
+        playlist_entry::ActiveModel {
+            id: Set(dangling_entry_id.clone()),
+            playlist_id: Set(playlist.id.to_string()),
+            entry_type: Set("presentation".to_string()),
+            presentation_id: Set(Some(orphaned.id.to_string())),
+            position: Set(1),
+            midi_note: Set(None),
+            label: Set(None),
+        }
+        .insert(&repo.db)
+        .await
+        .unwrap();
+
+        let deleted = repo.backfill_orphaned_playlist_entries().await.unwrap();
+        assert_eq!(deleted, 1, "only the dangling entry must be swept");
+
+        assert!(
+            playlist_entry::Entity::find_by_id(dangling_entry_id)
+                .one(&repo.db)
+                .await
+                .unwrap()
+                .is_none(),
+            "the tombstoned presentation's entry must be gone"
+        );
+        assert!(
+            playlist_entry::Entity::find_by_id(live_entry_id)
+                .one(&repo.db)
+                .await
+                .unwrap()
+                .is_some(),
+            "the live presentation's entry must survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_is_a_noop_on_a_clean_db() {
+        let repo = repo().await;
+        let deleted = repo.backfill_orphaned_playlist_entries().await.unwrap();
+        assert_eq!(deleted, 0);
     }
 }

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -400,10 +400,30 @@ impl AppState {
         state
             .configure_companion_service(companion_enabled, companion_port)
             .await?;
+        state.backfill_orphaned_playlist_entries_on_boot().await;
         state.spawn_background_tasks();
         state.maybe_spawn_sync(config.sync.peer_url.clone());
         state.ai_proxy.auto_start().await;
         Ok(state)
+    }
+
+    /// One-time startup backfill (#658): sweep `playlist_entry` rows a
+    /// GENUINE incoming tombstone left dangling before the #649 fix landed
+    /// (the old code only cleaned a FORCED tombstone's entries, and the
+    /// stale tombstone re-arriving today is `SkippedNotNewer` under the
+    /// strict LWW gate, so it can never re-trigger the cleanup on its own).
+    /// Never blocks boot — logs and continues on failure, matching the
+    /// periodic trash-prune tasks in `background_tasks.rs`. Extracted from
+    /// `from_config` to keep that constructor under the function-length cap.
+    async fn backfill_orphaned_playlist_entries_on_boot(&self) {
+        match self.repository.backfill_orphaned_playlist_entries().await {
+            Ok(n) if n > 0 => tracing::info!(
+                deleted = n,
+                "backfilled playlist entries orphaned by the pre-#649 tombstone bug"
+            ),
+            Ok(_) => {}
+            Err(err) => tracing::warn!(?err, "playlist-entry backfill sweep failed"),
+        }
     }
 
     /// Restore the active NDI video source on startup, gated on BOTH the NDI


### PR DESCRIPTION
## Review-fix: startup backfill for pre-#649 orphaned playlist entries (v0.4.232)

Closes #658

### What

Adversarial post-merge review of PR #657 (sync batch #626+#649) found one 🟡 completeness gap — fixed here per the settled design on #658:

- The #649 cleanup only fires inside an ACCEPTED tombstone write; `playlist_entry` rows already orphaned by the PRE-fix bug on deployed DBs were never revisited (re-arriving tombstone = `SkippedNotNewer`). If the peer revived the song before the 30-day prune, the dangling entry silently became a live playlist reference again.
- Now: one-time startup sweep (`backfill_orphaned_playlist_entries_on_boot`) deleting `playlist_entries` whose presentation is tombstoned, mirroring the `prune_orphan_slide_stage_layouts` pattern; ONE INFO log when >0 rows swept. Safe post-#649 — no legitimate state leaves an entry referencing a tombstoned presentation.

### CI-fix commit (fallout, same PR)

- `395932a0`: test seeding used `ActiveModel::insert()` whose auto-increment readback can't find a String-PK row (`RecordNotFound`) — switched to the proven `Entity::insert().exec()` pattern used by the real writer and sibling tests. No assertions weakened, no production code touched.

### How verified

- RED→GREEN (`66649575` → `37c25e84`); version bump 0.4.232 first commit.
- Pipeline run 31104759943 fully green (checks → test/quality → coverage → build → E2E ×3 + NDI → deploy-dev).
- Settled design + review evidence: #658 (review found 0 🔴, 14 suspicions refuted with source evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
