### PR TITLE
v0.4.236: post-merge review fixes — live-mode paste-chooser trap, stale-response clobber, silent end-of-list paste, overscroll, #625 wiring self-test

### DIFF
--- a/.claude/settings.local.json.omniroute-backup
+++ b/.claude/settings.local.json.omniroute-backup
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:20128",
+    "ANTHROPIC_AUTH_TOKEN": "sk-fda006aa2eae9640-cbfc4f-037fb198",
+    "ANTHROPIC_CUSTOM_HEADERS": "x-omniroute-thinking-marker: off"
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-bible"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "presenter-core",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-core"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-importer"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-migration"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-ndi"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "axum",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-persistence"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "presenter-server"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/presenter-ui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.235"
+version = "0.4.236"
 edition = "2021"
 authors = ["Presenter Team <drlik.zbynek@gmail.com>"]
 license = "MIT"

--- a/crates/presenter-ui/Cargo.lock
+++ b/crates/presenter-ui/Cargo.lock
@@ -1279,7 +1279,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "presenter-core"
-version = "0.4.235"
+version = "0.4.236"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -20,7 +20,8 @@ use super::slide_save::{
 };
 use super::slide_selection::{
     cut_memo, render_insertion_bar, render_select_checkbox, selected_memo,
-    setup_clipboard_keyboard, setup_selection_clear_on_switch, SlideSelectionPanel,
+    setup_clipboard_keyboard, setup_paste_chooser_clear_on_live,
+    setup_selection_clear_on_switch, SlideSelectionPanel,
 };
 
 #[component]
@@ -78,9 +79,12 @@ pub fn SlideList() -> impl IntoView {
     }
 
     // #554: clear selection/clipboard on song switch + the window C/X/V/Escape
-    // shortcut listener. Both are one-time setups.
+    // shortcut listener. F1: also disarm the paste-target chooser on a
+    // switch to live mode (Escape/Clear can't reach it there — see
+    // `setup_paste_chooser_clear_on_live`). All one-time setups.
     setup_selection_clear_on_switch(ctx.clone(), op.clone());
     setup_clipboard_keyboard(ctx.clone(), op.clone());
+    setup_paste_chooser_clear_on_live(ctx.clone(), op.clone());
 
     let trigger_slide = move |pres_id: String, slide_id: String, next_slide_id: Option<String>| {
         let playlist_id = ctx.selected_playlist_id.get_untracked();

--- a/crates/presenter-ui/src/components/slide_list.rs
+++ b/crates/presenter-ui/src/components/slide_list.rs
@@ -20,8 +20,8 @@ use super::slide_save::{
 };
 use super::slide_selection::{
     cut_memo, render_insertion_bar, render_select_checkbox, selected_memo,
-    setup_clipboard_keyboard, setup_paste_chooser_clear_on_live,
-    setup_selection_clear_on_switch, SlideSelectionPanel,
+    setup_clipboard_keyboard, setup_paste_chooser_clear_on_live, setup_selection_clear_on_switch,
+    SlideSelectionPanel,
 };
 
 #[component]

--- a/crates/presenter-ui/src/components/slide_selection.rs
+++ b/crates/presenter-ui/src/components/slide_selection.rs
@@ -255,8 +255,19 @@ fn anchor_slide_id_for_gap(ctx: &AppContext, gap: usize) -> Option<String> {
 /// Paste the clipboard at `gap` (0..=len). Copy → the paste endpoint (by
 /// ANCHOR slide id, #558 V8); Cut → the existing reorder endpoint via
 /// `cut_splice_order` (already carries the full target order, so it has no
-/// raw-index race to fix).
+/// raw-index race to fix). This is the ONE entry point every paste trigger
+/// (insertion-bar click/drop, the toolbar Paste button, Ctrl+V) funnels
+/// through, so it is also the single place that guards against queuing a
+/// second paste while one is already resolving (F3).
 pub(super) fn paste_at_gap(ctx: &AppContext, op: &OperatorState, gap: usize) {
+    // F3: never queue a second paste while one is still in flight — without
+    // this, a rapid double-click on the Paste button, held Ctrl+V
+    // key-repeat, or a stray extra bar click could each fire their own
+    // paste back-to-back, every one landing wherever the end of the list
+    // happened to be when IT resolved, with no undo.
+    if op.paste_in_flight.get_untracked() {
+        return;
+    }
     let Some(clipboard) = op.clipboard.get_untracked() else {
         return;
     };
@@ -269,6 +280,7 @@ pub(super) fn paste_at_gap(ctx: &AppContext, op: &OperatorState, gap: usize) {
         clear_selection_and_clipboard(op);
         return;
     }
+    op.paste_in_flight.set(true);
     match clipboard.mode {
         ClipboardMode::Copy => {
             let anchor_slide_id = anchor_slide_id_for_gap(ctx, gap);
@@ -323,6 +335,18 @@ async fn apply_slides_guarded(
     }
 }
 
+/// Is `pres_id` still the presentation currently open? An async paste
+/// response can resolve well after the operator has switched away — or
+/// switched to a different presentation and started a FRESH copy there
+/// (F2). A late response for an abandoned presentation must never
+/// disarm/wipe the state belonging to whatever is open now.
+fn still_on_presentation(ctx: &AppContext, pres_id: &str) -> bool {
+    ctx.selected_presentation
+        .get_untracked()
+        .map(|pres| pres.id.to_string() == pres_id)
+        .unwrap_or(false)
+}
+
 fn paste_copy(
     ctx: &AppContext,
     op: &OperatorState,
@@ -337,23 +361,36 @@ fn paste_copy(
     leptos::task::spawn_local(async move {
         match api::presentations::paste_slides(&pres_id, ids, anchor_slide_id).await {
             Ok(slides) => {
+                let pres_id_for_guard = pres_id.clone();
                 apply_slides_guarded(&ctx, &op, pres_id, slides, my_seq).await;
-                // Copy clipboard is KEPT so the user can paste again — but
-                // the "choosing a paste target" interaction (#602 defect 3)
-                // is OVER: this completed paste, so the grid returns to its
-                // normal multi-column layout. A later re-paste (toolbar
-                // Paste button / Ctrl+V) re-arms the chooser instead of
-                // silently reusing this now-stale gap (#602 re-paste
-                // regression) — `paste_target_gap` must not survive a
-                // completed interaction either.
-                op.choosing_paste_target.set(false);
-                op.paste_target_gap.set(None);
+                // F2: guard with the SAME still-here check the 409 arm
+                // below uses. Without it, a success response landing after
+                // the operator switched presentations and started a FRESH
+                // copy/cut there would disarm the FRESH chooser out from
+                // under them.
+                if still_on_presentation(&ctx, &pres_id_for_guard) {
+                    // Copy clipboard is KEPT so the user can paste again —
+                    // but the "choosing a paste target" interaction (#602
+                    // defect 3) is OVER: this completed paste, so the grid
+                    // returns to its normal multi-column layout. A later
+                    // re-paste (toolbar Paste button / Ctrl+V) re-arms the
+                    // chooser instead of silently reusing this now-stale
+                    // gap (#602 re-paste regression) — `paste_target_gap`
+                    // must not survive a completed interaction either.
+                    op.choosing_paste_target.set(false);
+                    op.paste_target_gap.set(None);
+                }
             }
             Err(ApiError::Status(422, _)) => {
-                op.clipboard.set(None);
-                op.choosing_paste_target.set(false);
-                op.paste_target_gap.set(None);
-                ctx.show_toast("Those slides no longer exist", "error");
+                // F2: same still-here guard — a stale 422 for an abandoned
+                // presentation must not wipe a FRESH clipboard the operator
+                // may have already set up on whatever they switched to.
+                if still_on_presentation(&ctx, &pres_id) {
+                    op.clipboard.set(None);
+                    op.choosing_paste_target.set(false);
+                    op.paste_target_gap.set(None);
+                    ctx.show_toast("Those slides no longer exist", "error");
+                }
             }
             Err(ApiError::Status(409, _)) => {
                 // #558 V8: the anchor slide vanished (a concurrent structural
@@ -370,27 +407,19 @@ fn paste_copy(
                 // selected would be exactly the V4 bug this guards against.
                 // Recover ONLY if `pres_id` is STILL the selected
                 // presentation; otherwise there is nothing to recover onto.
-                let still_here = ctx
-                    .selected_presentation
-                    .get_untracked()
-                    .map(|pres| pres.id.to_string() == pres_id)
-                    .unwrap_or(false);
-                if still_here {
+                if still_on_presentation(&ctx, &pres_id) {
                     // #558 X1: the W1 guard above only covers the window
                     // BEFORE this recovery GET — its OWN `.await` opens a
                     // SECOND window the operator can switch presentations
-                    // (or make another edit) in. Re-check BOTH `still_here`
+                    // (or make another edit) in. Re-check BOTH still-here
                     // and the `slide_edit_seq` guard (the identical idiom
                     // `apply_slides_guarded` uses on the success path) once
                     // the GET resolves; apply only if both still hold, else
                     // drop the response silently — nothing to recover onto.
                     if let Ok(detail) = api::presentations::get_presentation(&pres_id).await {
-                        let still_here_after_fetch = ctx
-                            .selected_presentation
-                            .get_untracked()
-                            .map(|pres| pres.id.to_string() == pres_id)
-                            .unwrap_or(false);
-                        if still_here_after_fetch && op.slide_edit_seq.get_untracked() == my_seq {
+                        if still_on_presentation(&ctx, &pres_id)
+                            && op.slide_edit_seq.get_untracked() == my_seq
+                        {
                             ctx.selected_presentation.set(Some(detail.presentation));
                             ctx.show_toast(
                                 "Paste position changed — refreshed, try again",
@@ -411,34 +440,50 @@ fn paste_copy(
                 ctx.show_toast("Paste failed — try again", "error");
             }
         }
+        // F3: the request has now fully resolved (every arm above,
+        // including the 409 arm's own nested `.await`, has run) — clear
+        // the in-flight guard so the NEXT paste activation is allowed.
+        op.paste_in_flight.set(false);
     });
 }
 
-/// Paste at the currently armed gap — or, if nothing is armed and the
-/// chooser isn't already active, RE-ARM it instead of silently pasting at a
-/// stale/default gap. A completed paste clears both `choosing_paste_target`
-/// and `paste_target_gap` (#602 defect 3), so a later Paste button / Ctrl+V
+/// Paste at the currently armed gap — or, if nothing is armed, RE-ARM the
+/// chooser and wait instead of silently pasting at a stale/default gap. A
+/// completed paste clears both `choosing_paste_target` and
+/// `paste_target_gap` (#602 defect 3), so a later Paste button / Ctrl+V
 /// with a retained clipboard must ask "where?" again — exactly like Copy/Cut
 /// starting a fresh interaction — rather than reuse the last-hovered gap or
 /// silently land at the end (#602 re-paste-into-several-gaps regression).
+///
+/// F3: the OLD guard here (`gap.is_none() && !choosing`) only deferred the
+/// FIRST activation with nothing hovered — a SECOND activation (an ordinary
+/// double-click on the Paste button, or Ctrl+V key-repeat) found
+/// `choosing_paste_target` already `true` and fell through to
+/// `unwrap_or(len)`, silently pasting at the END of the list with no undo.
+/// Falling through is gone: with no gap armed, EVERY activation just
+/// (re-)arms the chooser and returns, no matter how many times it fires.
 fn paste_at_target_or_rearm(ctx: &AppContext, op: &OperatorState) {
     if op.clipboard.get_untracked().is_none() {
         return;
     }
-    if op.paste_target_gap.get_untracked().is_none() && !op.choosing_paste_target.get_untracked() {
+    let Some(gap) = op.paste_target_gap.get_untracked() else {
         op.choosing_paste_target.set(true);
         return;
-    }
+    };
     let len = current_slide_ids(ctx).len();
-    let gap = op.paste_target_gap.get_untracked().unwrap_or(len).min(len);
-    paste_at_gap(ctx, op, gap);
+    paste_at_gap(ctx, op, gap.min(len));
 }
 
 fn paste_cut(ctx: &AppContext, op: &OperatorState, pres_id: String, ids: Vec<String>, gap: usize) {
     let current = current_slide_ids(ctx);
     let Some(final_order) = cut_splice_order(&current, &ids, gap) else {
         // A stale cut (an id vanished): drop the clipboard + marks.
+        // `paste_at_gap` already set `paste_in_flight` before calling in —
+        // this early return never reaches the spawned task below, so it
+        // must clear the flag itself or every later paste would be
+        // permanently blocked (F3).
         clear_selection_and_clipboard(op);
+        op.paste_in_flight.set(false);
         ctx.show_toast("Those slides no longer exist", "error");
         return;
     };
@@ -458,6 +503,8 @@ fn paste_cut(ctx: &AppContext, op: &OperatorState, pres_id: String, ids: Vec<Str
                 ctx.show_toast("Move failed — try again", "error");
             }
         }
+        // F3: request fully resolved — allow the next paste activation.
+        op.paste_in_flight.set(false);
     });
 }
 
@@ -473,6 +520,29 @@ pub(super) fn setup_selection_clear_on_switch(ctx: AppContext, op: OperatorState
             }
         }
         current
+    });
+}
+
+/// Disarm the "choosing a paste target" interaction the moment the view
+/// switches to LIVE mode (F1). `choosing_paste_target` is what drives
+/// `slide_list.rs`'s single-column grid class and its clickable "paste
+/// here" insertion bars — but BOTH normal ways to clear it are themselves
+/// gated on edit mode and so are dead once live mode is active: Escape
+/// early-returns on `mode == "live"` in `setup_clipboard_keyboard` above,
+/// and the panel hosting the Clear button is hidden by its own
+/// `mode != "live"` visibility check in `SlideSelectionPanel`. Without this
+/// watcher, a chooser armed right before switching to live stays armed
+/// forever — the grid stays stuck single-column with a bar a stray click
+/// can use to silently reorder slides during a live service. Root-caused
+/// here (one watcher) rather than adding an `is_edit &&` guard at every
+/// render site that reads the flag. Called once from `SlideList`.
+pub(super) fn setup_paste_chooser_clear_on_live(ctx: AppContext, op: OperatorState) {
+    let mode = ctx.mode;
+    Effect::new(move |_| {
+        if mode.get() == "live" {
+            op.choosing_paste_target.set(false);
+            op.paste_target_gap.set(None);
+        }
     });
 }
 
@@ -559,6 +629,7 @@ pub fn SlideSelectionPanel() -> impl IntoView {
     let mode = ctx.mode;
     let selected_slide_ids = op.selected_slide_ids;
     let clipboard = op.clipboard;
+    let paste_target_gap = op.paste_target_gap;
     let visible = move || {
         mode.get() != "live"
             && (!selected_slide_ids.with(|s| s.is_empty()) || clipboard.get().is_some())
@@ -619,7 +690,19 @@ pub fn SlideSelectionPanel() -> impl IntoView {
                                 class="operator__list-action"
                                 data-action="paste"
                                 data-role="slide-paste"
-                                title="Paste at the highlighted gap (Ctrl+V)"
+                                // F3: this activation may just be ARMING the
+                                // chooser (no gap highlighted yet) rather
+                                // than pasting — the static "at the
+                                // highlighted gap" wording was wrong for
+                                // that first click. Reflect which state
+                                // this button is actually in.
+                                title=move || {
+                                    if paste_target_gap.get().is_some() {
+                                        "Paste at the highlighted gap (Ctrl+V)"
+                                    } else {
+                                        "Click a gap to choose where to paste, then Paste again (Ctrl+V)"
+                                    }
+                                }
                                 prop:disabled=move || clipboard.get().is_none()
                                 on:click=move |_| paste_at_target_or_rearm(&ctx_paste, &op_paste)
                             >

--- a/crates/presenter-ui/src/state/operator.rs
+++ b/crates/presenter-ui/src/state/operator.rs
@@ -161,6 +161,14 @@ pub struct OperatorState {
     /// (only Clear/Escape/reload recovered it) because the class was keyed
     /// on `clipboard.is_some()`, which Copy never clears.
     pub choosing_paste_target: RwSignal<bool>,
+    /// True from the moment a paste request is dispatched (`paste_at_gap`)
+    /// until its response (success or error) has been fully handled (F3).
+    /// Guards against queuing a second paste while one is still resolving —
+    /// without it, a rapid double-click on the Paste button, or held
+    /// Ctrl+V key-repeat, could fire several pastes back-to-back, each
+    /// landing wherever the end of the list happened to be when IT
+    /// resolved, with no undo.
+    pub paste_in_flight: RwSignal<bool>,
 }
 
 impl OperatorState {
@@ -212,6 +220,7 @@ impl OperatorState {
             paste_target_gap: RwSignal::new(None),
             dragging_clipboard: RwSignal::new(false),
             choosing_paste_target: RwSignal::new(false),
+            paste_in_flight: RwSignal::new(false),
         }
     }
 }

--- a/crates/presenter-ui/styles/operator.css
+++ b/crates/presenter-ui/styles/operator.css
@@ -2166,6 +2166,12 @@ body.operator[data-view="settings"] [data-view-panel="settings"] {
 .operator__slides {
   flex: 1;
   overflow-y: auto;
+  /* F4: restored after #602 removed the OTHER `.operator__slides` rule
+     above as a dead duplicate — `overscroll-behavior` was declared ONLY
+     there, so it silently vanished from the whole stylesheet along with
+     the genuinely-dead properties. Without it, a touch/trackpad scroll
+     past the end of this grid chains to scrolling the page underneath. */
+  overscroll-behavior: contain;
   padding: 0.35rem;
   /* #556 F5: see the other .operator__slides rule above — the song bubble
      reserves its own space as an in-flow sticky grid row now, no manual

--- a/scripts/dev/feature_router_check.sh
+++ b/scripts/dev/feature_router_check.sh
@@ -25,18 +25,30 @@ set -euo pipefail
 #
 # Exit codes:
 #   0  all four routers present (prints "OK")
-#   1  a router is missing (prints "MISSING:<name>", the first one found)
+#   1  one or more routers are missing (prints "MISSING:<name>" for EVERY
+#      missing router, one per line, before exiting — F5: the extraction
+#      into this script had turned the old inline loop's "check ALL four,
+#      report ALL of them" behavior into "exit on the FIRST missing one",
+#      so the operator had to re-run the gate to discover the next
+#      missing router instead of seeing every gap in one pass)
 # ============================================================================
 
 SEARCH_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
+missing=()
 for name in bible libraries playlists presentations; do
   flat="$SEARCH_ROOT/crates/presenter-server/src/router/${name}.rs"
   dir_mod="$SEARCH_ROOT/crates/presenter-server/src/router/${name}/mod.rs"
   if [[ ! -f "$flat" && ! -f "$dir_mod" ]]; then
-    echo "MISSING:${name}"
-    exit 1
+    missing+=("$name")
   fi
 done
+
+if (( ${#missing[@]} > 0 )); then
+  for name in "${missing[@]}"; do
+    echo "MISSING:${name}"
+  done
+  exit 1
+fi
 
 echo "OK"

--- a/scripts/dev/quality-check.sh
+++ b/scripts/dev/quality-check.sh
@@ -57,8 +57,15 @@ router_check_out=$(bash "$ROOT_DIR/scripts/dev/feature_router_check.sh" "$ROOT_D
 router_check_rc=$?
 set -e
 if (( router_check_rc != 0 )); then
-  missing_name="${router_check_out#MISSING:}"
-  fail "Missing feature router: crates/presenter-server/src/router/${missing_name}.rs (or .../${missing_name}/mod.rs)"
+  # F5: the checker now reports EVERY missing router (one "MISSING:<name>"
+  # line each), not just the first — walk all of them so a single run
+  # surfaces every gap instead of making the operator re-run the gate to
+  # discover the next one.
+  while IFS= read -r router_line; do
+    [[ "$router_line" == MISSING:* ]] || continue
+    missing_name="${router_line#MISSING:}"
+    fail "Missing feature router: crates/presenter-server/src/router/${missing_name}.rs (or .../${missing_name}/mod.rs)"
+  done <<< "$router_check_out"
 fi
 
 # 2) router.rs should not contain legacy presentation handlers

--- a/tests/ci/feature-router-gate.test.sh
+++ b/tests/ci/feature-router-gate.test.sh
@@ -32,6 +32,28 @@ set -euo pipefail
 #      directory-only fixture. This pins the FIX, not just current behavior.
 #   5. RED   — the real gate script FAILS when one router is MISSING (the
 #      core negative case — catches accidental deletion of a router).
+#   6. RED, ALL reported — the real gate script reports EVERY missing router
+#      (not just the first) when SEVERAL are missing at once (F6/#666 — the
+#      #625 extraction had silently turned the old inline loop's "check all
+#      four, report all of them" into "exit on the first missing one").
+#   7. WIRING — quality-check.sh's section 1 still actually CALLS
+#      feature_router_check.sh, and the call is not neutered with a trailing
+#      `|| true` (F6/#666: the #625 fix pinned the SCRIPT but not the CALLER
+#      wiring — deleting the call from quality-check.sh, or `|| true`-ing it,
+#      left every assertion above green while quietly disabling the real
+#      gate).
+#   8. RED, END-TO-END — quality-check.sh's OWN section-1 code, extracted
+#      VERBATIM from the live file (never a hand-copy, so this can't drift
+#      out of sync with a later edit the way #625 itself did), executed
+#      against a fixture with a missing router: the real `fail()` call must
+#      actually fire. This is the strong proof #666/F6 asks for — it
+#      reproduces both the "call deleted" AND the "call `|| true`'d" failure
+#      modes assertion 7 checks for statically, but by literally RUNNING the
+#      current wiring instead of pattern-matching its text. Runs in
+#      isolation from the REST of quality-check.sh (cargo fmt/clippy/
+#      deny/audit etc.) — those are irrelevant to what this gate pins and,
+#      on this project's Tier-0 dev box, clippy/build steps are policy-
+#      forbidden to run locally at all.
 #
 # Run in CI by the Test job's "Run CI shell tests" step (alongside the other
 # tests/ci/*.test.sh regression tests). Exits 0 only when all assertions pass.
@@ -39,9 +61,15 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECKER="$ROOT_DIR/scripts/dev/feature_router_check.sh"
+QC_SCRIPT="$ROOT_DIR/scripts/dev/quality-check.sh"
 
 if [[ ! -f "$CHECKER" ]]; then
   echo "::error::feature-router gate self-test: feature_router_check.sh not found at $CHECKER" >&2
+  exit 1
+fi
+
+if [[ ! -f "$QC_SCRIPT" ]]; then
+  echo "::error::feature-router gate self-test: quality-check.sh not found at $QC_SCRIPT" >&2
   exit 1
 fi
 
@@ -210,6 +238,75 @@ else
 fi
 rm -rf "$WORK"
 trap - EXIT
+
+# --- Assertion 6: RED, ALL reported — F5: every missing router is listed,
+# not just the first ----------------------------------------------------------
+echo ""
+echo "[6] TWO missing routers at once (must report BOTH, not just the first — F5):"
+WORK="$(build_fixture dir)"
+trap 'rm -rf "$WORK"' EXIT
+rm -rf "$WORK/$ROUTER_BASE/bible" "$WORK/$ROUTER_BASE/presentations"
+set +e
+res="$(check_routers_present "$WORK")"
+rc=$?
+set -e
+if (( rc == 1 )) && grep -qx "MISSING:bible" <<< "$res" && grep -qx "MISSING:presentations" <<< "$res"; then
+  ok "both missing routers reported in one run (bible AND presentations) — output: ${res//$'\n'/, }"
+else
+  bad "did not report ALL missing routers in one run (exit $rc, res='$res')"
+fi
+rm -rf "$WORK"
+trap - EXIT
+
+# --- Assertion 7: WIRING — quality-check.sh still calls the real checker,
+# not deleted and not neutered with '|| true' (F6/#666) -----------------------
+echo ""
+echo "[7] quality-check.sh WIRING — section 1 must still invoke"
+echo "    feature_router_check.sh, not deleted and not '|| true'-neutered:"
+if grep -Fq 'bash "$ROOT_DIR/scripts/dev/feature_router_check.sh" "$ROOT_DIR"' "$QC_SCRIPT" \
+   && ! grep -F 'feature_router_check.sh' "$QC_SCRIPT" | grep -q '|| true'; then
+  ok "quality-check.sh still calls feature_router_check.sh, not neutered with '|| true'"
+else
+  bad "quality-check.sh no longer wires in feature_router_check.sh (deleted, renamed, or '|| true'-neutered)"
+fi
+
+# --- Assertion 8: RED, END-TO-END — quality-check.sh's OWN section-1 code,
+# extracted VERBATIM from the live file (never a hand-copy), genuinely fails
+# on a missing router (F6/#666 — the strongest proof: this is the code that
+# ships, actually executed, not a description of it) --------------------------
+echo ""
+echo "[8] quality-check.sh's ACTUAL section-1 code (extracted live, not"
+echo "    hand-copied), run against a fixture with a MISSING router — must"
+echo "    genuinely record a failure via its own fail() call:"
+section1="$(sed -n '/^# 1) Router feature modules present\./,/^# 2) router\.rs should not contain/p' "$QC_SCRIPT" | sed '$d')"
+if [[ -z "$section1" ]]; then
+  bad "could not locate quality-check.sh's section 1 by its marker comments — did the markers move?"
+else
+  WORK="$(build_fixture dir)"
+  trap 'rm -rf "$WORK"' EXIT
+  # The extracted text calls "$ROOT_DIR/scripts/dev/feature_router_check.sh"
+  # — give the fixture its own copy of the REAL current checker so ROOT_DIR
+  # can be pointed entirely at the fixture (both the "search root" arg AND
+  # the script lookup resolve inside it), matching how quality-check.sh
+  # really runs (repo root serves both roles there too).
+  mkdir -p "$WORK/scripts/dev"
+  cp "$CHECKER" "$WORK/scripts/dev/feature_router_check.sh"
+  rm -rf "$WORK/$ROUTER_BASE/bible"
+  extraction_fail_count="$(
+    ROOT_DIR="$WORK"
+    failures=()
+    fail() { failures+=("$*"); }
+    eval "$section1"
+    printf '%s\n' "${#failures[@]}"
+  )"
+  rm -rf "$WORK"
+  trap - EXIT
+  if [[ "$extraction_fail_count" =~ ^[1-9][0-9]*$ ]]; then
+    ok "quality-check.sh's real section-1 code recorded a failure for the missing router (fail() fired ${extraction_fail_count}x)"
+  else
+    bad "quality-check.sh's real section-1 code did NOT record a failure for a missing router (fail() fired '$extraction_fail_count' times) — the #625 gap has recurred at the CALLER"
+  fi
+fi
 
 # --- Summary ----------------------------------------------------------------
 echo ""

--- a/tests/e2e/wasm-slide-multiselect.spec.ts
+++ b/tests/e2e/wasm-slide-multiselect.spec.ts
@@ -119,17 +119,33 @@ async function switchToPresentation(
     .first();
   await expect(result).toBeVisible({ timeout: 15_000 });
   await result.click();
+  // F7: scoped to the worship panel — the operator shell mounts the Bible
+  // grid (`[data-view-panel="bible"]`) ALWAYS, even when it's not the
+  // active view, and it renders its own `[data-slide-id]` cards
+  // (pages/bible_slides.rs). An unscoped document-wide query can match a
+  // slide id that ALSO happens to exist in the (hidden) Bible grid — these
+  // specs pass today only because they never prepare a Bible passage.
   await page.waitForFunction(
-    (slideId) => document.querySelector(`[data-slide-id="${slideId}"]`) !== null,
+    (slideId) =>
+      document.querySelector(
+        `[data-view-panel="worship"] [data-slide-id="${slideId}"]`,
+      ) !== null,
     firstExpectedSlideId,
     { timeout: 15_000 },
   );
 }
 
-/** The main texts of the slide cards in DOM order (edit-mode textareas). */
+/** The main texts of the slide cards in DOM order (edit-mode textareas).
+ * F7: scoped to `[data-view-panel="worship"]` — see the comment in
+ * `switchToPresentation` above for why an unscoped `[data-slide-id]` query
+ * is unsafe (the always-mounted Bible grid renders the same attribute). */
 async function mainTextsInOrder(page: import("@playwright/test").Page) {
   return page.evaluate(() =>
-    Array.from(document.querySelectorAll("[data-slide-id]")).map(
+    Array.from(
+      document.querySelectorAll(
+        '[data-view-panel="worship"] [data-slide-id]',
+      ),
+    ).map(
       (card) =>
         (card.querySelector('textarea[data-field="main"]') as HTMLTextAreaElement | null)
           ?.value ?? "",
@@ -137,11 +153,14 @@ async function mainTextsInOrder(page: import("@playwright/test").Page) {
   );
 }
 
+/** F7: scoped to `[data-view-panel="worship"]` — see `mainTextsInOrder`. */
 async function domSlideOrder(page: import("@playwright/test").Page) {
   return page.evaluate(() =>
-    Array.from(document.querySelectorAll("[data-slide-id]")).map((s) =>
-      s.getAttribute("data-slide-id"),
-    ),
+    Array.from(
+      document.querySelectorAll(
+        '[data-view-panel="worship"] [data-slide-id]',
+      ),
+    ).map((s) => s.getAttribute("data-slide-id")),
   );
 }
 
@@ -982,6 +1001,188 @@ test.describe("WASM Operator Slide Multi-Select (#554)", () => {
     // ...WITHOUT discarding the retained Copy clipboard — the toolbar Paste
     // button must still be enabled for a re-paste with no re-copy needed.
     await expect(page.locator('[data-role="slide-paste"]')).toBeEnabled();
+
+    expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
+  });
+
+  test("switching to LIVE mode disarms an armed paste chooser — grid never stays stuck single-column (F1)", async ({
+    page,
+    request,
+  }) => {
+    const consoleIssues: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+      }
+    });
+
+    const lib = `E2E MSel F1 LiveSwitch ${Date.now()}`;
+    const { slideIds } = await createPresentationWithSlides(request, 4, lib);
+    await openPresentationInEditMode(page, lib);
+
+    await checkboxFor(page, slideIds[0]).click();
+    await page.locator('[data-role="slide-copy"]').click();
+
+    // Chooser armed: single column, "Paste here" bars visible + clickable.
+    await expect(insertBar(page, 0)).toBeVisible();
+    expect(await gridColumnCount(page)).toBe(1);
+
+    // Switch to LIVE mode WHILE the chooser is still armed — the exact
+    // sequence F1 flags. Escape and the selection panel's Clear button
+    // (the only two normal ways to disarm it) are BOTH gated on edit mode,
+    // so without the fix the grid stays stuck single-column with a
+    // clickable bar that could mutate slide order during a live service.
+    await page.locator('[data-role="mode-toggle"][data-mode="live"]').click();
+    await page.waitForFunction(
+      () => document.body.getAttribute("data-mode") === "live",
+      { timeout: 5_000 },
+    );
+
+    // The grid must return to normal multi-column and the bars must be
+    // gone — never present, let alone clickable, in live mode.
+    await expect
+      .poll(() => gridColumnCount(page), { timeout: 10_000 })
+      .toBeGreaterThan(1);
+    await expect(page.locator('[data-role="slide-insert-bar"]')).toHaveCount(0);
+
+    // Switching back to edit must NOT silently re-arm the chooser — the
+    // clipboard is still retained (Copy semantics keep it for a re-paste),
+    // but the operator must explicitly press Paste again to choose a NEW
+    // target; the grid stays multi-column until they do.
+    await page.locator('[data-role="mode-toggle"][data-mode="edit"]').click();
+    await page.waitForFunction(
+      () => document.body.getAttribute("data-mode") === "edit",
+      { timeout: 5_000 },
+    );
+    expect(await gridColumnCount(page)).toBeGreaterThan(1);
+    await expect(page.locator('[data-role="slide-insert-bar"]')).toHaveCount(0);
+    await expect(page.locator('[data-role="slide-paste"]')).toBeEnabled();
+
+    expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
+  });
+
+  test("a late successful paste for an abandoned presentation never disarms a FRESH chooser on the one switched to (F2)", async ({
+    page,
+    request,
+  }) => {
+    const libA = `E2E MSel F2 GuardA ${Date.now()}`;
+    const { slideIds: idsA } = await createPresentationWithSlides(request, 2, libA);
+    const libB = `E2E MSel F2 GuardB ${Date.now()}`;
+    const { slideIds: idsB } = await createPresentationWithSlides(request, 2, libB);
+
+    await openPresentationInEditMode(page, libA);
+    await checkboxFor(page, idsA[0]).click();
+    await page.locator('[data-role="slide-copy"]').click();
+
+    // Hold A's paste response open until this test explicitly releases it —
+    // same technique as the #558 V4 race test above.
+    let releaseA: () => void = () => {};
+    const released = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const pasteResponse = page.waitForResponse(
+      (r) => r.url().includes("/slides/paste") && r.request().method() === "POST",
+    );
+    await page.route("**/slides/paste", async (route) => {
+      const response = await request.fetch(route.request());
+      const body = await response.body();
+      await released;
+      await route.fulfill({
+        status: response.status(),
+        headers: response.headers(),
+        body,
+      });
+    });
+
+    await insertBar(page, 0).click(); // fires A's (now-delayed) paste
+
+    // Switch to B WHILE A's paste is still in flight, and start a FRESH
+    // copy/chooser there.
+    await switchToPresentation(page, libB, idsB[0]);
+    await checkboxFor(page, idsB[0]).click();
+    await page.locator('[data-role="slide-copy"]').click();
+    await expect(insertBar(page, 0)).toBeVisible();
+    expect(await gridColumnCount(page)).toBe(1);
+
+    // Let A's delayed SUCCESS response land on B's page. Without the F2
+    // guard, its Ok-arm writes (`choosing_paste_target=false`,
+    // `paste_target_gap=None`) run unconditionally and would disarm B's
+    // FRESH chooser out from under the operator.
+    releaseA();
+    await pasteResponse;
+    // Positive sentinel, not a poll on the negative condition (see the V4
+    // race test's own rationale above): the browser drains A's already-
+    // resolved response continuation before dispatching a new UI input, so
+    // by the time this click's effect is visible A's response is fully
+    // processed.
+    await checkboxFor(page, idsB[1]).click();
+    await expect(
+      page.locator('[data-role="slide-selection-count"]'),
+    ).toHaveText("2 selected");
+
+    // B's chooser must still be armed — A's late success must not have
+    // touched it.
+    await expect(insertBar(page, 0)).toBeVisible();
+    expect(await gridColumnCount(page)).toBe(1);
+    // And B's own slide order is untouched by A's paste result.
+    expect(await domSlideOrder(page)).toEqual(idsB);
+  });
+
+  test("a second Paste activation with no gap armed does not silently paste at the end (F3)", async ({
+    page,
+    request,
+  }) => {
+    const consoleIssues: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+      }
+    });
+
+    const lib = `E2E MSel F3 Rearm ${Date.now()}`;
+    const { slideIds } = await createPresentationWithSlides(request, 3, lib);
+    await openPresentationInEditMode(page, lib);
+
+    // Fail the test outright if a paste POST is EVER fired by the inert
+    // activations below — the old bug's silent end-of-list paste was
+    // exactly this network call firing when it should not have.
+    let unexpectedPaste = false;
+    page.on("request", (req) => {
+      if (req.url().includes("/slides/paste") && req.method() === "POST") {
+        unexpectedPaste = true;
+      }
+    });
+
+    await checkboxFor(page, slideIds[0]).click();
+    await page.locator('[data-role="slide-copy"]').click();
+    // Copy already arms the chooser (`choosing_paste_target=true`) with NO
+    // gap hovered — clicking Paste now, and again, is exactly the
+    // "activation with no gap armed" the old guard
+    // (`gap.is_none() && !choosing`) only deferred ONCE before falling
+    // through to `unwrap_or(len)` on any later activation.
+    await expect(insertBar(page, 0)).toBeVisible();
+
+    await page.locator('[data-role="slide-paste"]').click();
+    await page.locator('[data-role="slide-paste"]').click();
+
+    expect(
+      unexpectedPaste,
+      "an inert Paste activation (no gap armed) must never fire a paste request",
+    ).toBe(false);
+    expect(await mainTextsInOrder(page)).toEqual([
+      "Slide 1",
+      "Slide 2",
+      "Slide 3",
+    ]);
+
+    // The chooser must still be ARMED and usable — pick the real gap now,
+    // and it must paste EXACTLY once (not twice, from a queued end-of-list
+    // paste the old bug would have already fired).
+    await insertBar(page, 0).click();
+    await expect
+      .poll(() => mainTextsInOrder(page), { timeout: 10_000 })
+      .toEqual(["Slide 1", "Slide 1", "Slide 2", "Slide 3"]);
+    expect(await mainTextsInOrder(page)).toHaveLength(4);
 
     expect(consoleIssues, `console issues: ${consoleIssues.join(" | ")}`).toEqual([]);
   });


### PR DESCRIPTION
Post-merge adversarial review of v0.4.235 (PR #666) produced 7 findings (5 🟡 / 2 🔵). All are fixed here.

## Findings fixed

**F1 🟡 grid could stay stuck single-column in LIVE mode** — insertion bars and the single-column class were gated on `choosing_paste_target` alone. Switching to live mode while the chooser was armed left the grid collapsed with clickable "Paste here" bars, and both clearing paths are dead in live mode (the selection panel hides, the Escape handler early-returns) — a stray bar click would reorder slides during a service. New `setup_paste_chooser_clear_on_live` effect disarms the chooser on the live switch, following the existing `setup_selection_clear_on_switch` pattern. Reachability predates v0.4.235, but the flag's lifecycle is #602's own subject.

**F2 🟡 late response clobbered a fresh clipboard** — the Ok and 422 arms wrote `choosing_paste_target` / `paste_target_gap` / `clipboard` unconditionally after an `.await`, without the "still here" guard the 409 arm already documents (#558 W1/X1/X3). Switching presentation mid-flight and starting a new copy would get the fresh chooser disarmed and the fresh clipboard wiped. Extracted `still_on_presentation()` and applied it to all three arms.

**F3 🟡 double-click Paste / held Ctrl+V silently pasted at the end** — the re-arm guard deferred only ONE activation; a second with no gap armed fell through to `unwrap_or(len)`. No undo exists. `paste_at_target_or_rearm` now never falls through, and a new `paste_in_flight` guard in the shared `paste_at_gap` entry point stops queued pastes from key-repeat (cleared on `paste_cut`'s early-return path too). The button `title` is now reactive instead of claiming a highlighted gap that may not exist.

**F4 🟡 `overscroll-behavior: contain` was silently dropped** — the deleted `.operator__slides` block was not a dead duplicate; cascade order only kills redeclared properties, and this one existed nowhere else (`grep` → 0 hits), so touch/trackpad scroll past the grid chained to the page. Restored on the surviving rule.

**F5 🔵 gate reported only the first missing router** — the extraction lost the old inline loop's report-all behavior. Now collects every missing name.

**F6 🟡 the #625 gap was moved, not closed** — the self-test pinned the check script but not its WIRING: deleting (or `|| true`-ing) the call in `quality-check.sh` left all assertions green. Added assertion 7 (the invocation is present and un-neutered) and assertion 8 (extracts quality-check.sh's own section-1 code by its marker comments and asserts it genuinely fails against a missing-router fixture). Proven RED under both neutering variants, GREEN after restore.

**F7 🔵 remaining unscoped E2E lookups** — `mainTextsInOrder`, `domSlideOrder` and the presentation-switch wait still queried `[data-slide-id]` document-wide, spanning the always-mounted Bible grid that caused the original shard-3 failure. Scoped to `[data-view-panel="worship"]`.

## Also

`style: cargo fmt in presenter-ui` — `cargo fmt --all` skips that crate (workspace-excluded, own `Cargo.lock`), and CI runs a separate `cargo fmt --check` inside it. Local workspace fmt was clean while CI's Format job failed on `slide_list.rs`.

## Tests

RED commit `5303ed3c` (new E2E coverage for F1/F2/F3 + the F7 scoping) precedes GREEN `26125dfa`. F6's assertions were proven to fail against both sabotage variants before the fix landed.

Pipeline 31484712986: all 22 jobs green, dev deploy verified at v0.4.236.
