### PR TITLE
v0.4.235: slide multi-select/copy-paste UX fixes (#602), feature-router gate self-test (#625), deploy skill Tier-0 reconcile (#627)

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -354,3 +354,17 @@ just re-uniting the two DAG branches at the merge commit), so it's always safe t
 immediately after ANY `--merge`-style PR merge, before starting the next commit on dev
 (version bump or otherwise). `git rev-list --count origin/dev..origin/main` should read
 `0` before you push anything else.
+
+## Pipeline run can appear MINUTES late after a push (GitHub delay)
+
+A `git push` to dev normally spawns the Pipeline run within seconds — but after GitHub
+infra hiccups the run can appear MINUTES later (observed 2026-08-07: push at 07:0x, run
+created ~07:20, then ran normally to success). A missing run right after push is NOT a
+lost event: query by exact SHA before re-triggering anything:
+
+```bash
+gh api "repos/zbynekdrlik/presenter/actions/runs?head_sha=$(git rev-parse HEAD)" \
+  --jq '.total_count, (.workflow_runs[] | "\(.id) \(.name) \(.status)")'
+```
+
+Only if it stays absent for ~15+ min consider `gh workflow run pipeline.yml --ref dev`.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: presenter-deploy
 description: >
-  Local build-deploy-iterate workflow and CLIProxyAPI login procedure for presenter on dev2.
-  Use when building locally, deploying to dev, or setting up the Claude AI login.
+  Push-to-CI iterate workflow (Tier-0: CI builds/tests/deploys, only cheap checks run
+  locally), the HOTFIX MODE local-build exception, and the CLIProxyAPI login procedure
+  for presenter on dev2. Use when pushing a change, deploying to dev, or setting up the
+  Claude AI login.
 triggers:
   - local build
   - deploy to dev
@@ -14,35 +16,42 @@ triggers:
 
 # Presenter Deploy Skill
 
-## Local Build-Deploy-Iterate (Tier-0 Machine)
+## Push-to-CI Iterate (Tier-0 Machine)
 
-CI takes ~38 min per push. Iterate locally; push only when the feature works end-to-end.
-This project is Tier-0 (#592): heavy builds run on GitHub runners, not locally. The
-`block-tier0-local-build.sh` hook blocks local `cargo build`/`cargo test`. Use CI for
-compilation; this machine only runs the self-hosted E2E + deploy steps.
+**#627: this section used to say "Tier-0" in its heading while its own numbered steps
+prescribed exactly the local build+deploy loop Tier-0 bans — `block-tier0-local-build.sh`
+fails step 2/3 immediately, by design.** This is the corrected, actually-runnable
+sequence.
 
-Build order matters (WASM embedded into server at compile time via `include_dir!`):
+This project is Tier-0 (#592): heavy compilation (`cargo build`, `cargo build
+--release`, `trunk build`, `wasm-pack build`, a test run that RUNS tests) happens ONLY
+on GitHub-hosted runners. Locally, only cheap checks are allowed/expected before every
+push (`.claude/skills/local-builds`):
 
-1. **Format + lint** (mandatory before every push):
-   `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
+```bash
+cargo fmt --all --check
+cargo check --workspace --tests
+cargo clippy --workspace --all-targets -- -D warnings   # Rust-only, no codegen/link
+```
 
-2. **WASM I/F first** (server embeds dist/ at compile time):
-   `bash scripts/build-ui.sh`  ← ALWAYS use this; it builds with **nightly +
-   `-Zbuild-std` + target-cpu=mvp** (Safari-12 MVP wasm). Do NOT run a plain
-   `trunk build` on stable — see the #465 note below.
-   Manual equivalent: `RUSTUP_TOOLCHAIN=nightly trunk build --release` from
-   `crates/presenter-ui` (the nightly + MVP `.cargo/config.toml` is what makes it work).
+`presenter-ui` is OUTSIDE the workspace (its own `Cargo.lock`, WASM target) — its cheap
+check is separate, see the "WASM build mechanics" note below.
 
-3. **Server** -- run from WORKSPACE ROOT, not a subcrate directory:
-   `cd /home/newlevel/devel/presenter/presenter-dev2`
-   Build the server binary (release mode, from workspace root).
+CI (`pipeline.yml`, push to `dev`, ~38 min) then does the FULL loop for you: WASM build
+(`scripts/build-ui.sh` under nightly + `-Zbuild-std`), the server release build, E2E, and
+the `presenter-dev` systemd swap on the self-hosted runner. There is no separate manual
+"build it yourself, then deploy it yourself" step for routine work — the ONLY sanctioned
+exception is an explicitly user-declared production emergency (**HOTFIX MODE**, below),
+which still lands its commit through these same CI gates retroactively.
 
-4. **Deploy to dev*.* local machine -- no SSH needed):
-   `sudo systemctl stop presenter-dev`
-   `cp target/release/presenter-server /opt/presenter-dev/presenter-server`
-   `sudo systemctl start presenter-dev`
-
-5. **Verify**: `curl http://10.77.8.134:8080/healthz`
+1. **Cheap checks** (above), then push to `dev`.
+2. **Monitor CI to a terminal state** (`ci-monitoring` global rule): `gh run list` /
+   `gh run view <id> --json status,conclusion`. On failure: `gh run view <id>
+   --log-failed` — fix the root cause and push again, never re-run a local build to
+   "see if it passes" (it can't; the hook blocks it).
+3. **Verify the CI-deployed result** — the same binary CI just swapped in, not one you
+   built by hand: `curl http://10.77.8.134:8080/healthz`, then open
+   `http://10.77.8.134:8080/ui/operator` for a functional check.
 
 ## Disk budget — incremental compilation disabled (#585)
 
@@ -94,33 +103,41 @@ per-profile `incremental = true` override slipping into either
 `.cargo/config.toml` before reaching for the purge — the setting, not the
 purge, is the actual fix; purging just reclaims space already spent.
 
-### Local WASM build — use `scripts/build-ui.sh`, NOT plain `trunk build` (#465 resolved)
+### WASM build mechanics — reference knowledge, NOT a local prescription (#465 resolved)
 
-The local WASM build **works** — via `scripts/build-ui.sh`. The #465 symptom
-(`failed to find the __wbindgen_externref_table_alloc function`) only happens
-when you run a **plain `trunk build` on the stable toolchain**: rustc 1.82+
-enables wasm `reference-types` by default, emitting an externref table the
-wasm-bindgen step can't resolve. The project's canonical build avoids this
-entirely: `scripts/build-ui.sh` runs `RUSTUP_TOOLCHAIN=nightly trunk build`
-with `crates/presenter-ui/.cargo/config.toml`'s `-Zbuild-std` +
-`-Ctarget-cpu=mvp`, which recompiles std for the MVP wasm target (reference-types
-OFF). So:
+**`scripts/build-ui.sh` is what CI's build job runs** (and, if ever needed, HOTFIX MODE
+below) — it is not a routine local step under Tier-0. This is WHY it exists and what it
+avoids, kept here so a CI build-job failure is legible:
 
-- **Build WASM locally with `bash scripts/build-ui.sh`** (verified working on dev2,
-  rustc 1.96, wasm-bindgen 0.2.122). Then `cargo build --release -p presenter-server`
-  embeds `dist/`, and Playwright E2E run locally. `RUSTFLAGS=-Ctarget-feature=-reference-types`
-  does NOT help — the fix is the nightly + build-std-mvp path, not RUSTFLAGS.
-- A plain `cd crates/presenter-ui && trunk build` on stable WILL fail by design —
-  that is expected, not a bug. Use the script.
-- Cheap Rust-only check (no wasm-bindgen): `cd crates/presenter-ui && cargo check
-  --target wasm32-unknown-unknown` (+ clippy). `presenter-ui` is OUTSIDE the
-  workspace (own `Cargo.lock`, version `0.1.x`): `cargo <cmd> -p presenter-ui` from
-  root fails — run from `crates/presenter-ui/`.
+The #465 symptom (`failed to find the __wbindgen_externref_table_alloc function`) happens
+when you run a **plain `trunk build` on the stable toolchain**: rustc 1.82+ enables wasm
+`reference-types` by default, emitting an externref table the wasm-bindgen step can't
+resolve. `scripts/build-ui.sh` avoids this entirely: it runs `RUSTUP_TOOLCHAIN=nightly
+trunk build` with `crates/presenter-ui/.cargo/config.toml`'s `-Zbuild-std` +
+`-Ctarget-cpu=mvp`, which recompiles std for the MVP wasm target (reference-types OFF).
+`RUSTFLAGS=-Ctarget-feature=-reference-types` does NOT help — the fix is the nightly +
+build-std-mvp path, not RUSTFLAGS.
 
-## Running Playwright E2E locally (#461)
+- A plain `cd crates/presenter-ui && trunk build` on stable WILL fail by design (and is
+  ALSO Tier-0 hook-blocked regardless of toolchain) — that is expected, not a bug.
+- **The one thing actually allowed locally:** a cheap Rust-only check, no wasm-bindgen, no
+  trunk: `cd crates/presenter-ui && cargo check --target wasm32-unknown-unknown` (+
+  `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`).
+  `presenter-ui` is OUTSIDE the workspace (own `Cargo.lock`, version `0.1.x`): `cargo
+  <cmd> -p presenter-ui` from root fails — run from `crates/presenter-ui/`.
 
-To validate a stage/UI change with the real Playwright specs before pushing
-(saves a ~45-min CI cycle):
+## Playwright E2E — how CI runs them (#461, #627: no supported local loop under Tier-0)
+
+**There is no supported push-free local Playwright loop on this box.** `startTestServer`
+needs a FRESH `presenter-server`/`presenter-importer` binary built WITH the E2E feature
+flags — building one is exactly the `cargo build --release` the Tier-0 hook blocks, and a
+stale/old binary tests stale/old code, which defeats the point. Default flow: push to
+`dev`, let CI's `e2e` job build + run the specs on the self-hosted runner, read `gh run
+view <id> --log-failed` on a red run rather than trying to reproduce it with a hand-built
+binary.
+
+**If HOTFIX MODE is active** (explicit user declaration only — see below) and a genuine
+local E2E run is warranted, the mechanics CI itself uses are:
 
 1. **Rebuild the server after ANY WASM change.** The server embeds `dist/` at
    compile time, so `bash scripts/build-ui.sh` ALONE is not enough — the running
@@ -139,6 +156,10 @@ To validate a stage/UI change with the real Playwright specs before pushing
    is in-scope; restart right after). Run with `--workers=1` (specs serialize on
    the fixed ports).
    `npx playwright test <spec> -g "<title>" --reporter=line --workers=1`
+
+**Spec-writing knowledge (applies wherever the spec runs — CI, same as any sanctioned
+local run):**
+
 4. Stage specs seed via the HTTP API: `POST /stage/layout {code}`, `POST
    /playlists`, `PUT /playlists/{id}/entries`, `POST /stage/state {presentationId,
    currentSlideId, playlistId}` (returns 204) → the matching playlist entry goes
@@ -150,17 +171,25 @@ To validate a stage/UI change with the real Playwright specs before pushing
    `WorshipSnv`), `.stage__bible-text`/`.stage__bible-reference` for a triggered
    verse (set `POST /stage/layout {code:"bible"}` first so the mirror renders it).
 
-### Proving RED→GREEN locally with a real rebuild, not just commit order (#568/#569)
+### Proving RED→GREEN — default is commit order + CI, not a local rebuild (#568/#569, #627)
 
-`regression-test-first` requires RED before GREEN in commit order — but you can go one step
-further and actually PROVE the RED failure locally before committing: `git stash push -- <the fix
-files, NOT the new test files>` (leaves the new spec(s) staged/committed, reverts only the
-production code), rebuild WASM+server (steps 2–3), run the new spec(s) and confirm they fail for
-the RIGHT reason, then `git stash pop`, rebuild again, and confirm green. Costs ~2 extra
-build-and-test cycles (~15 min combined on this box) but catches two real classes of mistakes
-cheaply: (1) a test that can't actually fail (a tautology, or testing the wrong thing) stays green
-even with the fix reverted; (2) a fix so complete you forgot to also verify the OLD behavior was
-real (confirms you're not just adding a passing assertion to already-working code).
+**Default (every normal PR, this Tier-0 box):** `regression-test-first` requires RED
+before GREEN in COMMIT ORDER — commit the new failing test(s) first (source still
+unfixed), commit the fix second, push once, and let CI prove both states: the test file
+alone (checked out at the RED commit) would fail against the not-yet-fixed source, and
+CI's actual run at the final (GREEN) commit passes. This needs no local build at all.
+
+**If HOTFIX MODE is active** and a genuine local rebuild is already underway (per the
+Playwright section above), you can go one step further and PROVE the RED failure
+locally before committing: `git stash push -- <the fix files, NOT the new test
+files>` (leaves the new spec(s) staged/committed, reverts only the production code),
+rebuild WASM+server, run the new spec(s) and confirm they fail for the RIGHT reason,
+then `git stash pop`, rebuild again, and confirm green. Catches two real classes of
+mistakes cheaply: (1) a test that can't actually fail (a tautology, or testing the wrong
+thing) stays green even with the fix reverted; (2) a fix so complete you forgot to also
+verify the OLD behavior was real (confirms you're not just adding a passing assertion to
+already-working code). This is a HOTFIX-mode bonus, not something to reach for on a
+normal Tier-0 PR — it needs the same local build the Playwright section above gates.
 
 ### GOTCHA — a stale/ambiguous `target/release/presenter-server` silently shadows your fresh fix (#558)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.234"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.234"
+version = "0.4.235"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.224"
+version = "0.4.235"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -162,14 +162,19 @@ pub fn SlideList() -> impl IntoView {
                     let op_dragover = op.clone();
                     let op_drop = op.clone();
                     let op_bubble = op.clone();
-                    let clipboard_for_class = op.clipboard;
+                    let choosing_paste_target_for_class = op.choosing_paste_target;
                     view! {
                         <div
-                            // #554: single column while the clipboard is active so
-                            // every inter-slide gap is one unambiguous full-width
-                            // "paste here" bar.
+                            // #554/#602: single column while ACTIVELY CHOOSING a
+                            // paste target so every inter-slide gap is one
+                            // unambiguous full-width "paste here" bar. Bound to
+                            // `choosing_paste_target`, NOT to "a clipboard
+                            // exists" (#602 defect 3) — a completed Copy-paste
+                            // deliberately keeps the clipboard non-empty for a
+                            // re-paste, which used to leave this grid stuck in
+                            // single-column forever.
                             class=move || {
-                                if clipboard_for_class.get().is_some() {
+                                if choosing_paste_target_for_class.get() {
                                     "operator__slides operator__slides--clipboard"
                                 } else {
                                     "operator__slides"
@@ -232,12 +237,15 @@ pub fn SlideList() -> impl IntoView {
                     let resolved: Vec<ResolvedSlide> = resolve_sequence(&raw_slides);
                     let is_live = mode == "live";
                     let is_edit = !is_live;
-                    // #554: the ONE tracked clipboard read in this render
-                    // closure — a non-empty clipboard re-renders the list with
-                    // "paste here" bars in every gap (deliberate, infrequent,
-                    // never racing in-flight typing: shortcuts are guarded and
-                    // the panel buttons blur+save first).
-                    let clipboard_active = op.clipboard.get().is_some();
+                    // #554/#602: the ONE tracked read in this render closure —
+                    // actively CHOOSING a paste target re-renders the list
+                    // with "paste here" bars in every gap (deliberate,
+                    // infrequent, never racing in-flight typing: shortcuts are
+                    // guarded and the panel buttons blur+save first). Bound to
+                    // `choosing_paste_target`, not `clipboard.is_some()`, so
+                    // the bars disappear the moment a paste completes even
+                    // when Copy deliberately keeps the clipboard alive.
+                    let clipboard_active = op.choosing_paste_target.get();
                     let slide_count = raw_slides.len();
 
                     let mut prev_effective: Option<String> = None;

--- a/crates/presenter-ui/src/components/slide_selection.rs
+++ b/crates/presenter-ui/src/components/slide_selection.rs
@@ -203,6 +203,9 @@ fn set_clipboard(ctx: &AppContext, op: &OperatorState, mode: ClipboardMode) {
         mode,
         presentation_id: pres_id,
     }));
+    // #602 defect 3: entering the clipboard begins the "choosing a paste
+    // target" interaction — this is what turns the grid single-column.
+    op.choosing_paste_target.set(true);
 }
 
 /// Clear the clipboard, selection, anchor, and paste target (Escape / Clear /
@@ -212,6 +215,7 @@ pub(super) fn clear_selection_and_clipboard(op: &OperatorState) {
     op.selected_slide_ids.set(std::collections::HashSet::new());
     op.selection_anchor_id.set(None);
     op.paste_target_gap.set(None);
+    op.choosing_paste_target.set(false);
 }
 
 /// The slide id CURRENTLY at index `gap` — the anchor a paste inserted at
@@ -308,10 +312,17 @@ fn paste_copy(
         match api::presentations::paste_slides(&pres_id, ids, anchor_slide_id).await {
             Ok(slides) => {
                 apply_slides_guarded(&ctx, &op, pres_id, slides, my_seq).await;
-                // Copy clipboard is KEPT so the user can paste again.
+                // Copy clipboard is KEPT so the user can paste again — but
+                // the "choosing a paste target" interaction (#602 defect 3)
+                // is OVER: this completed paste, so the grid returns to its
+                // normal multi-column layout. A later re-paste (toolbar
+                // Paste button / Ctrl+V) still works from the retained
+                // clipboard without re-entering single-column mode.
+                op.choosing_paste_target.set(false);
             }
             Err(ApiError::Status(422, _)) => {
                 op.clipboard.set(None);
+                op.choosing_paste_target.set(false);
                 ctx.show_toast("Those slides no longer exist", "error");
             }
             Err(ApiError::Status(409, _)) => {
@@ -488,7 +499,10 @@ pub(super) fn setup_clipboard_keyboard(ctx: AppContext, op: OperatorState) {
 /// The sticky selection panel above the slide list (edit mode). Shows the count
 /// and Copy / Cut / Paste / Clear, plus a draggable block handle when the
 /// clipboard is non-empty. Visible only when something is selected OR the
-/// clipboard is non-empty.
+/// clipboard is non-empty. #602 defect 2: each action button carries its
+/// keyboard shortcut as VISIBLE text (not just a hover `title`) so the
+/// clipboard actions are discoverable without prior knowledge the moment a
+/// selection exists.
 #[component]
 pub fn SlideSelectionPanel() -> impl IntoView {
     let ctx = use_ctx!(AppContext);
@@ -529,20 +543,35 @@ pub fn SlideSelectionPanel() -> impl IntoView {
                                 class="operator__list-action"
                                 data-action="copy"
                                 data-role="slide-copy"
+                                title="Copy the selected slides (Ctrl+C)"
                                 on:click=move |_| copy_selection(&ctx_copy, &op_copy)
-                            >"Copy"</button>
+                            >
+                                "Copy "
+                                <span
+                                    class="operator__slide-selection-shortcut"
+                                    data-role="slide-selection-shortcut"
+                                >"Ctrl+C"</span>
+                            </button>
                             <button
                                 type="button"
                                 class="operator__list-action"
                                 data-action="cut"
                                 data-role="slide-cut"
+                                title="Cut the selected slides (Ctrl+X)"
                                 on:click=move |_| cut_selection(&ctx_cut, &op_cut)
-                            >"Cut"</button>
+                            >
+                                "Cut "
+                                <span
+                                    class="operator__slide-selection-shortcut"
+                                    data-role="slide-selection-shortcut"
+                                >"Ctrl+X"</span>
+                            </button>
                             <button
                                 type="button"
                                 class="operator__list-action"
                                 data-action="paste"
                                 data-role="slide-paste"
+                                title="Paste at the highlighted gap (Ctrl+V)"
                                 prop:disabled=move || clipboard.get().is_none()
                                 on:click=move |_| {
                                     let len = current_slide_ids(&ctx_paste).len();
@@ -553,14 +582,27 @@ pub fn SlideSelectionPanel() -> impl IntoView {
                                         .min(len);
                                     paste_at_gap(&ctx_paste, &op_paste, gap);
                                 }
-                            >"Paste"</button>
+                            >
+                                "Paste "
+                                <span
+                                    class="operator__slide-selection-shortcut"
+                                    data-role="slide-selection-shortcut"
+                                >"Ctrl+V"</span>
+                            </button>
                             <button
                                 type="button"
                                 class="operator__list-action"
                                 data-action="clear"
                                 data-role="slide-clear"
+                                title="Clear the selection and clipboard (Esc)"
                                 on:click=move |_| clear_selection_and_clipboard(&op_clear)
-                            >"Clear"</button>
+                            >
+                                "Clear "
+                                <span
+                                    class="operator__slide-selection-shortcut"
+                                    data-role="slide-selection-shortcut"
+                                >"Esc"</span>
+                            </button>
                             <Show when=move || clipboard.get().is_some() fallback=|| ()>
                                 {
                                     let dragging_clipboard = op_drag.dragging_clipboard;

--- a/crates/presenter-ui/src/components/slide_selection.rs
+++ b/crates/presenter-ui/src/components/slide_selection.rs
@@ -102,8 +102,18 @@ pub(super) fn render_select_checkbox(
             data-slide-select-index=index
             prop:checked=move || checked.get()
             on:click=move |ev: web_sys::MouseEvent| {
-                ev.prevent_default();
+                // #602 defect 1: NO `ev.prevent_default()` here. Canceling
+                // the click's default action triggers the input's HTML
+                // "canceled activation steps", which revert the native
+                // `checked` IDL property AFTER this listener returns — i.e.
+                // AFTER Leptos's queued `prop:checked` effect (above)
+                // already wrote the new value. The revert wins, so native
+                // `.checked` desyncs from app state forever while the
+                // reactive UI (selection count, `--selected` card class)
+                // stays correct. `on:click` itself is kept — Shift+click
+                // needs `shift_key()`, which `on:change` cannot see.
                 let ids = current_slide_ids(&ctx);
+                let mut handled_as_range = false;
                 if ev.shift_key() {
                     if let Some(anchor_id) = op.selection_anchor_id.get_untracked() {
                         // #558 V9: resolve the anchor's CURRENT index by id —
@@ -116,19 +126,35 @@ pub(super) fn render_select_checkbox(
                             &op.selected_slide_ids.get_untracked(),
                         ) {
                             op.selected_slide_ids.set(next);
-                            return;
+                            handled_as_range = true;
                         }
                     }
                 }
-                // Plain click (or Shift with no anchor yet, or a vanished
-                // anchor): toggle this id.
-                let sid = slide_id.clone();
-                op.selected_slide_ids.update(|set| {
-                    if !set.remove(&sid) {
-                        set.insert(sid);
-                    }
-                });
-                op.selection_anchor_id.set(Some(slide_id.clone()));
+                if !handled_as_range {
+                    // Plain click (or Shift with no anchor yet, or a
+                    // vanished anchor): toggle this id.
+                    let sid = slide_id.clone();
+                    op.selected_slide_ids.update(|set| {
+                        if !set.remove(&sid) {
+                            set.insert(sid);
+                        }
+                    });
+                    op.selection_anchor_id.set(Some(slide_id.clone()));
+                }
+                // Without `prevent_default`, the browser's own native toggle
+                // already applied its OWN idea of `checked` before this
+                // listener even ran — which may not match the app state
+                // above (e.g. a Shift+click on an already-checked box that
+                // the range logic leaves checked, or one it un-checks).
+                // Force the clicked element's native `checked` to match the
+                // real post-update state; peers touched by a Shift range get
+                // theirs from the normal reactive `prop:checked` effect —
+                // only the element that received THIS click needs the
+                // explicit sync.
+                let now_selected = op.selected_slide_ids.get_untracked().contains(&slide_id);
+                if let Some(input) = ev.target().and_then(|t| t.dyn_into::<web_sys::HtmlInputElement>().ok()) {
+                    input.set_checked(now_selected);
+                }
             }
         />
     }
@@ -316,13 +342,17 @@ fn paste_copy(
                 // the "choosing a paste target" interaction (#602 defect 3)
                 // is OVER: this completed paste, so the grid returns to its
                 // normal multi-column layout. A later re-paste (toolbar
-                // Paste button / Ctrl+V) still works from the retained
-                // clipboard without re-entering single-column mode.
+                // Paste button / Ctrl+V) re-arms the chooser instead of
+                // silently reusing this now-stale gap (#602 re-paste
+                // regression) — `paste_target_gap` must not survive a
+                // completed interaction either.
                 op.choosing_paste_target.set(false);
+                op.paste_target_gap.set(None);
             }
             Err(ApiError::Status(422, _)) => {
                 op.clipboard.set(None);
                 op.choosing_paste_target.set(false);
+                op.paste_target_gap.set(None);
                 ctx.show_toast("Those slides no longer exist", "error");
             }
             Err(ApiError::Status(409, _)) => {
@@ -382,6 +412,26 @@ fn paste_copy(
             }
         }
     });
+}
+
+/// Paste at the currently armed gap — or, if nothing is armed and the
+/// chooser isn't already active, RE-ARM it instead of silently pasting at a
+/// stale/default gap. A completed paste clears both `choosing_paste_target`
+/// and `paste_target_gap` (#602 defect 3), so a later Paste button / Ctrl+V
+/// with a retained clipboard must ask "where?" again — exactly like Copy/Cut
+/// starting a fresh interaction — rather than reuse the last-hovered gap or
+/// silently land at the end (#602 re-paste-into-several-gaps regression).
+fn paste_at_target_or_rearm(ctx: &AppContext, op: &OperatorState) {
+    if op.clipboard.get_untracked().is_none() {
+        return;
+    }
+    if op.paste_target_gap.get_untracked().is_none() && !op.choosing_paste_target.get_untracked() {
+        op.choosing_paste_target.set(true);
+        return;
+    }
+    let len = current_slide_ids(ctx).len();
+    let gap = op.paste_target_gap.get_untracked().unwrap_or(len).min(len);
+    paste_at_gap(ctx, op, gap);
 }
 
 fn paste_cut(ctx: &AppContext, op: &OperatorState, pres_id: String, ids: Vec<String>, gap: usize) {
@@ -473,9 +523,7 @@ pub(super) fn setup_clipboard_keyboard(ctx: AppContext, op: OperatorState) {
                 ShortcutAction::Paste => {
                     if op.clipboard.get_untracked().is_some() {
                         ev.prevent_default();
-                        let len = current_slide_ids(&ctx).len();
-                        let gap = op.paste_target_gap.get_untracked().unwrap_or(len).min(len);
-                        paste_at_gap(&ctx, &op, gap);
+                        paste_at_target_or_rearm(&ctx, &op);
                     }
                 }
                 ShortcutAction::Clear => {
@@ -573,15 +621,7 @@ pub fn SlideSelectionPanel() -> impl IntoView {
                                 data-role="slide-paste"
                                 title="Paste at the highlighted gap (Ctrl+V)"
                                 prop:disabled=move || clipboard.get().is_none()
-                                on:click=move |_| {
-                                    let len = current_slide_ids(&ctx_paste).len();
-                                    let gap = op_paste
-                                        .paste_target_gap
-                                        .get_untracked()
-                                        .unwrap_or(len)
-                                        .min(len);
-                                    paste_at_gap(&ctx_paste, &op_paste, gap);
-                                }
+                                on:click=move |_| paste_at_target_or_rearm(&ctx_paste, &op_paste)
                             >
                                 "Paste "
                                 <span

--- a/crates/presenter-ui/src/state/operator.rs
+++ b/crates/presenter-ui/src/state/operator.rs
@@ -150,6 +150,17 @@ pub struct OperatorState {
     pub paste_target_gap: RwSignal<Option<usize>>,
     /// True while the clipboard block is being dragged toward an insertion gap.
     pub dragging_clipboard: RwSignal<bool>,
+    /// True while the operator is actively CHOOSING a paste target (#602
+    /// defect 3): the single-column grid + "Paste here" bars are bound to
+    /// THIS interaction, never to "a clipboard exists". Set true the moment
+    /// a copy/cut populates the clipboard; set false the moment a paste
+    /// COMPLETES (Copy or Cut alike) — even though a completed Copy
+    /// deliberately KEEPS `clipboard` non-empty so the toolbar Paste button
+    /// / Ctrl+V can paste again without re-copying. Without this split, a
+    /// completed Copy-paste left the grid stuck in single-column forever
+    /// (only Clear/Escape/reload recovered it) because the class was keyed
+    /// on `clipboard.is_some()`, which Copy never clears.
+    pub choosing_paste_target: RwSignal<bool>,
 }
 
 impl OperatorState {
@@ -200,6 +211,7 @@ impl OperatorState {
             selection_anchor_id: RwSignal::new(None),
             paste_target_gap: RwSignal::new(None),
             dragging_clipboard: RwSignal::new(false),
+            choosing_paste_target: RwSignal::new(false),
         }
     }
 }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -1182,20 +1182,10 @@ body.operator {
   color: var(--operator-accent-dark);
 }
 
-.operator__slides {
-  flex: 1;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 0.35rem;
-  /* #556 F5: no more manual `padding-top` reservation — the song bubble is
-     now an in-flow, sticky first grid row (see `.operator__slides-bubble`)
-     that reserves its own space at every scroll position, not just at
-     scrollTop=0. */
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.9rem;
-  min-height: 0;
-}
+/* #602 side finding: this used to duplicate `.operator__slides` with a
+   hardcoded `repeat(3, ...)`, dead because the later rule (search
+   `--operator-slide-columns`) always wins on specificity/source order.
+   Removed — the live rule is the one below with the CSS-var column count. */
 
 .operator__slide-card {
   background: var(--operator-panel);
@@ -3156,14 +3146,26 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
 
 /* #554 slide multi-select + clipboard */
 .operator__slide-select {
-  width: 1.05rem;
-  height: 1.05rem;
+  width: 1.15rem;
+  height: 1.15rem;
   cursor: pointer;
   accent-color: var(--operator-accent-dark);
+  border-radius: 3px;
+}
+/* #602 defect 1: the native `accent-color` tick alone was too subtle at grid
+   density for the checked state to register — a visible glow around the
+   checkbox itself, distinct from the unchecked state, so it reads at a
+   glance instead of requiring a hunt for a 17px tick. */
+.operator__slide-select:checked {
+  outline: 2px solid var(--operator-accent-dark);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(59, 124, 255, 0.3);
 }
 .operator__slide-card--selected {
-  border-color: rgba(59, 124, 255, 0.55);
-  box-shadow: 0 0 0 2px rgba(59, 124, 255, 0.22);
+  border-color: var(--operator-accent-dark);
+  box-shadow:
+    0 0 0 2px rgba(59, 124, 255, 0.45),
+    inset 0 0 0 9999px rgba(59, 124, 255, 0.12);
 }
 .operator__slide-card--cut {
   opacity: 0.55;
@@ -3196,6 +3198,13 @@ body.operator[data-mode="live"][data-bible-tab="prepared"]
   font-size: 0.8rem;
   color: var(--operator-muted);
   margin-right: auto;
+}
+/* #602 defect 2: the shortcut hint printed inside each action button —
+   visible on screen the moment a selection exists, not just on hover. */
+.operator__slide-selection-shortcut {
+  font-size: 0.68rem;
+  opacity: 0.7;
+  font-weight: 400;
 }
 .operator__slide-selection-drag {
   cursor: grab;

--- a/scripts/dev/feature_router_check.sh
+++ b/scripts/dev/feature_router_check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Feature-router presence gate (Issue #605, extracted #625).
+#
+# quality-check.sh section 1 checks that the four feature routers (bible,
+# libraries, playlists, presentations) exist. A feature module may be a FLAT
+# FILE (`router/<name>.rs`) OR a DIRECTORY of submodules (`router/<name>/mod.rs`
+# — e.g. `bible/`, split in #590 the same way `router/integrations/` already
+# was) — either form satisfies the check (fixed in PR #604, commit 9521cf94;
+# pinned by tests/ci/feature-router-gate.test.sh).
+#
+# Extracted into its own script (mirroring scripts/dev/placeholder_check.sh /
+# fn_length_check.py) so the CI gate and the self-test run the EXACT SAME
+# logic instead of two copies that can drift apart. #625: the self-test used
+# to hand-copy this loop as its own bash function, so reverting the REAL gate
+# here to the old flat-file-only assumption left the self-test green — the
+# self-test was proving nothing about the production check it claimed to pin.
+#
+# Usage:   feature_router_check.sh [search_root]
+#   search_root  Directory whose crates/presenter-server/src/router/ subtree
+#                is checked. Defaults to the repository root (two levels up
+#                from this script's own directory).
+#
+# Exit codes:
+#   0  all four routers present (prints "OK")
+#   1  a router is missing (prints "MISSING:<name>", the first one found)
+# ============================================================================
+
+SEARCH_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+for name in bible libraries playlists presentations; do
+  flat="$SEARCH_ROOT/crates/presenter-server/src/router/${name}.rs"
+  dir_mod="$SEARCH_ROOT/crates/presenter-server/src/router/${name}/mod.rs"
+  if [[ ! -f "$flat" && ! -f "$dir_mod" ]]; then
+    echo "MISSING:${name}"
+    exit 1
+  fi
+done
+
+echo "OK"

--- a/scripts/dev/quality-check.sh
+++ b/scripts/dev/quality-check.sh
@@ -47,11 +47,19 @@ fail() { failures+=("$*"); }
 #    (`router/<name>.rs`) OR a directory of submodules (`router/<name>/mod.rs`
 #    — e.g. `bible/`, split in #590 the same way `router/integrations/`
 #    already was) — either form satisfies the check.
-for name in bible libraries playlists presentations; do
-  flat="crates/presenter-server/src/router/${name}.rs"
-  dir_mod="crates/presenter-server/src/router/${name}/mod.rs"
-  [[ -f "$flat" || -f "$dir_mod" ]] || fail "Missing feature router: $flat (or $dir_mod)"
-done
+#
+# The check itself lives in scripts/dev/feature_router_check.sh (#625) so the
+# gate self-test (tests/ci/feature-router-gate.test.sh) can invoke the EXACT
+# SAME logic this gate runs, instead of a hand-copied duplicate that stays
+# green even if this check regresses to the old flat-file-only assumption.
+set +e
+router_check_out=$(bash "$ROOT_DIR/scripts/dev/feature_router_check.sh" "$ROOT_DIR")
+router_check_rc=$?
+set -e
+if (( router_check_rc != 0 )); then
+  missing_name="${router_check_out#MISSING:}"
+  fail "Missing feature router: crates/presenter-server/src/router/${missing_name}.rs (or .../${missing_name}/mod.rs)"
+fi
 
 # 2) router.rs should not contain legacy presentation handlers
 if command -v rg >/dev/null 2>&1 && rg -n "(insert_slide_handler|duplicate_slide_handler|delete_slide_handler|reorder_slides_handler|update_slide_content_handler)" crates/presenter-server/src/router.rs >/dev/null; then

--- a/tests/ci/feature-router-gate.test.sh
+++ b/tests/ci/feature-router-gate.test.sh
@@ -3,25 +3,34 @@ set -euo pipefail
 
 # ============================================================================
 # Self-test / regression guard for the feature-router presence gate
-# (Issue #605 — pins the directory-aware fix shipped in PR #604, commit 9521cf94).
+# (Issue #605 — pins the directory-aware fix shipped in PR #604, commit 9521cf94;
+# #625 — made this test actually EXERCISE the real gate script instead of a
+# hand-copied duplicate).
 #
 # quality-check.sh section 1 checks that the four feature routers (bible,
 # libraries, playlists, presentations) exist. The original check hard-coded a
 # FLAT-FILE assumption (`router/<name>.rs`). When #590 split `bible.rs` into a
 # `bible/` DIRECTORY, the check false-failed. The fix generalized it to accept
-# either `router/<name>.rs` OR `router/<name>/mod.rs`.
+# either `router/<name>.rs` OR `router/<name>/mod.rs`, and #625 extracted that
+# logic into scripts/dev/feature_router_check.sh (the same script
+# quality-check.sh itself calls) so THIS self-test invokes the EXACT SAME
+# production code — not a copy that could silently drift out of sync with a
+# revert to the real check (the bug #625 was filed to fix: assertions 1-3/5
+# used to call a hand-copied `check_routers_present` reimplementation, so
+# reverting quality-check.sh's real check to flat-file-only left every one of
+# them green).
 #
 # What it proves:
-#   1. GREEN — the generalized presence check PASSES when all four routers
-#      exist as FLAT FILES (`<name>.rs`).
-#   2. GREEN — the generalized presence check PASSES when all four routers
-#      exist as DIRECTORIES (`<name>/mod.rs`) — the exact case the OLD flat-
-#      file-only check false-failed on.
+#   1. GREEN — the real gate script PASSES when all four routers exist as
+#      FLAT FILES (`<name>.rs`).
+#   2. GREEN — the real gate script PASSES when all four routers exist as
+#      DIRECTORIES (`<name>/mod.rs`) — the exact case the OLD flat-file-only
+#      check false-failed on.
 #   3. GREEN — MIXED shapes (some flat, some dir) PASS.
-#   4. RED   — the OLD flat-file-only check FAILS on the directory-only
-#      fixture. This pins the FIX, not just current behavior — if someone
-#      reverts to the flat-file assumption, this assertion breaks.
-#   5. RED   — the generalized check FAILS when one router is MISSING (the
+#   4. RED   — the OLD flat-file-only check (a deliberate HISTORICAL snapshot
+#      of the pre-9521cf94 logic, not the live script) FAILS on the
+#      directory-only fixture. This pins the FIX, not just current behavior.
+#   5. RED   — the real gate script FAILS when one router is MISSING (the
 #      core negative case — catches accidental deletion of a router).
 #
 # Run in CI by the Test job's "Run CI shell tests" step (alongside the other
@@ -29,10 +38,10 @@ set -euo pipefail
 # ============================================================================
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-QC="$ROOT_DIR/scripts/dev/quality-check.sh"
+CHECKER="$ROOT_DIR/scripts/dev/feature_router_check.sh"
 
-if [[ ! -f "$QC" ]]; then
-  echo "::error::feature-router gate self-test: quality-check.sh not found at $QC" >&2
+if [[ ! -f "$CHECKER" ]]; then
+  echo "::error::feature-router gate self-test: feature_router_check.sh not found at $CHECKER" >&2
   exit 1
 fi
 
@@ -43,38 +52,15 @@ bad() { echo "::error::feature-router gate self-test FAILED: $*" >&2; fail_count
 
 # Extract ONLY the feature-router presence check (section 1) from
 # quality-check.sh so the test exercises the REAL production logic in isolation,
-# without triggering the heavyweight fmt/clippy/cargo-deny gates.
-#
-# The block is:
-#   for name in bible libraries playlists presentations; do
-#     flat="crates/presenter-server/src/router/${name}.rs"
-#     dir_mod="crates/presenter-server/src/router/${name}/mod.rs"
-#     [[ -f "$flat" || -f "$dir_mod" ]] || fail "Missing feature router: ..."
-#   done
-#
-# We reuse the same check by copying the loop body with a local `fail`
-# function that flips a flag. This stays in sync with quality-check.sh's
-# source because any regression to flat-file-only would break the DIFFERENTIAL
-# assertion (case 4) below, which calls the OLD buggy logic directly.
+# without triggering the heavyweight fmt/clippy/cargo-deny gates. #625: this
+# now calls scripts/dev/feature_router_check.sh — the SAME script
+# quality-check.sh section 1 invokes — instead of a hand-copied
+# reimplementation. A reimplementation could silently drift from (or a
+# revert could silently un-fix) the real gate while this self-test stayed
+# green regardless; calling the actual script closes that gap.
 check_routers_present() {
   local base="$1"
-  local missing=0
-  local missing_name=""
-  for name in bible libraries playlists presentations; do
-    flat="$base/crates/presenter-server/src/router/${name}.rs"
-    dir_mod="$base/crates/presenter-server/src/router/${name}/mod.rs"
-    if [[ ! -f "$flat" && ! -f "$dir_mod" ]]; then
-      missing=1
-      missing_name="$name"
-      break
-    fi
-  done
-  if (( missing == 1 )); then
-    echo "MISSING:$missing_name"
-    return 1
-  fi
-  echo "OK"
-  return 0
+  bash "$CHECKER" "$base"
 }
 
 # The OLD flat-file-only check (pre-9521cf94) — for the differential pin.

--- a/tests/e2e/wasm-slide-multiselect.spec.ts
+++ b/tests/e2e/wasm-slide-multiselect.spec.ts
@@ -93,7 +93,7 @@ async function openPresentationInEditMode(
   await page.waitForFunction(
     () =>
       (document
-        .querySelector('[data-role="slides"]')
+        .querySelector('[data-view-panel="worship"] [data-role="slides"]')
         ?.querySelectorAll("[data-slide-id]").length ?? 0) > 0,
     { timeout: 15_000 },
   );
@@ -157,7 +157,7 @@ function checkboxFor(page: import("@playwright/test").Page, slideId: string) {
  * defect 3). `> 1` = normal multi-column grid, `1` = the single-column
  * "choosing a paste target" layout. */
 async function gridColumnCount(page: import("@playwright/test").Page) {
-  return page.locator('[data-role="slides"]').evaluate((el) => {
+  return page.locator('[data-view-panel="worship"] [data-role="slides"]').evaluate((el) => {
     const cols = window.getComputedStyle(el).gridTemplateColumns.trim();
     return cols.length === 0 ? 0 : cols.split(/\s+/).length;
   });
@@ -260,13 +260,20 @@ test.describe("WASM Operator Slide Multi-Select (#554)", () => {
       .poll(() => mainTextsInOrder(page), { timeout: 10_000 })
       .toEqual(["Slide 4", "Slide 1", "Slide 2", "Slide 3", "Slide 4"]);
 
-    // Paste again at a TRUE MIDDLE gap (gap 2 of the now-5-slide list).
+    // Paste again at a TRUE MIDDLE gap (gap 2 of the now-5-slide list). The
+    // first paste completed the interaction (#602 defect 3), so the "paste
+    // here" bars are gone — re-arm the chooser via the toolbar Paste button
+    // before picking the new gap (#602 defect: re-paste into a different gap).
+    await page.locator('[data-role="slide-paste"]').click();
+    await expect(insertBar(page, 2)).toBeVisible();
     await insertBar(page, 2).click();
     await expect
       .poll(() => mainTextsInOrder(page), { timeout: 10_000 })
       .toEqual(["Slide 4", "Slide 1", "Slide 4", "Slide 2", "Slide 3", "Slide 4"]);
 
-    // Paste at the END (trailing bar = index len).
+    // Paste at the END (trailing bar = index len) — re-arm again first.
+    await page.locator('[data-role="slide-paste"]').click();
+    await expect(insertBar(page, 6)).toBeVisible();
     await insertBar(page, 6).click();
     await expect
       .poll(() => mainTextsInOrder(page), { timeout: 10_000 })

--- a/tests/e2e/wasm-slide-multiselect.spec.ts
+++ b/tests/e2e/wasm-slide-multiselect.spec.ts
@@ -151,6 +151,18 @@ function checkboxFor(page: import("@playwright/test").Page, slideId: string) {
   );
 }
 
+/** Number of tracks the `[data-role="slides"]` grid currently renders — the
+ * browser expands `grid-template-columns` to one pixel value per track, so
+ * splitting the computed value on whitespace gives the column count (#602
+ * defect 3). `> 1` = normal multi-column grid, `1` = the single-column
+ * "choosing a paste target" layout. */
+async function gridColumnCount(page: import("@playwright/test").Page) {
+  return page.locator('[data-role="slides"]').evaluate((el) => {
+    const cols = window.getComputedStyle(el).gridTemplateColumns.trim();
+    return cols.length === 0 ? 0 : cols.split(/\s+/).length;
+  });
+}
+
 function insertBar(page: import("@playwright/test").Page, gap: number) {
   return page.locator(`[data-role="slide-insert-bar"][data-insert-index="${gap}"]`);
 }
@@ -814,5 +826,156 @@ test.describe("WASM Operator Slide Multi-Select (#554)", () => {
     await page.waitForTimeout(500);
     expect(pasteFired).toBe(false);
     expect(await domSlideOrder(page)).toEqual(slideIds);
+  });
+
+  // ---------------------------------------------------------------------
+  // #602: checkbox visibility, copy discoverability, grid-stuck regression.
+  // ---------------------------------------------------------------------
+
+  test("selecting a slide gives the checkbox AND the card a visible checked appearance (#602 defect 1)", async ({
+    page,
+    request,
+  }) => {
+    const consoleIssues: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+      }
+    });
+
+    const lib = `E2E Sel602 Checked ${Date.now()}`;
+    const { slideIds } = await createPresentationWithSlides(request, 2, lib);
+    await openPresentationInEditMode(page, lib);
+
+    const checkbox = checkboxFor(page, slideIds[0]);
+    const otherCheckbox = checkboxFor(page, slideIds[1]);
+    await expect(checkbox).not.toBeChecked();
+    await expect(otherCheckbox).not.toBeChecked();
+
+    const card = page.locator(`[data-slide-id="${slideIds[0]}"]`);
+    const boxShadowBefore = await card.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    const outlineBefore = await checkbox.evaluate(
+      (el) => window.getComputedStyle(el).outlineStyle,
+    );
+
+    await checkbox.click();
+
+    // The checked state must reach the DOM (regression test would have
+    // already caught a broken binding, but re-assert it here too)...
+    await expect(checkbox).toBeChecked();
+    await expect(otherCheckbox).not.toBeChecked();
+
+    // ...AND it must be VISUALLY distinguishable — a computed style change
+    // on the checkbox itself (defect 1's actual gap: no `:checked` rule
+    // existed at all) and on the card.
+    const outlineAfter = await checkbox.evaluate(
+      (el) => window.getComputedStyle(el).outlineStyle,
+    );
+    expect(outlineAfter).not.toBe(outlineBefore);
+
+    const boxShadowAfter = await card.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    expect(boxShadowAfter).not.toBe(boxShadowBefore);
+
+    // The untouched sibling checkbox stays plain — the change is scoped to
+    // the checked one, not a global style shift.
+    const otherOutline = await otherCheckbox.evaluate(
+      (el) => window.getComputedStyle(el).outlineStyle,
+    );
+    expect(otherOutline).toBe(outlineBefore);
+
+    expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
+  });
+
+  test("clipboard action shortcuts are visible on screen the moment a selection exists (#602 defect 2)", async ({
+    page,
+    request,
+  }) => {
+    const consoleIssues: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+      }
+    });
+
+    const lib = `E2E Sel602 Discover ${Date.now()}`;
+    const { slideIds } = await createPresentationWithSlides(request, 2, lib);
+    await openPresentationInEditMode(page, lib);
+
+    // No selection, no clipboard yet — the panel (and its shortcut hints)
+    // is not shown at all.
+    await expect(page.locator('[data-role="slide-selection-panel"]')).toHaveCount(0);
+
+    await checkboxFor(page, slideIds[0]).click();
+
+    const panel = page.locator('[data-role="slide-selection-panel"]');
+    await expect(panel).toBeVisible();
+
+    // The available actions and their keyboard shortcuts must be visible
+    // ON SCREEN (not merely discoverable via a hover tooltip) the moment a
+    // selection exists — ticket acceptance criterion 2.
+    const shortcuts = panel.locator('[data-role="slide-selection-shortcut"]');
+    await expect(shortcuts).toHaveCount(4);
+    expect(await shortcuts.allTextContents()).toEqual([
+      "Ctrl+C",
+      "Ctrl+X",
+      "Ctrl+V",
+      "Esc",
+    ]);
+    for (const hint of await shortcuts.all()) {
+      await expect(hint).toBeVisible();
+    }
+
+    expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
+  });
+
+  test("grid returns to multi-column after a completed Copy-paste — never stuck single-column (#602 defect 3)", async ({
+    page,
+    request,
+  }) => {
+    const consoleIssues: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+      }
+    });
+
+    const lib = `E2E Sel602 GridStuck ${Date.now()}`;
+    const { slideIds } = await createPresentationWithSlides(request, 4, lib);
+    await openPresentationInEditMode(page, lib);
+
+    // Normal grid before anything is selected/copied.
+    expect(await gridColumnCount(page)).toBeGreaterThan(1);
+
+    await checkboxFor(page, slideIds[0]).click();
+    await page.locator('[data-role="slide-copy"]').click();
+
+    // Actively CHOOSING a paste target: single column, "Paste here" bars.
+    await expect(insertBar(page, 0)).toBeVisible();
+    expect(await gridColumnCount(page)).toBe(1);
+
+    await insertBar(page, 0).click();
+    await expect
+      .poll(() => mainTextsInOrder(page), { timeout: 10_000 })
+      .toEqual(["Slide 1", "Slide 1", "Slide 2", "Slide 3", "Slide 4"]);
+
+    // #602 defect 3 — the actual regression: a completed Copy-paste used to
+    // leave the clipboard (deliberately) non-empty forever, and the
+    // single-column class was keyed on "a clipboard exists", so the grid
+    // stayed stuck in one column until Clear/Escape/a page reload. The
+    // completed paste must restore the normal multi-column grid...
+    await expect
+      .poll(() => gridColumnCount(page), { timeout: 10_000 })
+      .toBeGreaterThan(1);
+    await expect(page.locator('[data-role="slide-insert-bar"]')).toHaveCount(0);
+
+    // ...WITHOUT discarding the retained Copy clipboard — the toolbar Paste
+    // button must still be enabled for a re-paste with no re-copy needed.
+    await expect(page.locator('[data-role="slide-paste"]')).toBeEnabled();
+
+    expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## What changed

**#602 — slide multi-select and copy/paste were unusable.** Three separate defects fixed:

- **Selection was invisible.** The checkbox never reported its native `checked` state: `render_select_checkbox()` called `ev.prevent_default()` on `on:click`, which triggers the HTML "canceled activation steps" — the browser reverts the input's `checked` property *after* the listener returns, i.e. after Leptos's reactive `prop:checked` effect already wrote `true`. App state was correct ("1 selected", card `--selected`) while the box stayed visually unchecked forever. Fixed by dropping `prevent_default()` (keeping `on:click` for Shift+click) and explicitly syncing the clicked input to the post-update state. Cards and checkboxes now also carry a visible checked appearance.
- **Copy/paste was undiscoverable.** Clipboard shortcuts are now surfaced in the UI.
- **The grid stayed stuck single-column after a paste.** A new `choosing_paste_target` flag decouples paste-target mode from clipboard contents, so the grid returns to multi-column once a paste completes — while the clipboard is retained for re-paste.
- **Re-paste regression caught by CI and fixed in the same batch:** clearing `choosing_paste_target` on paste also removed the "paste here" bars, killing the copy-once → paste-into-several-gaps workflow and leaving Ctrl+V/toolbar paste aimed at a stale gap. The toolbar Paste button and `ShortcutAction::Paste` now re-arm the gap chooser when nothing is armed, and completion clears `paste_target_gap`.

**#625 — the feature-router gate could be reverted without CI noticing.** The self-test carried a hand-copied duplicate of the check instead of invoking it. Extracted `scripts/dev/feature_router_check.sh`; `quality-check.sh` and the self-test now both call the real script, so a revert breaks the self-test.

**#627 — deploy skill contradicted the actual Tier-0 policy**, prescribing local build-deploy steps that are hook-blocked on this machine. Reconciled with reality.

## Tests

- RED: `806b38b4` added three failing E2E tests in `wasm-slide-multiselect.spec.ts` (one per #602 defect).
- GREEN: `94926f77` (implementation) + `6dcc5e0e` (the three CI-surfaced root causes).
- `tests/ci/feature-router-gate.test.sh` now invokes the real check script (#625).
- One E2E helper was scoped to `[data-view-panel="worship"]` — `[data-role="slides"]` matches two permanently-mounted grids (worship + Bible), which was a latent strict-mode collision.

Pipeline 31475089092: all 22 jobs green, dev deploy verified at v0.4.235.

Closes #602
Closes #625
Closes #627
