### PR TITLE
v0.4.234: post-merge review fixes — AI error chain, WHEP wiring tests, ai-eval hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.233"
+version = "0.4.234"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.233"
+version = "0.4.234"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-server/src/router/ai.rs
+++ b/crates/presenter-server/src/router/ai.rs
@@ -304,6 +304,17 @@ pub(super) fn compute_ai_status_error(
     }
 }
 
+/// Render a `check_connectivity` failure for the `/ai/status` `error` field (#624).
+///
+/// `check_connectivity` wraps the underlying transport failure (DNS, TLS,
+/// timeout, connection refused) in an outer `.context("failed to reach AI
+/// API")`. Rendering it with `.to_string()` shows only that outermost
+/// context and silently drops the real cause — this uses anyhow's
+/// alternate-mode formatting (`{:#}`) to render the full chain instead.
+pub(super) fn render_connectivity_error(e: &anyhow::Error) -> String {
+    e.to_string()
+}
+
 #[instrument(skip_all)]
 pub(super) async fn check_status(
     State(state): State<AppState>,
@@ -313,7 +324,7 @@ pub(super) async fn check_status(
 
     let connectivity_result = crate::ai::client::check_connectivity(&settings).await;
     let connectivity_ok = connectivity_result.is_ok();
-    let connectivity_err_msg = connectivity_result.err().map(|e| e.to_string());
+    let connectivity_err_msg = connectivity_result.err().map(|e| render_connectivity_error(&e));
 
     let connected = compute_ai_connected(connectivity_ok, proxy_status.claude_authenticated);
 

--- a/crates/presenter-server/src/router/ai.rs
+++ b/crates/presenter-server/src/router/ai.rs
@@ -281,8 +281,9 @@ pub(super) fn compute_ai_connected(connectivity_ok: bool, claude_authenticated: 
 /// "AI proxy unreachable" string — which is misleading when the actual
 /// failure is an HTTP-level error such as 401 (bad/expired API key) or 500
 /// (proxy-side crash). `connectivity_error` carries that real message
-/// (`check_connectivity`'s `anyhow::Error` rendered via `.to_string()`) so
-/// the caller can see WHY the proxy is unreachable, not just that it is.
+/// (`check_connectivity`'s `anyhow::Error` rendered via
+/// `render_connectivity_error`, see below) so the caller can see WHY the
+/// proxy is unreachable, not just that it is.
 ///
 /// Extracted as a pure function so the branch logic is unit-testable without
 /// constructing a live ProxyManager + network connectivity (same rationale
@@ -312,7 +313,7 @@ pub(super) fn compute_ai_status_error(
 /// context and silently drops the real cause — this uses anyhow's
 /// alternate-mode formatting (`{:#}`) to render the full chain instead.
 pub(super) fn render_connectivity_error(e: &anyhow::Error) -> String {
-    e.to_string()
+    format!("{e:#}")
 }
 
 #[instrument(skip_all)]

--- a/crates/presenter-server/src/router/ai.rs
+++ b/crates/presenter-server/src/router/ai.rs
@@ -325,7 +325,9 @@ pub(super) async fn check_status(
 
     let connectivity_result = crate::ai::client::check_connectivity(&settings).await;
     let connectivity_ok = connectivity_result.is_ok();
-    let connectivity_err_msg = connectivity_result.err().map(|e| render_connectivity_error(&e));
+    let connectivity_err_msg = connectivity_result
+        .err()
+        .map(|e| render_connectivity_error(&e));
 
     let connected = compute_ai_connected(connectivity_ok, proxy_status.claude_authenticated);
 

--- a/crates/presenter-server/src/router/ai_tests.rs
+++ b/crates/presenter-server/src/router/ai_tests.rs
@@ -3,7 +3,7 @@
 //! connectivity check is necessary but not sufficient — actual AI readiness
 //! requires a valid Claude OAuth session as well.
 
-use crate::router::ai::{compute_ai_connected, compute_ai_status_error};
+use crate::router::ai::{compute_ai_connected, compute_ai_status_error, render_connectivity_error};
 
 #[test]
 fn connected_is_false_when_claude_not_authenticated_even_if_connectivity_ok() {
@@ -85,5 +85,24 @@ fn status_error_falls_back_to_generic_message_when_no_error_string_available() {
     assert_eq!(
         compute_ai_status_error(false, true, None),
         Some("AI proxy unreachable".to_string())
+    );
+}
+
+// #624 follow-up: `.to_string()` on an anyhow error only renders the
+// OUTERMOST `.context(...)` layer — `check_connectivity`'s real transport
+// failure (DNS/TLS/timeout/connection-refused) gets silently dropped behind
+// the "failed to reach AI API" wrapper context. `render_connectivity_error`
+// must render the FULL chain so the underlying cause stays visible.
+#[test]
+fn connectivity_error_renders_full_anyhow_chain() {
+    let err = anyhow::anyhow!("connection refused").context("failed to reach AI API");
+    let rendered = render_connectivity_error(&err);
+    assert!(
+        rendered.contains("failed to reach AI API"),
+        "rendered error must keep the outer context: {rendered}"
+    );
+    assert!(
+        rendered.contains("connection refused"),
+        "rendered error must keep the underlying cause, not just the outer context: {rendered}"
     );
 }

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -762,6 +762,63 @@ mod tests {
         );
     }
 
+    /// #630 follow-up: the two wiring tests above cover `post_whep_session`
+    /// and `patch_whep_session`'s `.map_err(map_signaller_error)?` call
+    /// sites, but leave `post_whep_endpoint`'s `map_post_whep_error(err)?`
+    /// (line ~139) unproven the same way — on a libndi-free CI runner
+    /// `ndi_manager()` is always `None`, so the "manager missing" 503
+    /// short-circuits before that line is ever reached by an existing
+    /// handler-level test. `set_ndi_handle` injects a `Fake` manager so the
+    /// call site is reached deterministically, regardless of libndi.
+    #[tokio::test]
+    async fn post_whep_endpoint_wires_map_post_whep_error_at_its_call_site() {
+        let mut state = fresh_state().await;
+        state.set_ndi_handle(NdiManagerHandle::Fake(FakeNdiControl::with_whep_outcome(
+            WhepOutcome::SourceNotActive,
+        )));
+        let result = post_whep_endpoint(
+            Path("00000000-0000-0000-0000-000000000000".to_string()),
+            Query(WhepPostQuery::default()),
+            State(state),
+            empty_body(),
+        )
+        .await;
+        let resp = result.expect(
+            "map_post_whep_error must translate SourceNotActive into an Ok(204) reply, not an Err",
+        );
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "map_post_whep_error must map SourceNotActive to 204, not fall through to map_signaller_error's 404"
+        );
+    }
+
+    /// Same call-site-wiring gap as above, for `delete_whep_session`'s
+    /// `map_delete_whep_error(err)?` (line ~221).
+    #[tokio::test]
+    async fn delete_whep_session_wires_map_delete_whep_error_at_its_call_site() {
+        let mut state = fresh_state().await;
+        state.set_ndi_handle(NdiManagerHandle::Fake(FakeNdiControl::with_whep_outcome(
+            WhepOutcome::SourceNotActive,
+        )));
+        let result = delete_whep_session(
+            Path((
+                "00000000-0000-0000-0000-000000000000".to_string(),
+                "session-id".to_string(),
+            )),
+            State(state),
+        )
+        .await;
+        let resp = result.expect(
+            "map_delete_whep_error must translate SourceNotActive into an Ok(204) reply, not an Err",
+        );
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "map_delete_whep_error must map SourceNotActive to 204 (idempotent delete), not fall through to map_signaller_error's 404"
+        );
+    }
+
     #[cfg(feature = "test-helpers")]
     #[tokio::test]
     async fn kill_pipeline_for_test_returns_404_or_503_for_unknown_source() {

--- a/crates/presenter-server/src/router/integrations/ndi_whep.rs
+++ b/crates/presenter-server/src/router/integrations/ndi_whep.rs
@@ -264,7 +264,7 @@ pub(crate) async fn kill_pipeline_for_test(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::ndi_control::{FakeNdiControl, NdiManagerHandle, WhepOutcome};
+    use crate::state::{FakeNdiControl, NdiManagerHandle, WhepOutcome};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 

--- a/crates/presenter-server/src/state/mod.rs
+++ b/crates/presenter-server/src/state/mod.rs
@@ -34,7 +34,9 @@ mod cache_manager;
 mod companion;
 mod companion_manager;
 mod integrations;
-pub(crate) mod ndi_control;
+mod ndi_control;
+#[cfg(test)]
+pub(crate) use ndi_control::{FakeNdiControl, NdiManagerHandle, WhepOutcome};
 mod osc;
 mod presentation_lock;
 mod presentations;

--- a/scripts/dev/ai-eval/README.md
+++ b/scripts/dev/ai-eval/README.md
@@ -25,8 +25,11 @@ installs, no ssh). Concretely:
 | The remaining ~70/~90 bulk corpus cases (corpus generator + more hand-written fixtures) | ❌ Not built — report §8 steps 6-7 |
 | CI wiring (`ai-eval.yml`, per-PR Layer-1-only lane) | ❌ Not built — report §8 step 11 |
 
-Running `./run.sh` today will count the corpus (currently 30 cases) and then fail loudly at
-whichever stage needs the driver — that is the intended, honest behavior of a skeleton, not a bug.
+Running bare `./run.sh` today fails loudly immediately, on the `drive` stage's missing
+`--candidate-url`/`--model` arguments — it never gets far enough to count the corpus. Passing
+both (`./run.sh --candidate-url <url> --model <name>`) gets past that check and THEN counts the
+corpus (currently 30 cases) before failing loudly at whichever stage needs the not-yet-built
+driver — that is the intended, honest behavior of a skeleton, not a bug.
 
 ## What this evaluates, and how
 

--- a/scripts/dev/ai-eval/judge/promptfooconfig.yaml
+++ b/scripts/dev/ai-eval/judge/promptfooconfig.yaml
@@ -52,12 +52,14 @@ defaultTest:
       config:
         temperature: 0
 
-# Caching: unchanged fixtures should never re-bill the judge model. Report §6.6: "Candidate and
-# judge pinned to temperature 0 and explicit model IDs; PROMPTFOO_CACHE_PATH set so unchanged
-# fixtures don't re-bill." Set PROMPTFOO_CACHE_PATH in the environment that invokes `npx
-# promptfoo eval` (ai-eval.yml, report §8 step 11) — not hardcoded here, since the right cache
-# location differs between a local run and the self-hosted CI runner.
-cache: true
+# Caching MUST stay off here: `repeat: 3` below exists to get 3 INDEPENDENT judge samples at
+# temperature 0 ("even greedy decoding isn't fully reproducible", report §6.4). At temperature 0
+# every repeat is a byte-identical request, so promptfoo's cache would serve repeats 2 and 3
+# straight from the cache of repeat 1 — degenerating the majority-of-3 vote into one sample
+# wearing a 3x label. Re-enable caching only if this ever moves to genuinely-different repeated
+# requests (e.g. varied few-shot ordering); until then it directly undermines the majority-vote
+# design this file exists to implement.
+cache: false
 
 # Report §6.4: "Judge at temperature 0, 3 runs, majority verdict for anything near threshold —
 # even greedy decoding isn't fully reproducible." promptfoo's `repeat` re-runs each test N times;

--- a/scripts/dev/ai-eval/judge/tests_from_traces.js
+++ b/scripts/dev/ai-eval/judge/tests_from_traces.js
@@ -10,6 +10,16 @@
 // Each test's `vars.caseId` selects the matching trace via trace_provider.js, and each of the
 // four rubric dimensions is attached as its own llm-rubric assertion so a single test's pass/fail
 // output shows exactly which dimension(s) failed rather than one blended verdict.
+//
+// Two failure-handling rules, both #662 follow-ups:
+//   1. No traces directory, or a traces directory with zero *.json files, is an ERROR, not an
+//      empty test list — an empty `tests:` array makes promptfoo report 0/0 and exit 0 (green),
+//      which would silently mask "the drive stage never ran" as a passing judge run.
+//   2. A single truncated/corrupt trace file must NOT abort the whole generator (and therefore
+//      every other case's judge run) via an unguarded JSON.parse throw. Each file is parsed in
+//      its own try/catch; a parse failure becomes a test that always FAILS (via a rubric that
+//      can never pass), carrying the filename and parse error in its description, so the one
+//      bad trace shows up as one visible failure instead of taking the rest of the suite down.
 
 const fs = require("fs");
 const path = require("path");
@@ -21,10 +31,30 @@ const RUBRICS = [
   "final-reply-language.md",
 ];
 
+function parseFailureTest(file, error) {
+  const caseId = file.replace(/\.json$/, "");
+  return {
+    description: `${caseId}: FAILED TO PARSE trace file (${error.message})`,
+    vars: { caseId },
+    assert: [
+      {
+        type: "equals",
+        // Deliberately unsatisfiable: the provider's actual output can never equal this
+        // sentinel, so the test always fails and surfaces the parse error in the report
+        // instead of being silently dropped from the suite.
+        value: `__UNPARSEABLE_TRACE__:${file}:${error.message}`,
+      },
+    ],
+  };
+}
+
 module.exports = function generateTests() {
   const tracesDir = path.join(__dirname, "..", "traces");
   if (!fs.existsSync(tracesDir)) {
-    return [];
+    throw new Error(
+      `no traces found — expected trace JSON under ${tracesDir}; run the drive stage first ` +
+        `(scripts/dev/ai-eval/run.sh --stage drive)`
+    );
   }
 
   const files = fs
@@ -32,9 +62,21 @@ module.exports = function generateTests() {
     .filter((f) => f.endsWith(".json"))
     .sort();
 
+  if (files.length === 0) {
+    throw new Error(
+      `no traces found — ${tracesDir} exists but contains no *.json files; run the drive stage ` +
+        `first (scripts/dev/ai-eval/run.sh --stage drive)`
+    );
+  }
+
   return files.map((file) => {
     const caseId = file.replace(/\.json$/, "");
-    const trace = JSON.parse(fs.readFileSync(path.join(tracesDir, file), "utf8"));
+    let trace;
+    try {
+      trace = JSON.parse(fs.readFileSync(path.join(tracesDir, file), "utf8"));
+    } catch (error) {
+      return parseFailureTest(file, error);
+    }
 
     return {
       description: `${caseId} (${trace.slice || "unknown-slice"})`,


### PR DESCRIPTION
## Post-merge review fixes for PR #663 (v0.4.234)

Follow-up addressing all 8 findings from the adversarial review of the merged #663 diff. Leaves #662 open (harness work continues there).

- **#624 follow-up** — `/ai/status` connectivity error rendered only the outermost anyhow context (`e.to_string()`), dropping the underlying cause (DNS/TLS/timeout). New `render_connectivity_error` renders the full chain via `{e:#}`. RED (`17620c3c`) → GREEN (`56f04cf8`), chain rendering pinned by test.
- **#630 follow-up** — wiring tests for the remaining 2 of 4 WHEP call sites (`post_whep_endpoint`, `delete_whep_session`) through their `map_*_error` mappers (`d32bdf77`); `mod ndi_control` narrowed back to private with `#[cfg(test)] pub(crate)` re-exports (`8246199c`).
- **ai-eval harness** — README wording (bare `./run.sh` fails on missing candidate args), judge `cache: false` (temp-0 `repeat: 3` must not be cache-served), robust trace loading (empty traces/ throws; corrupt trace file emits failing test instead of aborting the run) (`cd8850d9`).

Version 0.4.234. Pipeline green on `8963dda4` (all 22 jobs).
